### PR TITLE
fix: remove unused cargo alias commands

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,7 +5,3 @@ LIBCLANG_PATH = { value = "compile-env/lib", relative = true, force = true }
 
 [build]
 target = "x86_64-unknown-linux-gnu"
-
-[alias]
-just = ["just", "cargo"]
-sterile = ["just", "sterile", "cargo"]


### PR DESCRIPTION
These were part of an experiment which I shouldn't have ever checked in. They don't work, and wouldn't do anything useful even if they did work as intended.