### PR TITLE
justfile: Hide DOCKER_SOCKET command output

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,9 +46,7 @@ _dev_env_container := _dpdk_sys_container_repo + "/dev-env:" + _dpdk_sys_contain
 _doc_env_container := _dpdk_sys_container_repo + "/doc-env:" + _dpdk_sys_container_tag
 _compile_env_container := _dpdk_sys_container_repo + "/compile-env:" + _dpdk_sys_container_tag
 _network := "host"
-export DOCKER_HOST := x"${DOCKER_HOST:-unix:///var/run/docker.sock}"
-export DOCKER_SOCK := ```
-  set -x
+_docker_sock_cmd := replace_regex(_just_debuggable_, ".+", "$0;") + '''
   declare -r DOCKER_HOST="${DOCKER_HOST:-unix:///var/run/docker.sock}"
   declare -r without_unix="${DOCKER_HOST##unix://}"
   if [ -S "${without_unix}" ]; then
@@ -56,7 +54,9 @@ export DOCKER_SOCK := ```
   elif [ -S /var/run/docker.sock ]; then
     printf -- '%s' "/var/run/docker.sock"
   fi
-```
+'''
+export DOCKER_HOST := x"${DOCKER_HOST:-unix:///var/run/docker.sock}"
+export DOCKER_SOCK := shell(_docker_sock_cmd)
 
 # The git commit hash of the last commit to HEAD
 # We allow this command to fail in the sterile environment because git is not available there


### PR DESCRIPTION
The justfile would use a command snippet starting with `set -x` to determine the path of the Docker socket: this helps for debugging, but most of the time it only prints cryptic messages to the console each time we run `just`.

Make just print the output only when we set `debug=true`. We cannot use a variable in the triple-backquoted string, so we need a level of indirection with a separate command and a call to `shell()`.
