### PR TITLE
ci: Fix typo, remove verbose mode in commitlint linter workflow

### DIFF
--- a/.github/workflows/lint-commitlint.yml
+++ b/.github/workflows/lint-commitlint.yml
@@ -1,4 +1,4 @@
-# Make sure commi subject and description follow the Conventional Commits spec.
+# Make sure commit subject and description follow the Conventional Commits spec.
 # See https://www.conventionalcommits.org/
 
 name: "lint-commitlint.yml"
@@ -21,5 +21,3 @@ jobs:
           persist-credentials: "false"
       - name: "Run commitlint on Pull Request's commits"
         uses: "opensource-nepal/commitlint@v1"
-        with:
-          verbose: true


### PR DESCRIPTION
Fix a typo in the commit description, spotted by Sergei; also remove the use of the verbose output for the commitlint GitHub action, it is too verbose but brings no additional value on errors.
