### PR TITLE
Fix incorrect version spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arrayvec"
@@ -179,9 +179,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21696e6dfe1057a166a042c6d27b89a46aad2ee1003e6e1e03c49d54fd3270d7"
+checksum = "b8d8a704b617484e9d867a0423cd45f7577f008c4068e2e33378f8d3860a6d73"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,19 @@ resolver = "2"
 
 [workspace.dependencies]
 
-bindgen = { version = "0.70" }
-bolero = { version = "0.11" }
-cc = { version = "1" }
-doxygen-rs = { version = "0.4" }
-etherparse = { version = "0.15", default-features = false, features = [] }
-libc = { version = "0.2" }
-rstest = { version = "0.22", default-features = false, features = [] }
-serde = { version = "1", default-features = false, features = ["derive", "alloc", "rc"] }
-syscalls = { version = "0.6" }
-thiserror = { version = "2", package = "thiserror-no-std" } # replace with regular thiserror when https://github.com/dtolnay/thiserror/pull/304 lands
-tracing = { version = "0.1", default-features = false, features = ["attributes"] }
-tracing-subscriber = { version = "0.3" }
-tracing-test = { version = "0.2" }
+bindgen = { version = "0.70.1" }
+bolero = { version = "0.11.1" }
+cc = { version = "1.1.21" }
+doxygen-rs = { version = "0.4.0" }
+etherparse = { version = "0.16.0", default-features = false, features = [] }
+libc = { version = "0.2.158" }
+rstest = { version = "0.22.0", default-features = false, features = [] }
+serde = { version = "1.0.210", default-features = false, features = ["derive", "alloc", "rc"] }
+syscalls = { version = "0.6.18" }
+thiserror = { version = "2.0.0", package = "thiserror-no-std" } # replace with regular thiserror when https://github.com/dtolnay/thiserror/pull/304 lands
+tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
+tracing-subscriber = { version = "0.3.18" }
+tracing-test = { version = "0.2.5" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
The version spec for dependencies was sloppy (failed to specify minor and patch levels)..

Keep in mind that in cargo, dependency of type

```toml
foo = "x.y.z"
```

means `foo` must resolve with version `x'.y'.z'` where `x' == x`, `y' >= y`, and `z' >= z`

and that the default dependency resolver will maximize `y'` and `z'`.

That is, cargo assumes that projects are following semver and that you want the latest package which meets your desired API.

If you really needed a specific version you could say

```toml
foo = "=x.y.z"
```

which constrains the resolver