### PR TITLE
Fix dataplane tests and re-add package to default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 default-members = [
+	"dataplane",
 	"dpdk-sysroot-helper",
 	"errno",
 	"net",

--- a/dataplane/src/nat.rs
+++ b/dataplane/src/nat.rs
@@ -277,10 +277,8 @@ impl GlobalContext {
 mod tests {
     use super::*;
     use tracing::{info, warn};
-    use tracing_test::traced_test;
 
     #[test]
-    #[traced_test]
     fn basic_test() {
         let mut context = GlobalContext::new();
 


### PR DESCRIPTION
- **nat: Remove tracing_test**
- **workspace: Add dataplane to default members**

Refer to individual commit logs for details.
