### PR TITLE
justfile: Truncate container tag string if too long

### DIFF
--- a/justfile
+++ b/justfile
@@ -366,6 +366,8 @@ build-container: sterile-build
     declare build_time_epoch
     build_time_epoch="$(date --utc '+%s' --date="{{ _build_time }}")"
     declare -r build_time_epoch
+    tag="${build_date}.{{ _slug }}.{{ target }}.{{ profile }}.{{ _commit }}"
+    tag="${tag::128}"
     sudo -E docker build \
       --label "git.commit={{ _commit }}" \
       --label "git.branch={{ _branch }}" \
@@ -374,7 +376,7 @@ build-container: sterile-build
       --label "build.date=${build_date}" \
       --label "build.timestamp={{ _build_time }}" \
       --label "build.time_epoch=${build_time_epoch}" \
-      --tag "{{ _container_repo }}:${build_date}.{{ _slug }}.{{ target }}.{{ profile }}.{{ _commit }}" \
+      --tag "{{ _container_repo }}:${tag}" \
       --build-arg ARTIFACT="artifact/{{ target }}/{{ profile }}/scratch" \
       .
 


### PR DESCRIPTION
It seems (from CI failures and local tests) that container's tags can't be longer than 128 characters. Sometimes CI generates tag that are longer than this (thanks Dependabot for the extra-long branch names).

Make sure we don't break docker builds by having bash truncate the string if necessary.

Fixes: #21
