### PR TITLE
Run clippy in CI (plus some CI cleanup)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -110,8 +110,6 @@ jobs:
       - run: |
           just --yes debug="${{matrix.debug_just}}" fake-nix
 
-      # At this stage, for Pull Requests, we're back to the HEAD of the branch,
-      # start running tests for different configurations.
       - name: "test gnu dev"
         run: |
           just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -86,7 +86,7 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
       - name: "install rust"
-        uses: "dtolnay/rust-toolchain@stable"
+        uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "${{ matrix.rust }}"
           targets: "x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -116,21 +116,29 @@ jobs:
         run: |
           just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \
             cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \
+            cargo doc
 
       - name: "test musl dev"
         run: |
           just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl \
             cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl \
+            cargo doc
 
       - name: "test gnu release"
         run: |
           just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu \
             cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu \
+            cargo doc
 
       - name: "test musl release"
         run: |
           just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl \
             cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl \
+            cargo doc
 
       - name: "run clippy"
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,12 +10,12 @@
 name: "dev.yml"
 
 on:
-  pull_request: {}
+  pull_request: { }
   push:
     branches:
       - "main"
   merge_group:
-    types: ["checks_requested"]
+    types: [ "checks_requested" ]
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -70,11 +70,19 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - "stable"
-          - "beta"
-          - "nightly"
+          - # failures on stable block release
+            version: "stable"
+            optional: false
+          - # failures on beta block release
+            version: "beta"
+            optional: false
+          - # failures on the nightly channel are a clear "yellow" flag
+            version: "nightly"
+            optional: true
         debug_just:
           - "${{inputs.debug_just || false}}"
+    outputs:
+      result: "${{ matrix.rust.optional || steps.gnu_dev_test.conclusion == 'success' && steps.musl_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' && steps.musl_release_test.conclusion == 'success' }}"
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -88,7 +96,7 @@ jobs:
       - name: "install rust"
         uses: "dtolnay/rust-toolchain@master"
         with:
-          toolchain: "${{ matrix.rust }}"
+          toolchain: "${{ matrix.rust.version }}"
           targets: "x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl"
           components: "rustfmt,clippy"
       - name: "Checkout"
@@ -110,39 +118,50 @@ jobs:
       - run: |
           just --yes debug="${{matrix.debug_just}}" fake-nix
 
-      - name: "test gnu dev"
+      - id: "gnu_dev_test"
+        name: "test gnu dev"
         run: |
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-gnu \
             cargo test
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-gnu \
             cargo doc
+        continue-on-error: ${{ matrix.rust.optional }}
 
-      - name: "test musl dev"
+      - id: "musl_dev_test"
+        name: "test musl dev"
         run: |
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-musl \
             cargo test
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-musl \
             cargo doc
+        continue-on-error: ${{ matrix.rust.optional }}
 
-      - name: "test gnu release"
+      - id: "gnu_release_test"
+        name: "test gnu release"
         run: |
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
             cargo test
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
             cargo doc
+        continue-on-error: ${{ matrix.rust.optional }}
 
-      - name: "test musl release"
+      - id: "musl_release_test"
+        name: "test musl release"
         run: |
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-musl \
             cargo test
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl \
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-musl \
             cargo doc
+        continue-on-error: ${{ matrix.rust.optional }}
 
-      - name: "run clippy"
+      - id: "clippy"
+        name: "run clippy"
         run: |
-          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} cargo clippy
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust.version}} cargo clippy
+        continue-on-error: ${{ matrix.rust.optional }}
 
-      - name: "build each commit"
+      - id: "build_each_commit"
+        name: "build each commit"
         run: |
           # Run a simple build for each separate commit (for "pull_request")
           # or for the HEAD of the branch (other events).
@@ -155,7 +174,7 @@ jobs:
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
             printf "::group::Build commit %s\n" "$(git log --oneline --no-decorate -n 1)"
