### PR TITLE
nat: Use iptrie instead of custom LPM implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "dpdk",
+ "iptrie",
  "net",
  "serde",
  "serde_yml",
@@ -426,6 +427,21 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iptrie"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2688e40b354466a90b89a55f8ce68acd0022f7f73aabd9968128ceafa7e239"
+dependencies = [
+ "ipnet",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4.5.27", default-features = false, features = ["std"] }
 ctrlc = { version = "3.4.5", default-features = false, features = [] }
 doxygen-rs = { version = "0.4.0", default-features = false, features = [] }
 etherparse = { version = "0.17.0", default-features = false, features = [] }
+iptrie = { version = "0.9.1", default-features = false, features = [] }
 serde = { version = "1.0.213", default-features = false }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
 thiserror = { version = "2.0.11", default-features = false, features = [] }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -6,11 +6,11 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-
 clap = { workspace = true, features = ["derive"] }
 ctrlc = { workspace = true, features = ["termination"] }
-net = { workspace = true, features = ["serde"] }
 dpdk = { workspace = true }
+iptrie = { workspace = true }
+net = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_yml = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Replace our PrefixTrie implementation with the one from the iptrie crate.

We get some added complexity due to the fact that (as far as I can tell, and in spite of what the crate's README says) there seems to be no way to store a type that represents both IPv4 and IPv6 prefixes; so we end up with two distinct maps. We wrap these into a struct PrefixTrie (distinct from the one we had so far: it no longer implements the map), to avoid dealing with IP versions in the implmementation of the PifTable and the GlobalContext. We also have to implement the Debug trait for the PrefixTrie, given that the LPM map we use does not provide it.

PrefixTrie's insert() function will eventually be reworked, when we change the definition of the endpoints to use CIDR objects rather than a combination of address + prefix length.

Note: iptrie is also introduced in #211.
