### PR TITLE
.gitignore: Fix ignore pattern for artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/target/**
 /.bin/**
 /.vscode/**
-/artifacts/**
+/artifact/**
 /compile-env/**
 /design-docs/src/mdbook/book/**
 /design-docs/src/mdbook/src/mdbook-plantuml-img/**


### PR DESCRIPTION
We can have several artifacts, but the directory name is singular. Fix.

:facepalm: 