-            (just debug="${{matrix.debug_just}}" cargo +${{matrix.rust}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu) || exit 1
+            (just debug="${{matrix.debug_just}}" cargo +${{matrix.rust.version}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu) || exit 1
             printf "::endgroup::\n"
           done
           printf "::notice::HEAD remains at %s\n" "$(git log --oneline --no-decorate -n 1)"
@@ -176,7 +195,7 @@ jobs:
     if: ${{ always() && needs.build.result != 'skipped' }}
     steps:
       - name: "Flag any build matrix failures"
-        if: ${{ needs.build.result != 'success' }}
+        if: ${{ needs.build.outputs.result != 'true' }}
         run: |
           >&2 echo "A critical step failed!"
           exit 1

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,6 +66,11 @@ jobs:
   build:
     needs: [ check_changes ]
     if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
+    permissions:
+      issues: "write"
+      pull-requests: "write"
+      contents: "write"
+      id-token: "write"
     strategy:
       fail-fast: false
       matrix:
@@ -179,6 +184,22 @@ jobs:
           done
           printf "::notice::HEAD remains at %s\n" "$(git log --oneline --no-decorate -n 1)"
         continue-on-error: ${{ matrix.rust.optional }}
+
+      - name: "Note failure of optional steps"
+        uses: "actions/github-script@v7"
+        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.musl_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.musl_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            let body = "### :warning: One or more optional CI steps have failed!\n\n";
+            body += "_[click here to lament thy folly](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           toolchain: "${{ matrix.rust }}"
           targets: "x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl"
+          components: "rustfmt,clippy"
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
@@ -119,6 +120,10 @@ jobs:
       - name: "test musl release"
         run: |
           just debug=true rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl cargo test
+
+      - name: "run clippy"
+        run: |
+          just debug=true rust=${{matrix.rust}} cargo clippy
 
       - name: "build each commit"
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -139,13 +139,6 @@ jobs:
           printf "::notice::HEAD remains at %s\n" "$(git log --oneline --no-decorate -n 1)"
         continue-on-error: ${{ matrix.rust.optional }}
 
-
-      - uses: "actions/upload-artifact@v4"
-        if: ${{ always() }}
-        with:
-          name: "test-results-${{ matrix.rust }}"
-          path: "target/nextest/"
-
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: "mxschmitt/action-tmate@v3"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,6 +23,11 @@ on:
         description: "Run with tmate enabled"
         required: false
         default: false
+      debug_just:
+        type: "boolean"
+        description: "enable to see debug statements from just recipes"
+        required: false
+        default: false
 
 concurrency:
   group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after }}"
@@ -68,6 +73,8 @@ jobs:
           - "stable"
           - "beta"
           - "nightly"
+        debug_just:
+          - "${{inputs.debug_just || false}}"
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -96,34 +103,38 @@ jobs:
         run: |
           cargo install cargo-deny
       - run: |
-          just debug=true cargo deny check
+          just debug="${{matrix.debug_just}}" cargo deny check
       - name: refresh-compile-env
         run: |
-          just --yes debug=true refresh-compile-env
+          just --yes debug="${{matrix.debug_just}}" refresh-compile-env
       - run: |
-          just --yes debug=true fake-nix
+          just --yes debug="${{matrix.debug_just}}" fake-nix
 
       # At this stage, for Pull Requests, we're back to the HEAD of the branch,
       # start running tests for different configurations.
       - name: "test gnu dev"
         run: |
-          just debug=true rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-gnu \
+            cargo test
 
       - name: "test musl dev"
         run: |
-          just debug=true rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=dev target=x86_64-unknown-linux-musl \
+            cargo test
 
       - name: "test gnu release"
         run: |
-          just debug=true rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-gnu \
+            cargo test
 
       - name: "test musl release"
         run: |
-          just debug=true rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl cargo test
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} profile=release target=x86_64-unknown-linux-musl \
+            cargo test
 
       - name: "run clippy"
         run: |
-          just debug=true rust=${{matrix.rust}} cargo clippy
+          just debug="${{matrix.debug_just}}" rust=${{matrix.rust}} cargo clippy
 
       - name: "build each commit"
         run: |
@@ -138,7 +149,7 @@ jobs:
           for commit in $COMMITS ; do
             git checkout $commit || exit 1
             printf "::group::Build commit %s\n" "$(git log --oneline --no-decorate -n 1)"
