### PR TITLE
Prep for 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,9 +713,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "ryu"

--- a/net/src/tcp/port.rs
+++ b/net/src/tcp/port.rs
@@ -46,7 +46,7 @@ impl TcpPort {
     /// Submitting a zero value as port is undefined behavior.
     #[allow(unsafe_code)]
     pub const unsafe fn new_unchecked(port: u16) -> TcpPort {
-        TcpPort(NonZero::new_unchecked(port))
+        TcpPort(unsafe { NonZero::new_unchecked(port) })
     }
 }
 

--- a/net/src/udp/port.rs
+++ b/net/src/udp/port.rs
@@ -56,7 +56,7 @@ impl UdpPort {
     #[must_use]
     #[allow(unsafe_code)] // safety requirements documented
     pub const unsafe fn new_unchecked(port: u16) -> UdpPort {
-        UdpPort(NonZero::new_unchecked(port))
+        UdpPort(unsafe { NonZero::new_unchecked(port) })
     }
 }
 


### PR DESCRIPTION
On 2025-02-20, the rust team expects to [release version 1.85.0 of the compiler](https://releases.rs/docs/1.85.0/).
As with all releases, 1.85.0 brings new features and such.
However, 1.85.0 is slightly unusual in that it will be the first release wherein the 2024 _edition_ of rust will be considered stable.
Edition updates are intended to be released [on a three-year cadence](https://rust-lang.github.io/rfcs/3501-edition-2024.html#edition-cadence:~:text=Editions%20are%20intended%20to%20be%20released%20on%20a%20three%2Dyear%20cadence)
So we don't need to do this often.
_But_, we should do it promptly and properly when these dates come around.

For those unfamiliar with the edition system, have a look at

1. _[What are Editions](https://doc.rust-lang.org/edition-guide/editions/)_
2. _[Stability without stagnation](https://blog.rust-lang.org/2014/10/30/Stability.html)_

Fortunately, this edition update (as with every edition update I have ever done), has proven to be trivial.
In fact, [the update process is automated](https://blog.rust-lang.org/2025/01/22/rust-2024-beta.html)!

In our case, we were only incompatible with one of the many minor improvements found in this edition; one of the lints graduated to `warning` status.
See [`unsafe_op_in_unsafe_fn`](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html) for details.

More details about the 2024 edition can be found in

1. [the 2024 edition guide](https://doc.rust-lang.org/edition-guide/rust-2024/index.html)
2. [the 2024 edition RFC](https://rust-lang.github.io/rfcs/3501-edition-2024.html)

This patch series includes the recommended changes to make our code compatible with the 2024 edition.

The rust team requests and encourages folks to follow the update procedure _before_ the final release cut if possible to allow maximum latitude for the community to complain about any issues that may arise in concept or implementation.

Fortunately, the rust team also has [crater](https://github.com/rust-lang/crater) 

> Crater is a tool to run experiments across parts of the Rust ecosystem.
> Its primary purpose is to detect regressions in the Rust compiler, and it does this by building a large number of crates, running their test suites and comparing the results between two versions of the Rust compiler.

so severe problems tend to be caught _long_ before we reach this stage.

Still, it's straightforward and we need to do it anyway, so here we go.


