### PR TITLE
justfile: Sanitize branch names before using them in container tags

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ _commit := `git rev-parse HEAD 2>/dev/null || echo "sterile"`
 # The git branch we are currnetly on
 # We allow this command to fail in the sterile environment because git is not available there
 
-_branch := `git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "sterile"`
+_branch := `(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "sterile") | tr -c '[:alnum:]\n' '-'`
 
 # The git tree state (clean or dirty)
 # We allow this command to fail in the sterile environment because git is not available there


### PR DESCRIPTION
Using the branch name as part of containers tags fails when branch names contain characters that are not valid for container tags (or not valid at the location where we use the branch name in the tag string).

To prevent the CI workflow from failing when the Pull Request branch name contains a slash, for example, sanitize the branch name before using it.

We sanitize it by translating (`tr`) everything that is not (`-c`) an alphanumeric character (`[:alnum:]`) or a line break (`\n`) into dashes. We keep line breaks because we don't want the final line break appended by echo to be converted into a dash; assigning the string to `_branch` will trim the ending line break anyway.

Fixes: #21
