### PR TITLE
Adjust "inner" naming convention to tuple struct convention

### DIFF
--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -9,9 +9,7 @@ use std::num::NonZero;
 
 /// An `ICMPv4` header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Icmp4 {
-    inner: Icmpv4Header,
-}
+pub struct Icmp4(Icmpv4Header);
 
 impl Parse for Icmp4 {
     type Error = LengthError;
@@ -31,7 +29,7 @@ impl Parse for Icmp4 {
             buf = buf.len()
         );
         let consumed = NonZero::new(buf.len() - rest.len()).ok_or_else(|| unreachable!())?;
-        Ok((Self { inner }, consumed))
+        Ok((Self(inner), consumed))
     }
 }
 
@@ -39,7 +37,7 @@ impl DeParse for Icmp4 {
     type Error = ();
 
     fn size(&self) -> NonZero<usize> {
-        NonZero::new(self.inner.header_len()).unwrap_or_else(|| unreachable!())
+        NonZero::new(self.0.header_len()).unwrap_or_else(|| unreachable!())
     }
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<usize>, DeParseError<Self::Error>> {
@@ -50,7 +48,7 @@ impl DeParse for Icmp4 {
                 actual: len,
             }));
         };
-        buf[..self.size().get()].copy_from_slice(&self.inner.to_bytes());
+        buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }
 }

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -9,9 +9,7 @@ use std::num::NonZero;
 
 /// An `ICMPv6` header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Icmp6 {
-    inner: Icmpv6Header,
-}
+pub struct Icmp6(Icmpv6Header);
 
 impl Parse for Icmp6 {
     type Error = LengthError;
@@ -31,7 +29,7 @@ impl Parse for Icmp6 {
             buf = buf.len()
         );
         let consumed = NonZero::new(buf.len() - rest.len()).ok_or_else(|| unreachable!())?;
-        Ok((Self { inner }, consumed))
+        Ok((Self(inner), consumed))
     }
 }
 
@@ -39,7 +37,7 @@ impl DeParse for Icmp6 {
     type Error = ();
 
     fn size(&self) -> NonZero<usize> {
-        NonZero::new(self.inner.header_len()).unwrap_or_else(|| unreachable!())
+        NonZero::new(self.0.header_len()).unwrap_or_else(|| unreachable!())
     }
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<usize>, DeParseError<Self::Error>> {
@@ -50,7 +48,7 @@ impl DeParse for Icmp6 {
                 actual: len,
             }));
         };
-        buf[..self.size().get()].copy_from_slice(&self.inner.to_bytes());
+        buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }
 }

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -9,13 +9,11 @@ use etherparse::IpNumber;
 ///
 /// This exists to allow us to implement [`Arbitrary`] without violating rust's orphan rules.
 #[repr(transparent)]
-pub struct NextHeader {
-    inner: IpNumber,
-}
+pub struct NextHeader(IpNumber);
 
 impl From<NextHeader> for IpNumber {
     fn from(value: NextHeader) -> Self {
-        value.inner
+        value.0
     }
 }
 
@@ -23,20 +21,18 @@ impl NextHeader {
     /// Generate a new [`NextHeader`]
     #[must_use]
     pub fn new(inner: u8) -> Self {
-        Self {
-            inner: IpNumber::from(inner),
-        }
+        Self(IpNumber::from(inner))
     }
 
     /// Return the [`NextHeader`] represented as a `u8`
     #[must_use]
     pub fn as_u8(&self) -> u8 {
-        self.inner.0
+        self.0 .0
     }
 
     /// Set the value of this [`NextHeader`] to an arbitrary `u8`
     pub fn set_u8(&mut self, inner: u8) {
-        self.inner = IpNumber::from(inner);
+        self.0 = IpNumber::from(inner);
     }
 }
 

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -17,9 +17,7 @@ use tracing::{debug, trace};
 ///
 /// This may appear in IPv4 and IPv6 headers.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IpAuth {
