### PR TITLE
Fix Clippy reports for NAT tests

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -147,7 +147,8 @@ jobs:
         if: "${{ matrix.rust.version != 'nightly' }}"
         name: "run clippy"
         run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} cargo clippy
+          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} \
+            cargo clippy --all-targets --all-features -- -D warnings
         continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "build_each_commit"

--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -105,7 +105,7 @@ jobs:
         if: ${{ always() }}
         run: |
           just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
-            sterile cargo clippy
+            sterile cargo clippy --all-targets --all-features -- -D warnings
 
 
       - name: "Setup tmate session for debug"

--- a/dataplane/src/nat/fabric.rs
+++ b/dataplane/src/nat/fabric.rs
@@ -394,10 +394,10 @@ mod tests {
         // Serialize, deserialize
 
         let serialized = serde_yml::to_string(&vpc1).expect("Failed to serialize");
-        println!("{}", serialized);
+        println!("{serialized}");
 
         let deserialized: Vpc = serde_yml::from_str(&serialized).expect("Failed to deserialize");
-        println!("{:?}", deserialized);
+        println!("{serialized:?}");
 
         assert_eq!(deserialized.pif_table.pifs.len(), 1);
         assert_eq!(deserialized.get_pif(&"pif1".into()), Some(&pif1));

--- a/dataplane/src/nat/iplist.rs
+++ b/dataplane/src/nat/iplist.rs
@@ -256,33 +256,35 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Mixed IPv4 and IPv6 prefixes not supported")]
     fn test_incompatible_list_types_v4() {
         // Try adding a prefix of a different IP version
         build_v4_iplist().add_prefix(prefix_v6("aa::0/32"));
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Prefix overlap not supported")]
     fn test_unsupported_overlap_v4() {
         // Try adding a prefix of a different IP version
         build_v4_iplist().add_prefix(prefix_v4("10.0.1.0/24"));
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Prefix overlap not supported")]
     fn test_unsupported_overlap_v6() {
         // Try adding an overlapping prefix
         build_v6_iplist().add_prefix(prefix_v6("aa:11::/64"));
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Mixed IPv4 and IPv6 prefixes not supported")]
     fn test_incompatible_list_types_v6() {
         // Try adding an overlapping prefix
         build_v6_iplist().add_prefix(prefix_v4("10.0.0.0/24"));
     }
 
+    // Hey Clippy, it's OK to have "+ 0" in sums to better understand how we compute the offsets
+    #[allow(clippy::identity_op)]
     #[test]
     fn test_iplist_v4() {
         let list = build_v4_iplist();
@@ -315,6 +317,8 @@ mod tests {
         assert_eq!(list.get_addr(3 * 4 + 256 + 1), None);
     }
 
+    // Hey Clippy, it's OK to have "+ 0" in sums to better understand how we compute the offsets
+    #[allow(clippy::identity_op)]
     #[test]
     fn test_iplist_v6() {
         let list = build_v6_iplist();

--- a/dataplane/src/nat/mod.rs
+++ b/dataplane/src/nat/mod.rs
@@ -473,7 +473,7 @@ mod tests {
         let hdr0_out = &packets_out[0]
             .try_ipv4()
             .expect("Failed to get IPv4 header");
-        println!("L3 header: {:?}", hdr0_out);
+        println!("L3 header: {hdr0_out:?}");
         assert_eq!(hdr0_out.source().inner(), addr_v4("4.4.4.4"));
     }
 
@@ -496,7 +496,7 @@ mod tests {
         let hdr0_out = &packets_out[0]
             .try_ipv4()
             .expect("Failed to get IPv4 header");
-        println!("L3 header: {:?}", hdr0_out);
+        println!("L3 header: {hdr0_out:?}");
         assert_eq!(hdr0_out.destination(), addr_v4("8.8.8.4"));
     }
 }


### PR DESCRIPTION
- **fix(nat): Fix Clippy reports in tests**
- **ci(clippy): Run Clippy on all targets**

Can you believe it? Our CI doesn't run Clippy on all targets, and allowed Clippy reports to creep in via the unit tests!

Fix the issues in NAT tests. Then, make sure we run Clippy on all targets. While at it, let's also tell it to use all features and to fail on warnings.
