### PR TITLE
Move the pipeline code to separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "iptrie",
  "net",
  "ordermap",
+ "pipeline",
  "routing",
  "serde",
  "serde_yml",
@@ -865,6 +866,19 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pipeline"
+version = "0.1.0"
+dependencies = [
+ "dataplane-id",
+ "dyn-iter",
+ "net",
+ "ordermap",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"errno",
 	"id",
 	"net",
+	"pipeline",
 	"routing",
 ]
 
@@ -17,6 +18,7 @@ default-members = [
 	"errno",
 	"id",
 	"net",
+	"pipeline",
 	"routing",
 ]
 
@@ -32,6 +34,7 @@ dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = 
 errno = { path = "./errno", package = "dataplane-errno" }
 id = { path = "./id", package = "dataplane-id" }
 net = { path = "./net" }
+pipeline = { path = "./pipeline" }
 routing = { path = "./routing" }
 
 # External

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -14,6 +14,7 @@ iptrie = { workspace = true }
 dyn-iter = { workspace = true }
 net = { workspace = true, features = ["serde"] }
 ordermap = { workspace = true, features = ["std"] }
+pipeline = { workspace = true }
 routing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yml = { workspace = true }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -7,7 +7,6 @@
 
 mod args;
 mod nat;
-mod pipeline;
 
 use dpdk::dev::{Dev, TxOffloadConfig};
 use dpdk::eal::Eal;
@@ -19,9 +18,9 @@ use dpdk::{dev, eal, socket};
 use tracing::{info, trace, warn};
 
 use crate::args::{CmdArgs, Parser};
-use crate::pipeline::sample_nfs::Passthrough;
-use crate::pipeline::{DynPipeline, NetworkFunction};
 use net::packet::Packet;
+use pipeline::sample_nfs::Passthrough;
+use pipeline::{DynPipeline, NetworkFunction};
 
 #[global_allocator]
 static GLOBAL_ALLOCATOR: RteAllocator = RteAllocator::new_uninitialized();

--- a/dataplane/src/nat/mod.rs
+++ b/dataplane/src/nat/mod.rs
@@ -43,7 +43,7 @@ mod prefixtrie;
 use crate::nat::fabric::{PeeringPolicy, Pif, Vpc};
 use crate::nat::iplist::IpList;
 use crate::nat::prefixtrie::PrefixTrie;
-use crate::pipeline::NetworkFunction;
+use pipeline::NetworkFunction;
 
 use net::buffer::PacketBufferMut;
 use net::headers::Net;

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -4,7 +4,7 @@
 //! [`PacketBuffer`] and related traits
 
 #[cfg(any(test, feature = "test_buffer"))]
-mod test_buffer;
+pub mod test_buffer;
 
 use core::fmt::Debug;
 #[allow(unused_imports)] // re-export

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pipeline"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "Apache-2.0"
+
+[dependencies]
+dyn-iter = { workspace = true }
+id = { workspace = true }
+net = { workspace = true }
+ordermap = { workspace = true, features = ["std"] }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+net = { workspace = true, features = ["test_buffer"] }

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 license = "Apache-2.0"
 
+[lib]
+doctest = false
+
 [dependencies]
 dyn-iter = { workspace = true }
 id = { workspace = true }

--- a/pipeline/src/dyn_nf.rs
+++ b/pipeline/src/dyn_nf.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use crate::pipeline::NetworkFunction;
+use crate::NetworkFunction;
 use dyn_iter::{DynIter, IntoDynIterator};
 use net::buffer::PacketBufferMut;
 use net::packet::Packet;

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use crate::pipeline::dyn_nf::DynNetworkFunctionImpl;
-use crate::pipeline::{DynNetworkFunction, NetworkFunction, nf_dyn};
+#![allow(clippy::missing_errors_doc)]
+
+use crate::dyn_nf::DynNetworkFunctionImpl;
+use crate::{DynNetworkFunction, NetworkFunction, nf_dyn};
 use dyn_iter::{DynIter, IntoDynIterator};
 use id::Id;
 use net::buffer::PacketBufferMut;
@@ -10,6 +12,7 @@ use net::packet::Packet;
 use ordermap::OrderMap;
 use std::any::Any;
 
+/// A type that represents an Id for a stage or NF
 pub type StageId<Buf> = Id<Box<dyn DynNetworkFunction<Buf>>>;
 
 /// A dynamic pipeline that can be updated at runtime.
