### PR TITLE
README.md: Fix link for rustup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ managed by the Fabric, or to communicate with endpoints outside of the Fabric.
 - A recent `x86_64` linux machine is required for development
 - Bash (you very likely have this)
 - [Docker][docker] (install through your package manager)
-- Cargo / Rust (install via [`rustup`])
+- Cargo / Rust (install via [`rustup`][rustup])
 
   * :warning: You need a recent version of rust (1.82.0 or better) to build the project.
 


### PR DESCRIPTION
In a previous commit I tried to clean up the README file, but I broke the link to rustup's website. Let's fix it.

I meant to check whether the backquotes in the link would break, but only remembered to do so when the PR was merged :facepalm: 