### PR TITLE
Add abstraction for header manipulation and Packet structure for dataplane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /design-docs/src/mdbook/book/**
 /design-docs/src/mdbook/src/mdbook-plantuml-img/**
 /dev-env-template/**
-/dpdk-sys/dpdk_wrapper-precompile.h.*
+/dpdk-sys/dpdk_wrapper-precompile.h*
 /dpdk-sys/.macro_eval.c
 **/__fuzz__/**
 **.profraw

--- a/dataplane/src/packet.rs
+++ b/dataplane/src/packet.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use net::buffer::PacketBufferMut;
+use net::eth::EthError;
+use net::headers::{AbstractHeaders, AbstractHeadersMut, Headers, TryHeaders, TryHeadersMut};
+use net::parse::{DeParse, DeParseError, Parse, ParseError};
+use std::cmp::Ordering;
+use std::num::NonZero;
+
+#[derive(Debug)]
+pub struct Packet<Buf: PacketBufferMut> {
+    headers: Headers,
+    /// The total number of bytes _originally_ consumed when parsing this packet
+    /// Mutations to `packet` can cause the re-serialized size of the packet to grow or shrink.
+    consumed: NonZero<u16>,
+    pub mbuf: Buf, // TODO: find a way to make this private
+}
+#[derive(Debug, thiserror::Error)]
+pub struct InvalidPacket<Buf: PacketBufferMut> {
+    #[allow(unused)]
+    mbuf: Buf,
+    #[source]
+    error: ParseError<EthError>,
+}
+
+impl<Buf: PacketBufferMut> Packet<Buf> {
+    pub fn new(mbuf: Buf) -> Result<Packet<Buf>, InvalidPacket<Buf>> {
+        let (headers, consumed) = match Headers::parse(mbuf.as_ref()) {
+            Ok((packet, consumed)) => (packet, consumed),
+            Err(error) => {
+                return Err(InvalidPacket { mbuf, error });
+            }
+        };
+        Ok(Packet {
+            headers,
+            consumed,
+            mbuf,
+        })
+    }
+
+    pub(crate) fn reserialize(self) -> Buf {
+        // TODO: prove that these unreachable statements are optimized out
+        // The `unreachable` statements in the first block should be easily optimized out, but best
+        // to confirm.
+        let needed = self.headers.size();
+        let mut mbuf = self.mbuf;
+        let mut mbuf = match needed.cmp(&self.consumed) {
+            Ordering::Equal => mbuf,
+            Ordering::Less => {
+                let prepend = needed.get() - self.consumed.get();
+                match mbuf.prepend(prepend) {
+                    Ok(_) => {}
+                    Err(e) => unreachable!("configuration error: {:?}", e),
+                };
+                mbuf
+            }
+            Ordering::Greater => {
+                let trim = self.consumed.get() - needed.get();
+                if trim > self.headers.size().get() {
+                    panic!("attempting to trim a nonsensical amount of data: {trim}");
+                }
+                match mbuf.trim_from_start(trim) {
+                    Ok(_) => {}
+                    Err(e) => unreachable!("configuration error: {:?}", e),
+                };
+                mbuf
+            }
+        };
+        // TODO: prove that these unreachable statements are optimized out
+        // This may be _very_ hard to do since the compiler may not have perfect
+        // visibility here.
+        match self.headers.deparse(mbuf.as_mut()) {
+            Ok(_) => mbuf,
+            Err(DeParseError::Length(fatal)) => unreachable!("{fatal:?}", fatal = fatal),
+            Err(DeParseError::Invalid(())) => unreachable!("invalid write operation"),
+            Err(DeParseError::BufferTooLong(len)) => {
+                unreachable!("buffer too long: {len}", len = len)
+            }
+        }
+    }
+}
+
+impl<Buf: PacketBufferMut> TryHeaders for Packet<Buf> {
+    fn headers(&self) -> &impl AbstractHeaders {
+        &self.headers
+    }
+}
+
+impl<Buf: PacketBufferMut> TryHeadersMut for Packet<Buf> {
+    fn headers_mut(&mut self) -> &mut impl AbstractHeadersMut {
+        &mut self.headers
+    }
+}

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -20,6 +20,7 @@ use crate::udp::{Udp, UdpEncap};
 use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::Vxlan;
 use arrayvec::ArrayVec;
+use core::fmt::Debug;
 use std::num::NonZero;
 use tracing::debug;
 
@@ -367,110 +368,568 @@ impl Headers {
             }
         }
     }
+}
 
-    pub fn eth(&self) -> &Eth {
+// Eth traits
+
+pub trait WithEth {
+    fn eth(&self) -> &Eth;
+}
+
+pub trait WithEthMut {
+    fn eth_mut(&mut self) -> &mut Eth;
+}
+
+pub trait TryEth {
+    fn try_eth(&self) -> Option<&Eth>;
+}
+
+pub trait TryEthMut {
+    fn try_eth_mut(&mut self) -> Option<&mut Eth>;
+}
+
+impl WithEth for Headers {
+    fn eth(&self) -> &Eth {
         &self.eth
     }
+}
 
-    pub fn eth_mut(&mut self) -> &mut Eth {
+impl WithEthMut for Headers {
+    fn eth_mut(&mut self) -> &mut Eth {
         &mut self.eth
     }
+}
 
-    pub fn ipv4(&self) -> Option<&Ipv4> {
+impl TryEth for Headers {
+    fn try_eth(&self) -> Option<&Eth> {
+        Some(self.eth())
+    }
+}
+
+impl TryEthMut for Headers {
+    fn try_eth_mut(&mut self) -> Option<&mut Eth> {
+        Some(self.eth_mut())
+    }
+}
+
+// Ipv4 traits
+
+pub trait WithIpv4 {
+    fn ipv4(&self) -> &Ipv4;
+}
+
+pub trait WithIpv4Mut {
+    fn ipv4_mut(&mut self) -> &mut Ipv4;
+}
+
+pub trait TryIpv4 {
+    fn try_ipv4(&self) -> Option<&Ipv4>;
+}
+
+pub trait TryIpv4Mut {
+    fn try_ipv4_mut(&mut self) -> Option<&mut Ipv4>;
+}
+
+impl TryIpv4 for Headers {
+    fn try_ipv4(&self) -> Option<&Ipv4> {
         match &self.net {
             Some(Net::Ipv4(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn ipv4_mut(&mut self) -> Option<&mut Ipv4> {
+impl TryIpv4Mut for Headers {
+    fn try_ipv4_mut(&mut self) -> Option<&mut Ipv4> {
         match &mut self.net {
             Some(Net::Ipv4(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn ipv6(&self) -> Option<&Ipv6> {
+// Ipv6 traits
+
+pub trait WithIpv6 {
+    fn ipv6(&self) -> &Ipv6;
+}
+
+pub trait WithIpv6Mut {
+    fn ipv6_mut(&mut self) -> &mut Ipv6;
+}
+
+pub trait TryIpv6 {
+    fn try_ipv6(&self) -> Option<&Ipv6>;
+}
+
+pub trait TryIpv6Mut {
+    fn try_ipv6_mut(&mut self) -> Option<&mut Ipv6>;
+}
+
+impl TryIpv6 for Headers {
+    fn try_ipv6(&self) -> Option<&Ipv6> {
         match &self.net {
             Some(Net::Ipv6(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn ipv6_mut(&mut self) -> Option<&mut Ipv6> {
+impl TryIpv6Mut for Headers {
+    fn try_ipv6_mut(&mut self) -> Option<&mut Ipv6> {
         match &mut self.net {
             Some(Net::Ipv6(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn tcp(&self) -> Option<&Tcp> {
+// Tcp traits
+
+pub trait WithTcp {
+    fn tcp(&self) -> &Tcp;
+}
+
+pub trait WithTcpMut {
+    fn tcp_mut(&mut self) -> &mut Tcp;
+}
+
+pub trait TryTcp {
+    fn try_tcp(&self) -> Option<&Tcp>;
+}
+
+pub trait TryTcpMut {
+    fn try_tcp_mut(&mut self) -> Option<&mut Tcp>;
+}
+
+impl TryTcp for Headers {
+    fn try_tcp(&self) -> Option<&Tcp> {
         match &self.transport {
             Some(Transport::Tcp(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn tcp_mut(&mut self) -> Option<&mut Tcp> {
+impl TryTcpMut for Headers {
+    fn try_tcp_mut(&mut self) -> Option<&mut Tcp> {
         match &mut self.transport {
             Some(Transport::Tcp(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn udp(&self) -> Option<&Udp> {
+// UDP traits
+
+pub trait WithUdp {
+    fn udp(&self) -> &Udp;
+}
+
+pub trait WithUdpMut {
+    fn udp_mut(&mut self) -> &mut Udp;
+}
+
+pub trait TryUdp {
+    fn try_udp(&self) -> Option<&Udp>;
+}
+
+pub trait TryUdpMut {
+    fn try_udp_mut(&mut self) -> Option<&mut Udp>;
+}
+
+impl TryUdp for Headers {
+    fn try_udp(&self) -> Option<&Udp> {
         match &self.transport {
             Some(Transport::Udp(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn udp_mut(&mut self) -> Option<&mut Udp> {
+impl TryUdpMut for Headers {
+    fn try_udp_mut(&mut self) -> Option<&mut Udp> {
         match &mut self.transport {
             Some(Transport::Udp(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn icmp(&self) -> Option<&Icmp4> {
+// Icmp traits
+
+pub trait WithIcmp {
+    fn icmp(&self) -> &Icmp4;
+}
+
+pub trait WithIcmpMut {
+    fn icmp_mut(&mut self) -> &mut Icmp4;
+}
+
+pub trait TryIcmp {
+    fn try_icmp(&self) -> Option<&Icmp4>;
+}
+
+pub trait TryIcmpMut {
+    fn try_icmp_mut(&mut self) -> Option<&mut Icmp4>;
+}
+
+impl TryIcmp for Headers {
+    fn try_icmp(&self) -> Option<&Icmp4> {
         match &self.transport {
             Some(Transport::Icmp4(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn icmp_mut(&mut self) -> Option<&mut Icmp4> {
+impl TryIcmpMut for Headers {
+    fn try_icmp_mut(&mut self) -> Option<&mut Icmp4> {
         match &mut self.transport {
             Some(Transport::Icmp4(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn icmp6(&self) -> Option<&Icmp6> {
+// ICMP6 traits
+
+pub trait WithIcmp6 {
+    fn icmp6(&self) -> &Icmp6;
+}
+
+pub trait WithIcmp6Mut {
+    fn icmp6_mut(&mut self) -> &mut Icmp6;
+}
+
+pub trait TryIcmp6 {
+    fn try_icmp6(&self) -> Option<&Icmp6>;
+}
+
+pub trait TryIcmp6Mut {
+    fn try_icmp6_mut(&mut self) -> Option<&mut Icmp6>;
+}
+
+impl TryIcmp6 for Headers {
+    fn try_icmp6(&self) -> Option<&Icmp6> {
         match &self.transport {
             Some(Transport::Icmp6(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn icmp6_mut(&mut self) -> Option<&mut Icmp6> {
+impl TryIcmp6Mut for Headers {
+    fn try_icmp6_mut(&mut self) -> Option<&mut Icmp6> {
         match &mut self.transport {
             Some(Transport::Icmp6(header)) => Some(header),
             _ => None,
         }
     }
+}
 
-    pub fn vxlan(&self) -> Option<&Vxlan> {
+// Vxlan traits
+
+pub trait WithVxlan {
+    fn vxlan(&self) -> &Vxlan;
+}
+
+pub trait WithVxlanMut {
+    fn vxlan_mut(&mut self) -> &mut Vxlan;
+}
+
+pub trait TryVxlan {
+    fn try_vxlan(&self) -> Option<&Vxlan>;
+}
+
+pub trait TryVxlanMut {
+    fn try_vxlan_mut(&mut self) -> Option<&mut Vxlan>;
+}
+
+impl TryVxlan for Headers {
+    fn try_vxlan(&self) -> Option<&Vxlan> {
         match &self.udp_encap {
             Some(UdpEncap::Vxlan(vxlan)) => Some(vxlan),
             _ => None,
         }
     }
+}
 
-    pub fn vxlan_mut(&mut self) -> Option<&mut Vxlan> {
+impl TryVxlanMut for Headers {
+    fn try_vxlan_mut(&mut self) -> Option<&mut Vxlan> {
         match &mut self.udp_encap {
             Some(UdpEncap::Vxlan(vxlan)) => Some(vxlan),
             _ => None,
         }
+    }
+}
+
+impl From<Eth> for Header {
+    fn from(value: Eth) -> Self {
+        Header::Eth(value)
+    }
+}
+
+impl From<Vlan> for Header {
+    fn from(value: Vlan) -> Self {
+        Header::Vlan(value)
+    }
+}
+
+impl From<Ipv4> for Header {
+    fn from(value: Ipv4) -> Self {
+        Header::Ipv4(value)
+    }
+}
+
+impl From<Ipv6> for Header {
+    fn from(value: Ipv6) -> Self {
+        Header::Ipv6(value)
+    }
+}
+
+impl From<Net> for Header {
+    fn from(value: Net) -> Self {
+        match value {
+            Net::Ipv4(ip) => Header::from(ip),
+            Net::Ipv6(ip) => Header::from(ip),
+        }
+    }
+}
+
+impl From<IpAuth> for Header {
+    fn from(value: IpAuth) -> Self {
+        Header::IpAuth(value)
+    }
+}
+
+impl From<Ipv6Ext> for Header {
+    fn from(value: Ipv6Ext) -> Self {
+        Header::IpV6Ext(value)
+    }
+}
+
+impl From<Udp> for Header {
+    fn from(value: Udp) -> Self {
+        Header::Udp(value)
+    }
+}
+
+impl From<Tcp> for Header {
+    fn from(value: Tcp) -> Self {
+        Header::Tcp(value)
+    }
+}
+
+impl From<Icmp4> for Header {
+    fn from(value: Icmp4) -> Self {
+        Header::Icmp4(value)
+    }
+}
+
+impl From<Icmp6> for Header {
+    fn from(value: Icmp6) -> Self {
+        Header::Icmp6(value)
+    }
+}
+
+impl From<Transport> for Header {
+    fn from(value: Transport) -> Self {
+        match value {
+            Transport::Tcp(x) => Header::from(x),
+            Transport::Udp(x) => Header::from(x),
+            Transport::Icmp4(x) => Header::from(x),
+            Transport::Icmp6(x) => Header::from(x),
+        }
+    }
+}
+
+impl From<Vxlan> for Header {
+    fn from(value: Vxlan) -> Self {
+        Header::Encap(UdpEncap::Vxlan(value))
+    }
+}
+
+impl From<UdpEncap> for Header {
+    fn from(value: UdpEncap) -> Self {
+        Header::Encap(value)
+    }
+}
+
+pub trait AbstractHeaders:
+    Debug + TryEth + TryIpv4 + TryIpv6 + TryTcp + TryUdp + TryIcmp + TryIcmp6 + TryVxlan
+{
+}
+
+impl<T> AbstractHeaders for T where
+    T: Debug + TryEth + TryIpv4 + TryIpv6 + TryTcp + TryUdp + TryIcmp + TryIcmp6 + TryVxlan
+{
+}
+
+pub trait AbstractHeadersMut:
+    TryEthMut + TryIpv4Mut + TryIpv6Mut + TryTcpMut + TryUdpMut + TryIcmpMut + TryIcmp6Mut + TryVxlanMut
+{
+}
+impl<T> AbstractHeadersMut for T where
+    T: TryEthMut
+        + TryIpv4Mut
+        + TryIpv6Mut
+        + TryTcpMut
+        + TryUdpMut
+        + TryIcmpMut
+        + TryIcmp6Mut
+        + TryVxlanMut
+{
+}
+
+pub trait TryHeaders {
+    fn headers(&self) -> &impl AbstractHeaders;
+}
+
+pub trait TryHeadersMut {
+    fn headers_mut(&mut self) -> &mut impl AbstractHeadersMut;
+}
+
+impl<T> TryEth for T
+where
+    T: TryHeaders,
+{
+    fn try_eth(&self) -> Option<&Eth> {
+        self.headers().try_eth()
+    }
+}
+
+impl<T> TryIpv4 for T
+where
+    T: TryHeaders,
+{
+    fn try_ipv4(&self) -> Option<&Ipv4> {
+        self.headers().try_ipv4()
+    }
+}
+
+impl<T> TryIpv6 for T
+where
+    T: TryHeaders,
+{
+    fn try_ipv6(&self) -> Option<&Ipv6> {
+        self.headers().try_ipv6()
+    }
+}
+
+impl<T> TryTcp for T
+where
+    T: TryHeaders,
+{
+    fn try_tcp(&self) -> Option<&Tcp> {
+        self.headers().try_tcp()
+    }
+}
+
+impl<T> TryUdp for T
+where
+    T: TryHeaders,
+{
+    fn try_udp(&self) -> Option<&Udp> {
+        self.headers().try_udp()
+    }
+}
+
+impl<T> TryIcmp for T
+where
+    T: TryHeaders,
+{
+    fn try_icmp(&self) -> Option<&Icmp4> {
+        self.headers().try_icmp()
+    }
+}
+
+impl<T> TryIcmp6 for T
+where
+    T: TryHeaders,
+{
+    fn try_icmp6(&self) -> Option<&Icmp6> {
+        self.headers().try_icmp6()
+    }
+}
+
+impl<T> TryVxlan for T
+where
+    T: TryHeaders,
+{
+    fn try_vxlan(&self) -> Option<&Vxlan> {
+        self.headers().try_vxlan()
+    }
+}
+
+impl<T> TryEthMut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_eth_mut(&mut self) -> Option<&mut Eth> {
+        self.headers_mut().try_eth_mut()
+    }
+}
+
+impl<T> TryIpv4Mut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_ipv4_mut(&mut self) -> Option<&mut Ipv4> {
+        self.headers_mut().try_ipv4_mut()
+    }
+}
+
+impl<T> TryIpv6Mut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_ipv6_mut(&mut self) -> Option<&mut Ipv6> {
+        self.headers_mut().try_ipv6_mut()
+    }
+}
+
+impl<T> TryTcpMut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_tcp_mut(&mut self) -> Option<&mut Tcp> {
+        self.headers_mut().try_tcp_mut()
+    }
+}
+
+impl<T> TryUdpMut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_udp_mut(&mut self) -> Option<&mut Udp> {
+        self.headers_mut().try_udp_mut()
+    }
+}
+
+impl<T> TryIcmpMut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_icmp_mut(&mut self) -> Option<&mut Icmp4> {
+        self.headers_mut().try_icmp_mut()
+    }
+}
+
+impl<T> TryIcmp6Mut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_icmp6_mut(&mut self) -> Option<&mut Icmp6> {
+        self.headers_mut().try_icmp6_mut()
+    }
+}
+
+impl<T> TryVxlanMut for T
+where
+    T: TryHeadersMut,
+{
+    fn try_vxlan_mut(&mut self) -> Option<&mut Vxlan> {
+        self.headers_mut().try_vxlan_mut()
     }
 }

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -23,6 +23,9 @@ use tracing::{debug, trace};
 pub mod addr;
 pub mod flow_label;
 
+#[cfg(any(test, feature = "arbitrary"))]
+pub use contract::*;
+
 /// An IPv6 header
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv6(Ipv6Header);

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -6,7 +6,6 @@
 pub mod checksum;
 pub mod port;
 
-use crate::headers::Header;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParsePayload, Reader,
 };
@@ -190,12 +189,6 @@ impl ParsePayload for Udp {
             }
             _ => None,
         }
-    }
-}
-
-impl From<UdpEncap> for Header {
-    fn from(value: UdpEncap) -> Self {
-        Header::Encap(value)
     }
 }
 


### PR DESCRIPTION
Add back some of the changes that didn't make it from #233

* Adds abstraction for ethparse headers in net so that we can later enforce correct manipulations
* Add tests for full header parsing
* Add `Packet` to dataplane and drop `MetaPacket`
  * `Packet` manages its own Mbuf and abstracts the buffer type for testing

These changes are a prelude to a better Pipeline interface that can actually be tested and works with different Iterator types.  That PR is still WIP, but close.