### PR TITLE
chore: Add missing license info in Cargo.toml files

### DIFF
--- a/dpdk-sys/Cargo.toml
+++ b/dpdk-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 edition = "2024"
 description = "Low-level bindings to the Data Plane Development Kit (DPDK)"
 publish = false
+license = "Apache-2.0"
 
 [lib]
 doctest = false

--- a/dpdk/Cargo.toml
+++ b/dpdk/Cargo.toml
@@ -3,6 +3,7 @@ name = "dpdk"
 version = "0.1.0"
 edition = "2024"
 publish = false
+license = "Apache-2.0"
 
 [features]
 default = ["serde"]

--- a/id/Cargo.toml
+++ b/id/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dataplane-id"
 version = "0.1.0"
 edition = "2024"
+publish = false
 license = "Apache-2.0"
 
 # TODO: fix doctests in sterile env

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -3,6 +3,7 @@ name = "net"
 version = "0.0.1"
 edition = "2024"
 publish = false
+license = "Apache-2.0"
 
 [features]
 default = []

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -3,6 +3,7 @@ name = "routing"
 version = "0.1.0"
 edition = "2024"
 publish = false
+license = "Apache-2.0"
 
 [features]
 auto-learn = []


### PR DESCRIPTION
To avoid ambiguity in terms of licensing, explicitly provide a license parameters in the Cargo.toml of all packages in the repository. This should also help FOSSA, which currently struggles to determine the license for these crates.

The license is set to Apache-2.0, as for the packages that already stated a license.

Relates to #332