### PR TITLE
CI: Fix "just build-sweep" step

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -149,8 +149,12 @@ jobs:
 
       - id: "build_each_commit"
         name: "build each commit"
+        if: "${{ github.event.pull_request || github.event.merge_group }}"
         run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust="${{matrix.rust.version}}" build-sweep
+          BASE="${{ github.event.pull_request.base.sha || github.event.merge_group.base.sha }}"
+          just debug_justfile="${{matrix.debug_justfile}}" rust="${{matrix.rust.version}}" \
+            build-sweep ${BASE}
+          printf "::notice::HEAD back to %s\n" "$(git log --oneline --no-decorate -n 1)"
         continue-on-error: ${{ matrix.rust.optional }}
 
       - name: "Note failure of optional steps"

--- a/justfile
+++ b/justfile
@@ -399,6 +399,6 @@ build-sweep start="main":
     fi
     # Get all commits since {{ start }}, in chronological order
     while read -r commit; do
-      git checkout "${commit}" || exit 1
+      git -c advice.detachedHead=false checkout "${commit}" || exit 1
       { just debug_justfile={{ debug_justfile }} cargo +{{ rust }} build --locked --profile=dev --target=x86_64-unknown-linux-gnu; } || exit 1
     done < <(git rev-list --reverse "{{ start }}".."$(git rev-parse HEAD)")

--- a/justfile
+++ b/justfile
@@ -393,6 +393,7 @@ mdbook *args="build":
 [script]
 build-sweep start="main":
     {{ _just_debuggable_ }}
+    set -euo pipefail
     if [ {{ _clean }} != "clean" ]; then
       >&2 echo "can not build-sweep with dirty branch (would risk data loss)"
       exit 1


### PR DESCRIPTION
- **build: Dismiss warning on detached HEAD check-out in "just build-sweep"**
- **build: Exit on error (-o pipefail) for "just build-sweep"**
- **ci: Fix "just build-sweep" step in dev workflow**
