### PR TITLE
ci: Remove unused "just.version" from matrix in dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,8 +40,6 @@ jobs:
             optional: true
           - toolchain: "nightly"
             optional: true
-        just:
-          - version: "1.36.0"
     continue-on-error: ${{ matrix.rust.optional }}
     runs-on: "lab"
     timeout-minutes: 45


### PR DESCRIPTION
We have set a version for just in the CI workflow but don't use it. Remove it.

Fixes: #70
