### PR TITLE
ci: Fix step condition, to fix docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,18 +90,18 @@ jobs:
           cp -r ./design-docs/src/mdbook/book "${{ github.workspace }}/publish/design-docs"
 
       - name: "(Push) Setup Pages"
-        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
+        if: "${{ !github.event.pull_request && github.event_name != 'merge_group' }}"
         uses: "actions/configure-pages@v5"
 
       - name: "(Push) Upload design-docs"
-        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
+        if: "${{ !github.event.pull_request && github.event_name != 'merge_group' }}"
         uses: "actions/upload-pages-artifact@v3"
         with:
           # Upload design-docs build directory content
           path: 'publish/design-docs'
 
       - name: "(Push) Deploy to GitHub Pages"
-        if: "${{ !github.event.pull_request && !github.event_name == 'merge_group' }}"
+        if: "${{ !github.event.pull_request && github.event_name != 'merge_group' }}"
         id: "deployment"
         uses: "actions/deploy-pages@v4"
         env:


### PR DESCRIPTION
Operator precedence matters... `!github.event_name == 'merge_group'` is likely different from `github.event_name != 'merge_group'`, and the condition to run the publish Action would fail to validate even on `push` events. Let's fix.

Fixes: #99
