### PR TITLE
build: fix incorrect commit message in bump.yml

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -57,12 +57,12 @@ jobs:
         uses: "peter-evans/create-pull-request@v7"
         with:
           branch: "bump/dpdk-sys"
-          title: "bump/dpdk-sys"
+          title: "build(dpdk-sys): bump"
           labels: |
             automated
             dependencies
           signoff: "true"
-          commit-message: "bump/dpdk-sys"
+          commit-message: "automated bump of dpdk-sys"
           sign-commits: "true"
           body: "bump dpdk-sys"
 


### PR DESCRIPTION
The automated commit doesn't pass CI anymore now that we are using a more refined commit message format.

This commit fixes that.