### PR TITLE
ci: Add workflow to ensure Rust code is consistently formatted

### DIFF
--- a/.github/workflows/lint-cargo-fmt.yml
+++ b/.github/workflows/lint-cargo-fmt.yml
@@ -1,0 +1,36 @@
+# Make sure Rust source code is consistently formatted with rustfmt.
+
+name: "lint-cargo-fmt.yml"
+
+on:
+  pull_request: {}
+
+concurrency:
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  format-check:
+    name: "Check formatting for Rust code"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Install Rust toolchain"
+        uses: "dtolnay/rust-toolchain@stable"
+        with:
+          toolchain: "nightly"
+          components: "rustfmt"
+
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: "1"
+          persist-credentials: "false"
+
+      - name: "Check formatting"
+        run: |
+          cargo fmt --check
+
+      - name: "How to fix"
+        if: ${{ failure() }}
+        run: |
+          echo "::notice::Try fixing the issue with 'cargo fmt --all', then commit the changes."


### PR DESCRIPTION
Rather than leaving formatting decisions up to every developer, enforce them consistently with rustfmt. To do so, add a workflow that checks that the code has been properly formatted, with "cargo fmt --check".

The objective of creating this workflow early, while there are few formatting reports to address, is to avoid having a huge commit at a later time to fix formatting throughout the repository.
