### PR TITLE
fix: Move Packet to net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -389,7 +389,6 @@ dependencies = [
 name = "dataplane"
 version = "0.1.0"
 dependencies = [
- "ahash",
  "clap",
  "ctrlc",
  "dataplane-id",
@@ -572,9 +571,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -624,9 +623,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libloading"
@@ -725,6 +724,7 @@ dependencies = [
 name = "net"
 version = "0.0.1"
 dependencies = [
+ "ahash",
  "arbitrary",
  "arrayvec",
  "bolero",
@@ -798,15 +798,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "ordermap"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55fdf45a2b1e929e3656d404395767e05c98b6ebd8157eb31e370077d545160"
+checksum = "6e98f974336ceffd5b1b1f4fcbb89a23c8dcd334adc4b8612f11b7fa99944535"
 dependencies = [
  "indexmap",
 ]
@@ -871,7 +871,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -924,7 +924,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -1036,9 +1036,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
  "bitflags",
  "errno",
@@ -1530,11 +1530,31 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.23",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-ahash = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 ctrlc = { workspace = true, features = ["termination"] }
 dpdk = { workspace = true }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -7,9 +7,6 @@
 
 mod args;
 mod nat;
-mod packet;
-mod packet_hash;
-mod packet_meta;
 mod pipeline;
 
 use dpdk::dev::{Dev, TxOffloadConfig};
@@ -22,9 +19,9 @@ use dpdk::{dev, eal, socket};
 use tracing::{info, trace, warn};
 
 use crate::args::{CmdArgs, Parser};
-use crate::packet::Packet;
 use crate::pipeline::sample_nfs::Passthrough;
 use crate::pipeline::{DynPipeline, NetworkFunction};
+use net::packet::Packet;
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: RteAllocator = RteAllocator::new_uninitialized();

--- a/dataplane/src/nat/mod.rs
+++ b/dataplane/src/nat/mod.rs
@@ -43,7 +43,6 @@ mod prefixtrie;
 use crate::nat::fabric::{PeeringPolicy, Pif, Vpc};
 use crate::nat::iplist::{IpList, IpListType};
 use crate::nat::prefixtrie::PrefixTrie;
-use crate::packet::Packet;
 use crate::pipeline::NetworkFunction;
 
 use net::buffer::PacketBufferMut;
@@ -51,6 +50,7 @@ use net::headers::Net;
 use net::headers::{TryHeadersMut, TryIpMut};
 use net::ipv4::UnicastIpv4Addr;
 use net::ipv6::UnicastIpv6Addr;
+use net::packet::Packet;
 use net::vxlan::Vni;
 use std::collections::HashMap;
 use std::fmt::Debug;

--- a/dataplane/src/pipeline/dyn_nf.rs
+++ b/dataplane/src/pipeline/dyn_nf.rs
@@ -15,8 +15,8 @@ use std::marker::PhantomData;
 ///
 /// # See Also
 ///
-/// [`nf_dyn`]
-/// [`crate::pipeline::DynPipeline`]
+/// * [`nf_dyn`]
+/// * [`crate::pipeline::DynPipeline`]
 pub trait DynNetworkFunction<Buf: PacketBufferMut>: Any {
     /// The `process_dyn` method takes an iterator of [`Packet`] objects,
     /// However, unlike [`NetworkFunction::process`], this method does not require concrete
@@ -55,8 +55,8 @@ impl<Buf: PacketBufferMut, NF: NetworkFunction<Buf>> DynNetworkFunctionImpl<Buf,
 ///
 /// # See Also
 ///
-/// [`DynNetworkFunction`]
-/// [`crate::pipeline::DynPipeline`]
+/// * [`DynNetworkFunction`]
+/// * [`crate::pipeline::DynPipeline`]
 pub fn nf_dyn<Buf: PacketBufferMut + 'static, NF: NetworkFunction<Buf> + 'static>(
     nf: NF,
 ) -> Box<dyn DynNetworkFunction<Buf>> {

--- a/dataplane/src/pipeline/dyn_nf.rs
+++ b/dataplane/src/pipeline/dyn_nf.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use crate::pipeline::NetworkFunction;
 use dyn_iter::{DynIter, IntoDynIterator};
 use net::buffer::PacketBufferMut;
+use net::packet::Packet;
 use std::any::Any;
 use std::marker::PhantomData;
-
-use crate::packet::Packet;
-use crate::pipeline::NetworkFunction;
 
 /// Trait for an object that processes a stream of packets.
 ///
@@ -19,13 +18,13 @@ use crate::pipeline::NetworkFunction;
 /// [`nf_dyn`]
 /// [`crate::pipeline::DynPipeline`]
 pub trait DynNetworkFunction<Buf: PacketBufferMut>: Any {
-    /// The `process_dyn` method takes an iterator of [`crate::packet::Packet`] objects,
+    /// The `process_dyn` method takes an iterator of [`Packet`] objects,
     /// However, unlike [`NetworkFunction::process`], this method does not require concrete
     /// iterator types.
     ///
-    /// To call this method, import the [`dyn_iter::IntoDynIterator`] trait and use the
-    /// `into_dyn_iter` method to get a [`dyn_iter::DynIter`] to use with this method.
-    /// Generally you should not need to call this method directly, instead just call
+    /// To call this method, import the [`IntoDynIterator`] trait and use the
+    /// `into_dyn_iter` method to get a [`DynIter`] to use with this method.
+    /// Generally, you should not need to call this method directly, instead call
     /// [`DynPipeline::process`][crate::pipeline::DynPipeline::process] with a concrete iterator
     /// type.  However, if you only have a dynamic iterator, you can use this method to process the
     /// packets.

--- a/dataplane/src/pipeline/pipeline.rs
+++ b/dataplane/src/pipeline/pipeline.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use crate::pipeline::dyn_nf::DynNetworkFunctionImpl;
+use crate::pipeline::{DynNetworkFunction, NetworkFunction, nf_dyn};
 use dyn_iter::{DynIter, IntoDynIterator};
 use id::Id;
 use net::buffer::PacketBufferMut;
+use net::packet::Packet;
 use ordermap::OrderMap;
 use std::any::Any;
-
-use crate::packet::Packet;
-use crate::pipeline::dyn_nf::DynNetworkFunctionImpl;
-use crate::pipeline::{DynNetworkFunction, NetworkFunction, nf_dyn};
 
 pub type StageId<Buf> = Id<Box<dyn DynNetworkFunction<Buf>>>;
 

--- a/dataplane/src/pipeline/sample_nfs.rs
+++ b/dataplane/src/pipeline/sample_nfs.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use crate::pipeline::NetworkFunction;
 use net::buffer::PacketBufferMut;
 use net::eth::mac::{DestinationMac, Mac};
 use net::headers::{TryEthMut, TryHeaders, TryIpv4Mut, TryIpv6Mut};
+use net::packet::Packet;
 use tracing::{debug, trace};
-
-use crate::packet::Packet;
-use crate::pipeline::NetworkFunction;
 
 /// Network function that uses [`debug!`] to print the parsed packet headers.
 pub struct InspectHeaders;

--- a/dataplane/src/pipeline/static_nf.rs
+++ b/dataplane/src/pipeline/static_nf.rs
@@ -2,13 +2,12 @@
 // Copyright Open Network Fabric Authors
 
 use net::buffer::PacketBufferMut;
+use net::packet::Packet;
 use std::marker::PhantomData;
-
-use crate::packet::Packet;
 
 /// Trait for an object that processes a stream of packets.
 pub trait NetworkFunction<Buf: PacketBufferMut> {
-    /// The `process` method takes an iterator of [`crate::packet::Packet`] objects,
+    /// The `process` method takes an iterator of [`Packet`] objects,
     /// applies the appropriate transformations (or drops) and returns an iterator of
     /// modified packets.
     ///

--- a/dataplane/src/pipeline/test_utils.rs
+++ b/dataplane/src/pipeline/test_utils.rs
@@ -3,6 +3,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+use crate::pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
+use crate::pipeline::{DynNetworkFunction, nf_dyn};
 use net::buffer::TestBuffer;
 use net::eth::Eth;
 use net::eth::ethtype::EthType;
@@ -10,13 +12,10 @@ use net::eth::mac::{DestinationMac, Mac, SourceMac};
 use net::headers::{Headers, Net};
 use net::ipv4::Ipv4;
 use net::ipv4::addr::UnicastIpv4Addr;
+use net::packet::{InvalidPacket, Packet};
 use net::parse::DeParse;
 use std::default::Default;
 use std::net::Ipv4Addr;
-
-use crate::packet::{InvalidPacket, Packet};
-use crate::pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
-use crate::pipeline::{DynNetworkFunction, nf_dyn};
 
 /// Generates an infinite sequence of network functions.
 ///

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -11,6 +11,7 @@ arbitrary = ["dep:arbitrary", "dep:bolero"]
 test_buffer = []
 
 [dependencies]
+ahash = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 arrayvec = { workspace = true }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -26,6 +26,7 @@ pub mod ip;
 pub mod ip_auth;
 pub mod ipv4;
 pub mod ipv6;
+pub mod packet;
 pub mod parse;
 pub mod tcp;
 pub mod udp;

--- a/net/src/packet/hash.rs
+++ b/net/src/packet/hash.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
-//
+
 //! Module to compute packet hashes
 
 use super::Packet;
+use crate::buffer::PacketBufferMut;
+use crate::headers::{Net, Transport, TryHeaders, TryIp, TryTransport};
 use ahash::AHasher;
-use net::buffer::PacketBufferMut;
-use net::headers::{Net, Transport, TryHeaders, TryIp, TryTransport};
 use std::hash::{Hash, Hasher};
 
 impl<Buf: PacketBufferMut> Packet<Buf> {

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use routing::vrf::VrfId;
 use std::collections::HashMap;
 use std::net::IpAddr;
+
+/// Every VRF is univocally identified with a numerical VRF id
+pub type VrfId = u32;
 
 #[derive(Debug, Default)]
 pub struct InterfaceId(u32);
 #[allow(unused)]
 impl InterfaceId {
+    #[must_use]
     pub fn new(val: u32) -> Self {
         Self(val)
     }
+    #[must_use]
     pub fn get_id(&self) -> u32 {
         self.0
     }
@@ -21,9 +25,11 @@ impl InterfaceId {
 pub struct BridgeDomain(u32);
 #[allow(unused)]
 impl BridgeDomain {
+    #[must_use]
     pub fn get_id(&self) -> u32 {
         self.0
     }
+    #[must_use]
     pub fn with_id(id: u32) -> Self {
         Self(id)
     }
@@ -82,6 +88,7 @@ pub struct PacketDropStats {
 
 impl PacketDropStats {
     #[allow(dead_code)]
+    #[must_use]
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_owned(),
@@ -96,10 +103,12 @@ impl PacketDropStats {
             .or_insert(value);
     }
     #[allow(dead_code)]
+    #[must_use]
     pub fn get_stat(&self, reason: DoneReason) -> Option<u64> {
         self.reasons.get(&reason).copied()
     }
     #[allow(dead_code)]
+    #[must_use]
     pub fn get_stats(&self) -> &HashMap<DoneReason, u64> {
         &self.reasons
     }
@@ -108,7 +117,8 @@ impl PacketDropStats {
 #[cfg(test)]
 pub mod test {
     use super::DoneReason;
-    use crate::packet_meta::PacketDropStats;
+    use super::PacketDropStats;
+
     #[test]
     fn test_packet_drop_stats() {
         let mut stats = PacketDropStats::new("Stats:pipeline-FOO-stage-BAR");


### PR DESCRIPTION
`Packet` (et. al.) need to live in net to avoid circular dependencies with, for example, the routing crate.

This logic was created in dataplane but never truly belonged there in the first place.