### PR TITLE
Add a pipeline interface to chain together processing stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "net",
  "serde",
  "serde_yml",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -19,3 +19,6 @@ tracing-subscriber = { workspace = true, features = ["default"] }
 
 [dev-dependencies]
 tracing-test = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(none)'] }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -13,6 +13,7 @@ net = { workspace = true, features = ["serde"] }
 dpdk = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yml = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["default"] }
 

--- a/dataplane/src/config.rs
+++ b/dataplane/src/config.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use std::collections::HashMap;
+
+pub struct Vpc {
+    #[allow(dead_code)]
+    pub vni: u32,
+}
+
+pub struct Config {
+    // Add appropriate configuration fields here
+    #[allow(dead_code)]
+    pub vni_to_vpc_id: HashMap<u32, Vpc>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self {
+            vni_to_vpc_id: HashMap::new(),
+        }
+    }
+}

--- a/dataplane/src/pipeline.rs
+++ b/dataplane/src/pipeline.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(
+    unsafe_code,
+    missing_docs,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+use std::error::Error;
+
+use dpdk::mem::Mbuf;
+use net::packet::Packet;
+use net::vxlan::Vni;
+
+use crate::config::Config;
+
+// FIXME(mvachhar) add actual data here
+pub struct Metadata {
+    #[allow(dead_code)]
+    pub vni: Option<Vni>,
+}
+
+pub struct MetaPacket {
+    pub packet: Packet,
+    #[allow(dead_code)]
+    pub metadata: Metadata,
+    #[allow(dead_code)]
+    pub outer_packet: Option<Box<Packet>>,
+    pub mbuf: Mbuf,
+}
+
+pub trait PipelineStage {
+    fn start(&mut self) -> Result<(), Box<dyn Error>>;
+
+    // FIXME(mvachhar) This interface is likely to change once we figure out
+    // how to do this in a thread-safe manner, please use sparingly while
+    // we figure out the best way to do this.
+    fn update_config(&mut self, config: &Config) -> Result<(), Box<dyn Error>>;
+
+    fn process(
+        &mut self,
+        packets: Box<dyn Iterator<Item = MetaPacket>>,
+    ) -> Box<dyn Iterator<Item = MetaPacket>>;
+}
+
+pub struct Pipeline {
+    stages: Vec<Box<dyn PipelineStage>>,
+    started: bool,
+}
+
+#[derive(thiserror::Error, Clone, Debug)]
+pub enum PipelineError {
+    #[error("Pipeline already started")]
+    AlreadyStarted,
+}
+
+impl Pipeline {
+    pub fn new() -> Self {
+        Self {
+            stages: vec![],
+            started: false,
+        }
+    }
+
+    pub fn add_stage(&mut self, stage: Box<dyn PipelineStage>) -> Result<(), PipelineError> {
+        if self.started {
+            return Err(PipelineError::AlreadyStarted);
+        }
+        self.stages.push(stage);
+        Ok(())
+    }
+
+    pub fn start(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.started {
+            return Err(Box::new(PipelineError::AlreadyStarted));
+        }
+        self.started = true;
+        let result: Result<Vec<_>, _> = self.stages.iter_mut().map(|stage| stage.start()).collect();
+        result.map(|_| ())
+    }
+
+    pub fn update_config(&mut self, config: &Config) -> Result<(), Box<dyn Error>> {
+        let result: Result<Vec<_>, _> = self
+            .stages
+            .iter_mut()
+            .map(|stage| stage.update_config(config))
+            .collect();
+        result.map(|_| ())
+    }
+
+    pub fn process_packets(
+        &mut self,
+        packets: Box<dyn Iterator<Item = MetaPacket>>,
+    ) -> Box<dyn Iterator<Item = MetaPacket>> {
+        self.stages
+            .iter_mut()
+            .fold(packets, |packets, stage| stage.process(packets))
+    }
+}
+
+#[non_exhaustive]
+pub struct Passthrough;
+
+impl Passthrough {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl PipelineStage for Passthrough {
+    fn start(&mut self) -> Result<(), Box<dyn Error>> {
+        // nothing to do
+        Ok(())
+    }
+
+    fn update_config(&mut self, _: &Config) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    fn process(
+        &mut self,
+        packets: Box<dyn Iterator<Item = MetaPacket>>,
+    ) -> Box<dyn Iterator<Item = MetaPacket>> {
+        packets
+    }
+}

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -144,6 +144,7 @@ impl Display for Mac {
     }
 }
 /// A [`Mac`] which is legal as a source in an ethernet header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct SourceMac(Mac);
 
@@ -181,6 +182,7 @@ impl SourceMac {
 }
 
 /// A [`Mac`] which is legal as a destination in an ethernet header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct DestinationMac(Mac);
 

--- a/net/src/packet.rs
+++ b/net/src/packet.rs
@@ -280,8 +280,7 @@ pub struct TooManyVlans;
 
 impl Packet {
     /// Create a new packet with the supplied `Eth` header.
-    #[allow(dead_code)]
-    fn new(eth: Eth) -> Packet {
+    pub fn new(eth: Eth) -> Packet {
         Packet {
             eth,
             vlan: ArrayVec::default(),


### PR DESCRIPTION
## Draft

This PR is here as a draft for discussion and refinement, when ready we can merge.

This PR:
* Adds a `Pipeline` object and `PipelineStage` trait to build a packet processing pipeline
* Adds a dummy Config object to use in the `PipelineStage` trait.

This this PR does *not* do:
* Implement a proper thread-safe config interface
* Fully implement the MetaPacket interface - we need to develop this based on stage needs
  * As part of this, we need to figure out how to represent the selected output interface/encap/etc.
* Does not deal with any async interface to pause processing a packet and wakeup stages later