### PR TITLE
.gitignore: Add artifact directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/target/**
 /.bin/**
 /.vscode/**
+/artifacts/**
 /compile-env/**
 /design-docs/src/mdbook/book/**
 /design-docs/src/mdbook/src/mdbook-plantuml-img/**


### PR DESCRIPTION
This directory is generated when packaging the dataplane executable as a container. Tell Git to ignore it.
