### PR TITLE
ci: Fix concurrency group for merge queue

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -30,7 +30,7 @@ on:
         default: false
 
 concurrency:
-  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after }}"
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ on:
         default: false
 
 concurrency:
-  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after }}"
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}"
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/lint-cargo-fmt.yml
+++ b/.github/workflows/lint-cargo-fmt.yml
@@ -8,7 +8,7 @@ on:
     types: ["checks_requested"]
 
 concurrency:
-  group: "${{ github.workflow }}:${{ github.event.pull_request.number }}"
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -25,7 +25,7 @@ on:
         default: false
 
 concurrency:
-  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after }}"
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adding two Pull Requests to the merge queue recently, we noticed that the workflows for the first one were cancelled:

    Canceling since a higher priority waiting request for 'dev.yml:'
    exists

([Reference](https://github.com/githedgehog/dataplane/actions/runs/13305862243/job/37156589226))

Let's adjust the concurrency group name to account for the different runs in the merge queue, and avoid having one Pull Request cancelling the others.
