### PR TITLE
Fix rustdoc warnings in dpdk, dataplane packages

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -2,6 +2,8 @@
 // Copyright Open Network Fabric Authors
 
 #![deny(clippy::all, clippy::pedantic)]
+#![deny(rustdoc::all)]
+#![allow(rustdoc::missing_crate_level_docs)]
 
 mod args;
 mod nat;

--- a/dataplane/src/pipeline/dyn_nf.rs
+++ b/dataplane/src/pipeline/dyn_nf.rs
@@ -26,8 +26,9 @@ pub trait DynNetworkFunction<Buf: PacketBufferMut>: Any {
     /// To call this method, import the [`dyn_iter::IntoDynIterator`] trait and use the
     /// `into_dyn_iter` method to get a [`dyn_iter::DynIter`] to use with this method.
     /// Generally you should not need to call this method directly, instead just call
-    /// [`DynPipeline::process`] with a concrete iterator type.  However, if you only
-    /// have a dynamic iterator, you can use this method to process the packets.
+    /// [`DynPipeline::process`][crate::pipeline::DynPipeline::process] with a concrete iterator
+    /// type.  However, if you only have a dynamic iterator, you can use this method to process the
+    /// packets.
     fn process_dyn<'a>(&'a mut self, input: DynIter<'a, Packet<Buf>>) -> DynIter<'a, Packet<Buf>>;
 }
 

--- a/dataplane/src/pipeline/mod.rs
+++ b/dataplane/src/pipeline/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+#![allow(rustdoc::private_doc_tests)]
+
 //! # Pipeline Building Blocks
 //!
 //! This module provides the building blocks for constructing pipelines of network functions.

--- a/dataplane/src/pipeline/mod.rs
+++ b/dataplane/src/pipeline/mod.rs
@@ -31,12 +31,14 @@
 //! Note that `pipeline` implements the [`NetworkFunction`] trait and can be used anywhere a
 //! network function is expected.
 //!
-//! > [!WARNING]
-//! >
-//! > Keep statically linked chains short, ideally less than 8 stages.
-//! >
-//! > The [`StaticChain::chain`] triggers compiler/linker limitations, long chains cause long
-//! > compile times and eventually cause the linker to run out of memory.
+//! <div class="warning">
+//!
+//! Keep statically linked chains short, ideally less than 8 stages.
+//!
+//! The [`StaticChain::chain`] triggers compiler/linker limitations, long chains cause long
+//! compile times and eventually cause the linker to run out of memory.
+//!
+//! </div>
 //!
 //! ## Dynamic Pipeline
 //!

