### PR TITLE
ci: Add linter for making sure we follow the  Conventional Commits spec

### DIFF
--- a/.github/workflows/lint-commitlint.yml
+++ b/.github/workflows/lint-commitlint.yml
@@ -1,0 +1,25 @@
+# Make sure commi subject and description follow the Conventional Commits spec.
+# See https://www.conventionalcommits.org/
+
+name: "lint-commitlint.yml"
+
+on:
+  pull_request: {}
+
+concurrency:
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          persist-credentials: "false"
+      - name: "Run commitlint on Pull Request's commits"
+        uses: "opensource-nepal/commitlint@v1"
+        with:
+          verbose: true


### PR DESCRIPTION
We have decided to enforce a structured formatting for the commit subject and description in the repository, namely the [Conventional Commit specification][0]. Add a CI workflow to make sure that new commits in Pull Requests abide by the specification.

I first tried to use https://github.com/wagoid/commitlint-github-action, which pulls by default the rules from [`@commitlint/config-conventional`][1], but I found them too restrictive. In particular, it enforces additional requirements on case that are not in the spec; worse, it unconditionally enforces maximum line lengths on subject, body and footer length. While I'm all in for restricting the subject's length, and generally wrapping the commit description, this makes it impossible to paste long links in the body or footer, or a large code snippet or command output in the body. So I went with https://github.com/marketplace/actions/conventional-commitlint instead, which seems to enforce the spec (and limit subject's length, which I believe is good) only.

We can switch to something more flexible in the future and refine our own rule set if necessary, but I find this seems to be a good start.

[0]: https://www.conventionalcommits.org/en/v1.0.0/
[1]: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional
