### PR TITLE
build: calm cargo doc lints for dpdk-sys

### DIFF
--- a/dpdk-sys/Cargo.toml
+++ b/dpdk-sys/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 description = "Low-level bindings to the Data Plane Development Kit (DPDK)"
 publish = false
 
+[lib]
+doctest = false
+doc = false
+
 [build-dependencies]
 bindgen = { workspace = true, features = ["runtime", "experimental"]}
 doxygen-rs = { workspace = true }


### PR DESCRIPTION
The dpdk-sys crate uses pre-processing to translate doxygen to rustdoc.

But cargo-doc doesn't see all of that pre-processing so it goes crazy on the lints and makes a lot of CI noise.

We don't need the cargo-doc for the generated bindings so just turn that off.