### PR TITLE
fix: use `produce` instead of `r#gen`

### DIFF
--- a/net/src/eth/ethtype.rs
+++ b/net/src/eth/ethtype.rs
@@ -61,7 +61,7 @@ mod contract {
 
     impl TypeGenerator for EthType {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            Some(EthType::new(u.r#gen()?))
+            Some(EthType::new(u.produce()?))
         }
     }
 

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -236,7 +236,7 @@ mod contract {
 
     impl TypeGenerator for SourceMac {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            let mut mac: Mac = u.r#gen()?;
+            let mut mac: Mac = u.produce()?;
             mac.0[0] &= 0b1111_1110;
             if mac.is_zero() {
                 mac.0[5] = 1;
@@ -247,7 +247,7 @@ mod contract {
 
     impl TypeGenerator for DestinationMac {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            let mut mac: Mac = u.r#gen()?;
+            let mut mac: Mac = u.produce()?;
             if mac.is_zero() {
                 mac.0[5] = 1;
             }

--- a/net/src/eth/mod.rs
+++ b/net/src/eth/mod.rs
@@ -236,8 +236,8 @@ mod contract {
         type Output = Eth;
         /// Generate an [`Eth`] with the [`EthType`] specified in `Self`
         fn generate<D: Driver>(&self, u: &mut D) -> Option<Self::Output> {
-            let source_mac: SourceMac = u.r#gen()?;
-            let destination_mac: DestinationMac = u.r#gen()?;
+            let source_mac: SourceMac = u.produce()?;
+            let destination_mac: DestinationMac = u.produce()?;
             let eth = Eth::new(source_mac, destination_mac, self.0);
             Some(eth)
         }
@@ -246,7 +246,7 @@ mod contract {
     impl TypeGenerator for Eth {
         /// Generate an arbitrary [`Eth`] header
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            GenWithEthType(u.r#gen()?).generate(u)
+            GenWithEthType(u.produce()?).generate(u)
         }
     }
 }

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -1105,8 +1105,8 @@ mod contract {
             // The exception is IPv4/6 extension headers (because those values are large and boxed).
             // As a result, we will need to generate more bytes once we want to start testing more
             // exotic packets.  For now, I will double to be safe.
-            let mut arbitrary_bytes: [u8; 2 * size_of::<Headers>()] = driver.r#gen()?;
-            let arbitrary_eth: Eth = driver.r#gen()?;
+            let mut arbitrary_bytes: [u8; 2 * size_of::<Headers>()] = driver.produce()?;
+            let arbitrary_eth: Eth = driver.produce()?;
             // ensure that the start of the arbitrary bytes for some valid ethernet header.
             arbitrary_eth
                 .deparse(&mut arbitrary_bytes)
@@ -1126,16 +1126,16 @@ mod contract {
         type Output = Headers;
 
         fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-            let common_eth_type: CommonEthType = driver.r#gen()?;
+            let common_eth_type: CommonEthType = driver.produce()?;
             let eth = GenWithEthType(common_eth_type.into()).generate(driver)?;
             match common_eth_type {
                 CommonEthType::Ipv4 => {
-                    let common_next_header: ipv4::CommonNextHeader = driver.r#gen()?;
+                    let common_next_header: ipv4::CommonNextHeader = driver.produce()?;
                     let ipv4 =
                         ipv4::GenWithNextHeader(common_next_header.into()).generate(driver)?;
                     match common_next_header {
                         ipv4::CommonNextHeader::Tcp => {
-                            let tcp: Tcp = driver.r#gen()?;
+                            let tcp: Tcp = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),
@@ -1147,7 +1147,7 @@ mod contract {
                             Some(headers)
                         }
                         ipv4::CommonNextHeader::Udp => {
-                            let udp: Udp = driver.r#gen()?;
+                            let udp: Udp = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),
@@ -1159,7 +1159,7 @@ mod contract {
                             Some(headers)
                         }
                         ipv4::CommonNextHeader::Icmp4 => {
-                            let icmp: Icmp4 = driver.r#gen()?;
+                            let icmp: Icmp4 = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),
@@ -1173,12 +1173,12 @@ mod contract {
                     }
                 }
                 CommonEthType::Ipv6 => {
-                    let common_next_header: ipv6::CommonNextHeader = driver.r#gen()?;
+                    let common_next_header: ipv6::CommonNextHeader = driver.produce()?;
                     let ipv6 =
                         ipv6::GenWithNextHeader(common_next_header.into()).generate(driver)?;
                     match common_next_header {
                         ipv6::CommonNextHeader::Tcp => {
-                            let tcp: Tcp = driver.r#gen()?;
+                            let tcp: Tcp = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),
@@ -1190,7 +1190,7 @@ mod contract {
                             Some(headers)
                         }
                         ipv6::CommonNextHeader::Udp => {
-                            let udp: Udp = driver.r#gen()?;
+                            let udp: Udp = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),
@@ -1202,7 +1202,7 @@ mod contract {
                             Some(headers)
                         }
                         ipv6::CommonNextHeader::Icmp6 => {
-                            let icmp6: Icmp6 = driver.r#gen()?;
+                            let icmp6: Icmp6 = driver.produce()?;
                             let headers = Headers {
                                 eth,
                                 vlan: Default::default(),

--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -84,7 +84,7 @@ mod contract {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
             // TODO: 20 bytes is far too small to properly test the space of `Icmp4`
             // We will need better error handling if we want to bump it up tho.
-            let buffer: [u8; 20] = driver.r#gen()?;
+            let buffer: [u8; 20] = driver.produce()?;
             let icmp4 = match Icmp4::parse(&buffer) {
                 Ok((icmp4, _)) => icmp4,
                 Err(ParseError::Length(l)) => unreachable!("{:?}", l),

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -84,7 +84,7 @@ mod contract {
 
     impl TypeGenerator for Icmp6 {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            let buf: [u8; BYTE_SLICE_SIZE] = driver.r#gen()?;
+            let buf: [u8; BYTE_SLICE_SIZE] = driver.produce()?;
             let header = match Icmp6::parse(&buf) {
                 Ok((h, _)) => h,
                 Err(e) => unreachable!("{e:?}", e = e),

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -61,7 +61,7 @@ mod contract {
 
     impl TypeGenerator for NextHeader {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(NextHeader::new(driver.r#gen()?))
+            Some(NextHeader::new(driver.produce()?))
         }
     }
 }

--- a/net/src/ipv4/addr.rs
+++ b/net/src/ipv4/addr.rs
@@ -44,7 +44,7 @@ mod contract {
 
     impl TypeGenerator for UnicastIpv4Addr {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            let raw = u.r#gen::<[u8; 4]>()?;
+            let raw = u.produce::<[u8; 4]>()?;
             let ip = Ipv4Addr::from(raw);
             if ip.is_multicast() {
                 // multicast addresses start with 0b1110

--- a/net/src/ipv4/dscp.rs
+++ b/net/src/ipv4/dscp.rs
@@ -50,7 +50,7 @@ mod contract {
 
     impl TypeGenerator for Dscp {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            let raw = driver.r#gen::<u8>()? & Dscp::MAX.0.value();
+            let raw = driver.produce::<u8>()? & Dscp::MAX.0.value();
             Some(Dscp(
                 Ipv4Dscp::try_new(raw).unwrap_or_else(|_| unreachable!()),
             ))

--- a/net/src/ipv4/ecn.rs
+++ b/net/src/ipv4/ecn.rs
@@ -38,7 +38,7 @@ mod contract {
 
     impl TypeGenerator for Ecn {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(Ecn::new(driver.r#gen::<u8>()? & 0b0000_0011).unwrap_or_else(|_| unreachable!()))
+            Some(Ecn::new(driver.produce::<u8>()? & 0b0000_0011).unwrap_or_else(|_| unreachable!()))
         }
     }
 }

--- a/net/src/ipv4/frag_offset.rs
+++ b/net/src/ipv4/frag_offset.rs
@@ -50,7 +50,7 @@ mod contract {
     impl TypeGenerator for FragOffset {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
             Some(
-                FragOffset::new(driver.r#gen::<u16>()? & FragOffset::MAX.0.value())
+                FragOffset::new(driver.produce::<u16>()? & FragOffset::MAX.0.value())
                     .unwrap_or_else(|e| unreachable!("{e:?}")),
             )
         }

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -415,8 +415,8 @@ mod contract {
         /// Generates an arbitrary [`Ipv4`] header with the [`NextHeader`] specified in `self`.
         fn generate<D: Driver>(&self, u: &mut D) -> Option<Self::Output> {
             let mut header = Ipv4(Ipv4Header::default());
-            header.set_source(u.r#gen()?);
-            header.set_destination(Ipv4Addr::from(u.r#gen::<u32>()?));
+            header.set_source(u.produce()?);
+            header.set_destination(Ipv4Addr::from(u.produce::<u32>()?));
 
             // safe in so far as the whole point of this method is to generate a header with
             // the specified `NextHeader`.
@@ -425,13 +425,13 @@ mod contract {
                 header.set_next_header(self.0);
             }
             header
-                .set_ttl(u.r#gen()?)
-                .set_dscp(u.r#gen()?)
-                .set_ecn(u.r#gen()?)
-                .set_dont_fragment(u.r#gen()?)
-                .set_more_fragments(u.r#gen()?)
-                .set_identification(u.r#gen()?)
-                .set_fragment_offset(u.r#gen()?);
+                .set_ttl(u.produce()?)
+                .set_dscp(u.produce()?)
+                .set_ecn(u.produce()?)
+                .set_dont_fragment(u.produce()?)
+                .set_more_fragments(u.produce()?)
+                .set_identification(u.produce()?)
+                .set_fragment_offset(u.produce()?);
             Some(header)
         }
     }
@@ -448,7 +448,7 @@ mod contract {
         ///
         /// Unfortunately, the current implementation does not cover [`Ipv4::options`].
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            GenWithNextHeader(u.r#gen()?).generate(u)
+            GenWithNextHeader(u.produce()?).generate(u)
         }
     }
 }

--- a/net/src/ipv6/addr.rs
+++ b/net/src/ipv6/addr.rs
@@ -44,7 +44,7 @@ mod contract {
 
     impl TypeGenerator for UnicastIpv6Addr {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            let ip = Ipv6Addr::from(driver.r#gen::<u128>()?);
+            let ip = Ipv6Addr::from(driver.produce::<u128>()?);
             // multicast ipv6 addresses begin with 0xFF
             // map back to unicast space if we hit a multicast address
             if ip.is_multicast() {

--- a/net/src/ipv6/flow_label.rs
+++ b/net/src/ipv6/flow_label.rs
@@ -76,7 +76,7 @@ mod contract {
     impl TypeGenerator for FlowLabel {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
             Some(
-                FlowLabel::new(driver.r#gen::<u32>()? & FlowLabel::MAX.0.value())
+                FlowLabel::new(driver.produce::<u32>()? & FlowLabel::MAX.0.value())
                     .unwrap_or_else(|_| unreachable!()),
             )
         }

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -472,12 +472,12 @@ mod contract {
         fn generate<D: Driver>(&self, u: &mut D) -> Option<Ipv6> {
             let mut header = Ipv6(Ipv6Header::default());
             header
-                .set_source(u.r#gen()?)
-                .set_destination(Ipv6Addr::from(u.r#gen::<u128>()?))
+                .set_source(u.produce()?)
+                .set_destination(Ipv6Addr::from(u.produce::<u128>()?))
                 .set_next_header(self.0)
-                .set_flow_label(u.r#gen()?)
-                .set_traffic_class(u.r#gen()?)
-                .set_hop_limit(u.r#gen()?);
+                .set_flow_label(u.produce()?)
+                .set_traffic_class(u.produce()?)
+                .set_hop_limit(u.produce()?);
             Some(header)
         }
     }
@@ -485,7 +485,7 @@ mod contract {
     impl TypeGenerator for Ipv6 {
         /// Generate a completely arbitrary [`Ipv6`] header.
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            GenWithNextHeader(u.r#gen()?).generate(u)
+            GenWithNextHeader(u.produce()?).generate(u)
         }
     }
 }

--- a/net/src/tcp/mod.rs
+++ b/net/src/tcp/mod.rs
@@ -375,21 +375,21 @@ mod contract {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
             let mut header = Tcp(TcpHeader::default());
             header
-                .set_source(u.r#gen()?)
-                .set_destination(u.r#gen()?)
-                .set_checksum(u.r#gen()?)
-                .set_sequence_number(u.r#gen()?)
-                .set_ack(u.r#gen()?)
-                .set_ack_number(u.r#gen()?)
-                .set_cwr(u.r#gen()?)
-                .set_ece(u.r#gen()?)
-                .set_fin(u.r#gen()?)
-                .set_psh(u.r#gen()?)
-                .set_rst(u.r#gen()?)
-                .set_syn(u.r#gen()?)
-                .set_urg(u.r#gen()?)
-                .set_window_size(u.r#gen()?)
-                .set_urgent_pointer(u.r#gen()?);
+                .set_source(u.produce()?)
+                .set_destination(u.produce()?)
+                .set_checksum(u.produce()?)
+                .set_sequence_number(u.produce()?)
+                .set_ack(u.produce()?)
+                .set_ack_number(u.produce()?)
+                .set_cwr(u.produce()?)
+                .set_ece(u.produce()?)
+                .set_fin(u.produce()?)
+                .set_psh(u.produce()?)
+                .set_rst(u.produce()?)
+                .set_syn(u.produce()?)
+                .set_urg(u.produce()?)
+                .set_window_size(u.produce()?)
+                .set_urgent_pointer(u.produce()?);
             Some(header)
         }
     }

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -203,10 +203,10 @@ mod contract {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
             const MIN_LENGTH: u16 = Udp::MIN_LENGTH.get();
             let mut header = Udp(UdpHeader::default());
-            header.set_source(u.r#gen()?);
-            header.set_destination(u.r#gen()?);
-            header.set_checksum(u.r#gen()?);
-            let length = u.r#gen::<u16>()?;
+            header.set_source(u.produce()?);
+            header.set_destination(u.produce()?);
+            header.set_checksum(u.produce()?);
+            let length = u.produce::<u16>()?;
             match length {
                 #[allow(unsafe_code)] // trivially safe const-eval
                 0..MIN_LENGTH => unsafe {

--- a/net/src/vlan/mod.rs
+++ b/net/src/vlan/mod.rs
@@ -351,7 +351,7 @@ mod contract {
 
     impl TypeGenerator for Vid {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            let raw = u.r#gen::<u16>()? & Vid::MAX.0.get();
+            let raw = u.produce::<u16>()? & Vid::MAX.0.get();
             match Vid::new(raw) {
                 Ok(vid) => Some(vid),
                 Err(InvalidVid::Zero) => Some(Vid::MIN),
@@ -363,7 +363,7 @@ mod contract {
 
     impl TypeGenerator for Pcp {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            match Pcp::new(driver.r#gen::<u8>()? & Pcp::MAX.0) {
+            match Pcp::new(driver.produce::<u8>()? & Pcp::MAX.0) {
                 Ok(pcp) => Some(pcp),
                 Err(InvalidPcp(_)) => unreachable!(),
             }
@@ -378,9 +378,9 @@ mod contract {
 
         fn generate<D: Driver>(&self, u: &mut D) -> Option<Self::Output> {
             let ethertype = self.0;
-            let vid = u.r#gen()?;
-            let pcp = u.r#gen()?;
-            let dei = u.r#gen()?;
+            let vid = u.produce()?;
+            let pcp = u.produce()?;
+            let dei = u.produce()?;
             Some(Vlan::new(vid, ethertype, pcp, dei))
         }
     }
@@ -401,7 +401,7 @@ mod contract {
         type Output = Vlan;
         /// Generate a [`Vlan`] header with a [`CommonEthType`]
         fn generate<D: Driver>(&self, driver: &mut D) -> Option<Vlan> {
-            GenWithEthType(driver.r#gen::<CommonEthType>()?.into()).generate(driver)
+            GenWithEthType(driver.produce::<CommonEthType>()?.into()).generate(driver)
         }
     }
 }

--- a/net/src/vxlan/vni.rs
+++ b/net/src/vxlan/vni.rs
@@ -114,7 +114,7 @@ mod contract {
 
     impl TypeGenerator for Vni {
         fn generate<D: Driver>(u: &mut D) -> Option<Self> {
-            let raw: u32 = u.r#gen::<u32>()? & Vni::MAX;
+            let raw: u32 = u.produce::<u32>()? & Vni::MAX;
             if raw == 0 {
                 Some(Vni::new_checked(1).unwrap_or_else(|e| unreachable!("{e:?}")))
             } else {


### PR DESCRIPTION
We can switch to a better method name now that https://github.com/camshaft/bolero/pull/270 is merged and bolero 0.13 is available.