### PR TITLE
fix (and lint) dependabot.yml

### DIFF
--- a/.github/workflows/lint-just-fmt.yml
+++ b/.github/workflows/lint-just-fmt.yml
@@ -3,7 +3,10 @@
 name: "lint-just-fmt.yml"
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - "justfile"
+      - ".github/workflows/lint-just-fmt.yml"
   merge_group:
     types: ["checks_requested"]
 

--- a/.github/workflows/lint-validate-dependabot.yml
+++ b/.github/workflows/lint-validate-dependabot.yml
@@ -1,0 +1,14 @@
+name: "lint-validate-dependabot.yml"
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/dependabot-validate.yml"
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "marocchino/validate-dependabot@v3"
+        id: "validate"


### PR DESCRIPTION
Based on the recent nonsense PR sequence trying to update dependabot.yml, it seems reasonable to include this.