### PR TITLE
Allow dependabot to suggest major version upgrades for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - automated
-      - dependencies
+      - "automated"
+      - "dependencies"
   - package-ecosystem: "cargo"
     target-branch: "main"
     commit-message:
@@ -21,8 +21,8 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - automated
-      - dependencies
+      - "automated"
+      - "dependencies"
     versioning-strategy: "lockfile-only"
     groups:
       dev-dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       - "dependencies"
     versioning-strategy: "lockfile-only"
     groups:
-      dev-dependencies:
+      dependencies:
         applies-to: "version-updates"
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,23 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "cargo"
+    target-branch: "main"
+    commit-message:
+      prefix: "bump(cargo): (MAJOR)"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "automated"
+      - "dependencies"
+      - "dependencies/major"
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      dependencies:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
It is likely that many of the generated PRs will need to be rejected and redone done by hand (given that they are breaking by definition).

That said, this functions as an automatic detection mechanism for dependencies which do a major version bump.
We have no special reason to sleep on those changes; they aren't going to get any easier if we keep developing against deprecated or removed APIs.