### PR TITLE
ci: Add workflow to prevent merging PRs with 'dont-merge' label

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -1,0 +1,16 @@
+name: Mergeability
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    name: Check mergeability based on labels
+    steps:
+      - if: ${{ contains(github.event.*.labels.*.name, 'dont-merge') }}
+        name: Fail test due to 'dont-merge' label presence
+        run: exit 1
+      - name: Allow merging
+        run: exit 0


### PR DESCRIPTION
Sometimes, it is useful to have an option to prevent maintainers from merging a Pull Request when reviews are in and all checks are green but merging should be deferred for whatever reason. This commit adds a workflow that fails if a Pull Request has a label containing [the substring 'dont-merge'][0].

This mechanism is inspired by what Cilium does with [maintainer's little helper][1] and the implementation is based on [this blog post from Jesse Squires and Ben Asher][2].

[0]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#contains
[1]: https://github.com/cilium/github-actions/blob/d6fb4a25efefa0f830dce582af2510eb7eed6397/README.md?plain=1#L55
[2]: https://www.jessesquires.com/blog/2021/08/24/useful-label-based-github-actions-workflows/#do-not-merge
