### PR TITLE
Make header fields public, make ip headers unicast by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,16 @@ Because this repository uses a custom sysroot with custom libraries and binaries
 To do this, add the following to your `.vscode/settings.json` file:
 
 ```json
-{
-    "rust-analyzer.server.extraEnv": {
-        "CARGO": "<absolute path to dataplane directory>/bin/cargo"
-    }
+"rust-analyzer.server.extraEnv": {
+  "CARGO": "<absolute path to dataplane directory>/bin/cargo"
 }
+```
+
+You'll also want to run `cargo clippy` on save.
+To do this, add the following to your `.vscode/settings.json` file:
+
+```json
+"rust-analyzer.check.command": "clippy"
 ```
 
 > [!NOTE]

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -23,7 +23,6 @@ pub mod addr;
 /// An IPv6 header
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv6(Ipv6Header);
-
 impl Ipv6 {
     /// The minimum length (in bytes) of an [`Ipv6`] header.
     // Safety: const-evaluated and trivially safe.

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -26,11 +26,11 @@ const MAX_NET_EXTENSIONS: usize = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Packet {
-    eth: Eth,
-    net: Option<Net>,
-    transport: Option<Transport>,
-    vlan: ArrayVec<Vlan, MAX_VLANS>,
-    net_ext: ArrayVec<NetExt, MAX_NET_EXTENSIONS>,
+    pub eth: Eth,
+    pub net: Option<Net>,
+    pub transport: Option<Transport>,
+    pub vlan: ArrayVec<Vlan, MAX_VLANS>,
+    pub net_ext: ArrayVec<NetExt, MAX_NET_EXTENSIONS>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
* Adds instructions for setting up `clippy` with `rust-anlayzer` in vscode.
* Makes header fields in parsed packets public for use outside the `net` crate
* Makes ip source addresses unicast by type, checked when parsed/set