### PR TITLE
style: Add clippy.toml to allow unwrap(), expect(), panics in tests

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+# https://doc.rust-lang.org/stable/clippy/configuration.html
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-unwrap-in-tests = true

--- a/net/src/eth/mod.rs
+++ b/net/src/eth/mod.rs
@@ -251,7 +251,6 @@ mod contract {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in test code for unreachable cases
 #[cfg(test)]
 mod test {
     const HEADER_LEN_USIZE: usize = Eth::HEADER_LEN.get() as usize;

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -1221,7 +1221,6 @@ mod contract {
 }
 
 #[cfg(any(test, kani))]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod test {
     use crate::headers::Headers;
     use crate::headers::contract::CommonHeaders;

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -453,7 +453,6 @@ mod contract {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in test code
 #[cfg(test)]
 mod test {
     use crate::ipv4::{Ipv4, Ipv4Error};

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -491,7 +491,6 @@ mod contract {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod test {
     use crate::ipv6::{Ipv6, Ipv6Error};
     use crate::parse::{DeParse, IntoNonZeroUSize, Parse, ParseError};

--- a/net/src/packet/hash.rs
+++ b/net/src/packet/hash.rs
@@ -53,7 +53,6 @@ impl<Buf: PacketBufferMut> Packet<Buf> {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 #[cfg(test)]
 mod tests {
     use crate::buffer::{PacketBufferMut, TestBuffer};

--- a/net/src/tcp/mod.rs
+++ b/net/src/tcp/mod.rs
@@ -395,7 +395,6 @@ mod contract {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in tests
 #[cfg(test)]
 mod test {
     use crate::parse::{DeParse, IntoNonZeroUSize, Parse, ParseError};

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -236,7 +236,6 @@ mod contract {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in test code
 #[cfg(test)]
 mod test {
     use crate::parse::IntoNonZeroUSize;

--- a/net/src/vlan/mod.rs
+++ b/net/src/vlan/mod.rs
@@ -407,7 +407,6 @@ mod contract {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod test {
     use super::*;
     use crate::vlan::Vid;

--- a/net/src/vxlan/mod.rs
+++ b/net/src/vxlan/mod.rs
@@ -163,7 +163,6 @@ impl ParsePayload for Vxlan {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in test code
 #[cfg(test)]
 mod test {
     use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, Parse, ParseError};

--- a/net/src/vxlan/vni.rs
+++ b/net/src/vxlan/vni.rs
@@ -125,7 +125,6 @@ mod contract {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)] // valid in test code
 mod test {
     use super::*;
 

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -124,7 +124,6 @@ pub use pipeline::{DynPipeline, StageId};
 #[allow(unused)]
 pub use static_nf::{NetworkFunction, StaticChain};
 
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 #[cfg(test)]
 mod test {
     use net::eth::mac::{DestinationMac, Mac};

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -186,7 +186,6 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for DynPipeline<Buf> {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 #[cfg(test)]
 mod test {
     use dyn_iter::IntoDynIterator;

--- a/pipeline/src/sample_nfs.rs
+++ b/pipeline/src/sample_nfs.rs
@@ -28,7 +28,7 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for InspectHeaders {
 pub struct BroadcastMacs;
 
 impl<Buf: PacketBufferMut> NetworkFunction<Buf> for BroadcastMacs {
-    #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    #[allow(clippy::unwrap_used)]
     fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
         &'a mut self,
         input: Input,

--- a/pipeline/src/static_nf.rs
+++ b/pipeline/src/static_nf.rs
@@ -75,7 +75,6 @@ impl<Buf: PacketBufferMut, Nf: NetworkFunction<Buf>> StaticChain<Buf> for Nf {
     }
 }
 
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 #[cfg(test)]
 mod test {
     use net::eth::mac::{DestinationMac, Mac};

--- a/pipeline/src/test_utils.rs
+++ b/pipeline/src/test_utils.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 use crate::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders, Passthrough};
 use crate::{DynNetworkFunction, nf_dyn};
 use net::buffer::TestBuffer;


### PR DESCRIPTION
Instead of manually allowing unwrap(), expect(), and panics in every test module, introduce a clippy.toml file at the root of the repository, using the relevant configuration options to allow these functions inside of test modules.

With this configuration file, most macros are now unnecessary; clean them up.