-    inner: Box<IpAuthHeader>,
-}
+pub struct IpAuth(Box<IpAuthHeader>);
 
 impl Parse for IpAuth {
     type Error = etherparse::err::ip_auth::HeaderSliceError;
@@ -35,7 +33,7 @@ impl Parse for IpAuth {
             buf = buf.len()
         );
         let consumed = NonZero::new(buf.len() - rest.len()).ok_or_else(|| unreachable!())?;
-        Ok((Self { inner }, consumed))
+        Ok((Self(inner), consumed))
     }
 }
 
@@ -51,7 +49,7 @@ impl ParsePayload for IpAuth {
     type Next = IpAuthNext;
 
     fn parse_payload(&self, cursor: &mut Reader) -> Option<Self::Next> {
-        match self.inner.next_header {
+        match self.0.next_header {
             IpNumber::TCP => cursor
                 .parse::<Tcp>()
                 .map_err(|e| {
@@ -91,7 +89,7 @@ impl ParsePayload for IpAuth {
                     .ok()
             }
             _ => {
-                trace!("unsupported protocol: {:?}", self.inner.next_header);
+                trace!("unsupported protocol: {:?}", self.0.next_header);
                 None
             }
         }

--- a/net/src/tcp/mod.rs
+++ b/net/src/tcp/mod.rs
@@ -17,9 +17,7 @@ pub use contract::*;
 
 /// A TCP header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Tcp {
-    inner: TcpHeader,
-}
+pub struct Tcp(TcpHeader);
 
 impl Tcp {
     /// The minimum length of a [`Tcp`]
@@ -30,39 +28,39 @@ impl Tcp {
     /// Get the source port
     #[must_use]
     pub const fn source(&self) -> TcpPort {
-        debug_assert!(self.inner.source_port != 0);
+        debug_assert!(self.0.source_port != 0);
         #[allow(unsafe_code)] // non-zero checked in [`Parse`] and `new`.
         unsafe {
-            TcpPort::new_unchecked(self.inner.source_port)
+            TcpPort::new_unchecked(self.0.source_port)
         }
     }
 
     /// Set the source port
     pub fn set_source(&mut self, port: TcpPort) -> &mut Self {
-        self.inner.source_port = port.into();
+        self.0.source_port = port.into();
         self
     }
 
     /// Get the destination port
     #[must_use]
     pub const fn destination(&self) -> TcpPort {
-        debug_assert!(self.inner.destination_port != 0);
+        debug_assert!(self.0.destination_port != 0);
         #[allow(unsafe_code)] // non-zero checked in [`Parse`] and `new`.
         unsafe {
-            TcpPort::new_unchecked(self.inner.destination_port)
+            TcpPort::new_unchecked(self.0.destination_port)
         }
     }
 
     /// Set the destination port
     pub fn set_destination(&mut self, port: TcpPort) -> &mut Self {
-        self.inner.destination_port = port.into();
+        self.0.destination_port = port.into();
         self
     }
 
     /// The number of 32-bit words in the TCP Header & TCP header options
     #[must_use]
     pub fn data_offset(&self) -> u8 {
-        self.inner.data_offset()
+        self.0.data_offset()
     }
 
     // TODO: safety proof, this should never panic (use no_panic crate)
@@ -70,68 +68,68 @@ impl Tcp {
     #[must_use]
     pub fn header_len(&self) -> NonZero<usize> {
         #[allow(clippy::unwrap_used)] // trivially sound as `header_len` is const and non-zero
-        NonZero::new(self.inner.header_len()).unwrap_or_else(|| unreachable!())
+        NonZero::new(self.0.header_len()).unwrap_or_else(|| unreachable!())
     }
 
     // TODO: wrapper type for checksum
     /// get the checksum of the header as a `u16`
     #[must_use]
     pub const fn checksum(&self) -> u16 {
-        self.inner.checksum
+        self.0.checksum
     }
 
     /// Get the sequence number of the header.
     #[must_use]
     pub const fn sequence_number(&self) -> u32 {
-        self.inner.sequence_number
+        self.0.sequence_number
     }
 
     /// Returns true if the syn flag is set in this header
     #[must_use]
     pub const fn syn(&self) -> bool {
-        self.inner.syn
+        self.0.syn
     }
 
     /// Returns true if the ack flag is set in this header
     #[must_use]
     pub const fn ack(&self) -> bool {
-        self.inner.ack
+        self.0.ack
     }
 
     /// Returns true if the fin flag is set in this header
     #[must_use]
     pub const fn fin(&self) -> bool {
-        self.inner.fin
+        self.0.fin
     }
 
     /// Returns true if the rst flag is set in this header
     #[must_use]
     pub const fn rst(&self) -> bool {
-        self.inner.rst
+        self.0.rst
     }
 
     /// Returns true if the psh flag is set in this header
     #[must_use]
     pub const fn psh(&self) -> bool {
-        self.inner.psh
+        self.0.psh
     }
 
     /// Returns true if the urg flag is set in this header
     #[must_use]
     pub const fn urg(&self) -> bool {
-        self.inner.urg
+        self.0.urg
     }
 
     /// Returns true if the ece flag is set in this header
     #[must_use]
     pub const fn ece(&self) -> bool {
-        self.inner.ece
+        self.0.ece
     }
 
     /// Returns true if the cwr flag is set in this header
     #[must_use]
     pub const fn cwr(&self) -> bool {
-        self.inner.cwr
+        self.0.cwr
     }
 
     /// Returns true if the (experimental) nonce-sum is set in this header
@@ -139,13 +137,13 @@ impl Tcp {
     /// See [rfc3540](https://datatracker.ietf.org/doc/html/rfc3540) for details.
     #[must_use]
     pub const fn ns(&self) -> bool {
-        self.inner.ns
+        self.0.ns
     }
 
     /// Returns the window size of the tcp header.
     #[must_use]
     pub const fn window_size(&self) -> u16 {
-        self.inner.window_size
+        self.0.window_size
     }
 
     /// Returns the urgent pointer of the tcp header.
@@ -153,7 +151,7 @@ impl Tcp {
     /// This value is only relevant if the urg flag is set (see [`Tcp::urg`]).
     #[must_use]
     pub const fn urgent_pointer(&self) -> u16 {
-        self.inner.urgent_pointer
+        self.0.urgent_pointer
     }
 
     /// Returns any tcp options present in this header as a slice.
@@ -161,57 +159,57 @@ impl Tcp {
     /// Returns `None` if no such options exist.
     #[must_use]
     pub fn options(&self) -> Option<&[u8]> {
-        if self.inner.options.is_empty() {
+        if self.0.options.is_empty() {
             return None;
         }
-        Some(&self.inner.options.as_slice()[..self.inner.options.len()])
+        Some(&self.0.options.as_slice()[..self.0.options.len()])
     }
 
     /// Set the syn flag
     pub fn set_syn(&mut self, syn: bool) -> &mut Self {
-        self.inner.syn = syn;
+        self.0.syn = syn;
         self
     }
 
     /// Set the ack flag
     pub fn set_ack(&mut self, ack: bool) -> &mut Self {
-        self.inner.ack = ack;
+        self.0.ack = ack;
         self
     }
 
     /// Set the fin flag
     pub fn set_fin(&mut self, fin: bool) -> &mut Self {
-        self.inner.fin = fin;
+        self.0.fin = fin;
         self
     }
 
     /// Set the rst flag
     pub fn set_rst(&mut self, rst: bool) -> &mut Self {
-        self.inner.rst = rst;
+        self.0.rst = rst;
         self
     }
 
     /// Set the psh flag
     pub fn set_psh(&mut self, psh: bool) -> &mut Self {
-        self.inner.psh = psh;
+        self.0.psh = psh;
         self
     }
 
     /// Set the urg flag
     pub fn set_urg(&mut self, urg: bool) -> &mut Self {
-        self.inner.urg = urg;
+        self.0.urg = urg;
         self
     }
 
     /// Set the ece flag
     pub fn set_ece(&mut self, ece: bool) -> &mut Self {
-        self.inner.ece = ece;
+        self.0.ece = ece;
         self
     }
 
     /// Set the cwr flag
     pub fn set_cwr(&mut self, cwr: bool) -> &mut Self {
-        self.inner.cwr = cwr;
+        self.0.cwr = cwr;
         self
     }
 
@@ -224,7 +222,7 @@ impl Tcp {
     /// Generally, only a tcp implementation should edit the window size.
     /// This method is supplied mostly for packet generation.
     pub fn set_window_size(&mut self, window_size: u16) -> &mut Self {
-        self.inner.window_size = window_size;
+        self.0.window_size = window_size;
         self
     }
 
@@ -237,13 +235,13 @@ impl Tcp {
     /// Generally, only a tcp implementation should edit the urgent pointer.
     /// This method is supplied mostly for packet generation.
     pub fn set_urgent_pointer(&mut self, urgent_pointer: u16) -> &mut Self {
-        self.inner.urgent_pointer = urgent_pointer;
+        self.0.urgent_pointer = urgent_pointer;
         self
     }
 
     /// Set the checksum
     pub fn set_checksum(&mut self, checksum: u16) -> &mut Self {
-        self.inner.checksum = checksum;
+        self.0.checksum = checksum;
         self
     }
 
@@ -256,7 +254,7 @@ impl Tcp {
     /// Generally, only a tcp implementation should edit the sequence number.
     /// This method is supplied mostly for packet generation.
     pub fn set_sequence_number(&mut self, sequence_number: u32) -> &mut Self {
-        self.inner.sequence_number = sequence_number;
+        self.0.sequence_number = sequence_number;
         self
     }
 
@@ -269,7 +267,7 @@ impl Tcp {
     /// Generally, only a tcp implementation should edit the ack number.
     /// This method is supplied mostly for packet generation.
     pub fn set_ack_number(&mut self, ack_number: u32) -> &mut Self {
-        self.inner.acknowledgment_number = ack_number;
+        self.0.acknowledgment_number = ack_number;
         self
     }
 }
@@ -317,7 +315,7 @@ impl Parse for Tcp {
         if inner.destination_port == 0 {
             return Err(ParseError::Invalid(TcpError::ZeroDestPort));
         }
-        let parsed = Self { inner };
+        let parsed = Self(inner);
         Ok((parsed, consumed))
     }
 }
@@ -326,7 +324,7 @@ impl DeParse for Tcp {
     type Error = ();
 
     fn size(&self) -> NonZero<usize> {
-        NonZero::new(self.inner.header_len()).unwrap_or_else(|| unreachable!())
+        NonZero::new(self.0.header_len()).unwrap_or_else(|| unreachable!())
     }
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<usize>, DeParseError<Self::Error>> {
@@ -337,7 +335,7 @@ impl DeParse for Tcp {
                 actual: len,
             }));
         };
-        buf[..self.size().get()].copy_from_slice(&self.inner.to_bytes());
+        buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }
 }
@@ -351,9 +349,7 @@ mod contract {
     impl<'a> Arbitrary<'a> for Tcp {
         // TODO: add support for arbitrary tcp options
         fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-            let mut header = Tcp {
-                inner: TcpHeader::default(),
-            };
+            let mut header = Tcp(TcpHeader::default());
             header
                 .set_source(u.arbitrary()?)
                 .set_destination(u.arbitrary()?)


### PR DESCRIPTION
Feedback is that `inner` is a confusing name for these fields. `inner` was chosen on the grounds that there is an outer and an inner type (i.e. a transparent wrapper type which qualifies the wrapped inner type).

Still, if `.0` is easier for folks to think about then I won't argue.

This should have been done as part of commit 695633370144fd1e9d766974808217cf0a4b8942 (see https://github.com/githedgehog/dataplane/commit/695633370144fd1e9d766974808217cf0a4b8942) but I did not think about it at the time