### PR TITLE
[RFC] justfile: Remove references to dev-env container

### DIFF
--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -1,5 +1,5 @@
-# This is a sterile build and test workflow that uses the `dev-env` container image
-# to build and test the project in a sterile environment.
+# This is a sterile build and test workflow that uses the `compile-env`
+# container image to build and test the project in a sterile environment.
 # Artifacts produced by this workflow are intended to be used for production.
 
 name: "sterile.yml"


### PR DESCRIPTION
I don't remember for sure, but looking at the code, it seems to me that we no longer use (or build) the `dev-env` container, we just use the `compile-env` container nowadays?

If that's the case, we may want to merge this Pr, that removes references to `dev-env` in the repo's `justfile`. If indeed we no longer need this container, we should also remove the generated images from ghcr.io.