@@ -31,7 +34,9 @@ pub enum PipelineError {
 }
 
 impl<Buf: PacketBufferMut> DynPipeline<Buf> {
+    /// Create a [`DynPipeline`].
     #[allow(unused)]
+    #[must_use]
     pub fn new() -> Self {
         Self {
             nfs: OrderMap::new(),
@@ -43,6 +48,7 @@ impl<Buf: PacketBufferMut> DynPipeline<Buf> {
     /// This method takes a [`NetworkFunction`] and adds it to the pipeline.
     ///
     #[allow(unused)]
+    #[must_use]
     pub fn add_stage<NF: NetworkFunction<Buf> + 'static>(self, nf: NF) -> Self {
         self.add_stage_dyn(nf_dyn(nf))
     }
@@ -69,6 +75,7 @@ impl<Buf: PacketBufferMut> DynPipeline<Buf> {
     /// [`DynNetworkFunction`]
     /// [`nf_dyn`]
     #[allow(unused)]
+    #[must_use]
     pub fn add_stage_dyn(mut self, nf: Box<dyn DynNetworkFunction<Buf>>) -> Self {
         self.internal_add_stage_dyn_with_id(StageId::<Buf>::new(), nf);
         self
@@ -153,6 +160,7 @@ impl<Buf: PacketBufferMut> DynPipeline<Buf> {
     /// # See Also
     ///
     #[allow(unused)]
+    #[must_use]
     pub fn get_stage_dyn_by_id<T: DynNetworkFunction<Buf>>(&self, id: &StageId<Buf>) -> Option<&T> {
         self.nfs
             .get(id)
@@ -186,10 +194,10 @@ mod test {
     use net::eth::mac::{DestinationMac, Mac};
     use net::headers::{Net, TryEth, TryIp, TryIpv4};
 
-    use crate::pipeline::dyn_nf::DynNetworkFunctionImpl;
-    use crate::pipeline::sample_nfs::DecrementTtl;
-    use crate::pipeline::test_utils::DynStageGenerator;
-    use crate::pipeline::{DynNetworkFunction, DynPipeline, NetworkFunction, StageId};
+    use crate::dyn_nf::DynNetworkFunctionImpl;
+    use crate::sample_nfs::DecrementTtl;
+    use crate::test_utils::DynStageGenerator;
+    use crate::{DynNetworkFunction, DynPipeline, NetworkFunction, StageId};
     use net::packet::test_utils::build_test_ipv4_packet;
 
     type TestStageId = StageId<TestBuffer>;

--- a/pipeline/src/sample_nfs.rs
+++ b/pipeline/src/sample_nfs.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use crate::pipeline::NetworkFunction;
+use crate::NetworkFunction;
 use net::buffer::PacketBufferMut;
 use net::eth::mac::{DestinationMac, Mac};
 use net::headers::{TryEthMut, TryHeaders, TryIpv4Mut, TryIpv6Mut};

--- a/pipeline/src/static_nf.rs
+++ b/pipeline/src/static_nf.rs
@@ -57,6 +57,7 @@ impl<Buf: PacketBufferMut, NF1: NetworkFunction<Buf>, NF2: NetworkFunction<Buf>>
 ///
 /// </div>
 pub trait StaticChain<Buf: PacketBufferMut>: NetworkFunction<Buf> {
+    /// Chain a network function (self) with another, producing a third
     #[allow(unused)]
     fn chain<NF: NetworkFunction<Buf>>(self, nf: NF) -> impl NetworkFunction<Buf>;
 }
@@ -80,8 +81,8 @@ mod test {
     use net::eth::mac::{DestinationMac, Mac};
     use net::headers::{TryEth, TryIpv4};
 
-    use crate::pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
-    use crate::pipeline::{NetworkFunction, StaticChain};
+    use crate::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
+    use crate::{NetworkFunction, StaticChain};
     use net::packet::test_utils::build_test_ipv4_packet;
 
     #[test]

--- a/pipeline/src/test_utils.rs
+++ b/pipeline/src/test_utils.rs
@@ -3,8 +3,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use crate::pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
-use crate::pipeline::{DynNetworkFunction, nf_dyn};
+use crate::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
+use crate::{DynNetworkFunction, nf_dyn};
 use net::buffer::TestBuffer;
 
 /// Generates an infinite sequence of network functions.


### PR DESCRIPTION
This is needed to avoid circular dependencies.