### PR TITLE
ci: For merge groups, add event type, skip publishing docs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - "main"
   merge_group:
+    types: ["checks_requested"]
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "main"
   merge_group:
+    types: ["checks_requested"]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -89,18 +90,18 @@ jobs:
           cp -r ./design-docs/src/mdbook/book "${{ github.workspace }}/publish/design-docs"
 
       - name: "(Push) Setup Pages"
-        if: "${{ !github.event.pull_request }}"
+        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
         uses: "actions/configure-pages@v5"
 
       - name: "(Push) Upload design-docs"
-        if: "${{ !github.event.pull_request }}"
+        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
         uses: "actions/upload-pages-artifact@v3"
         with:
           # Upload design-docs build directory content
           path: 'publish/design-docs'
 
       - name: "(Push) Deploy to GitHub Pages"
-        if: "${{ !github.event.pull_request }}"
+        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
         id: "deployment"
         uses: "actions/deploy-pages@v4"
         env:

--- a/.github/workflows/lint-cargo-fmt.yml
+++ b/.github/workflows/lint-cargo-fmt.yml
@@ -4,6 +4,8 @@ name: "lint-cargo-fmt.yml"
 
 on:
   pull_request: {}
+  merge_group:
+    types: ["checks_requested"]
 
 concurrency:
   group: "${{ github.workflow }}:${{ github.event.pull_request.number }}"
@@ -13,6 +15,9 @@ jobs:
   format-check:
     name: "Check formatting for Rust code"
     runs-on: "ubuntu-latest"
+    # Skip this job in merge group checks; but we need the workflow to run,
+    # given that the status check is required for merging.
+    if: "${{ github.event.pull_request }}"
     steps:
       - name: "Install Rust toolchain"
         uses: "dtolnay/rust-toolchain@stable"

--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -5,11 +5,16 @@ name: "mergeability.yml"
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
+  merge_group:
+    types: ["checks_requested"]
 
 jobs:
   check-labels:
     runs-on: "ubuntu-latest"
     name: "Check mergeability based on labels"
+    # Skip this job in merge group checks; but we need the workflow to run,
+    # given that the status check is required for merging.
+    if: "${{ github.event.pull_request }}"
     steps:
       - if: ${{ contains(github.event.*.labels.*.name, 'dont-merge') }}
         name: "Fail test due to 'dont-merge' label presence"

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "main"
   merge_group:
+    types: ["checks_requested"]
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
**Fix for working with merge queues.**

We do not want to publish a new version of the documentation when running CI checks in a merge queue. Let's skip the relevant steps.

Let's also specify the event type for merge groups. As per GitHub's documentation:

    Although only the checks_requested activity type is supported,
    specifying the activity type will keep your workflow specific if
    more activity types are added in the future.

Note: Looking more specifically at the docs workflow, I think we could improve the workflow regarding whether or not to publish. In particular, we could have another bool parameter for the `workflow_dispatch`, because we don't necessarily want to publish a new version when running it. I think that ideally, we should split the `build` workflow for docs into `build`, `publish`, `preview`. But given that I don't see this documentation remain in the repository long term (the docs for the Gateway will likely be in the official docs for the Fabric), I haven't spent more time on this for now.