-            (just debug=true cargo +${{matrix.rust}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu) || exit 1
+            (just debug="${{matrix.debug_just}}" cargo +${{matrix.rust}} build --locked --profile=dev --target=x86_64-unknown-linux-gnu) || exit 1
             printf "::endgroup::\n"
           done
           printf "::notice::HEAD remains at %s\n" "$(git log --oneline --no-decorate -n 1)"

--- a/.github/workflows/lint-cargo-fmt.yml
+++ b/.github/workflows/lint-cargo-fmt.yml
@@ -20,7 +20,7 @@ jobs:
     if: "${{ github.event.pull_request }}"
     steps:
       - name: "Install Rust toolchain"
-        uses: "dtolnay/rust-toolchain@stable"
+        uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "nightly"
           components: "rustfmt"

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -73,7 +73,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "install rust"
-        uses: "dtolnay/rust-toolchain@stable"
+        uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "${{ matrix.rust }}"
           targets: "x86_64-unknown-linux-gnu"
@@ -156,7 +156,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "install rust"
-        uses: "dtolnay/rust-toolchain@stable"
+        uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "${{ matrix.rust }}"
           targets: "x86_64-unknown-linux-gnu"
@@ -169,7 +169,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "install rust"
-        uses: "dtolnay/rust-toolchain@stable"
+        uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "${{ matrix.rust }}"
           targets: "x86_64-unknown-linux-gnu"

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -100,6 +100,12 @@ jobs:
         run: |
           just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl sterile cargo test
 
+      - name: "run clippy"
+        if: ${{ always() }}
+        run: |
+          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu sterile cargo clippy
+
+
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         uses: "mxschmitt/action-tmate@v3"

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -18,6 +18,11 @@ on:
         description: "Run with tmate enabled"
         required: false
         default: false
+      debug_just:
+        type: "boolean"
+        description: "enable to see debug statements from just recipes"
+        required: false
+        default: false
 
 concurrency:
   group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after }}"
@@ -83,27 +88,32 @@ jobs:
       - name: "dev/gnu sterile test"
         if: ${{ always() }}
         run: |
-          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
+            sterile cargo test
 
       - name: "release/gnu sterile test"
         if: ${{ always() }}
         run: |
-          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
+            sterile cargo test
 
       - name: "dev/musl sterile test"
         if: ${{ always() }}
         run: |
-          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl \
+            sterile cargo test
 
       - name: "release/musl sterile test"
         if: ${{ always() }}
         run: |
-          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
+            sterile cargo test
 
       - name: "run clippy"
         if: ${{ always() }}
         run: |
-          just debug=true rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu sterile cargo clippy
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
+            sterile cargo clippy
 
 
       - name: "Setup tmate session for debug"
@@ -126,6 +136,8 @@ jobs:
       matrix:
         rust:
           - "stable"
+        debug_just:
+          - "${{inputs.debug_just || false}}"
     name: "Push containers"
     steps:
       - name: "login to ghcr.io"
@@ -157,15 +169,19 @@ jobs:
       - run: |
           cargo install cargo-deny
       - run: |
-          just debug=true cargo deny check
+          just debug="${{matrix.debug_just}}" cargo deny check
       - run: |
-          just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-gnu push-container
+          just debug="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-gnu \
+            push-container
       - run: |
-          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu push-container
+          just debug="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
+            push-container
       - run: |
-          just debug=true rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl push-container
+          just debug="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl \
+            push-container
       - run: |
-          just debug=true rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl push-container
+          just debug="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
+            push-container
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -90,24 +90,32 @@ jobs:
         run: |
           just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
             sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
+            sterile cargo doc
 
       - name: "release/gnu sterile test"
         if: ${{ always() }}
         run: |
           just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
             sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
+            sterile cargo doc
 
       - name: "dev/musl sterile test"
         if: ${{ always() }}
         run: |
           just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl \
             sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl \
+            sterile cargo doc
 
       - name: "release/musl sterile test"
         if: ${{ always() }}
         run: |
           just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
             sterile cargo test
+          just debug="${{inputs.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
+            sterile cargo doc
 
       - name: "run clippy"
         if: ${{ always() }}

