### PR TITLE
Packet utils

### DIFF
--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -9,6 +9,7 @@ mod hash;
 mod meta;
 #[cfg(any(test, feature = "test_buffer"))]
 pub mod test_utils;
+pub mod utils;
 
 use crate::buffer::PacketBufferMut;
 use crate::eth::EthError;

--- a/net/src/packet/utils.rs
+++ b/net/src/packet/utils.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Packet higher-level methods to allow for code reuse
+
+use std::net::IpAddr;
+
+use crate::eth::Eth;
+use crate::eth::ethtype::EthType;
+use crate::eth::mac::Mac;
+use crate::headers::Net::{Ipv4, Ipv6};
+use crate::headers::{TryEth, TryIp};
+use crate::ip::NextHeader;
+use crate::packet::Packet;
+use crate::packet::PacketBufferMut;
+
+impl<Buf: PacketBufferMut> Packet<Buf> {
+    /// Get the destination mac address of a [`Packet`]
+    /// Returns None if the packet does not have an Ethernet header
+    pub fn eth_destination(&self) -> Option<Mac> {
+        self.try_eth().map(|eth| eth.destination().inner())
+    }
+
+    /// Get the source mac address of a [`Packet`]
+    /// Returns None if the packet does not have an Ethernet header
+    pub fn eth_source(&self) -> Option<Mac> {
+        self.try_eth().map(|eth| eth.source().inner())
+    }
+
+    /// Get the ether type of an [`Packet`]
+    /// Returns None if the packet does not have an Ethernet header
+    pub fn eth_type(&self) -> Option<EthType> {
+        self.try_eth().map(Eth::ether_type)
+    }
+
+    /// Get the source ip address of an IPv4 / IPv6 [`Packet`]
+    /// Returns None if the packet does not have an IP header
+    pub fn ip_source(&self) -> Option<IpAddr> {
+        self.try_ip().map(|net| match net {
+            Ipv4(ipv4) => IpAddr::V4(ipv4.source().inner()),
+            Ipv6(ipv6) => IpAddr::V6(ipv6.source().inner()),
+        })
+    }
+
+    /// Get the destination ip address of an IPv4 / IPv6 [`Packet`]
+    /// Returns None if the packet does not have an IP header
+    pub fn ip_destination(&self) -> Option<IpAddr> {
+        self.try_ip().map(|net| match net {
+            Ipv4(ipv4) => IpAddr::V4(ipv4.destination()),
+            Ipv6(ipv6) => IpAddr::V6(ipv6.destination()),
+        })
+    }
+
+    /// Get the Ip protocol / next-header of an IPv4 / IPv6 [`Packet`]
+    /// Returns None if the packet does not have an IP header
+    pub fn ip_proto(&self) -> Option<NextHeader> {
+        self.try_ip().map(|net| match net {
+            Ipv4(ipv4) => NextHeader(ipv4.protocol()),
+            Ipv6(ipv6) => ipv6.next_header(),
+        })
+    }
+}


### PR DESCRIPTION
Adds several getters for packet fields frequently retrieved, using in the results generalized types like std::net::IpAddr or Mac, (instead of DestinationMac or SourceMac) so that consumers need not depend on or distinguish those types. The methods are meant for code reuse, readability and ergonomics.