### PR TITLE
CODEOWNERS: Add basic CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners file for Dataplane
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Keep it simple for now: assign everything to a single team, to allow
+# automatic notifications and review assignments.
+
+* @githedgehog/dataplane-reviewers


### PR DESCRIPTION
Make everything owned by a single team. The idea is to be able to have auto-assignment for reviews on Pull Requests. We can use finer-grained ownership later if necessary.