--- a/dataplane/src/nat.rs
+++ b/dataplane/src/nat.rs
@@ -224,7 +224,7 @@ impl GlobalContext {
             let file_path = entry.path();
             if file_path
                 .extension()
-                .map_or(false, |ext| ext == "yaml" || ext == "yml")
+                .is_some_and(|ext| ext == "yaml" || ext == "yml")
             {
                 let file_content = fs::read_to_string(&file_path).expect("Failed to read file");
                 let vpc: Vpc = serde_yml::from_str(&file_content).expect("Failed to parse YAML");
@@ -241,7 +241,7 @@ impl GlobalContext {
             let file_path = entry.path();
             if file_path
                 .extension()
-                .map_or(false, |ext| ext == "yaml" || ext == "yml")
+                .is_some_and(|ext| ext == "yaml" || ext == "yml")
             {
                 let file_content = fs::read_to_string(&file_path).expect("Failed to read file");
                 let pif: Pif = serde_yml::from_str(&file_content).expect("Failed to parse YAML");
@@ -289,8 +289,8 @@ mod tests {
             pwd = std::env::current_dir().unwrap().display()
         );
         // Load VPCs and PIFs
-        context.load_vpcs(&Path::new("src").join("nat").join("vpcs").as_path());
-        context.load_pifs(&Path::new("src").join("nat").join("pifs").as_path());
+        context.load_vpcs(Path::new("src").join("nat").join("vpcs").as_path());
+        context.load_pifs(Path::new("src").join("nat").join("pifs").as_path());
 
         // Example global lookup
         let ip: IpAddr = "11.11.0.5".parse().unwrap();

--- a/net/src/eth/ethertype.rs
+++ b/net/src/eth/ethertype.rs
@@ -15,7 +15,7 @@ pub use contract::*;
 /// The main point of wrapping this type is to
 ///
 /// 1. Eventually (potentially) 1.0 our crate without requiring the same of etherparse,
-/// 2. Permit the implementation of the [Arbitrary] trait on this type
+/// 2. Permit the implementation of the `Arbitrary` trait on this type
 ///    to allow us to property test the rest of our code.
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/net/src/eth/mod.rs
+++ b/net/src/eth/mod.rs
@@ -37,9 +37,11 @@ pub enum EthError {
 }
 
 /// Errors which can occur while setting the source [`Mac`] of a [`Packet`]
+///
+/// [`Packet`]: crate::packet::Packet
 #[derive(Debug, thiserror::Error)]
 pub enum SourceMacAddressError {
-    /// Multicast [`Macs`] are not legal as source [`Mac`]
+    /// Multicast [`Mac`]s are not legal as a source [`Mac`]
     #[error("invalid source mac address: multicast macs are illegal as source macs")]
     MulticastSource(Mac),
     /// Zero is not a legal source
@@ -48,6 +50,8 @@ pub enum SourceMacAddressError {
 }
 
 /// Errors which can occur while setting the destination [`Mac`] of a [`Packet`]
+///
+/// [`Packet`]: crate::packet::Packet
 #[derive(Debug, thiserror::Error)]
 pub enum DestinationMacAddressError {
     /// Zero is not a legal source

--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -47,7 +47,7 @@ impl DeParse for Icmp4 {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -47,7 +47,7 @@ impl DeParse for Icmp6 {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -7,7 +7,7 @@ use etherparse::IpNumber;
 
 /// Thin wrapper around [`IpNumber`]
 ///
-/// This exists to allow us to implement [`Arbitrary`] without violating rust's orphan rules.
+/// This exists to allow us to implement `Arbitrary` without violating rust's orphan rules.
 #[repr(transparent)]
 pub struct NextHeader(IpNumber);
 

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -24,12 +24,12 @@ pub struct Ipv4(Ipv4Header);
 
 impl Ipv4 {
     /// The minimum length of an IPv4 header (i.e., a header with no options)
-    #[allow(unsafe_code)] // const-eval and trivially safe
-    pub const MIN_LEN: NonZero<usize> = unsafe { NonZero::new_unchecked(20) };
+    #[allow(clippy::unwrap_used)] // const-eval and trivially safe
+    pub const MIN_LEN: NonZero<usize> = NonZero::new(20).unwrap();
 
     /// The maximum length of an IPv4 header (i.e., a header with full options)
-    #[allow(unsafe_code)] // const-eval and trivially safe
-    pub const MAX_LEN: NonZero<usize> = unsafe { NonZero::new_unchecked(60) };
+    #[allow(clippy::unwrap_used)] // const-eval and trivially safe
+    pub const MAX_LEN: NonZero<usize> = NonZero::new(60).unwrap();
 
     /// Get the source ip address of the header
     #[must_use]
@@ -266,7 +266,7 @@ impl DeParse for Ipv4 {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }

--- a/net/src/ipv6/addr.rs
+++ b/net/src/ipv6/addr.rs
@@ -15,7 +15,7 @@ use std::net::Ipv6Addr;
 pub struct UnicastIpv6Addr(Ipv6Addr);
 
 impl UnicastIpv6Addr {
-    /// Returns the supplied [`Ipv6Addr`] as a [`UnicastIpv6Address`]
+    /// Returns the supplied [`Ipv6Addr`] as a [`UnicastIpv6Addr`]
     /// after confirming that it is in fact unicast.
     ///
     /// # Errors

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -126,7 +126,7 @@ impl Ipv6 {
     ///
     /// # Errors
     ///
-    /// Will return a [`HopLimitAlreadyZero`] error if the hop limit is already zero :)
+    /// Will return a [`HopLimitAlreadyZeroError`] error if the hop limit is already zero :)
     pub fn decrement_hop_limit(&mut self) -> Result<(), HopLimitAlreadyZeroError> {
         if self.0.hop_limit == 0 {
             return Err(HopLimitAlreadyZeroError);
@@ -158,6 +158,8 @@ impl Ipv6 {
     ///
     /// This method makes no attempt to ensure that the supplied [`next_header`] value is valid for
     /// the packet to which this header belongs (if any).
+    ///
+    /// [`next_header`]: crate::ip::NextHeader
     pub fn set_next_header(&mut self, next_header: IpNumber) -> &mut Self {
         self.0.next_header = next_header;
         self

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -26,9 +26,8 @@ pub struct Ipv6(Ipv6Header);
 
 impl Ipv6 {
     /// The minimum length (in bytes) of an [`Ipv6`] header.
-    // Safety: const-evaluated and trivially safe.
-    #[allow(unsafe_code)]
-    pub const MIN_LEN: NonZero<usize> = unsafe { NonZero::new_unchecked(40) };
+    #[allow(clippy::unwrap_used)] // safe due to const eval
+    pub const MIN_LEN: NonZero<usize> = NonZero::new(40).unwrap();
 
     /// Get the source [`Ipv6Addr`] for this header
     #[must_use]
@@ -217,7 +216,7 @@ impl DeParse for Ipv6 {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }
@@ -490,15 +489,15 @@ mod test {
     fn parse_arbitrary_bytes_too_short() {
         bolero::check!()
             .with_arbitrary()
-            .for_each(|slice: &[u8; Ipv6::MIN_LEN.get() - 1]| {
-                match Ipv6::parse(slice) {
+            .for_each(
+                |slice: &[u8; Ipv6::MIN_LEN.get() - 1]| match Ipv6::parse(slice) {
                     Err(ParseError::Length(e)) => {
                         assert_eq!(e.expected, Ipv6::MIN_LEN);
                         assert_eq!(e.actual, Ipv6::MIN_LEN.get() - 1);
                     }
                     _ => unreachable!(),
-                };
-            });
+                },
+            );
     }
 
     #[test]

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -222,7 +222,7 @@ impl DeParse for Packet {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         let mut cursor = Writer::new(buf);
         cursor.write(&self.eth)?;
         for vlan in &self.vlan {
@@ -237,7 +237,7 @@ impl DeParse for Packet {
             Some(ref net) => {
                 cursor.write(net)?;
             }
-        };
+        }
 
         match self.transport {
             None => {

--- a/net/src/parse.rs
+++ b/net/src/parse.rs
@@ -92,7 +92,7 @@ impl Reader<'_> {
                 expected: n,
                 actual: self.remaining,
             });
-        };
+        }
         self.remaining -= n.get();
         Ok(())
     }
@@ -134,7 +134,7 @@ impl Writer<'_> {
                 expected: n,
                 actual: self.remaining,
             });
-        };
+        }
         self.remaining -= n.get();
         Ok(())
     }

--- a/net/src/tcp/mod.rs
+++ b/net/src/tcp/mod.rs
@@ -334,7 +334,7 @@ impl DeParse for Tcp {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -17,8 +17,8 @@ pub struct Udp(UdpHeader);
 impl Udp {
     /// The minimum length of a valid UDP header (technically also the maximum length).
     /// The name choice here is for consistency with other header types.
-    #[allow(unsafe_code)] // trivially safe const-eval
-    pub const MIN_LENGTH: NonZero<usize> = unsafe { NonZero::new_unchecked(8) };
+    #[allow(clippy::unwrap_used)] // safe due to const-eval
+    pub const MIN_LENGTH: NonZero<usize> = NonZero::new(8).unwrap();
 
     /// Get the header's source port
     #[must_use]
@@ -129,7 +129,7 @@ impl DeParse for Udp {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }

--- a/net/src/vlan/mod.rs
+++ b/net/src/vlan/mod.rs
@@ -55,12 +55,12 @@ impl InvalidVid {
 
 impl Vid {
     /// The minimum legal [`Vid`] value (1).
-    #[allow(unsafe_code)] // safe due to const eval
-    pub const MIN: Vid = Vid(unsafe { NonZero::new_unchecked(1) });
+    #[allow(clippy::unwrap_used)] // safe due to const eval
+    pub const MIN: Vid = Vid(NonZero::new(1).unwrap());
 
     /// The maximum legal [`Vid`] value (2^12 - 2).
-    #[allow(unsafe_code)] // safe due to const eval
-    pub const MAX: Vid = Vid(unsafe { NonZero::new_unchecked(4094) });
+    #[allow(clippy::unwrap_used)] // safe due to const eval
+    pub const MAX: Vid = Vid(NonZero::new(4094).unwrap());
 
     /// Create a new [`Vid`] from a `u16`.
     ///
@@ -196,9 +196,8 @@ impl Vlan {
     /// The minimum (and maximum) length of a [`Vlan`] header.
     ///
     /// Name choice for consistency.
-    // safety: trivial and const-eval
-    #[allow(unsafe_code)]
-    pub const MIN_LENGTH: NonZero<usize> = unsafe { NonZero::new_unchecked(4) };
+    #[allow(clippy::unwrap_used)] // safety: trivial and const-eval
+    pub const MIN_LENGTH: NonZero<usize> = NonZero::new(4).unwrap();
 
     // TODO: non-panic proof
     /// Create a new [Vlan] header.
@@ -315,7 +314,7 @@ impl DeParse for Vlan {
                 expected: self.size(),
                 actual: len,
             }));
-        };
+        }
         buf[..self.size().get()].copy_from_slice(&self.0.to_bytes());
         Ok(self.size())
     }
@@ -497,15 +496,15 @@ mod test {
     fn parse_noise_too_short() {
         bolero::check!()
             .with_arbitrary()
-            .for_each(|buf: &[u8; Vlan::MIN_LENGTH.get() - 1]| {
-                match Vlan::parse(buf) {
+            .for_each(
+                |buf: &[u8; Vlan::MIN_LENGTH.get() - 1]| match Vlan::parse(buf) {
                     Err(ParseError::Length(e)) => {
                         assert_eq!(e.actual, buf.len());
                         assert_eq!(e.expected, Vlan::MIN_LENGTH);
                     }
                     _ => unreachable!(),
-                };
-            });
+                },
+            );
     }
 
     #[test]

--- a/net/src/vxlan/mod.rs
+++ b/net/src/vxlan/mod.rs
@@ -34,8 +34,8 @@ impl Vxlan {
     /// The minimum (and maximum) length of a [`Vxlan`] header.
     ///
     /// Naming for consistency with other headers.
-    #[allow(unsafe_code)] // trivially safe
-    pub const MIN_LENGTH: NonZero<usize> = unsafe { NonZero::new_unchecked(8) };
+    #[allow(clippy::unwrap_used)] // trivially safe const expression
+    pub const MIN_LENGTH: NonZero<usize> = NonZero::new(8).unwrap();
 
     /// The only legal set of flags for a VXLAN header.
     ///
@@ -240,7 +240,7 @@ mod test {
                     assert_eq!(e.actual, too_small_buffer.len());
                 }
                 _ => unreachable!(),
-            };
+            }
         });
     }
 


### PR DESCRIPTION
1. run clippy (it is honestly embarrassing that I forgot this before)
2. build the docs (equally embarrassing)
3. tame nightly clippy
4. tame nightly doc lints (we had a number of broken links)
5. make nightly build optional again

I know that testing your own CI is always convoluted and meta, but I do think [a quick fault injection test](https://github.com/githedgehog/dataplane/pull/218/commits/a4eef004ba724f4bf62b9619235bd6ae4a306d7a) is in order here.  Thus I bid thee, [behold my works](https://github.com/githedgehog/dataplane/actions/runs/13193895912)

I cooked a mock PR on top of this PR to illustrate that injecting a fault into the nightly (and only into the nightly) will cause us to pass CI but still generate [an admonition that nightly is broken](https://github.com/githedgehog/dataplane/pull/218)).