### PR TITLE
chore(dataplane): fix command line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bindgen = { version = "0.71.1", default-features = false, features = [] }
 bolero = { version = "0.13.0", default-features = false, features = [] }
 bytes = { version = "1.10.1", default-features = false, features = [] }
 # std feature currently globally required for clap
-clap = { version = "4.5.32", default-features = false, features = ["std"] }
+clap = { version = "4.5.32", default-features = true, features = [] }
 ctrlc = { version = "3.4.5", default-features = false, features = [] }
 doxygen-rs = { version = "0.4.2", default-features = false, features = [] }
 dyn-iter = { version = "1.0.1", default-features = false, features = [] }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["std", "derive", "usage"] }
 ctrlc = { workspace = true, features = ["termination"] }
 dpdk = { workspace = true }
 id = { workspace = true }


### PR DESCRIPTION
The command line was throwing an error when requesting --help Enabling the default features at the top level Cargo.toml seems to fix the problem.