### PR TITLE
ci: Skip dev.yml, sterile.yml if there are no code changes

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,7 +29,30 @@ permissions:
   id-token: "write"
 
 jobs:
+  check_changes:
+    name: "Deduce required tests from code changes"
+    runs-on: "ubuntu-latest"
+    outputs:
+      devfiles: "${{ steps.changes.outputs.devfiles }}"
+    steps:
+      - name: "Checkout"
+        if: "${{ !github.event.pull_request }}"
+        uses: "actions/checkout@v4"
+        with:
+          persist-credentials: "true"
+          fetch-depth: "0"
+      - name: "Check code changes"
+        uses: "dorny/paths-filter@v3"
+        id: "changes"
+        with:
+          filters: |
+            devfiles:
+              - '!(README.md|LICENSE|design-docs/**|.gitignore|.github/**)'
+              - '.github/workflows/dev.yml'
+
   build:
+    needs: [ check_changes ]
+    if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -139,10 +162,10 @@ jobs:
 
   summary:
     name: "summary"
-    if: ${{ always() }}
     runs-on: "ubuntu-latest"
     needs:
       - build
+    if: ${{ always() && needs.build.result != 'skipped' }}
     steps:
       - name: "Flag any build matrix failures"
         if: ${{ needs.build.result != 'success' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,10 +40,6 @@ jobs:
         uses: "dorny/paths-filter@v3"
         id: "changes"
         with:
-          # For "push" events, compare against the "ref" base branch.
-          # For "pull_request" events, this is ignored and will compare against
-          # the pull request base branch.
-          base: "${{ github.ref }}"
           filters: |
             docs:
               - '*.nix'

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -18,7 +18,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: "Deduce required tests from code changes"
+    runs-on: "ubuntu-latest"
+    outputs:
+      devfiles: "${{ steps.changes.outputs.devfiles }}"
+    steps:
+      - name: "Checkout"
+        if: "${{ !github.event.pull_request }}"
+        uses: "actions/checkout@v4"
+        with:
+          persist-credentials: "true"
+          fetch-depth: "0"
+      - name: "Check code changes"
+        uses: "dorny/paths-filter@v3"
+        id: "changes"
+        with:
+          filters: |
+            devfiles:
+              - '!(README.md|LICENSE|design-docs/**|.gitignore|.github/**)'
+              - '.github/workflows/sterile.yml'
+
   test:
+    needs: [ check_changes ]
+    if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
     permissions:
       contents: "read"
       packages: "read"
@@ -137,6 +160,8 @@ jobs:
           limit-access-to-actor: true
 
   push:
+    needs: [ check_changes ]
+    if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
     permissions:
       contents: "read"
       packages: "write"
@@ -199,11 +224,11 @@ jobs:
 
   summary:
     name: "summary"
-    if: ${{ always() }}
     runs-on: "ubuntu-latest"
     needs:
       - test
       - push
+    if: ${{ always() && needs.test.result != 'skipped' && needs.push.result != 'skipped' }}
     steps:
       - name: "Flag any test failures"
         if: ${{ needs.test.result != 'success' }}


### PR DESCRIPTION
Skip dev.yml and sterile.yml workflows if there are no relevant code change. This means we skip the main jobs if the only files changed in the PR are README.md, LICENSE, .gitignore, anything under design-docs, or anything under .github and apart from the definition of the workflow itself.
