### PR TITLE
README.md: Add RUSTC var to vscode setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ To do this, add the following to your `.vscode/settings.json` file:
 
 ```json
 "rust-analyzer.server.extraEnv": {
-  "CARGO": "<absolute path to dataplane directory>/bin/cargo"
+  "RUSTC": "<absolute path to dataplane directory>/compile-env/bin/rustc",
+  "CARGO": "<absolute path to dataplane directory>/compile-env/bin/cargo"
 }
 ```
 


### PR DESCRIPTION
Apparently, `RUSTC` is needed as well so that `rust-analyzer` doesn't use the system one instead of the sysroot one.