### PR TITLE
build: Add "just clippy" target

### DIFF
--- a/justfile
+++ b/justfile
@@ -393,6 +393,12 @@ mdbook *args="build":
       {{ _doc_env_container }} \
       {{ args }}
 
+# Serve rustdoc output locally (using port 8000)
+[script]
+rustdoc-serve:
+    echo "Launching web server, hit Ctrl-C to stop."
+    python -m http.server -d "target/{{ target }}/doc"
+
 # Build for each separate commit (for "pull_request") or for the HEAD of the branch (other events)
 [script]
 build-sweep start="main":

--- a/justfile
+++ b/justfile
@@ -98,7 +98,7 @@ _build_time := datetime_utc("%+")
 @default:
     just --list --justfile {{ justfile() }}
 
-# Run cargo with RUSTFLAGS computed based on profile.
+# Run cargo with RUSTFLAGS computed based on profile
 [script]
 cargo *args:
     # Ideally this would be done via Cargo.toml and .cargo/config.toml,
@@ -255,7 +255,7 @@ setup-test-env: allocate-2M-hugepages allocate-1G-hugepages mount-hugepages
 # Tear down environment for testing locally
 teardown-test-env: umount-hugepages
 
-# Dump the compile-env container into a sysroot for use by the build.
+# Dump the compile-env container into a sysroot for use by the build
 [script]
 create-compile-env:
     {{ _just_debuggable_ }}
@@ -368,6 +368,10 @@ push-container: build-container
       sudo -E docker push "{{ _container_repo }}:$(truncate128 "{{ _slug }}")"
     fi
 
+# Run Clippy like you're in CI
+[script]
+clippy: (cargo "clippy" "--all-targets" "--all-features" "--" "-D" "warnings")
+
 # run commands in a minimal mdbook container
 [script]
 mdbook *args="build":
@@ -389,7 +393,7 @@ mdbook *args="build":
       {{ _doc_env_container }} \
       {{ args }}
 
-# Build for each separate commit (for "pull_request") or for the HEAD of the branch (other events).
+# Build for each separate commit (for "pull_request") or for the HEAD of the branch (other events)
 [script]
 build-sweep start="main":
     {{ _just_debuggable_ }}


### PR DESCRIPTION
Add a `just clippy` target to the justfile to help run Clippy. Running Clippy on the codebase is easy: `cargo clippy` should do. However, this may not run Clippy the way one should expect:

- If run without `just`, this may not pass all required flags to cargo, and may result Clippy running with different options. One consequence would be some undesired updates to the Cargo.lock file, or some Clippy reports that don't show as expected.

- By default, `cargo clippy` or even `just cargo clippy` will not run Clippy for all features, and in particular, they will not run on unit tests. This may hide Clippy reports.

In CI, we already make sure we run Clippy on tests since commit 550c75136cf9 ("ci(clippy): Run Clippy on all targets"). This commit adds a `clippy` target to the justfile to help users doing the same locally, just like we do in CI, without having to remember to pass all the necessary arguments to Clippy.
