### PR TITLE
Minor improvements for docs workflow

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -14,6 +14,11 @@ on:
       - 'design-docs/**'
       - 'nix/**'
       - '.github/workflows/build-and-deploy-docs.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
- **CI: Rename docs build workflow, restrict to docs changes**
- **CI: Restrict docs workflow run on push to 'main' branch**
- **CI: Add concurrency group to docs workflow**

The main issue to solve after that is that - as far as I understand - we're overwriting the published version of the docs each time we create or update a PR. We need to create previews only for PRs, under a different URL. I haven't looked into it so far.
