### PR TITLE
Make `DynNetworkFunction` derive `Any`

### DIFF
--- a/dataplane/src/pipeline/dyn_nf.rs
+++ b/dataplane/src/pipeline/dyn_nf.rs
@@ -3,6 +3,7 @@
 
 use dyn_iter::{DynIter, IntoDynIterator};
 use net::buffer::PacketBufferMut;
+use std::any::Any;
 use std::marker::PhantomData;
 
 use crate::packet::Packet;
@@ -17,7 +18,7 @@ use crate::pipeline::NetworkFunction;
 ///
 /// [`nf_dyn`]
 /// [`crate::pipeline::DynPipeline`]
-pub trait DynNetworkFunction<Buf: PacketBufferMut> {
+pub trait DynNetworkFunction<Buf: PacketBufferMut>: Any {
     /// The `process_dyn` method takes an iterator of [`crate::packet::Packet`] objects,
     /// However, unlike [`NetworkFunction::process`], this method does not require concrete
     /// iterator types.
@@ -30,7 +31,7 @@ pub trait DynNetworkFunction<Buf: PacketBufferMut> {
     fn process_dyn<'a>(&'a mut self, input: DynIter<'a, Packet<Buf>>) -> DynIter<'a, Packet<Buf>>;
 }
 
-struct DynNetworkFunctionImpl<Buf: PacketBufferMut, NF: NetworkFunction<Buf>> {
+struct DynNetworkFunctionImpl<Buf: PacketBufferMut, NF: NetworkFunction<Buf> + 'static> {
     nf: NF,
     _marker: PhantomData<Buf>,
 }

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -12,8 +12,8 @@ use core::fmt::Debug;
 pub use test_buffer::*;
 
 /// Super trait representing the abstract operations which may be performed on a packet buffer.
-pub trait PacketBuffer: AsRef<[u8]> + Headroom {}
-impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom {}
+pub trait PacketBuffer: AsRef<[u8]> + Headroom + 'static {}
+impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom + 'static {}
 
 /// Super trait representing the abstract operations which may be performed on mutable a packet buffer.
 pub trait PacketBufferMut: PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart {}


### PR DESCRIPTION
Make it so that `DynNetworkFunction` implements `Any`.  The only constraint is that `DynNetworkFunction` has to be bound by `'static` and for that to happen, `PacketBufferMut` should be `'static`.  

The one change here is that any `NetworkFunction` that is to be put into a `DynPipeline` also has to be bound by `'static`.  That was the case anyway in the public API, but it is now true internally as well.

This PR is a precursor for some methods on `DynPipeline` that will allow pipeline stage lookup and downcast back to a concrete pipeline stage, though we need to do some other things for that to work, in particular, move to Rust 1.86 beta until April when 1.86 should be released.

Non-`'static` `NetworkFunction`s can still be statically chained.