### PR TITLE
DON'T MERGE - Test CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       contents: "read"
       pull-requests: "read"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     outputs:
       devfiles: "${{ steps.changes.outputs.devfiles }}"
     steps:
@@ -178,7 +178,7 @@ jobs:
 
   summary:
     name: "Summary"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     needs:
       - build
     if: ${{ always() && needs.build.result != 'skipped' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   check_changes:
     name: "Deduce required tests from code changes"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     outputs:
       docs: "${{ steps.changes.outputs.docs }}"
     steps:
@@ -57,7 +57,7 @@ jobs:
     name: "Build and deploy documentation"
     needs: [ check_changes ]
     if: "${{ needs.check_changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch' }}"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     steps:
 
       - uses: "cargo-bins/cargo-binstall@main"

--- a/.github/workflows/lint-cargo-fmt.yml
+++ b/.github/workflows/lint-cargo-fmt.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-check:
     name: "Check formatting for Rust code"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     # Skip this job in merge group checks; but we need the workflow to run,
     # given that the status check is required for merging.
     if: "${{ github.event.pull_request }}"

--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-labels:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     name: "Check mergeability based on labels"
     # Skip this job in merge group checks; but we need the workflow to run,
     # given that the status check is required for merging.

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   check_changes:
     name: "Deduce required tests from code changes"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     outputs:
       devfiles: "${{ steps.changes.outputs.devfiles }}"
     steps:
@@ -230,7 +230,7 @@ jobs:
 
   summary:
     name: "Summary"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     needs:
       - test
       - push

--- a/design-docs/src/mdbook/src/links.md
+++ b/design-docs/src/mdbook/src/links.md
@@ -1,5 +1,6 @@
 <!-- internal -->
 
+
 [configuration store]: /dataplane/design.md#configuration-store
 [control plane]: /dataplane/design.md#control-plane
 [dataplane model]: /dataplane/design.md#dataplane-model

--- a/scratch/src/main.rs
+++ b/scratch/src/main.rs
@@ -11,6 +11,7 @@ use std::net::Ipv4Addr;
 use std::time::Instant;
 use tracing::{debug, error, info, trace, warn};
 
+
 #[tracing::instrument(level = "trace", ret)]
 // TODO: proper safety.  This should return a Result but I'm being a savage for demo purposes.
 fn as_cstr(s: &str) -> CString {


### PR DESCRIPTION
GitHub is due to transition "ubuntu-latest" to Ubuntu 24.04 CI runners on 2025-01-17 (this Friday). Let's test that the workflow work just as well.
