### PR TITLE
ci: Fix bump.yml by calling the right script

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -53,7 +53,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends gettext
       - run: |
-          ./scripts/update-versions.sh
+          ./scripts/bump.sh
       - name: "Create Pull Request"
         uses: "peter-evans/create-pull-request@v7"
         with:


### PR DESCRIPTION
    /home/runner/work/_temp/7e997195-83d5-48ad-a437-f4358b8c7ac6.sh: line 1: ./scripts/update-versions.sh: No such file or directory

I believe we need to call bump.sh instead.

Fixes: https://github.com/githedgehog/dataplane/issues/142
