### PR TITLE
chore(justfile): Return to branch after "just build-sweep"

### DIFF
--- a/justfile
+++ b/justfile
@@ -398,8 +398,11 @@ build-sweep start="main":
       >&2 echo "can not build-sweep with dirty branch (would risk data loss)"
       exit 1
     fi
+    INIT_HEAD=$(git rev-parse --abbrev-ref HEAD)
     # Get all commits since {{ start }}, in chronological order
     while read -r commit; do
       git -c advice.detachedHead=false checkout "${commit}" || exit 1
       { just debug_justfile={{ debug_justfile }} cargo +{{ rust }} build --locked --profile=dev --target=x86_64-unknown-linux-gnu; } || exit 1
     done < <(git rev-list --reverse "{{ start }}".."$(git rev-parse HEAD)")
+    # Return to the initial branch if any (exit "detached HEAD" state)
+    git checkout "${INIT_HEAD}"


### PR DESCRIPTION
We have a "just build-sweep" command that we use to automate building each commit from a changeset in order, to make sure that we don't introduce intermediate failures that might hinder bisections. This command works by checking out a start commit, then iterating over until it comes back to the initial commit (the HEAD of the branch).

However, when we check out previous commits in the history to try and build the project at these commits, Git switches to "detached HEAD" mode. This is expected, and totally fine for our use case. There is one issue, though: we remain in "detached HEAD" mode even after we're done iterating. This may catch the user out off guard, for example if they try to amend the latest commit or to push their branch.

To avoid that, save the name of the branch, if any, before iterating, and on success, check out the branch again. On failure, we remain in "detached HEAD" state on the commit that caused the build failure, but this is to be expected and shouldn't surprise the user. If the user runs the command from "detached HEAD" state, then "git rev-parse" will return HEAD, and the last checkout will be a no-op.
