### PR TITLE
ci: Check Git repository status to avoid omitting Cargo.lock updates

### DIFF
--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -107,6 +107,14 @@ jobs:
           just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=dev target=x86_64-unknown-linux-gnu \
             sterile cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: "check Git status"
+        run: |
+          if ! git diff --quiet; then
+              printf '::error::Git working directory is dirty, missing Cargo.lock update?\n\n'
+              git --no-pager diff
+              printf '\nPlease commit the changes and update your Pull Request\n'
+              exit 1
+          fi
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -924,7 +924,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1530,11 +1530,31 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.23",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]


### PR DESCRIPTION
To avoid contributors forgetting to commit the Cargo.lock updates, let's add a step to the sterile.yml workflow, to check whether building or testing the changes resulted in an updated Cargo.lock file. To do that, we check the result value from `git diff --quiet`.
