### PR TITLE
ci: Fix concurrency group for license/headers check workflow

### DIFF
--- a/.github/workflows/lint-license-headers.yml
+++ b/.github/workflows/lint-license-headers.yml
@@ -8,7 +8,7 @@ on:
     types: ["checks_requested"]
 
 concurrency:
-  group: "${{ github.workflow }}:${{ github.event.pull_request.number }}"
+  group: "${{ github.workflow }}:${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Just like commit 5cbff3518fef ("ci: Fix concurrency group for merge queue"), but for lint-license-headers.yml that for some reason doesn't have the updated concurrency group format.
