### PR TITLE
CI: Disable "cargo doc" with release profile

### DIFF
--- a/.github/workflows/sterile.yml
+++ b/.github/workflows/sterile.yml
@@ -98,8 +98,6 @@ jobs:
         run: |
           just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
             sterile cargo test
-          just debug_justfile="${{inputs.debug_justfile}}" rust="${{matrix.rust}}" profile=release target=x86_64-unknown-linux-gnu \
-            sterile cargo doc
 
       - name: "run clippy"
         if: ${{ always() }}

--- a/dpdk-sys/Cargo.toml
+++ b/dpdk-sys/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 license = "Apache-2.0"
 
 [lib]
-doctest = false
 doc = false
 
 [build-dependencies]

--- a/id/Cargo.toml
+++ b/id/Cargo.toml
@@ -5,10 +5,6 @@ edition = "2024"
 publish = false
 license = "Apache-2.0"
 
-# TODO: fix doctests in sterile env
-[lib]
-doctest = false
-
 [features]
 default = ["serde"]
 bolero = ["dep:bolero"]


### PR DESCRIPTION
- **ci(sterile): Disable "cargo doc" with release profile**
- **build: Re-enable doctests in dpdk-sys and id crates**

See #362
