### PR TITLE
Remove musl support

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -87,7 +87,7 @@ jobs:
         debug_justfile:
           - "${{inputs.debug_justfile || false}}"
     outputs:
-      result: "${{ matrix.rust.optional || steps.gnu_dev_test.conclusion == 'success' && steps.musl_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' && steps.musl_release_test.conclusion == 'success' }}"
+      result: "${{ matrix.rust.optional || steps.gnu_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' }}"
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -102,7 +102,7 @@ jobs:
         uses: "dtolnay/rust-toolchain@master"
         with:
           toolchain: "${{ matrix.rust.version }}"
-          targets: "x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl"
+          targets: "x86_64-unknown-linux-gnu"
           components: "rustfmt,clippy"
       - name: "Checkout"
         uses: "actions/checkout@v4"
@@ -132,30 +132,12 @@ jobs:
             cargo doc
         continue-on-error: ${{ matrix.rust.optional }}
 
-      - id: "musl_dev_test"
-        name: "test musl dev"
-        run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-musl \
-            cargo test
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-musl \
-            cargo doc
-        continue-on-error: ${{ matrix.rust.optional }}
-
       - id: "gnu_release_test"
         name: "test gnu release"
         run: |
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
             cargo test
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
-            cargo doc
-        continue-on-error: ${{ matrix.rust.optional }}
-
-      - id: "musl_release_test"
-        name: "test musl release"
-        run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-musl \
-            cargo test
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-musl \
             cargo doc
         continue-on-error: ${{ matrix.rust.optional }}
 
@@ -173,7 +155,7 @@ jobs:
 
       - name: "Note failure of optional steps"
         uses: "actions/github-script@v7"
-        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.musl_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.musl_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
+        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
@@ -185,7 +167,6 @@ jobs:
               repo: context.repo.repo,
               body: body
             });
-
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -101,22 +101,6 @@ jobs:
           just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
             sterile cargo doc
 
-      - name: "dev/musl sterile test"
-        if: ${{ always() }}
-        run: |
-          just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl \
-            sterile cargo test
-          just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-musl \
-            sterile cargo doc
-
-      - name: "release/musl sterile test"
-        if: ${{ always() }}
-        run: |
-          just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
-            sterile cargo test
-          just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
-            sterile cargo doc
-
       - name: "run clippy"
         if: ${{ always() }}
         run: |
@@ -183,12 +167,6 @@ jobs:
             push-container
       - run: |
           just debug_justfile="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
-            push-container
-      - run: |
-          just debug_justfile="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=debug target=x86_64-unknown-linux-musl \
-            push-container
-      - run: |
-          just debug_justfile="${{matrix.debug_just}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-musl \
             push-container
 
       - name: "Setup tmate session for debug"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ managed by the Fabric, or to communicate with endpoints outside of the Fabric.
     ```bash
     rustup update
     ```
-  * :warning: You need to install both the glibc and musl targets to use the default builds.
+  * :warning: You need to install (at least) the glibc target to use the default builds.
 
     ```bash
     rustup target add x86_64-unknown-linux-gnu
-    rustup target add x86_64-unknown-linux-musl
     ```
 
 - [just][just] (install through your package manager or cargo)
@@ -53,7 +52,7 @@ just refresh-compile-env
 
 You should now have a directory called `compile-env` which contains the tools needed to build `dpdk-sys` such as `clang` and `lld`.
 You should also have `./compile-env/sysroot` which contains the libraries that `dpdk-sys` needs to link against.
-Both `x86_64-unknown-linux-gnu` and `x86_64-unknown-linux-musl` targets are currently supported.
+Only the `x86_64-unknown-linux-gnu` target is currently supported.
 
 ### Step 2. Fake nix
 
@@ -99,7 +98,7 @@ After running
 just cargo build --package=dataplane
 ```
 
-You should now have ELF executables in `target/x86_64-unknown-linux-gnu/debug/dataplane` and `target/x86_64-unknown-linux-musl/debug/dataplane`.
+You should now have an ELF executable in `target/x86_64-unknown-linux-gnu/debug/dataplane`.
 
 You can build in release mode with
 
@@ -107,7 +106,7 @@ You can build in release mode with
 just cargo build --package=dataplane --profile=release
 ```
 
-at which point the executables will be in `target/x86_64-unknown-linux-gnu/release/dataplane` and `target/x86_64-unknown-linux-musl/release/dataplane`.
+at which point you should have an executable in `target/x86_64-unknown-linux-gnu/release/dataplane`.
 
 ### Step 4. Run the tests (debug mode)
 
@@ -115,13 +114,6 @@ To run the test suite, you can run
 
 ```bash
 just cargo test
-```
-
-By default, this will run just the glibc tests.
-To run the test suite under musl, try
-
-```bash
-just cargo test --target x86_64-unknown-linux-musl
 ```
 
 To run the test suite under release mode

--- a/design-docs/src/mdbook/src/build/compile-env.md
+++ b/design-docs/src/mdbook/src/build/compile-env.md
@@ -54,17 +54,6 @@ The `compile-env` directory basically looks like this:
 ******_ dpdk-libs
 ******_ rdma-libs
 ******_ deps
-*** x86_64-unknown-linux-musl
-**** debug
-***** lib
-******_ dpdk-libs
-******_ rdma-libs
-******_ deps
-**** release
-***** lib
-******_ dpdk-libs
-******_ rdma-libs
-******_ deps
 @endwbs
 ```
 > High-level anatomy of the `compile-env`.

--- a/design-docs/src/mdbook/src/build/fake-nix.md
+++ b/design-docs/src/mdbook/src/build/fake-nix.md
@@ -47,17 +47,6 @@ After running `just fake-nix` you get this type of effect.
 *********_ dpdk-libs
 *********_ rdma-libs
 *********_ deps
-****** x86_64-unknown-linux-musl
-******* debug
-******** lib
-*********_ dpdk-libs
-*********_ rdma-libs
-*********_ deps
-******* release
-******** lib
-*********_ dpdk-libs
-*********_ rdma-libs
-*********_ deps
 nix_sym -> nix
 @endwbs
 ```

--- a/design-docs/src/mdbook/src/build/index.md
+++ b/design-docs/src/mdbook/src/build/index.md
@@ -180,5 +180,5 @@ Control plane components
 
 [`dpdk-sys`]: <https://github.com/githedgehog/dpdk-sys>
 [`dataplane`]: <https://github.com/githedgehog/dataplane>
-[^um-actually]: In fact, `dpdk-sys` produces four sysroots.  One for each combination of dev/release builds and gnu64 and musl64 builds.
+[^um-actually]: In fact, `dpdk-sys` produces two sysroots.  One for debug and one for release builds.
 


### PR DESCRIPTION
With the loss of [nix magic cache](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) we have to use a much worse cache option for dpdk-sys, which has required us to (at least for the moment) remove musl support (see https://github.com/githedgehog/dpdk-sys/pull/92/commits/59661ba91c2d31f02c51cfeec02954a1fe01fdd6).

This commit removes musl from the CI and docs.

Hopefully this change can be reverted at some point because the sysroot is truly harder to debug without musl.

> [!NOTE]
> ~~Don't merge this until https://github.com/githedgehog/dpdk-sys/pull/92 lands and we update the dpdk-sys.env file to match~~
> It occurs to me that we can just merge the dpdk-sys.env update as a different PR.  All that will mean is that we don't build musl for the moment (even if it is shipped with the sysroot).