### PR TITLE
Use documented version of free

### DIFF
--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -401,7 +401,7 @@ pub struct Mbuf {
 impl Drop for Mbuf {
     fn drop(&mut self) {
         unsafe {
-            dpdk_sys::rte_pktmbuf_free_w(self.raw.as_ptr());
+            dpdk_sys::rte_pktmbuf_free(self.raw.as_ptr());
         }
     }
 }


### PR DESCRIPTION
Trivial swap, but it is better to use the non `_w` vesions of dpdk-sys functions as they include doxygen -> rustdoc docs.