### PR TITLE
Fix incorrect docs publish triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
   build:
     name: "Build and deploy documentation"
     needs: [ check_changes ]
-    if: "${{ needs.check_changes.outputs.docs == 'true' }}"
+    if: "${{ needs.check_changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch' }}"
     runs-on: "ubuntu-latest"
     steps:
 


### PR DESCRIPTION
Graphviz should now be installed in the `dpdk-sys` upstream, but we don't see that because the workflow triggers are (now) incorrect after the rework