### PR TITLE
ci: Disable stable toolchain for dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,9 +75,12 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - # failures on stable block release
-            version: "stable"
-            optional: true
+          # Disabled until we reach 1.86 as stable, as it always fails.
+          # Uncomment when we revert commit 643de7afc7fc
+          # ("fix(justfile): Use beta release of rust, not stable")
+          #- # failures on stable block release
+          #  version: "stable"
+          #  optional: true
           - # failures on beta block release
             version: "beta"
             optional: false


### PR DESCRIPTION
We don't use the "stable" toolchain these days, given that we require Rust features that are in 1.86 (the current beta). Running the stable workflow in CI just burns resources and generates some noise in the discussion thread for the Pull Requests. Disable it.

This commit should be revert right before we revert commit 643de7afc7fc ("fix(justfile): Use beta release of rust, not stable").

Note: 1.86 is due to become stable on 3rd April (https://releases.rs/docs/1.86.0/).
