### PR TITLE
Clean up Rust Nightly warnings

### DIFF
--- a/.github/workflows/lint-commitlint.yml
+++ b/.github/workflows/lint-commitlint.yml
@@ -14,10 +14,28 @@ jobs:
   commitlint:
     runs-on: "ubuntu-latest"
     steps:
+
       - name: "Checkout"
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
           persist-credentials: "false"
+
+      # Acceptable commit subject types are:
+      #
+      # - build
+      # - bump
+      # - chore
+      # - ci
+      # - docs
+      # - feat
+      # - fix
+      # - perf
+      # - refactor
+      # - revert
+      # - style
+      # - test
+      #
+      # See https://github.com/opensource-nepal/commitlint/blob/main/src/commitlint/constants.py
       - name: "Run commitlint on Pull Request's commits"
         uses: "opensource-nepal/commitlint@v1"

--- a/dpdk/src/queue/rx.rs
+++ b/dpdk/src/queue/rx.rs
@@ -30,7 +30,6 @@ impl RxQueueIndex {
 }
 
 impl From<RxQueueIndex> for u16 {
-    #[must_use]
     fn from(value: RxQueueIndex) -> u16 {
         value.as_u16()
     }

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -30,14 +30,12 @@ impl From<Mac> for [u8; 6] {
 }
 
 impl AsRef<[u8; 6]> for Mac {
-    #[must_use]
     fn as_ref(&self) -> &[u8; 6] {
         &self.0
     }
 }
 
 impl AsMut<[u8; 6]> for Mac {
-    #[must_use]
     fn as_mut(&mut self) -> &mut [u8; 6] {
         &mut self.0
     }

--- a/net/src/vxlan/vni.rs
+++ b/net/src/vxlan/vni.rs
@@ -74,7 +74,6 @@ impl Vni {
 }
 
 impl AsRef<NonZero<u32>> for Vni {
-    #[must_use]
     fn as_ref(&self) -> &NonZero<u32> {
         &self.0
     }


### PR DESCRIPTION
- **ci: List acceptable commit types in commitlint's workflow file**
- **chore: Suppress Nightly's warnings on #[must_use]**

First commit is not related - just a comment addition in the commitlint workflow file.
