### PR TITLE
ci: Fix apt-get command in bump.yml, restore workflow summaries

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "install envsubst"
         run: |
           sudo apt-get update
-          sudo apt-get --yes --no-install-recommends gettext
+          sudo apt-get install --yes --no-install-recommends gettext
       - run: |
           ./scripts/update-versions.sh
       - name: "Create Pull Request"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -175,3 +175,16 @@ jobs:
         timeout-minutes: 60
         with:
           limit-access-to-actor: true
+
+  summary:
+    name: "summary"
+    runs-on: "ubuntu-latest"
+    needs:
+      - build
+    if: ${{ always() && needs.build.result != 'skipped' }}
+    steps:
+      - name: "Flag any build matrix failures"
+        if: ${{ needs.build.result != 'success' }}
+        run: |
+          >&2 echo "A critical step failed!"
+          exit 1

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,7 +68,7 @@ jobs:
           - "stable"
           - "beta"
           - "nightly"
-    name: "Developer build (Rust ${{ matrix.rust }})"
+    name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
     steps:
@@ -177,7 +177,7 @@ jobs:
           limit-access-to-actor: true
 
   summary:
-    name: "summary"
+    name: "Summary"
     runs-on: "ubuntu-latest"
     needs:
       - build

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -229,3 +229,22 @@ jobs:
         timeout-minutes: 60
         with:
           limit-access-to-actor: true
+
+  summary:
+    name: "summary"
+    runs-on: "ubuntu-latest"
+    needs:
+      - test
+      - push
+    if: ${{ always() && needs.test.result != 'skipped' && needs.push.result != 'skipped' }}
+    steps:
+      - name: "Flag any test failures"
+        if: ${{ needs.test.result != 'success' }}
+        run: |
+          >&2 echo "One or more required tests failed"
+          exit 1
+      - name: "Flag any push failures"
+        if: ${{ needs.push.result != 'success' }}
+        run: |
+          >&2 echo "One or more required pushes failed"
+          exit 1

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -59,7 +59,7 @@ jobs:
         rust:
           - "stable"
           - "nightly"
-    name: "Sterile test run (Rust ${{ matrix.rust }})"
+    name: "Sterile test run"
     steps:
       - name: "login to ghcr.io"
         uses: "docker/login-action@v3"
@@ -180,7 +180,7 @@ jobs:
         rust:
           - "stable"
           - "nightly"
-    name: "Push containers (Rust ${{ matrix.rust }})"
+    name: "Push containers"
     steps:
       - name: "login to ghcr.io"
         uses: "docker/login-action@v3"
@@ -231,7 +231,7 @@ jobs:
           limit-access-to-actor: true
 
   summary:
-    name: "summary"
+    name: "Summary"
     runs-on: "ubuntu-latest"
     needs:
       - test


### PR DESCRIPTION
The bump.yml workflow, running on a schedule, has [always failed to complete so far][0]. This is because an "apt-get" command is missing the "install" subcommand, resulting in apt trying to interpret the name of the package we want to install as a subcommand, making the workflow fail.

Fix the command, to hopefully make the workflow succeed.

[0]: https://github.com/githedgehog/dataplane/actions/workflows/bump.yml
