### PR TITLE
ci: Print debug output ("set -x") for all invocations of just

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cargo binstall --no-confirm cargo-deny
       - run: |
-          just cargo deny check
+          just debug=true cargo deny check
       - name: "install openssl and libssl-dev (needed for markdown-test-report)"
         run: |
           sudo apt-get update
@@ -80,12 +80,12 @@ jobs:
           cargo binstall --no-confirm markdown-test-report
       - name: refresh-compile-env
         run: |
-          just --yes refresh-compile-env
+          just --yes debug=true refresh-compile-env
       - run: |
-          just --yes fake-nix
+          just --yes debug=true fake-nix
 
       - run: |
-          just cargo +${{matrix.rust.toolchain}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu
+          just debug=true cargo +${{matrix.rust.toolchain}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu
         continue-on-error: ${{ matrix.rust.optional }}
       - name: "tests: rust ${{ matrix.rust.toolchain }} profile=dev target=x86_64-unknown-linux-gnu"
         run: |
@@ -105,7 +105,7 @@ jobs:
         continue-on-error: ${{ matrix.rust.optional }}
 
       - run: |
-          just cargo +${{matrix.rust.toolchain}} build --locked --profile=release --target=x86_64-unknown-linux-gnu
+          just debug=true cargo +${{matrix.rust.toolchain}} build --locked --profile=release --target=x86_64-unknown-linux-gnu
         continue-on-error: ${{ matrix.rust.optional }}
       - name: "tests: rust ${{ matrix.rust.toolchain }} profile=release target=x86_64-unknown-linux-gnu"
         run: |
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: ${{ matrix.rust.optional }}
 
       - run: |
-          just cargo +${{matrix.rust.toolchain}} build --locked --profile=release --target=x86_64-unknown-linux-musl
+          just debug=true cargo +${{matrix.rust.toolchain}} build --locked --profile=release --target=x86_64-unknown-linux-musl
         continue-on-error: ${{ matrix.rust.optional }}
       - name: "tests: rust ${{ matrix.rust.toolchain }} profile=release target=x86_64-unknown-linux-musl"
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: "Build design docs"
         run: |
-          just mdbook build
+          just debug=true mdbook build
 
       - name: "Copy design doc build to publish directory"
         run: |

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -56,7 +56,7 @@ jobs:
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
-          just rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu sterile test
+          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu sterile test
           mkdir dev.gnu
           cp -a ./target/nextest dev.gnu
 
@@ -64,7 +64,7 @@ jobs:
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu sterile test
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu sterile test
           mkdir release.gnu
           cp -a ./target/nextest release.gnu
 
@@ -72,7 +72,7 @@ jobs:
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
-          just rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl sterile test
+          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl sterile test
           mkdir dev.musl
           cp -a ./target/nextest dev.musl
 
@@ -80,7 +80,7 @@ jobs:
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl sterile test
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl sterile test
           mkdir release.musl
           cp -a ./target/nextest release.musl
 
@@ -100,28 +100,28 @@ jobs:
         run: |
           export GITHUB_STEP_SUMMARY
           export CARGO_TARGET_DIR=dev.gnu
-          just rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu report
+          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu report
 
       - name: "dev/musl report"
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
           export CARGO_TARGET_DIR=dev.musl
-          just rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl report
+          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl report
 
       - name: "release/gnu report"
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
           export CARGO_TARGET_DIR=release.gnu
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu report
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu report
 
       - name: "release/musl report"
         if: ${{ always() }}
         run: |
           export GITHUB_STEP_SUMMARY
           export CARGO_TARGET_DIR=release.musl
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl report
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl report
 
       - uses: "actions/upload-artifact@v4"
         if: ${{ always() }}
@@ -180,15 +180,15 @@ jobs:
       - run: |
           cargo binstall --no-confirm cargo-deny
       - run: |
-          just cargo deny check
+          just debug=true cargo deny check
       - run: |
-          just rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-gnu push-container
+          just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-gnu push-container
       - run: |
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu push-container
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu push-container
       - run: |
-          just rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl push-container
+          just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl push-container
       - run: |
-          just rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl push-container
+          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl push-container
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}


### PR DESCRIPTION
Let's get more logs from just in CI. We know we'll hit a bug and need them, eventually.
