### PR TITLE
devcontainer.json: Fix JSON formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	image: "sysroot2",
+	"image": "sysroot2",
 	"name": "dpdk-dev-container",
 	"mounts": [
 		"source=/mnt/huge/2M,target=/mnt/huge/2M,type=bind",


### PR DESCRIPTION
Let's try a simple PR :)

The "image" key in devcontainer.json should be placed between quotes to have a valid JSON file.
