### PR TITLE
Sample pipeline

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -7,6 +7,7 @@ mod args;
 mod nat;
 mod packet;
 mod packet_meta;
+mod packet_processor;
 mod pipeline;
 
 use dpdk::dev::{Dev, TxOffloadConfig};

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -6,6 +6,7 @@
 mod args;
 mod nat;
 mod packet;
+mod packet_meta;
 mod pipeline;
 
 use dpdk::dev::{Dev, TxOffloadConfig};

--- a/dataplane/src/packet.rs
+++ b/dataplane/src/packet.rs
@@ -8,6 +8,7 @@ use net::headers::{AbstractHeaders, AbstractHeadersMut, Headers, TryHeaders, Try
 use net::parse::{DeParse, DeParseError, Parse, ParseError};
 use std::cmp::Ordering;
 use std::num::NonZero;
+use tracing::error;
 
 #[derive(Debug)]
 pub struct Packet<Buf: PacketBufferMut> {
@@ -145,5 +146,15 @@ impl<Buf: PacketBufferMut> TryHeaders for Packet<Buf> {
 impl<Buf: PacketBufferMut> TryHeadersMut for Packet<Buf> {
     fn headers_mut(&mut self) -> &mut impl AbstractHeadersMut {
         &mut self.headers
+    }
+}
+
+impl<Buf: PacketBufferMut> Drop for Packet<Buf> {
+    fn drop(&mut self) {
+        if self.meta.drop.is_none() {
+            error!("Dropped packet without specifying reason")
+            // This should be a panic!(). Leaving it as just a log
+            // until related features adopt this, if adopted.
+        }
     }
 }

--- a/dataplane/src/packet_meta.rs
+++ b/dataplane/src/packet_meta.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use routing::vrf::VrfId;
+
+#[derive(Debug, Default)]
+pub struct InterfaceId(u32);
+#[allow(unused)]
+impl InterfaceId {
+    pub fn get_id(&self) -> u32 {
+        self.0
+    }
+    pub fn set_id(&mut self, id: u32) {
+        self.0 = id;
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct BridgeDomain(u32);
+#[allow(unused)]
+impl BridgeDomain {
+    pub fn get_id(&self) -> u32 {
+        self.0
+    }
+    pub fn with_id(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug)]
+pub enum DropReason {
+    InternalFailure,      /* catch-all for internal issues */
+    NotEthernet,          /* could not get eth header */
+    NotIp,                /* could not get IP header - maybe it's not ip */
+    MacNotForUs,          /* frame is not broadcast nor for us */
+    InterfaceDetached,    /* interface has not been attached to any VRF */
+    InterfaceAdmDown,     /* interface is admin down */
+    InterfaceOperDown,    /* interface is oper down : no link */
+    InterfaceUnknown,     /* the interface cannot be found */
+    InterfaceUnsupported, /* the operation is not supported on the interface */
+    VrfUnknown,           /* the vrf does not exist */
+    NatOutOfResources,    /* can't do NAT due to lack of resources */
+    RouteFailure,         /* missing routing information */
+}
+
+#[allow(unused)]
+#[derive(Debug, Default)]
+pub struct PacketMeta {
+    pub iif: InterfaceId,             /* incoming interface - set early */
+    pub oif: InterfaceId,             /* outgoing interface - set late */
+    pub is_l2bcast: bool,             /* frame is broadcast */
+    pub is_iplocal: bool,             /* frame contains an ip packet for local delivery */
+    pub vrf: Option<VrfId>,           /* for IP packet, the VRF to use to route it */
+    pub bridge: Option<BridgeDomain>, /* the bridge domain to forward the packet to */
+    pub drop: Option<DropReason>,     /* if Some, the reason why a packet was purposedly dropped.
+                                      This includes the delivery of the packet by the NF */
+
+    //#[cfg(test)]
+    pub descr: &'static str, /* packet annotation (we may enable for testing only) */
+}

--- a/dataplane/src/packet_meta.rs
+++ b/dataplane/src/packet_meta.rs
@@ -29,7 +29,7 @@ impl BridgeDomain {
 }
 
 #[allow(unused)]
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DropReason {
     InternalFailure,      /* catch-all for internal issues */
     NotEthernet,          /* could not get eth header */
@@ -43,6 +43,11 @@ pub enum DropReason {
     VrfUnknown,           /* the vrf does not exist */
     NatOutOfResources,    /* can't do NAT due to lack of resources */
     RouteFailure,         /* missing routing information */
+    RouteDrop,            /* routing explicitly requests pkts to be dropped */
+    HopLimitExceeded,     /* TTL / Hop count was exceeded */
+    Filtered,             /* The packet was administratively filtered */
+    Unhandled,            /* there exists no support to handle this type of packet */
+    Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
 }
 
 #[allow(unused)]
@@ -57,8 +62,11 @@ pub struct PacketMeta {
     pub drop: Option<DropReason>,     /* if Some, the reason why a packet was purposedly dropped.
                                       This includes the delivery of the packet by the NF */
 
-    //#[cfg(test)]
+    #[cfg(test)]
     pub descr: &'static str, /* packet annotation (we may enable for testing only) */
+    #[cfg(test)]
+    /* Keep the Packet in spite of calling packet.fate(). This is for testing */
+    pub keep: bool,
 }
 
 #[derive(Default, Debug)]

--- a/dataplane/src/packet_meta.rs
+++ b/dataplane/src/packet_meta.rs
@@ -8,11 +8,11 @@ use std::collections::HashMap;
 pub struct InterfaceId(u32);
 #[allow(unused)]
 impl InterfaceId {
+    pub fn new(val: u32) -> Self {
+        Self(val)
+    }
     pub fn get_id(&self) -> u32 {
         self.0
-    }
-    pub fn set_id(&mut self, id: u32) {
-        self.0 = id;
     }
 }
 
@@ -54,7 +54,7 @@ pub enum DropReason {
 #[derive(Debug, Default)]
 pub struct PacketMeta {
     pub iif: InterfaceId,             /* incoming interface - set early */
-    pub oif: InterfaceId,             /* outgoing interface - set late */
+    pub oif: Option<InterfaceId>,     /* outgoing interface - set late */
     pub is_l2bcast: bool,             /* frame is broadcast */
     pub is_iplocal: bool,             /* frame contains an ip packet for local delivery */
     pub vrf: Option<VrfId>,           /* for IP packet, the VRF to use to route it */

--- a/dataplane/src/packet_meta.rs
+++ b/dataplane/src/packet_meta.rs
@@ -53,14 +53,14 @@ pub enum DropReason {
 #[allow(unused)]
 #[derive(Debug, Default)]
 pub struct PacketMeta {
-    pub iif: InterfaceId,             /* incoming interface - set early */
-    pub oif: Option<InterfaceId>,     /* outgoing interface - set late */
-    pub is_l2bcast: bool,             /* frame is broadcast */
-    pub is_iplocal: bool,             /* frame contains an ip packet for local delivery */
-    pub vrf: Option<VrfId>,           /* for IP packet, the VRF to use to route it */
-    pub bridge: Option<BridgeDomain>, /* the bridge domain to forward the packet to */
-    pub drop: Option<DropReason>,     /* if Some, the reason why a packet was purposedly dropped.
-                                      This includes the delivery of the packet by the NF */
+    pub(crate) iif: InterfaceId,         /* incoming interface - set early */
+    pub(crate) oif: Option<InterfaceId>, /* outgoing interface - set late */
+    pub(crate) is_l2bcast: bool,         /* frame is broadcast */
+    pub(crate) is_iplocal: bool,         /* frame contains an ip packet for local delivery */
+    pub(crate) vrf: Option<VrfId>,       /* for IP packet, the VRF to use to route it */
+    pub(crate) bridge: Option<BridgeDomain>, /* the bridge domain to forward the packet to */
+    pub(crate) drop: Option<DropReason>, /* if Some, the reason why a packet was purposedly dropped.
+                                         This includes the delivery of the packet by the NF */
 
     #[cfg(test)]
     pub descr: &'static str, /* packet annotation (we may enable for testing only) */

--- a/dataplane/src/packet_processor/egress.rs
+++ b/dataplane/src/packet_processor/egress.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+//
+//! Implements an egress stage
+
+use crate::NetworkFunction;
+use crate::packet::Packet;
+use crate::packet_meta::DropReason;
+use routing::interface::{IfState, IfTable, IfType, Interface};
+
+use net::buffer::PacketBufferMut;
+use net::eth::mac::SourceMac;
+use net::headers::TryEthMut;
+
+use std::sync::Arc;
+use std::sync::RwLock;
+use tracing::{trace, warn};
+
+#[allow(unused)]
+pub struct Egress {
+    name: String,
+    iftable: Arc<RwLock<IfTable>>,
+}
+
+#[allow(dead_code)]
+impl Egress {
+    pub fn new(name: &str, iftable: &Arc<RwLock<IfTable>>) -> Self {
+        Self {
+            name: name.to_owned(),
+            iftable: iftable.clone(),
+        }
+    }
+}
+
+#[inline]
+fn interface_egress_ethernet<Buf: PacketBufferMut>(
+    interface: &Interface,
+    packet: &mut Packet<Buf>,
+) {
+    if let Some(our_mac) = interface.get_mac() {
+        if let Some(eth) = packet.try_eth_mut() {
+            eth.set_source(SourceMac::new(*our_mac).expect("Bad interface mac")); // fixme: interface should store Source mac?
+
+            /* serialize and send */
+            packet.pkt_drop(DropReason::Delivered);
+        } else {
+            // this should never happen at this stage
+            packet.pkt_drop(DropReason::NotEthernet);
+        }
+    } else {
+        unreachable!()
+    }
+}
+
+#[inline]
+fn interface_egress<Buf: PacketBufferMut>(interface: &Interface, packet: &mut Packet<Buf>) {
+    if interface.admin_state == IfState::Down {
+        packet.pkt_drop(DropReason::InterfaceAdmDown);
+    } else if interface.oper_state == IfState::Down {
+        packet.pkt_drop(DropReason::InterfaceOperDown);
+    } else {
+        match interface.iftype {
+            IfType::Ethernet(_) | IfType::Dot1q(_) => interface_egress_ethernet(interface, packet),
+            _ => packet.pkt_drop(DropReason::InterfaceUnsupported),
+        }
+    }
+}
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Egress {
+    fn nf_name(&self) -> &str {
+        &self.name
+    }
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        trace!(
+            "Stage '{}'...",
+            <Self as NetworkFunction<Buf>>::nf_name(self)
+        );
+        input.filter_map(|mut packet| {
+            if !packet.dropped() {
+                if let Some(oif) = &packet.meta.oif {
+                    if packet.meta.vrf.is_some() {
+                        packet.pkt_drop(DropReason::RouteFailure);
+                    } else if let Ok(iftable) = self.iftable.read() {
+                        if let Some(interface) = iftable.get_interface(oif.get_id()) {
+                            interface_egress(interface, &mut packet);
+                        } else {
+                            warn!("Unknown interface with id {}", oif.get_id());
+                            packet.pkt_drop(DropReason::InterfaceUnknown);
+                        }
+                    } else {
+                        panic!("poisoned");
+                    }
+                }
+            }
+            packet.fate()
+        })
+    }
+}

--- a/dataplane/src/packet_processor/ingress.rs
+++ b/dataplane/src/packet_processor/ingress.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+//
+//! Implements an ingress stage
+
+use crate::NetworkFunction;
+use crate::packet::Packet;
+use crate::packet_meta::DropReason;
+use routing::interface::{IfState, IfTable, IfType, Interface};
+
+use net::buffer::PacketBufferMut;
+use net::eth::mac::Mac;
+use net::headers::{TryEth, TryIpv4, TryIpv6};
+
+use std::sync::Arc;
+use std::sync::RwLock;
+use tracing::{error, trace, warn};
+
+pub struct Ingress {
+    name: String,
+    iftable: Arc<RwLock<IfTable>>,
+}
+
+#[allow(dead_code)]
+impl Ingress {
+    pub fn new(name: &str, iftable: &Arc<RwLock<IfTable>>) -> Self {
+        Self {
+            name: name.to_owned(),
+            iftable: iftable.clone(),
+        }
+    }
+}
+
+#[inline]
+fn interface_ingress_eth_bcast<Buf: PacketBufferMut>(
+    _interface: &Interface,
+    packet: &mut Packet<Buf>,
+) {
+    packet.meta.is_l2bcast = true;
+    packet.pkt_drop(DropReason::Unhandled);
+    warn!("Processing broadcast of ethernet frames is not supported");
+}
+
+#[inline]
+fn interface_ingress_eth_ucast_local<Buf: PacketBufferMut>(
+    interface: &Interface,
+    packet: &mut Packet<Buf>,
+) {
+    if packet.try_ipv4().is_some() || packet.try_ipv6().is_some() {
+        if let Some(vrf) = &interface.vrf {
+            if let Ok(vrf) = vrf.read() {
+                packet.meta.vrf = Some(vrf.vrfid);
+            } else {
+                error!("Failure reading vrf for interface {}", interface.name);
+                packet.pkt_drop(DropReason::InternalFailure);
+            }
+        } else {
+            warn!("Interface {} is detached", interface.name);
+            packet.pkt_drop(DropReason::InterfaceDetached);
+        }
+    } else {
+        warn!("Processing of non-ip traffic is not supported");
+        packet.pkt_drop(DropReason::NotIp);
+    }
+}
+
+#[inline]
+fn interface_ingress_eth_non_local<Buf: PacketBufferMut>(
+    _interface: &Interface,
+    dst_mac: Mac,
+    packet: &mut Packet<Buf>,
+) {
+    /* Here we would check if the interface is part of some
+    bridge domain. But we don't support bridging yet. */
+    warn!("Recvd frame for mac={}. Bridging is not supported", dst_mac);
+    packet.pkt_drop(DropReason::MacNotForUs);
+}
+
+#[inline]
+fn interface_ingress_eth<Buf: PacketBufferMut>(interface: &Interface, packet: &mut Packet<Buf>) {
+    if let Some(if_mac) = interface.get_mac() {
+        match packet.try_eth() {
+            None => packet.pkt_drop(DropReason::NotEthernet),
+            Some(eth) => {
+                let dmac = eth.destination().inner();
+                if dmac.is_broadcast() {
+                    interface_ingress_eth_bcast(interface, packet);
+                } else if dmac == *if_mac {
+                    interface_ingress_eth_ucast_local(interface, packet);
+                } else {
+                    interface_ingress_eth_non_local(interface, dmac, packet);
+                }
+            }
+        }
+    } else {
+        unreachable!();
+    }
+}
+
+#[inline]
+fn interface_ingress<Buf: PacketBufferMut>(interface: &Interface, packet: &mut Packet<Buf>) {
+    if !packet.dropped() {
+        if interface.admin_state == IfState::Down {
+            packet.pkt_drop(DropReason::InterfaceAdmDown);
+        } else if interface.oper_state == IfState::Down {
+            packet.pkt_drop(DropReason::InterfaceOperDown);
+        } else {
+            match interface.iftype {
+                IfType::Ethernet(_) | IfType::Dot1q(_) => interface_ingress_eth(interface, packet),
+                _ => {
+                    packet.pkt_drop(DropReason::InterfaceUnsupported);
+                }
+            }
+        }
+    }
+}
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Ingress {
+    fn nf_name(&self) -> &str {
+        &self.name
+    }
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        trace!(
+            "Stage '{}'....",
+            <Self as NetworkFunction<Buf>>::nf_name(self)
+        );
+        // It is assumed that packets have a non-zero iif annotated in their metadata,
+        // early set by dpdk workers, indicating the device they came from.
+        // FIXME: I'm assuming that the id is the Ifindex of the interface here.
+        // We'll be assuming the same for egress.
+        input.filter_map(|mut packet| {
+            if !packet.dropped() {
+                if let Ok(iftable) = self.iftable.read() {
+                    if let Some(interface) = iftable.get_interface(packet.meta.iif.get_id()) {
+                        interface_ingress(interface, &mut packet);
+                    } else {
+                        packet.pkt_drop(DropReason::InterfaceUnknown);
+                    }
+                } else {
+                    panic!("Poisoned");
+                }
+            }
+            packet.fate()
+        })
+    }
+}

--- a/dataplane/src/packet_processor/ipforward.rs
+++ b/dataplane/src/packet_processor/ipforward.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+//
+//! Implements an Ip forwarding stage
+
+use net::buffer::PacketBufferMut;
+use net::headers::{TryIpv4, TryIpv4Mut, TryIpv6, TryIpv6Mut};
+use routing::vrf::VrfId;
+use std::net::IpAddr;
+
+use crate::NetworkFunction;
+use crate::packet::Packet;
+use crate::packet_meta::{DropReason, InterfaceId};
+use tracing::{trace, warn};
+
+use std::str::FromStr;
+
+pub struct IpForwarder {
+    name: String,
+}
+
+#[allow(dead_code)]
+impl IpForwarder {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+        }
+    }
+}
+
+#[inline]
+fn get_packet_ipv4_destination<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Option<IpAddr> {
+    packet
+        .try_ipv4()
+        .map(|ipv4| IpAddr::from(ipv4.destination()))
+}
+#[inline]
+fn get_packet_ipv6_destination<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Option<IpAddr> {
+    packet
+        .try_ipv6()
+        .map(|ipv6| IpAddr::from(ipv6.destination()))
+}
+#[inline]
+fn get_packet_destination<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> IpAddr {
+    get_packet_ipv4_destination(packet).map_or_else(
+        || get_packet_ipv6_destination(packet).expect("Not ip"),
+        |a| a,
+    )
+}
+#[inline]
+fn decrement_ttl<Buf: PacketBufferMut>(packet: &mut Packet<Buf>, dst_address: IpAddr) {
+    match dst_address {
+        IpAddr::V4(_) => {
+            if let Some(ipv4) = packet.try_ipv4_mut() {
+                if ipv4.decrement_ttl().is_err() || ipv4.ttl() == 0 {
+                    packet.pkt_drop(DropReason::HopLimitExceeded);
+                }
+            } else {
+                unreachable!()
+            }
+        }
+        IpAddr::V6(_) => {
+            if let Some(ipv6) = packet.try_ipv6_mut() {
+                if ipv6.decrement_hop_limit().is_err() || ipv6.hop_limit() == 0 {
+                    packet.pkt_drop(DropReason::HopLimitExceeded);
+                }
+            } else {
+                unreachable!()
+            }
+        }
+    }
+}
+
+fn route_packet<Buf: PacketBufferMut>(
+    _router: &IpForwarder,
+    vrfid: VrfId,
+    packet: &mut Packet<Buf>,
+) {
+    let dst_address = get_packet_destination(packet);
+    decrement_ttl(packet, dst_address);
+    trace!("Forwarding packet to {} with vrf {}", dst_address, vrfid);
+
+    /* Warning
+      The following is just hardcoded for test purposes
+    */
+
+    if vrfid == 0 {
+        let for_us = IpAddr::from_str("10.0.0.2").expect("Bad address");
+        let routable = IpAddr::from_str("11.0.0.4").expect("Bad address");
+        let drop = IpAddr::from_str("8.8.8.8").expect("Bad address");
+
+        if dst_address == for_us {
+            packet.meta.is_iplocal = true;
+            packet.meta.vrf = Some(1);
+        } else if dst_address == routable {
+            packet.meta.oif = Some(InterfaceId::new(2));
+        } else if dst_address == drop {
+            packet.pkt_drop(DropReason::RouteDrop);
+        }
+    } else if vrfid == 1 {
+        packet.meta.oif = Some(InterfaceId::new(2));
+    } else {
+        warn!("Unknown vrf id {}", vrfid);
+    }
+
+    if !packet.meta.is_iplocal && packet.meta.oif.is_none() {
+        packet.pkt_drop(DropReason::RouteFailure);
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for IpForwarder {
+    fn nf_name(&self) -> &str {
+        &self.name
+    }
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        trace!(
+            "Stage '{}'...",
+            <Self as NetworkFunction<Buf>>::nf_name(self)
+        );
+        input.filter_map(|mut packet| {
+            if !packet.dropped() {
+                if let Some(vrfid) = packet.meta.vrf {
+                    route_packet(self, vrfid, &mut packet);
+                } else {
+                    warn!("packet without vrf metadata");
+                }
+            }
+            packet.fate()
+        })
+    }
+}

--- a/dataplane/src/packet_processor/ipstaticfilter.rs
+++ b/dataplane/src/packet_processor/ipstaticfilter.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+//
+//! Implements an Ip filtering stage
+
+use crate::NetworkFunction;
+use crate::packet::Packet;
+use crate::packet_meta::DropReason;
+use net::buffer::PacketBufferMut;
+use net::headers::TryIcmp;
+use tracing::trace;
+
+struct IpFilterRules {/* TODO */}
+impl IpFilterRules {
+    pub fn new() -> Self {
+        Self{
+            /* TODO */
+        }
+    }
+}
+
+#[allow(unused)]
+pub struct IpFilter {
+    name: String,
+    rules: IpFilterRules,
+}
+
+#[allow(dead_code)]
+impl IpFilter {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            rules: IpFilterRules::new(),
+        }
+    }
+}
+
+fn filter_packet<Buf: PacketBufferMut>(_ipfilter: &IpFilter, packet: &mut Packet<Buf>) {
+    /* WARNING: this is just a PoC:
+       Hardcoded rule to deny all Ipv4 ICMP traffic.
+       In a real implementation, here, we'd use the rules (IpFilterRules)
+       to determine if a packet is to pass or not.
+    */
+    if packet.try_icmp().is_some() {
+        trace!("Denied ICMP packet");
+        packet.pkt_drop(DropReason::Filtered);
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for IpFilter {
+    fn nf_name(&self) -> &str {
+        &self.name
+    }
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        trace!(
+            "Stage '{}'...",
+            <Self as NetworkFunction<Buf>>::nf_name(self)
+        );
+        input.filter_map(|mut packet| {
+            if !packet.dropped() {
+                filter_packet(self, &mut packet);
+            }
+            packet.fate()
+        })
+    }
+}

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+mod egress;
+mod ingress;
+mod ipforward;
+mod ipstaticfilter;
+mod stats;
+
+#[cfg(test)]
+mod test {
+    use crate::packet_meta::DropReason;
+    use crate::packet_meta::InterfaceId;
+    use crate::packet_meta::PacketDropStats;
+    use crate::pipeline::{DynPipeline, NetworkFunction};
+    use net::buffer::TestBuffer;
+    use net::eth::mac::Mac;
+    use net::vlan::Vid;
+    use routing::interface::*;
+    use routing::vrf::Vrf;
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use std::sync::RwLock;
+
+    use net::eth::Eth;
+    use net::eth::ethtype::EthType;
+    use net::eth::mac::{DestinationMac, SourceMac};
+    use net::headers::{Headers, Net};
+    use net::ip::NextHeader;
+    use net::ipv4::Ipv4;
+    use net::ipv4::addr::UnicastIpv4Addr;
+    use net::ipv6::Ipv6;
+    use net::ipv6::addr::UnicastIpv6Addr;
+    use net::parse::DeParse;
+    use std::default::Default;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::egress::Egress;
+    use super::ingress::Ingress;
+    use super::ipforward::IpForwarder;
+    use super::ipstaticfilter::IpFilter;
+    use super::stats::StatsSink;
+    use crate::Packet;
+
+    pub fn init_test_tracing() {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_target(true)
+            .with_line_number(true)
+            .with_thread_names(false)
+            .try_init();
+    }
+
+    /// Build test interface table
+    fn build_test_iftable() -> IfTable {
+        let mut iftable = IfTable::new();
+        let vrf = Arc::new(RwLock::new(Vrf::new("default-vrf", 0)));
+
+        /* create Eth1 */
+        let mut eth1 = Interface::new("eth0", 1);
+        eth1.set_admin_state(IfState::Up);
+        eth1.set_oper_state(IfState::Up);
+        eth1.set_iftype(IfType::Ethernet(IfDataEthernet {
+            mac: Mac::from([0x2, 0, 0, 0, 0, 1]),
+        }));
+        eth1.attach(&vrf).expect("Attach should succeed");
+
+        /* create Eth2 */
+        let mut eth2 = Interface::new("eth2", 2);
+        eth2.set_admin_state(IfState::Up);
+        eth2.set_oper_state(IfState::Up);
+        eth2.set_iftype(IfType::Dot1q(IfDataDot1q {
+            mac: Mac::from([0x2, 0, 0, 0, 0, 2]),
+            vlanid: Vid::new(100).unwrap(),
+        }));
+        eth2.attach(&vrf).expect("Attach should succeed");
+
+        /* Add the interfaces to the iftable */
+        iftable.add_interface(eth1);
+        iftable.add_interface(eth2);
+
+        iftable
+    }
+
+    /// Builds a sample 6-stage pipeline with ingress, ipfilter, 2 stages of routing, egress and
+    /// a stats-collecting stage.
+    fn build_processor_pipeline() -> (DynPipeline<TestBuffer>, Arc<RwLock<PacketDropStats>>) {
+        let iftable = Arc::new(RwLock::new(build_test_iftable()));
+        let stage_ingress = Ingress::new("Ingress", &iftable);
+        let stage_egress = Egress::new("Egress", &iftable);
+        let iprouter1 = IpForwarder::new("IP-Forward-1");
+        let iprouter2 = IpForwarder::new("IP-Forward-2");
+        let ipfilter = IpFilter::new("Pre-routing-1-filter");
+
+        let drop_stats = Arc::new(RwLock::new(PacketDropStats::new("Drop-stats-1")));
+        let sink = StatsSink::new("Pipeline-stats", &drop_stats);
+
+        let pipeline = DynPipeline::with_name("Router")
+            .add_stage(stage_ingress)
+            .add_stage(ipfilter)
+            .add_stage(iprouter1)
+            .add_stage(iprouter2)
+            .add_stage(stage_egress)
+            .add_stage(sink);
+        (pipeline, drop_stats.clone())
+    }
+
+    fn addr_v4(a: &str) -> Ipv4Addr {
+        Ipv4Addr::from_str(a).expect("Bad IPv4 address")
+    }
+    fn addr_v6(a: &str) -> Ipv6Addr {
+        Ipv6Addr::from_str(a).expect("Bad Ipv6 address")
+    }
+    fn build_test_ipv4_pkt(dst_ip: &str, dst_mac: Mac, proto: NextHeader) -> Packet<TestBuffer> {
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(UnicastIpv4Addr::new(addr_v4("1.2.3.4")).unwrap());
+        ipv4.set_destination(addr_v4(dst_ip));
+        ipv4.set_ttl(255);
+        unsafe {
+            ipv4.set_next_header(proto);
+        }
+
+        let mut headers = Headers::new(Eth::new(
+            SourceMac::new(Mac([0x2, 0, 0, 0, 0, 99])).unwrap(),
+            DestinationMac::new(dst_mac).unwrap(),
+            EthType::IPV4,
+        ));
+        headers.net = Some(Net::Ipv4(ipv4));
+
+        let mut buffer: TestBuffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+
+        Packet::new(buffer).unwrap()
+    }
+
+    fn build_test_ipv6_pkt(dst_ip: &str, dst_mac: Mac, proto: NextHeader) -> Packet<TestBuffer> {
+        let mut ipv6 = Ipv6::default();
+        ipv6.set_source(UnicastIpv6Addr::new(addr_v6("2001::1")).unwrap());
+        ipv6.set_destination(addr_v6(dst_ip));
+        ipv6.set_hop_limit(255);
+        ipv6.set_next_header(proto);
+
+        let mut headers = Headers::new(Eth::new(
+            SourceMac::new(Mac([0x2, 0, 0, 0, 0, 99])).unwrap(),
+            DestinationMac::new(dst_mac).unwrap(),
+            EthType::IPV6,
+        ));
+        headers.net = Some(Net::Ipv6(ipv6));
+
+        let mut buffer: TestBuffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+
+        Packet::new(buffer).unwrap()
+    }
+
+    impl Packet<TestBuffer> {
+        fn set_description(mut self, descr: &'static str) -> Self {
+            self.meta.descr = descr;
+            self
+        }
+        fn set_iif(mut self, iif: u32) -> Self {
+            self.meta.iif = InterfaceId::new(iif);
+            self
+        }
+        fn keep(mut self) -> Self {
+            self.meta.keep = true;
+            self
+        }
+    }
+
+    fn build_test_packets() -> Vec<Packet<TestBuffer>> {
+        let mut packets = Vec::new();
+
+        let p1 = build_test_ipv4_pkt("192.168.0.1", Mac([0x2, 0, 0, 0, 0, 29]), NextHeader::TCP)
+            .set_description("MAC not for us")
+            .set_iif(1)
+            .keep();
+
+        let p2 = build_test_ipv4_pkt("10.0.0.255", Mac::BROADCAST, NextHeader::UDP)
+            .set_description("broadcast")
+            .set_iif(1)
+            .keep();
+
+        let p3 = build_test_ipv4_pkt("10.0.0.2", Mac([0x2, 0, 0, 0, 0, 1]), NextHeader::UDP)
+            .set_description("for us")
+            .set_iif(1)
+            .keep();
+
+        let p4 = build_test_ipv4_pkt("11.0.0.4", Mac([0x2, 0, 0, 0, 0, 1]), NextHeader::UDP)
+            .set_description("forward")
+            .set_iif(1)
+            .keep();
+
+        let p5 = build_test_ipv4_pkt("11.0.0.5", Mac([0x2, 0, 0, 0, 0, 1]), NextHeader::ICMP)
+            .set_description("filtered")
+            .set_iif(1)
+            .keep();
+
+        let p6 = build_test_ipv6_pkt("2001::1:2:3", Mac([0x2, 0, 0, 0, 0, 1]), NextHeader::TCP)
+            .set_description("ipv6")
+            .set_iif(1)
+            .keep();
+
+        let p7 = build_test_ipv4_pkt("8.8.8.8", Mac([0x2, 0, 0, 0, 0, 1]), NextHeader::TCP)
+            .set_description("route-drop")
+            .set_iif(1)
+            .keep();
+
+        packets.push(p1);
+        packets.push(p2);
+        packets.push(p3);
+        packets.push(p4);
+        packets.push(p5);
+        packets.push(p6);
+        packets.push(p7);
+
+        packets
+    }
+
+    #[test]
+    fn test_pktprocessor() {
+        init_test_tracing();
+        let (mut pipeline, stats) = build_processor_pipeline();
+        let packets = build_test_packets();
+        let mut packets_out: Vec<_> = pipeline.process(packets.into_iter()).collect();
+
+        for pkt in packets_out.iter_mut() {
+            match pkt.meta.descr {
+                "MAC not for us" => {
+                    assert!(!pkt.meta.is_iplocal);
+                    assert!(!pkt.meta.is_l2bcast);
+                    assert_eq!(pkt.meta.drop, Some(DropReason::MacNotForUs));
+                }
+                "broadcast" => {
+                    assert!(pkt.meta.is_l2bcast);
+                    assert_eq!(pkt.meta.drop, Some(DropReason::Unhandled));
+                }
+                "for us" => {
+                    assert!(!pkt.meta.is_l2bcast);
+                    assert!(pkt.meta.is_iplocal);
+                }
+                "forward" => {
+                    assert!(!pkt.meta.is_l2bcast);
+                    assert!(!pkt.meta.is_iplocal);
+                }
+                "filtered" => {
+                    assert_eq!(pkt.meta.drop, Some(DropReason::Filtered));
+                }
+                "ipv6" => {}
+                "route-drop" => {
+                    assert_eq!(pkt.meta.drop, Some(DropReason::RouteDrop));
+                }
+                &_ => {
+                    println!("{}", pkt.meta.descr);
+                    panic!("Test error")
+                }
+            }
+        }
+
+        if let Ok(stats) = stats.read() {
+            println!("{stats:#?}");
+
+            /* all packets counted ? */
+            let total_count = stats.get_stats().iter().fold(0, |sum, entry| sum + entry.1) as usize;
+            assert_eq!(total_count, packets_out.len());
+
+            /* delivered */
+            let delivered = stats.get_stats().iter().fold(0, |sum, entry| {
+                if *entry.0 == DropReason::Delivered {
+                    sum + entry.1
+                } else {
+                    sum
+                }
+            }) as usize;
+
+            /* dropped */
+            let dropped = stats.get_stats().iter().fold(0, |sum, entry| {
+                if *entry.0 != DropReason::Delivered {
+                    sum + entry.1
+                } else {
+                    sum
+                }
+            }) as usize;
+
+            println!("total: {}", total_count);
+            println!("Delivered: {}", delivered);
+            println!("dropped: {}", dropped);
+        }
+    }
+}

--- a/dataplane/src/packet_processor/stats.rs
+++ b/dataplane/src/packet_processor/stats.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+//
+//! Implements a packet stats sink.
+//! Currently, it only includes `PacketDropStats`, but other type of statistics could
+//! be added like protocol breakdowns.
+
+use crate::NetworkFunction;
+use crate::packet::Packet;
+use crate::packet_meta::PacketDropStats;
+use net::buffer::PacketBufferMut;
+use tracing::trace;
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+#[allow(unused)]
+pub struct StatsSink {
+    name: String,
+    dropstats: Arc<RwLock<PacketDropStats>>,
+    // other stats here
+}
+
+#[allow(dead_code)]
+impl StatsSink {
+    pub fn new(name: &str, dropstats: &Arc<RwLock<PacketDropStats>>) -> Self {
+        Self {
+            name: name.to_owned(),
+            dropstats: dropstats.clone(),
+        }
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for StatsSink {
+    fn nf_name(&self) -> &str {
+        &self.name
+    }
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        trace!(
+            "Stage '{}'...",
+            <Self as NetworkFunction<Buf>>::nf_name(self)
+        );
+        // locking once instead of inside filter map closure
+        if let Ok(mut dropstats) = self.dropstats.write() {
+            input.filter_map(move |packet| {
+                if let Some(reason) = packet.get_drop() {
+                    dropstats.incr(reason, 1);
+                }
+                packet.fate()
+            })
+        } else {
+            panic!("Poisoned");
+        }
+    }
+}

--- a/dataplane/src/pipeline/dyn_nf.rs
+++ b/dataplane/src/pipeline/dyn_nf.rs
@@ -29,6 +29,13 @@ pub trait DynNetworkFunction<Buf: PacketBufferMut>: Any {
     /// [`DynPipeline::process`] with a concrete iterator type.  However, if you only
     /// have a dynamic iterator, you can use this method to process the packets.
     fn process_dyn<'a>(&'a mut self, input: DynIter<'a, Packet<Buf>>) -> DynIter<'a, Packet<Buf>>;
+
+    /// Allow objects implementing [`DynNetworkFunction`] to identify themselves by overriding this.
+    #[allow(dead_code)]
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn nf_name(&self) -> &str {
+        "anonymous-dynNF"
+    }
 }
 
 struct DynNetworkFunctionImpl<Buf: PacketBufferMut, NF: NetworkFunction<Buf> + 'static> {

--- a/dataplane/src/pipeline/pipeline.rs
+++ b/dataplane/src/pipeline/pipeline.rs
@@ -64,6 +64,9 @@ impl<Buf: PacketBufferMut + 'static> DynPipeline<Buf> {
 }
 
 impl<Buf: PacketBufferMut> DynNetworkFunction<Buf> for DynPipeline<Buf> {
+    fn nf_name(&self) -> &str {
+        self.name.as_str()
+    }
     fn process_dyn<'a>(&'a mut self, input: DynIter<'a, Packet<Buf>>) -> DynIter<'a, Packet<Buf>> {
         self.nfs
             .iter_mut()

--- a/dataplane/src/pipeline/pipeline.rs
+++ b/dataplane/src/pipeline/pipeline.rs
@@ -17,12 +17,27 @@ use crate::pipeline::{DynNetworkFunction, NetworkFunction, nf_dyn};
 #[derive(Default)]
 pub struct DynPipeline<Buf: PacketBufferMut> {
     nfs: Vec<Box<dyn DynNetworkFunction<Buf>>>,
+
+    #[allow(unused)]
+    name: String,
 }
 
+#[allow(unused)]
 impl<Buf: PacketBufferMut + 'static> DynPipeline<Buf> {
-    #[allow(unused)]
     pub fn new() -> Self {
-        Self { nfs: vec![] }
+        Self {
+            nfs: vec![],
+            name: "anonymous-pipeline".to_owned(),
+        }
+    }
+    pub fn with_name(name: &str) -> Self {
+        Self {
+            nfs: vec![],
+            name: name.to_owned(),
+        }
+    }
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Add a static network function to the pipeline.
@@ -42,7 +57,6 @@ impl<Buf: PacketBufferMut + 'static> DynPipeline<Buf> {
     ///
     /// [`DynNetworkFunction`]
     /// [`nf_dyn`]
-    #[allow(unused)]
     pub fn add_stage_dyn(mut self, nf: Box<dyn DynNetworkFunction<Buf>>) -> Self {
         self.nfs.push(nf);
         self

--- a/dataplane/src/pipeline/pipeline.rs
+++ b/dataplane/src/pipeline/pipeline.rs
@@ -3,6 +3,7 @@
 
 use dyn_iter::{DynIter, IntoDynIterator};
 use net::buffer::PacketBufferMut;
+use std::any::Any;
 
 use crate::packet::Packet;
 use crate::pipeline::{DynNetworkFunction, NetworkFunction, nf_dyn};
@@ -68,6 +69,20 @@ impl<Buf: PacketBufferMut + 'static> DynPipeline<Buf> {
             .iter()
             .find(|&nf| name == nf.nf_name())
             .map(|v| &**v)
+    }
+
+    /// Get a reference to a stage of the pipeline by name, type to the original
+    /// object type instead of the trait.
+    ///
+    /// Sample usage:
+    /// Suppose that there exists a stage called "Foo-1" of type `TypeFoo`.
+    /// A reference to the object implementing the stage/NF can be obtained back as
+    ///   `pipeline.get_stage_typed::<TypeFoo>("Foo-1");`
+    pub fn get_stage_typed<T: Any>(&self, name: &str) -> Option<&T> {
+        self.nfs
+            .iter()
+            .find(|&nf| name == nf.nf_name())
+            .map(|stage| (stage as &dyn Any).downcast_ref())?
     }
 }
 

--- a/dataplane/src/pipeline/pipeline.rs
+++ b/dataplane/src/pipeline/pipeline.rs
@@ -61,6 +61,14 @@ impl<Buf: PacketBufferMut + 'static> DynPipeline<Buf> {
         self.nfs.push(nf);
         self
     }
+
+    /// Get a reference to a stage of the pipeline by name
+    pub fn get_stage(&self, name: &str) -> Option<&dyn DynNetworkFunction<Buf>> {
+        self.nfs
+            .iter()
+            .find(|&nf| name == nf.nf_name())
+            .map(|v| &**v)
+    }
 }
 
 impl<Buf: PacketBufferMut> DynNetworkFunction<Buf> for DynPipeline<Buf> {

--- a/dataplane/src/pipeline/static_nf.rs
+++ b/dataplane/src/pipeline/static_nf.rs
@@ -23,6 +23,13 @@ pub trait NetworkFunction<Buf: PacketBufferMut> {
         &'a mut self,
         input: Input,
     ) -> impl Iterator<Item = Packet<Buf>> + 'a;
+
+    /// Allow objects implementing [`NetworkFunction`] to identify themselves by overriding this.
+    #[allow(dead_code)]
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn nf_name(&self) -> &str {
+        "anonymous-NF"
+    }
 }
 
 struct StaticChainImpl<Buf: PacketBufferMut, NF1: NetworkFunction<Buf>, NF2: NetworkFunction<Buf>> {

--- a/dataplane/src/pipeline/test_utils.rs
+++ b/dataplane/src/pipeline/test_utils.rs
@@ -8,6 +8,7 @@ use net::eth::Eth;
 use net::eth::ethtype::EthType;
 use net::eth::mac::{DestinationMac, Mac, SourceMac};
 use net::headers::{Headers, Net};
+use net::ip::NextHeader;
 use net::ipv4::Ipv4;
 use net::ipv4::addr::UnicastIpv4Addr;
 use net::parse::DeParse;
@@ -81,12 +82,15 @@ impl Iterator for DynStageGenerator {
 /// The Ethernet source and destination MAC addresses are 0x02:00:00:00:00:01 and 0x02:00:00:00:00:02
 /// respectively.
 ///
+#[allow(unsafe_code)]
 pub fn build_test_ipv4_packet(ttl: u8) -> Result<Packet<TestBuffer>, InvalidPacket<TestBuffer>> {
     let mut ipv4 = Ipv4::default();
     ipv4.set_source(UnicastIpv4Addr::new(Ipv4Addr::new(1, 2, 3, 4)).unwrap());
     ipv4.set_destination(Ipv4Addr::new(1, 2, 3, 4));
     ipv4.set_ttl(ttl);
-
+    unsafe {
+        ipv4.set_next_header(NextHeader::UDP);
+    }
     let mut headers = Headers::new(Eth::new(
         SourceMac::new(Mac([0x2, 0, 0, 0, 0, 1])).unwrap(),
         DestinationMac::new(Mac([0x2, 0, 0, 0, 0, 2])).unwrap(),

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -27,7 +27,7 @@ pub mod flow_label;
 pub use contract::*;
 
 /// An IPv6 header
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Ipv6(Ipv6Header);
 impl Ipv6 {
     /// The minimum length (in bytes) of an [`Ipv6`] header.

--- a/routing/src/interface.rs
+++ b/routing/src/interface.rs
@@ -186,6 +186,17 @@ impl Interface {
         }
         false
     }
+
+    //////////////////////////////////////////////////////////////////
+    /// Get mac address of interface, if any
+    //////////////////////////////////////////////////////////////////
+    pub fn get_mac(&self) -> Option<&Mac> {
+        match &self.iftype {
+            IfType::Ethernet(inner) => Some(&inner.mac),
+            IfType::Dot1q(inner) => Some(&inner.mac),
+            _ => None,
+        }
+    }
 }
 
 /// A table of network interface objects, keyed by some ifindex (u32)

--- a/routing/src/interface.rs
+++ b/routing/src/interface.rs
@@ -203,6 +203,7 @@ impl Interface {
 pub struct IfTable(pub(crate) HashMap<u32, Interface>);
 
 #[allow(dead_code)]
+#[allow(clippy::new_without_default)]
 impl IfTable {
     //////////////////////////////////////////////////////////////////
     /// Create an interface table. All interfaces should live here.

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -11,7 +11,7 @@ mod cpi_process;
 mod display;
 mod encapsulation;
 mod errors;
-mod interface;
+pub mod interface;
 mod nexthop;
 pub mod prefix;
 mod pretty_utils;

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -18,4 +18,4 @@ mod pretty_utils;
 mod rmac;
 mod routingdb;
 mod rpc_adapt;
-mod vrf;
+pub mod vrf;


### PR DESCRIPTION
rides on https://github.com/githedgehog/dataplane/pull/291

**Important notes**

Adding this to get some early feedback on:
  - the use of the packet metadata, as defined in #291 
  - the coding of stages & style
  - the fake PR creates a pipeline ("packet processor" module) with the following stages
        -  ingress
        -  ipfilter (a dummy stateless firewall)
        - 2 ip forward stages with hardcoded routes
        - egress
        - stats

* This is not to be merged as it contains hardcoded stuff
* I plan to reuse the skeleton with the real implementation.
* I use metadata 'keep' boolean = true which causes packets not to be dropped till the end. This option is only in build tests, but we may want to have it always.
* This may add extra overhead (minimal) since all packets are subject to all stages, but allows comfortably accounting them in a last stage, which just counts drop reasons.
* The test is very dummy, with 7 packets manually crafted to stimulate some cases (no boleros).
If executed, it should display:
```
2025-02-27T22:10:41.315468Z TRACE dataplane::packet_processor::ingress: 125: Stage 'Ingress'....
2025-02-27T22:10:41.315496Z TRACE dataplane::packet_processor::ipstaticfilter: 58: Stage 'Pre-routing-1-filter'...
2025-02-27T22:10:41.315506Z TRACE dataplane::packet_processor::ipforward: 119: Stage 'IP-Forward-1'...
2025-02-27T22:10:41.315513Z TRACE dataplane::packet_processor::ipforward: 119: Stage 'IP-Forward-2'...
2025-02-27T22:10:41.315520Z TRACE dataplane::packet_processor::egress: 76: Stage 'Egress'...
2025-02-27T22:10:41.315527Z TRACE dataplane::packet_processor::stats: 42: Stage 'Pipeline-stats'...
2025-02-27T22:10:41.315546Z  WARN dataplane::packet_processor::ingress: 75: Recvd frame for mac=02:00:00:00:00:1D. Bridging is not supported
2025-02-27T22:10:41.315575Z  WARN dataplane::packet_processor::ingress: 41: Processing broadcast of ethernet frames is not supported
2025-02-27T22:10:41.315591Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 10.0.0.2 with vrf 0
2025-02-27T22:10:41.315600Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 10.0.0.2 with vrf 1
2025-02-27T22:10:41.315612Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 11.0.0.4 with vrf 0
2025-02-27T22:10:41.315619Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 11.0.0.4 with vrf 0
2025-02-27T22:10:41.315630Z TRACE dataplane::packet_processor::ipstaticfilter: 45: Denied ICMP packet
2025-02-27T22:10:41.315643Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 2001::1:2:3 with vrf 0
2025-02-27T22:10:41.315654Z TRACE dataplane::packet_processor::ipforward: 81: Forwarding packet to 8.8.8.8 with vrf 0
PacketDropStats {
    name: "Drop-stats-1",
    reasons: {
        Unhandled: 1,
        Filtered: 1,
        RouteFailure: 1,
        RouteDrop: 1,
        Delivered: 2,
        MacNotForUs: 1,
    },
}
total: 7
Delivered: 2
dropped: 5
2025-02-27T22:10:41.315697Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315710Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315722Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315733Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315744Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315755Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
2025-02-27T22:10:41.315767Z TRACE net::buffer::test_buffer: 29: Dropping TestBuffer
```
        