### PR TITLE
Use version instead of branch for dplane-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,12 +453,13 @@ version = "0.0.1"
 [[package]]
 name = "dplane-rpc"
 version = "1.0.0"
-source = "git+https://github.com/githedgehog/dplane-rpc.git?branch=master#74dbcb7e8a0a3cfd5732fe48f28dee657b1e7397"
+source = "git+https://github.com/githedgehog/dplane-rpc.git#39effba501ee20c68746bec3b9c585d02fe941de"
 dependencies = [
  "bytes",
  "cbindgen",
  "log",
  "mac_address",
+ "mio",
  "num-derive",
  "num-traits",
  "tracing",
@@ -697,6 +698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "3"
 dpdk = { path = "./dpdk" }
 dpdk-sys = { path = "./dpdk-sys" }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper" }
-dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", branch = "master" }
+dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = "1.0.0" }
 errno = { path = "./errno", package = "dataplane-errno" }
 net = { path = "./net" }
 routing = { path = "./routing" }


### PR DESCRIPTION
~~Pipeline will fail while https://github.com/githedgehog/dplane-rpc/pull/25 is not merged~~
Pipeline should work now since referred to merged version 1.0.0.