### PR TITLE
justfile: Add compile-env images handling facilities

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,6 +30,9 @@ _container_repo := "ghcr.io/githedgehog/dataplane"
 # the rust channel to use (choose stable, beta, or nightly)
 
 rust := "beta"
+
+# Docker images
+
 [private]
 _dpdk_sys_container_repo := "ghcr.io/githedgehog/dpdk-sys"
 [private]
@@ -37,7 +40,17 @@ _dpdk_sys_container_tag := dpdk_sys_commit + ".rust-" + rust
 [private]
 _doc_env_container := _dpdk_sys_container_repo + "/doc-env:" + _dpdk_sys_container_tag
 [private]
-_compile_env_container := _dpdk_sys_container_repo + "/compile-env:" + _dpdk_sys_container_tag
+_compile_env_image_name := _dpdk_sys_container_repo + "/compile-env"
+[private]
+_compile_env_container := _compile_env_image_name + ":" + _dpdk_sys_container_tag
+
+# Warn if the compile-env image is deprecated (or missing)
+
+[private]
+_compile_env_check := if shell('docker image list --format "{{.Repository}}:{{.Tag}}" | grep -x "' + _compile_env_image_name + ':' + _dpdk_sys_container_tag + '" || true') == '' { shell('printf "\n/!\\ Latest compile-env not found, try \"just refresh-compile-env\"\n\n" >&2') } else { '' }
+
+# Docker settings
+
 [private]
 _network := "host"
 [private]

--- a/justfile
+++ b/justfile
@@ -289,6 +289,14 @@ remove-compile-env:
 [script]
 refresh-compile-env: pull remove-compile-env create-compile-env
 
+# clean up (delete) old compile-env images from system
+[script]
+prune-old-compile-env:
+    {{ _just_debuggable_ }}
+    docker image list "{{ _compile_env_image_name }}" --format "{{{{.Repository}}:{{{{.Tag}}" | \
+        grep -v "{{ _dpdk_sys_container_tag }}" || true | \
+        xargs -r docker image rm
+
 # Install "fake-nix" (required for local builds to function)
 [confirm("Fake a nix install (yes/no)")]
 [script]


### PR DESCRIPTION
- **build(justfile): Warn user when compile-env image is missing/outdated**
- **build(justfile): Add target to prune old compile-env image**

I know the check is barely readable; I decline all responsibility for `just --fmt`'s output.