### PR TITLE
ci: Disable "cargo clippy" with Nightly toolchain in dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -142,6 +142,9 @@ jobs:
         continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "clippy"
+        # Disable on nightly because cargo clippy is broken there,
+        # see https://github.com/githedgehog/dataplane/issues/309
+        if: "${{ matrix.rust.version != 'nightly' }}"
         name: "run clippy"
         run: |
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} cargo clippy
@@ -159,7 +162,7 @@ jobs:
 
       - name: "Note failure of optional steps"
         uses: "actions/github-script@v7"
-        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
+        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || (steps.clippy.outcome != 'success' && steps.clippy.outcome != 'skipped')) }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |


### PR DESCRIPTION
The step fails, presumably because of a compiler bug. As a result, all new Pull Requests get messages telling that the workflow has failed. This brings no useful info. If the step is broken for Nightly, let's as well disable it for now.

Link: https://github.com/githedgehog/dataplane/issues/309
