### PR TITLE
ci: Add test for building container with sterile build artifact

### DIFF
--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -152,10 +152,16 @@ jobs:
           cargo install cargo-deny
       - run: |
           just debug=true cargo deny check
+      # Default to "dev" profile
+      - run: |
+          just debug=true rust="${{matrix.rust}}" target=x86_64-unknown-linux-gnu push-container
       - run: |
           just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-gnu push-container
       - run: |
           just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu push-container
+      # Default to "dev" profile
+      - run: |
+          just debug=true rust="${{matrix.rust}}" target=x86_64-unknown-linux-musl push-container
       - run: |
           just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl push-container
       - run: |


### PR DESCRIPTION
We have the justfile/Dockerfile infra to build a container containing only the dataplane executable resulting from a sterile build, by running `just build-container`; but we have nothing to test it in CI. Incidentally, as of this writing, it is broken. Add a CI test in which we build the container.