### PR TITLE
bump: Fix Dependabot's commits title message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     target-branch: "main"
     commit-message:
-      prefix: "dep(github-actions):"
+      prefix: "bump(github-actions):"
     directories:
       - "/"
     schedule:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "cargo"
     target-branch: "main"
     commit-message:
-      prefix: "dep(cargo):"
+      prefix: "bump(cargo):"
     directories:
       - "/"
     schedule:


### PR DESCRIPTION
Dependabot uses "dep" as commit type, but the linter we have currently enforces the use of one of:

    build, ci, docs, feat, fix, perf, refactor, style, test, chore,
    revert, bump

We could change the linter, but for now let's simply change the commit type to "bump", which sounds accurate.
