### PR TITLE
net: rename UnicastIpv6Address to UnicastIpv6Addr.

### DIFF
--- a/net/src/ipv6/addr.rs
+++ b/net/src/ipv6/addr.rs
@@ -12,20 +12,20 @@ use std::net::Ipv6Addr;
 #[non_exhaustive]
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct UnicastIpv6Address(Ipv6Addr);
+pub struct UnicastIpv6Addr(Ipv6Addr);
 
-impl UnicastIpv6Address {
+impl UnicastIpv6Addr {
     /// Returns the supplied [`Ipv6Addr`] as a [`UnicastIpv6Address`]
     /// after confirming that it is in fact unicast.
     ///
     /// # Errors
     ///
     /// Returns the supplied [`Ipv6Addr`] in the [`Err`] case if the supplied address is multicast.
-    pub fn new(addr: Ipv6Addr) -> Result<UnicastIpv6Address, Ipv6Addr> {
+    pub fn new(addr: Ipv6Addr) -> Result<UnicastIpv6Addr, Ipv6Addr> {
         if addr.is_multicast() {
             Err(addr)
         } else {
-            Ok(UnicastIpv6Address(addr))
+            Ok(UnicastIpv6Addr(addr))
         }
     }
 
@@ -38,16 +38,16 @@ impl UnicastIpv6Address {
 
 #[cfg(any(test, feature = "arbitrary"))]
 mod contract {
-    use crate::ipv6::addr::UnicastIpv6Address;
+    use crate::ipv6::addr::UnicastIpv6Addr;
     use arbitrary::{Arbitrary, Unstructured};
     use std::net::Ipv6Addr;
 
-    impl<'a> Arbitrary<'a> for UnicastIpv6Address {
+    impl<'a> Arbitrary<'a> for UnicastIpv6Addr {
         fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
             loop {
                 let ip = Ipv6Addr::arbitrary(u)?;
                 if !ip.is_multicast() {
-                    return Ok(UnicastIpv6Address(ip));
+                    return Ok(UnicastIpv6Addr(ip));
                 }
             }
         }

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::icmp6::Icmp6;
 use crate::ip_auth::IpAuth;
-use crate::ipv6::addr::UnicastIpv6Address;
+use crate::ipv6::addr::UnicastIpv6Addr;
 use crate::packet::Header;
 use crate::parse::{
     DeParse, DeParseError, LengthError, Parse, ParseError, ParsePayload, ParsePayloadWith,
@@ -75,7 +75,7 @@ impl Ipv6 {
     }
 
     /// Set the source ip address of this header
-    pub fn set_source(&mut self, source: UnicastIpv6Address) -> &mut Self {
+    pub fn set_source(&mut self, source: UnicastIpv6Addr) -> &mut Self {
         self.inner.source = source.inner().octets();
         self
     }


### PR DESCRIPTION
This way, it follows the same naming convention as UnicastIpv4Addr.