--- a/dataplane/src/pipeline/static_nf.rs
+++ b/dataplane/src/pipeline/static_nf.rs
@@ -14,11 +14,12 @@ pub trait NetworkFunction<Buf: PacketBufferMut> {
     ///
     /// Note that a concrete iterator type is required to call this function and
     /// a concrete iterator type must be returned from this function (i.e., `impl Iterator`).
-    /// If you don't have a concrete iterator type, use the [`DynNetworkFunction`] trait instead.
+    /// If you don't have a concrete iterator type, use the
+    /// [`DynNetworkFunction`][crate::pipeline::DynPipeline] trait instead.
     ///
     /// # See Also
     ///
-    /// [`DynNetworkFunction`]
+    /// [`DynNetworkFunction`][crate::pipeline::DynPipeline]
     fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
         &'a mut self,
         input: Input,
@@ -49,10 +50,13 @@ impl<Buf: PacketBufferMut, NF1: NetworkFunction<Buf>, NF2: NetworkFunction<Buf>>
 ///
 /// This trait is automatically implemented for all objects that implement [`NetworkFunction`].
 ///
-/// > [!WARNING]
-/// > Do not use long chains of statically chained network functions.
-/// > This will cause the compiler to generate a large chain of functions that
-/// > causes the linker to run out of memory and crash.
+/// <div class="warning">
+///
+/// Do not use long chains of statically chained network functions.
+/// This will cause the compiler to generate a large chain of functions that
+/// causes the linker to run out of memory and crash.
+///
+/// </div>
 pub trait StaticChain<Buf: PacketBufferMut>: NetworkFunction<Buf> {
     #[allow(unused)]
     fn chain<NF: NetworkFunction<Buf>>(self, nf: NF) -> impl NetworkFunction<Buf>;

--- a/dpdk/src/dev.rs
+++ b/dpdk/src/dev.rs
@@ -854,11 +854,11 @@ impl Dev {
 /// The state of a [`Dev`]
 #[derive(Debug, PartialEq)]
 pub enum State {
-    /// A device in the [`Stopped`] state is not usable for packet processing but can be
-    /// re-configured in ways that a [`Started`] device generally cannot.
+    /// A device in the [`Stopped`][State::Stopped] state is not usable for packet processing but
+    /// can be re-configured in ways that a [`Started`][State::Started] device generally cannot.
     Stopped,
-    /// A device in the [`Started`] state is usable for packet processing but can generally not be
-    /// re-configured while [`Started`].
+    /// A device in the [`Started`][State::Started] state is usable for packet processing but can
+    /// generally not be re-configured while [`Started`][State::Started].
     Started,
 }
 

--- a/dpdk/src/eal.rs
+++ b/dpdk/src/eal.rs
@@ -54,7 +54,8 @@ pub enum InitError {
     AlreadyInitialized,
     #[error("The EAL initialization failed")]
     InitializationFailed(errno::Errno),
-    /// [`rte_eal_init`] returned an error code other than `0` (success) or `-1` (failure).
+    /// [`dpdk_sys::rte_eal_init`] returned an error code other than `0` (success) or `-1`
+    /// (failure).
     /// This likely represents a bug in the DPDK library.
     #[error("Unknown error {0} when initializing the EAL")]
     UnknownError(i32),
@@ -146,7 +147,7 @@ pub fn init(args: impl IntoIterator<Item = impl AsRef<str>>) -> Eal {
 impl Eal {
     /// Returns `true` if the [`Eal`] is using the PCI bus.
     ///
-    /// This is mostly a safe wrapper around [`rte_eal_has_pci`]
+    /// This is mostly a safe wrapper around [`dpdk_sys::rte_eal_has_pci`]
     /// which simply converts the return value to a [`bool`] instead of a [`c_int`].
     #[cold]
     #[tracing::instrument(level = "trace", skip(self), ret)]
@@ -155,7 +156,7 @@ impl Eal {
     }
 
     /// Exits the DPDK application with an error message, cleaning up the [`Eal`] as gracefully as
-    /// possible (by way of [`rte_exit`]).
+    /// possible (by way of [`dpdk_sys::rte_exit`]).
     ///
     /// This function never returns as it exits the application.
     ///

--- a/dpdk/src/flow/mod.rs
+++ b/dpdk/src/flow/mod.rs
@@ -58,8 +58,8 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_any`.
     Any = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ANY,
-    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_PORT_REPRESENTOR`]
-    /// [`RTE_FLOW_ITEM_TYPE_REPRESENTED_PORT`]
+    /// > **Deprecated** [`dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_PORT_REPRESENTOR`]
+    /// [`dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_REPRESENTED_PORT`]
     ///
     /// \[META\]
     ///
@@ -159,7 +159,7 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_geneve`.
     Geneve = 24,
-    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_VXLAN`]
+    /// > **Deprecated** [`dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_VXLAN`]
     ///
     /// Matches a VXLAN-GPE header.
     ///

--- a/dpdk/src/flow/mod.rs
+++ b/dpdk/src/flow/mod.rs
@@ -58,139 +58,338 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_any`.
     Any = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ANY,
-    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_PORT_REPRESENTOR`]\n [`RTE_FLOW_ITEM_TYPE_REPRESENTED_PORT`]\n\n [META]\n\n Matches traffic originating from (ingress) or going to (egress) a\n given DPDK port ID.\n\n See struct rte_flow_item_port_id.
+    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_PORT_REPRESENTOR`]
+    /// [`RTE_FLOW_ITEM_TYPE_REPRESENTED_PORT`]
+    ///
+    /// [META]
+    ///
+    /// Matches traffic originating from (ingress) or going to (egress) a
+    /// given DPDK port ID.
+    ///
+    /// See struct rte_flow_item_port_id.
     PortId = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_PORT_ID,
-    /// Matches a byte string of a given length at a given offset.\n\n See struct `rte_flow_item_raw`
+    /// Matches a byte string of a given length at a given offset.
+    ///
+    /// See struct `rte_flow_item_raw`
     Raw = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_RAW,
-    /// Matches an Ethernet header.\n\n See struct `rte_flow_item_eth`.
+    /// Matches an Ethernet header.
+    ///
+    /// See struct `rte_flow_item_eth`.
     Eth = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ETH,
-    /// Matches an 802.1Q/ad VLAN tag.\n\n See struct `rte_flow_item_vlan`.
+    /// Matches an 802.1Q/ad VLAN tag.
+    ///
+    /// See struct `rte_flow_item_vlan`.
     Vlan = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_VLAN,
-    /// Matches an IPv4 header.\n\n See struct `rte_flow_item_ipv4`.
+    /// Matches an IPv4 header.
+    ///
+    /// See struct `rte_flow_item_ipv4`.
     Ipv4 = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_IPV4,
-    /// Matches an IPv6 header.\n\n See struct `rte_flow_item_ipv6`.
+    /// Matches an IPv6 header.
+    ///
+    /// See struct `rte_flow_item_ipv6`.
     Ipv6 = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_IPV6,
-    /// Matches an ICMP header.\n\n See struct `rte_flow_item_icmp`.
+    /// Matches an ICMP header.
+    ///
+    /// See struct `rte_flow_item_icmp`.
     Icmp = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ICMP,
-    /// Matches a UDP header.\n\n See struct `rte_flow_item_udp`.
+    /// Matches a UDP header.
+    ///
+    /// See struct `rte_flow_item_udp`.
     Udp = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_UDP,
-    /// Matches a TCP header.\n\n See struct `rte_flow_item_tcp`.
+    /// Matches a TCP header.
+    ///
+    /// See struct `rte_flow_item_tcp`.
     Tcp = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_TCP,
-    /// Matches a SCTP header.\n\n See struct `rte_flow_item_sctp`.
+    /// Matches a SCTP header.
+    ///
+    /// See struct `rte_flow_item_sctp`.
     Sctp = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_SCTP,
-    /// Matches a VXLAN header.\n\n See struct `rte_flow_item_vxlan`.
+    /// Matches a VXLAN header.
+    ///
+    /// See struct `rte_flow_item_vxlan`.
     Vxlan = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_VXLAN,
-    /// Matches a `E_TAG` header.\n\n See struct `rte_flow_item_e_tag`.
+    /// Matches a `E_TAG` header.
+    ///
+    /// See struct `rte_flow_item_e_tag`.
     Etag = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_E_TAG,
-    /// Matches a NVGRE header.\n\n See struct `rte_flow_item_nvgre`.
+    /// Matches a NVGRE header.
+    ///
+    /// See struct `rte_flow_item_nvgre`.
     Nvgre = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_NVGRE,
-    /// Matches a MPLS header.\n\n See struct `rte_flow_item_mpls`.
+    /// Matches a MPLS header.
+    ///
+    /// See struct `rte_flow_item_mpls`.
     Mpls = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_MPLS,
-    /// Matches a GRE header.\n\n See struct `rte_flow_item_gre`.
+    /// Matches a GRE header.
+    ///
+    /// See struct `rte_flow_item_gre`.
     Gre = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_GRE,
-    /// [META]\n\n Fuzzy pattern match, expect faster than default.\n\n This is for device that support fuzzy matching option.\n Usually a fuzzy matching is fast, but the cost is accuracy.\n\n See struct `rte_flow_item_fuzzy`.
+    /// [META]
+    ///
+    /// Fuzzy pattern match, expect faster than default.
+    ///
+    /// This is for device that support fuzzy matching option.
+    /// Usually a fuzzy matching is fast, but the cost is accuracy.
+    ///
+    /// See struct `rte_flow_item_fuzzy`.
     Fuzzy = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_FUZZY,
-    /// Matches a GTP header.\n\n Configure flow for GTP packets.\n\n See struct `rte_flow_item_gtp`.
+    /// Matches a GTP header.
+    ///
+    /// Configure flow for GTP packets.
+    ///
+    /// See struct `rte_flow_item_gtp`.
     Gtp = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_GTP,
-    /// Matches a GTP header.\n\n Configure flow for GTP-C packets.\n\n See struct `rte_flow_item_gtp`.
+    /// Matches a GTP header.
+    ///
+    /// Configure flow for GTP-C packets.
+    ///
+    /// See struct `rte_flow_item_gtp`.
     Gtpc = 21,
-    /// Matches a GTP header.\n\n Configure flow for GTP-U packets.\n\n See struct `rte_flow_item_gtp`.
+    /// Matches a GTP header.
+    ///
+    /// Configure flow for GTP-U packets.
+    ///
+    /// See struct `rte_flow_item_gtp`.
     Gtpu = 22,
-    /// Matches a ESP header.\n\n See struct `rte_flow_item_esp`.
+    /// Matches a ESP header.
+    ///
+    /// See struct `rte_flow_item_esp`.
     Esp = 23,
-    /// Matches a GENEVE header.\n\n See struct `rte_flow_item_geneve`.
+    /// Matches a GENEVE header.
+    ///
+    /// See struct `rte_flow_item_geneve`.
     Geneve = 24,
-    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_VXLAN`]\n\n Matches a VXLAN-GPE header.\n\n See struct rte_flow_item_vxlan_gpe.
+    /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_VXLAN`]
+    ///
+    /// Matches a VXLAN-GPE header.
+    ///
+    /// See struct rte_flow_item_vxlan_gpe.
     VxlanGpe = 25,
-    /// Matches an ARP header for Ethernet/IPv4.\n\n See struct `rte_flow_item_arp_eth_ipv4`.
+    /// Matches an ARP header for Ethernet/IPv4.
+    ///
+    /// See struct `rte_flow_item_arp_eth_ipv4`.
     ArpEthIpv4 = 26,
-    /// Matches the presence of any IPv6 extension header.\n\n See struct `rte_flow_item_ipv6_ext`.
+    /// Matches the presence of any IPv6 extension header.
+    ///
+    /// See struct `rte_flow_item_ipv6_ext`.
     Ipv6Ext = 27,
-    /// Matches any `ICMPv6` header.\n\n See struct `rte_flow_item_icmp6`.
+    /// Matches any `ICMPv6` header.
+    ///
+    /// See struct `rte_flow_item_icmp6`.
     Icmp6 = 28,
-    /// Matches an `ICMPv6` neighbor discovery solicitation.\n\n See struct `rte_flow_item_icmp6_nd_ns`.
+    /// Matches an `ICMPv6` neighbor discovery solicitation.
+    ///
+    /// See struct `rte_flow_item_icmp6_nd_ns`.
     Icmp6NdNs = 29,
-    /// Matches an `ICMPv6` neighbor discovery advertisement.\n\n See struct `rte_flow_item_icmp6_nd_na`.
+    /// Matches an `ICMPv6` neighbor discovery advertisement.
+    ///
+    /// See struct `rte_flow_item_icmp6_nd_na`.
     Icmp6NdNa = 30,
-    /// Matches the presence of any `ICMPv6` neighbor discovery option.\n\n See struct `rte_flow_item_icmp6_nd_opt`.
+    /// Matches the presence of any `ICMPv6` neighbor discovery option.
+    ///
+    /// See struct `rte_flow_item_icmp6_nd_opt`.
     Icmp6NdOpt = 31,
-    /// Matches an `ICMPv6` neighbor discovery source Ethernet link-layer\n address option.\n\n See struct `rte_flow_item_icmp6_nd_opt_sla_eth`.
+    /// Matches an `ICMPv6` neighbor discovery source Ethernet link-layer
+    /// address option.
+    ///
+    /// See struct `rte_flow_item_icmp6_nd_opt_sla_eth`.
     Icmp6NdOptSlaEth = 32,
-    /// Matches an `ICMPv6` neighbor discovery target Ethernet link-layer\n address option.\n\n See struct `rte_flow_item_icmp6_nd_opt_tla_eth`.
+    /// Matches an `ICMPv6` neighbor discovery target Ethernet link-layer
+    /// address option.
+    ///
+    /// See struct `rte_flow_item_icmp6_nd_opt_tla_eth`.
     Icmp6NdOptTlaEth = 33,
-    /// Matches specified mark field.\n\n See struct `rte_flow_item_mark`.
+    /// Matches specified mark field.
+    ///
+    /// See struct `rte_flow_item_mark`.
     Mark = 34,
-    /// [META]\n\n Matches a metadata value.\n\n See struct `rte_flow_item_meta`.
+    /// [META]
+    ///
+    /// Matches a metadata value.
+    ///
+    /// See struct `rte_flow_item_meta`.
     Meta = 35,
-    /// Matches a GRE optional key field.\n\n The value should a big-endian 32bit integer.\n\n When this item present the K bit is implicitly matched as \"1\"\n in the default mask.\n\n `spec/mask` type:\n `rte_be32_t` *
+    /// Matches a GRE optional key field.
+    ///
+    /// The value should a big-endian 32bit integer.
+    ///
+    /// When this item present the K bit is implicitly matched as \"1\"
+    /// in the default mask.
+    ///
+    /// `spec/mask` type:
+    /// `rte_be32_t` *
     GreKey = 36,
-    /// Matches a GTP extension header: PDU session container.\n\n Configure flow for GTP packets with extension header type 0x85.\n\n See struct `rte_flow_item_gtp_psc`.
+    /// Matches a GTP extension header: PDU session container.
+    ///
+    /// Configure flow for GTP packets with extension header type 0x85.
+    ///
+    /// See struct `rte_flow_item_gtp_psc`.
     GtpPsc = 37,
-    /// Matches a `PPPoE` header.\n\n Configure flow for `PPPoE` session packets.\n\n See struct `rte_flow_item_pppoe`.
+    /// Matches a `PPPoE` header.
+    ///
+    /// Configure flow for `PPPoE` session packets.
+    ///
+    /// See struct `rte_flow_item_pppoe`.
     PppoeS = 38,
-    /// Matches a `PPPoE` header.\n\n Configure flow for `PPPoE` discovery packets.\n\n See struct `rte_flow_item_pppoe`.
+    /// Matches a `PPPoE` header.
+    ///
+    /// Configure flow for `PPPoE` discovery packets.
+    ///
+    /// See struct `rte_flow_item_pppoe`.
     PppoeD = 39,
-    /// Matches a `PPPoE` optional `proto_id` field.\n\n It only applies to `PPPoE` session packets.\n\n See struct `rte_flow_item_pppoe_proto_id`.
+    /// Matches a `PPPoE` optional `proto_id` field.
+    ///
+    /// It only applies to `PPPoE` session packets.
+    ///
+    /// See struct `rte_flow_item_pppoe_proto_id`.
     PppoeProtoId = 40,
-    /// Matches Network service header (NSH).\n See struct `rte_flow_item_nsh.\n`
+    /// Matches Network service header (NSH).
+    /// See struct `rte_flow_item_nsh.
+    ///`
     Nsh = 41,
-    /// Matches Internet Group Management Protocol (IGMP).\n See struct `rte_flow_item_igmp.\n`
+    /// Matches Internet Group Management Protocol (IGMP).
+    /// See struct `rte_flow_item_igmp.
+    ///`
     Igmp = 42,
-    /// Matches IP Authentication Header (AH).\n See struct `rte_flow_item_ah.\n`
+    /// Matches IP Authentication Header (AH).
+    /// See struct `rte_flow_item_ah.
+    ///`
     Ah = 43,
-    /// Matches a HIGIG header.\n see struct `rte_flow_item_higig2_hdr`.
+    /// Matches a HIGIG header.
+    /// see struct `rte_flow_item_higig2_hdr`.
     Higig2 = 44,
-    /// [META]\n\n Matches a tag value.\n\n See struct `rte_flow_item_tag`.
+    /// [META]
+    ///
+    /// Matches a tag value.
+    ///
+    /// See struct `rte_flow_item_tag`.
     Tag = 45,
-    /// Matches an ` L2TPv3 ` over IP header.\n\n Configure flow for `L2TPv3` over IP packets.\n\n See struct `rte_flow_item_l2tpv3oip`.
+    /// Matches an ` L2TPv3 ` over IP header.
+    ///
+    /// Configure flow for `L2TPv3` over IP packets.
+    ///
+    /// See struct `rte_flow_item_l2tpv3oip`.
     L2tpv3oIp = 46,
-    /// Matches PFCP Header.\n See struct `rte_flow_item_pfcp.\n`
+    /// Matches PFCP Header.
+    /// See struct `rte_flow_item_pfcp.
+    ///`
     Pfcp = 47,
-    /// Matches eCPRI Header.\n\n Configure flow for eCPRI over ETH or UDP packets.\n\n See struct `rte_flow_item_ecpri`.
+    /// Matches eCPRI Header.
+    ///
+    /// Configure flow for eCPRI over ETH or UDP packets.
+    ///
+    /// See struct `rte_flow_item_ecpri`.
     Ecpri = 48,
-    /// Matches the presence of IPv6 fragment extension header.\n\n See struct `rte_flow_item_ipv6_frag_ext`.
+    /// Matches the presence of IPv6 fragment extension header.
+    ///
+    /// See struct `rte_flow_item_ipv6_frag_ext`.
     Ipv6FragExt = 49,
-    /// Matches Geneve Variable Length Option\n\n See struct `rte_flow_item_geneve_opt`
+    /// Matches Geneve Variable Length Option
+    ///
+    /// See struct `rte_flow_item_geneve_opt`
     GeneveOpt = 50,
-    /// [META]\n\n Matches on packet integrity.\n For some devices the application needs to enable integration checks in HW\n before using this item.\n\n [`struct`] `rte_flow_item_integrity`.
+    /// [META]
+    ///
+    /// Matches on packet integrity.
+    /// For some devices the application needs to enable integration checks in HW
+    /// before using this item.
+    ///
+    /// [`struct`] `rte_flow_item_integrity`.
     Integrity = 51,
-    /// [META]\n\n Matches conntrack state.\n\n [`struct`] `rte_flow_item_conntrack`.
+    /// [META]
+    ///
+    /// Matches conntrack state.
+    ///
+    /// [`struct`] `rte_flow_item_conntrack`.
     Conntrack = 52,
-    /// [META]\n\n Matches traffic entering the embedded switch from the given ethdev.\n\n [`struct`] `rte_flow_item_ethdev`
+    /// [META]
+    ///
+    /// Matches traffic entering the embedded switch from the given ethdev.
+    ///
+    /// [`struct`] `rte_flow_item_ethdev`
     PortRepresentor = 53,
-    /// [META]\n\n Matches traffic entering the embedded switch from\n the entity represented by the given ethdev.\n\n [`struct`] `rte_flow_item_ethdev`
+    /// [META]
+    ///
+    /// Matches traffic entering the embedded switch from
+    /// the entity represented by the given ethdev.
+    ///
+    /// [`struct`] `rte_flow_item_ethdev`
     RepresentedPort = 54,
-    /// Matches a configured set of fields at runtime calculated offsets\n over the generic network header with variable length and\n flexible pattern\n\n [`struct`] `rte_flow_item_flex`.
+    /// Matches a configured set of fields at runtime calculated offsets
+    /// over the generic network header with variable length and
+    /// flexible pattern
+    ///
+    /// [`struct`] `rte_flow_item_flex`.
     Flex = 55,
-    /// Matches `L2TPv2` Header.\n\n See struct `rte_flow_item_l2tpv2`.
+    /// Matches `L2TPv2` Header.
+    ///
+    /// See struct `rte_flow_item_l2tpv2`.
     L2tpv2 = 56,
-    /// Matches PPP Header.\n\n See struct `rte_flow_item_ppp`.
+    /// Matches PPP Header.
+    ///
+    /// See struct `rte_flow_item_ppp`.
     Ppp = 57,
-    /// Matches GRE optional fields.\n\n See struct `rte_flow_item_gre_opt`.
+    /// Matches GRE optional fields.
+    ///
+    /// See struct `rte_flow_item_gre_opt`.
     GreOption = 58,
-    /// Matches `MACsec` Ethernet Header.\n\n See struct `rte_flow_item_macsec`.
+    /// Matches `MACsec` Ethernet Header.
+    ///
+    /// See struct `rte_flow_item_macsec`.
     MacSec = 59,
-    /// Matches Meter Color Marker.\n\n See struct `rte_flow_item_meter_color`.
+    /// Matches Meter Color Marker.
+    ///
+    /// See struct `rte_flow_item_meter_color`.
     MeterColor = 60,
-    /// Matches the presence of IPv6 routing extension header.\n\n [`struct`] `rte_flow_item_ipv6_routing_ext`.
+    /// Matches the presence of IPv6 routing extension header.
+    ///
+    /// [`struct`] `rte_flow_item_ipv6_routing_ext`.
     Ipv6RoutingExt = 61,
-    /// Matches an `ICMPv6` echo request.\n\n [`struct`] `rte_flow_item_icmp6_echo`.
+    /// Matches an `ICMPv6` echo request.
+    ///
+    /// [`struct`] `rte_flow_item_icmp6_echo`.
     Icmp6EchoRequest = 62,
-    /// Matches an `ICMPv6` echo reply.\n\n [`struct`] `rte_flow_item_icmp6_echo`.
+    /// Matches an `ICMPv6` echo reply.
+    ///
+    /// [`struct`] `rte_flow_item_icmp6_echo`.
     Icmp6EchoReply = 63,
-    /// Match Quota state\n\n [`struct`] `rte_flow_item_quota`
+    /// Match Quota state
+    ///
+    /// [`struct`] `rte_flow_item_quota`
     Quota = 64,
-    /// Matches on the aggregated port of the received packet.\n Used in case multiple ports are aggregated to a DPDK port.\n First port is number 1.\n\n [`struct`] `rte_flow_item_aggr_affinity`.
+    /// Matches on the aggregated port of the received packet.
+    /// Used in case multiple ports are aggregated to a DPDK port.
+    /// First port is number 1.
+    ///
+    /// [`struct`] `rte_flow_item_aggr_affinity`.
     AggrAffinity = 65,
-    /// Match Tx queue number.\n This is valid only for egress rules.\n\n [`struct`] `rte_flow_item_tx_queue`
+    /// Match Tx queue number.
+    /// This is valid only for egress rules.
+    ///
+    /// [`struct`] `rte_flow_item_tx_queue`
     TxQueue = 66,
-    /// Matches an `InfiniBand` base transport header in `RoCE` packet.\n\n [`struct`] `rte_flow_item_ib_bth`.
+    /// Matches an `InfiniBand` base transport header in `RoCE` packet.
+    ///
+    /// [`struct`] `rte_flow_item_ib_bth`.
     IbBth = 67,
-    /// Matches the packet type as defined in `rte_mbuf_ptype.\n\n` See struct `rte_flow_item_ptype.\n`
+    /// Matches the packet type as defined in `rte_mbuf_ptype.
+    ///
+    ///` See struct `rte_flow_item_ptype.
+    ///`
     Ptype = 68,
-    /// [META]\n\n Matches a random value.\n\n This value is not based on the packet data/headers.\n The application shouldn't assume that this value is kept\n during the lifetime of the packet.\n\n [`struct`] `rte_flow_item_random`.
+    /// [META]
+    ///
+    /// Matches a random value.
+    ///
+    /// This value is not based on the packet data/headers.
+    /// The application shouldn't assume that this value is kept
+    /// during the lifetime of the packet.
+    ///
+    /// [`struct`] `rte_flow_item_random`.
     Random = 69,
-    /// Match packet with various comparison types.\n\n See struct `rte_flow_item_compare`.
+    /// Match packet with various comparison types.
+    ///
+    /// See struct `rte_flow_item_compare`.
     Compare = 70,
 }
 

--- a/dpdk/src/flow/mod.rs
+++ b/dpdk/src/flow/mod.rs
@@ -36,19 +36,19 @@ pub const MAX_ACTION_NUM: usize = 16;
 #[derive(Debug)]
 #[repr(u32)]
 pub enum MatchType {
-    /// [META]
+    /// \[META\]
     ///
     /// End marker for item lists.
     /// Prevents further processing of items, thereby ending the pattern.
     /// No associated specification structure.
     End = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_END,
-    /// [META]
+    /// \[META\]
     ///
     /// Used as a placeholder for convenience.
     /// It is ignored and simply discarded by PMDs.
     /// No associated specification structure.
     Void = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_VOID,
-    /// [META]
+    /// \[META\]
     ///
     /// Inverted matching, i.e., process packets that do not match the pattern.
     /// No associated specification structure.
@@ -61,7 +61,7 @@ pub enum MatchType {
     /// > **Deprecated** [`RTE_FLOW_ITEM_TYPE_PORT_REPRESENTOR`]
     /// [`RTE_FLOW_ITEM_TYPE_REPRESENTED_PORT`]
     ///
-    /// [META]
+    /// \[META\]
     ///
     /// Matches traffic originating from (ingress) or going to (egress) a
     /// given DPDK port ID.
@@ -124,7 +124,7 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_gre`.
     Gre = dpdk_sys::rte_flow_item_type::RTE_FLOW_ITEM_TYPE_GRE,
-    /// [META]
+    /// \[META\]
     ///
     /// Fuzzy pattern match, expect faster than default.
     ///
@@ -203,7 +203,7 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_mark`.
     Mark = 34,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches a metadata value.
     ///
@@ -258,7 +258,7 @@ pub enum MatchType {
     /// Matches a HIGIG header.
     /// see struct `rte_flow_item_higig2_hdr`.
     Higig2 = 44,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches a tag value.
     ///
@@ -288,7 +288,7 @@ pub enum MatchType {
     ///
     /// See struct `rte_flow_item_geneve_opt`
     GeneveOpt = 50,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches on packet integrity.
     /// For some devices the application needs to enable integration checks in HW
@@ -296,19 +296,19 @@ pub enum MatchType {
     ///
     /// [`struct`] `rte_flow_item_integrity`.
     Integrity = 51,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches conntrack state.
     ///
     /// [`struct`] `rte_flow_item_conntrack`.
     Conntrack = 52,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches traffic entering the embedded switch from the given ethdev.
     ///
     /// [`struct`] `rte_flow_item_ethdev`
     PortRepresentor = 53,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches traffic entering the embedded switch from
     /// the entity represented by the given ethdev.
@@ -377,7 +377,7 @@ pub enum MatchType {
     ///` See struct `rte_flow_item_ptype.
     ///`
     Ptype = 68,
-    /// [META]
+    /// \[META\]
     ///
     /// Matches a random value.
     ///

--- a/dpdk/src/flow/mod.rs
+++ b/dpdk/src/flow/mod.rs
@@ -294,32 +294,32 @@ pub enum MatchType {
     /// For some devices the application needs to enable integration checks in HW
     /// before using this item.
     ///
-    /// [`struct`] `rte_flow_item_integrity`.
+    /// `struct rte_flow_item_integrity`.
     Integrity = 51,
     /// \[META\]
     ///
     /// Matches conntrack state.
     ///
-    /// [`struct`] `rte_flow_item_conntrack`.
+    /// `struct rte_flow_item_conntrack`.
     Conntrack = 52,
     /// \[META\]
     ///
     /// Matches traffic entering the embedded switch from the given ethdev.
     ///
-    /// [`struct`] `rte_flow_item_ethdev`
+    /// `struct rte_flow_item_ethdev`
     PortRepresentor = 53,
     /// \[META\]
     ///
     /// Matches traffic entering the embedded switch from
     /// the entity represented by the given ethdev.
     ///
-    /// [`struct`] `rte_flow_item_ethdev`
+    /// `struct rte_flow_item_ethdev`
     RepresentedPort = 54,
     /// Matches a configured set of fields at runtime calculated offsets
     /// over the generic network header with variable length and
     /// flexible pattern
     ///
-    /// [`struct`] `rte_flow_item_flex`.
+    /// `struct rte_flow_item_flex`.
     Flex = 55,
     /// Matches `L2TPv2` Header.
     ///
@@ -343,34 +343,34 @@ pub enum MatchType {
     MeterColor = 60,
     /// Matches the presence of IPv6 routing extension header.
     ///
-    /// [`struct`] `rte_flow_item_ipv6_routing_ext`.
+    /// `struct rte_flow_item_ipv6_routing_ext`.
     Ipv6RoutingExt = 61,
     /// Matches an `ICMPv6` echo request.
     ///
-    /// [`struct`] `rte_flow_item_icmp6_echo`.
+    /// `struct rte_flow_item_icmp6_echo`.
     Icmp6EchoRequest = 62,
     /// Matches an `ICMPv6` echo reply.
     ///
-    /// [`struct`] `rte_flow_item_icmp6_echo`.
+    /// `struct rte_flow_item_icmp6_echo`.
     Icmp6EchoReply = 63,
     /// Match Quota state
     ///
-    /// [`struct`] `rte_flow_item_quota`
+    /// `struct rte_flow_item_quota`
     Quota = 64,
     /// Matches on the aggregated port of the received packet.
     /// Used in case multiple ports are aggregated to a DPDK port.
     /// First port is number 1.
     ///
-    /// [`struct`] `rte_flow_item_aggr_affinity`.
+    /// `struct rte_flow_item_aggr_affinity`.
     AggrAffinity = 65,
     /// Match Tx queue number.
     /// This is valid only for egress rules.
     ///
-    /// [`struct`] `rte_flow_item_tx_queue`
+    /// `struct rte_flow_item_tx_queue`
     TxQueue = 66,
     /// Matches an `InfiniBand` base transport header in `RoCE` packet.
     ///
-    /// [`struct`] `rte_flow_item_ib_bth`.
+    /// `struct rte_flow_item_ib_bth`.
     IbBth = 67,
     /// Matches the packet type as defined in `rte_mbuf_ptype.
     ///
@@ -385,7 +385,7 @@ pub enum MatchType {
     /// The application shouldn't assume that this value is kept
     /// during the lifetime of the packet.
     ///
-    /// [`struct`] `rte_flow_item_random`.
+    /// `struct rte_flow_item_random`.
     Random = 69,
     /// Match packet with various comparison types.
     ///
@@ -654,19 +654,35 @@ pub enum FlowActionType {
     Indirect = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_INDIRECT,
     /// Color the packet to reflect the meter color result. Set the meter color in the mbuf to the selected color. See struct `rte_flow_action_meter_color`.
     MeterColor = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_METER_COLOR,
-    /// At embedded switch level, sends matching traffic to the given ethdev. [`struct`] `rte_flow_action_ethdev`
+    /// At embedded switch level, sends matching traffic to the given ethdev.
+    ///
+    /// `struct rte_flow_action_ethdev`
     PortRepresentor = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_PORT_REPRESENTOR,
-    /// At embedded switch level, send matching traffic to the entity represented by the given ethdev. [`struct`] `rte_flow_action_ethdev`
+    /// At embedded switch level, send matching traffic to the entity represented by the given ethdev.
+    ///
+    /// `struct rte_flow_action_ethdev`
     RepresentedPort = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_REPRESENTED_PORT,
-    /// Traffic metering and marking (MTR). [`struct`] `rte_flow_action_meter_mark` See file `rte_mtr.h` for MTR profile object configuration.
+    /// Traffic metering and marking (MTR).
+    ///
+    /// `struct rte_flow_action_meter_mark`
+    ///
+    /// See file `rte_mtr.h` for MTR profile object configuration.
     MeterMark = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_METER_MARK,
     /// Send packets to the kernel, without going to userspace at all. The packets will be received by the kernel driver sharing the same device as the DPDK port on which this action is configured. This action mostly suits bifurcated driver model. No associated configuration structure.
     SendToKernel = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_SEND_TO_KERNEL,
-    /// Apply the quota verdict (PASS or BLOCK) to a flow. [`struct`] `rte_flow_action_quota` [`struct`] `rte_flow_query_quota` [`struct`] `rte_flow_update_quota`
+    /// Apply the quota verdict (PASS or BLOCK) to a flow.
+    ///
+    /// `struct rte_flow_action_quota`
+    /// `struct rte_flow_query_quota`
+    /// `struct rte_flow_update_quota`
     Quota = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_QUOTA,
-    /// Action handle to reference flow actions list. [`struct`] `rte_flow_action_indirect_list`
+    /// Action handle to reference flow actions list.
+    ///
+    /// `struct rte_flow_action_indirect_list`
     IndirectList = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_INDIRECT_LIST,
-    /// NAT64 translation of IPv4/IPv6 headers. [`struct`] `rte_flow_action_nat64`
+    /// NAT64 translation of IPv4/IPv6 headers.
+    ///
+    /// `struct rte_flow_action_nat64`
     Nat64 = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_NAT64,
     // /// > **Deprecated** [`RTE_FLOW_ACTION_TYPE_PORT_REPRESENTOR`] [`RTE_FLOW_ACTION_TYPE_REPRESENTED_PORT`] Directs matching traffic to the physical function (PF) of the current device. No associated configuration structure.
     // RTE_FLOW_ACTION_TYPE_PF,

--- a/dpdk/src/flow/mod.rs
+++ b/dpdk/src/flow/mod.rs
@@ -372,10 +372,9 @@ pub enum MatchType {
     ///
     /// `struct rte_flow_item_ib_bth`.
     IbBth = 67,
-    /// Matches the packet type as defined in `rte_mbuf_ptype.
+    /// Matches the packet type as defined in `rte_mbuf_ptype`.
     ///
-    ///` See struct `rte_flow_item_ptype.
-    ///`
+    /// See struct `rte_flow_item_ptype`.
     Ptype = 68,
     /// \[META\]
     ///
@@ -393,7 +392,7 @@ pub enum MatchType {
     Compare = 70,
 }
 
-/// This is a wrapper around [`rte_flow_item`].
+/// This is a wrapper around `struct rte_flow_item`.
 pub enum FlowMatch {
     /// The end of a match
     End,
@@ -453,7 +452,7 @@ pub struct MatchTag {
 
 /// A metadata value to match on.
 ///
-/// see [`rte_flow_item_meta`]
+/// see `struct rte_flow_item_meta`
 #[derive(Debug, Clone, Copy)]
 pub struct MatchMeta {
     /// The meta-data to match on
@@ -597,11 +596,24 @@ pub enum FlowActionType {
     PassThrough = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_PASSTHRU,
     /// Redirects packets to a group on the current device.
     ///
-    /// See struct [`rte_flow_action_jump`]
+    /// See struct `struct rte_flow_action_jump`
     Jump = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_JUMP,
-    /// Attaches an integer value to packets and sets `RTE_MBUF_F_RX_FDIR` and `RTE_MBUF_F_RX_FDIR_ID` mbuf flags. See struct `rte_flow_action_mark`. One should negotiate mark delivery from the NIC to the PMD. [`rte_eth_rx_metadata_negotiate()`] [`RTE_ETH_RX_METADATA_USER_MARK`]
+    /// Attaches an integer value to packets and sets `RTE_MBUF_F_RX_FDIR` and
+    /// `RTE_MBUF_F_RX_FDIR_ID` mbuf flags.
+    ///
+    /// See struct `rte_flow_action_mark`.
+    ///
+    /// One should negotiate mark delivery from the NIC to the PMD.
+    ///
+    /// `rte_eth_rx_metadata_negotiate()`
+    /// `RTE_ETH_RX_METADATA_USER_MARK`
     Mark = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_MARK,
-    /// Flags packets. Similar to MARK without a specific value; only sets the `RTE_MBUF_F_RX_FDIR` mbuf flag. No associated configuration structure. One should negotiate flag delivery from the NIC to the PMD. [`rte_eth_rx_metadata_negotiate()`] [`RTE_ETH_RX_METADATA_USER_FLAG`]
+    /// Flags packets. Similar to MARK without a specific value; only sets the `RTE_MBUF_F_RX_FDIR`
+    /// mbuf flag. No associated configuration structure. One should negotiate flag delivery from
+    /// the NIC to the PMD.
+    ///
+    /// `rte_eth_rx_metadata_negotiate()`
+    /// `RTE_ETH_RX_METADATA_USER_FLAG`
     Flag = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_FLAG,
     /// Assigns packets to a given queue index. See struct `rte_flow_action_queue`.
     Queue = dpdk_sys::rte_flow_action_type::RTE_FLOW_ACTION_TYPE_QUEUE,

--- a/dpdk/src/lib.rs
+++ b/dpdk/src/lib.rs
@@ -28,6 +28,7 @@
 
 #![warn(clippy::all)]
 #![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![deny(rustdoc::all)]
 #![allow(private_bounds)]
 extern crate alloc;
 extern crate core;

--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -217,7 +217,7 @@ unsafe impl Sync for PoolInner {}
 pub struct PoolParams {
     /// The number of elements in the mbuf pool.
     /// The optimum size (in terms of memory usage) for a mempool is when n is a power of two minus
-    /// one: <var>n = 2<sup>q</sup> - 1
+    /// one: <var>n</var> = 2<sup>q</sup> - 1
     pub size: u32,
     /// Size of the per-core object cache.
     pub cache_size: u32,
@@ -385,7 +385,7 @@ impl Drop for PoolInner {
 ///
 /// # Note
 ///
-/// This is a 0-cost transparent wrapper around an [`rte_mbuf`] pointer.
+/// This is a 0-cost transparent wrapper around an [`dpdk_sys::rte_mbuf`] pointer.
 /// It can be "safely" transmuted _to_ an `*mut rte_mbuf` under the assumption that
 /// standard borrowing rules are observed.
 #[repr(transparent)]

--- a/dpdk/src/socket.rs
+++ b/dpdk/src/socket.rs
@@ -30,18 +30,19 @@ impl Drop for Manager {
 impl Manager {
     /// Initialize the DPDK socket manager.
     ///
-    /// Only [`Eal`] should only call this function, and only during initialization.
+    /// Only [`Eal`][crate::eal::Eal] should only call this function, and only during
+    /// initialization.
     pub(crate) fn init() -> Manager {
         debug!("Initializing DPDK socket manager");
         Manager
     }
 
-    /// [`Iterator`] over all the [`SocketId`]s available to the [`Eal`].
+    /// [`Iterator`] over all the [`SocketId`]s available to the [`Eal`][crate::eal::Eal].
     pub fn iter(&self) -> impl Iterator<Item = SocketId> {
         SocketId::iter()
     }
 
-    /// The number of sockets (aka NUMA nodes) on the [`Eal`].
+    /// The number of sockets (aka NUMA nodes) on the [`Eal`][crate::eal::Eal].
     #[must_use]
     pub fn count(&self) -> u32 {
         SocketId::count()
@@ -106,7 +107,7 @@ impl From<c_uint> for Index {
     }
 }
 
-/// Iterator over all the [`SocketId`]s available to the [`Eal`].
+/// Iterator over all the [`SocketId`]s available to the [`Eal`][crate::eal::Eal].
 struct SocketIdIterator {
     index: Index,
     count: c_uint,
@@ -143,11 +144,11 @@ impl Iterator for SocketIdIterator {
 ///
 /// A [`SocketId`] is not at all the same thing as a socket index!
 ///
-/// A socket index is a zero-based index into the list of sockets on the [`Eal`].
-/// For example, if the [`SocketId`]s on the [`Eal`] are `[2, 3, 5]`, then index `1` would refer
-/// to [`SocketId(3)`].
+/// A socket index is a zero-based index into the list of sockets on the [`Eal`][crate::eal::Eal].
+/// For example, if the [`SocketId`]s on the [`Eal`][crate::eal::Eal] are `[2, 3, 5]`, then index
+/// `1` would refer to [`SocketId(3)`].
 /// It needs to work this way because there is no rule stating that we have a contiguous,
-/// zero-indexed list of sockets in the [`Eal`].
+/// zero-indexed list of sockets in the [`Eal`][crate::eal::Eal].
 ///
 /// </div>
 ///
@@ -194,12 +195,12 @@ impl SocketId {
         }
     }
 
-    /// [`Iterator`] over all the [`SocketId`]s available to the [`Eal`].
+    /// [`Iterator`] over all the [`SocketId`]s available to the [`Eal`][crate::eal::Eal].
     pub(crate) fn iter() -> impl Iterator<Item = SocketId> {
         SocketIdIterator::new()
     }
 
-    /// The number of sockets (aka NUMA nodes) on the [`Eal`].
+    /// The number of sockets (aka NUMA nodes) on the [`Eal`][crate::eal::Eal].
     ///
     /// This is a wrapper around [`rte_socket_count`].
     ///


### PR DESCRIPTION
Address rustdoc complaints in dpdk and dataplane packages, and reject (the majority of) rustdoc reports in the future. This should make it easier to test rustdocs in the future, and avoid reintroducing broken links in these components.

Easier to review per-commit.
