### PR TITLE
fix: add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "beta"


### PR DESCRIPTION
This will help IDEs while we are on the beta.