### PR TITLE
vxlan encap / decap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ version = "0.0.1"
 dependencies = [
  "ahash",
  "arbitrary",
+ "arc-swap",
  "arrayvec",
  "bolero",
  "derive_builder",

--- a/dataplane/src/drivers/kernel.rs
+++ b/dataplane/src/drivers/kernel.rs
@@ -180,8 +180,14 @@ impl DriverKernel {
                         if let Some(oif) = &meta.oif {
                             /* lookup outgoing interface and xmit packet */
                             if let Some(outgoing) = kiftable.get_mut_by_index(oif.get_id()) {
-                                let mut out = pkt.reserialize();
-                                outgoing.sock.write_all(out.as_mut());
+                                match pkt.serialize() {
+                                    Ok(out) => {
+                                        outgoing.sock.write_all(out.as_ref());
+                                    }
+                                    Err(e) => {
+                                        error!("Failure serializing packet: {e:?}");
+                                    }
+                                }
                             } else {
                                 warn!("Unable to find interface with ifindex {}", oif.get_id());
                             }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -14,6 +14,7 @@ test_buffer = []
 [dependencies]
 ahash = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 derive_builder = { workspace = true, features = [] }

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -3,14 +3,14 @@
 
 //! [`PacketBuffer`] and related traits
 
-#[cfg(any(test, feature = "test_buffer"))]
+#[cfg(any(doc, test, feature = "test_buffer"))]
 pub mod test_buffer;
 
 use core::fmt::Debug;
 use std::error::Error;
 
 #[allow(unused_imports)] // re-export
-#[cfg(any(test, feature = "test_buffer"))]
+#[cfg(any(doc, test, feature = "test_buffer"))]
 pub use test_buffer::*;
 
 /// Super trait representing the abstract operations which may be performed on a packet buffer.

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -45,6 +45,9 @@ pub trait Prepend {
     type Error: Debug + Error;
     /// Prepend data to the buffer if possible.
     ///
+    /// If successful, this method returns a slice to the net start of the buffer.
+    /// The contents of the buffer will not be otherwise altered.
+    ///
     /// # Errors
     ///
     /// Returns [`Self::Error`] if an error occurs while performing this operation.

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -7,13 +7,15 @@
 pub mod test_buffer;
 
 use core::fmt::Debug;
+use std::error::Error;
+
 #[allow(unused_imports)] // re-export
 #[cfg(any(test, feature = "test_buffer"))]
 pub use test_buffer::*;
 
 /// Super trait representing the abstract operations which may be performed on a packet buffer.
-pub trait PacketBuffer: AsRef<[u8]> + Headroom + 'static {}
-impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom + 'static {}
+pub trait PacketBuffer: AsRef<[u8]> + Headroom + Debug + 'static {}
+impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom + Debug + 'static {}
 
 /// Super trait representing the abstract operations which may be performed on mutable a packet buffer.
 pub trait PacketBufferMut:
@@ -40,7 +42,7 @@ pub trait Tailroom {
 /// Trait representing the ability to prepend data to a packet buffer.
 pub trait Prepend {
     /// Error which may occur when attempting to prepend data to the buffer.
-    type Error: Debug;
+    type Error: Debug + Error;
     /// Prepend data to the buffer if possible.
     ///
     /// # Errors

--- a/net/src/buffer/test_buffer.rs
+++ b/net/src/buffer/test_buffer.rs
@@ -11,6 +11,10 @@ use crate::buffer::{
 };
 use tracing::trace;
 
+// only included for doc ref
+#[cfg(doc)]
+use crate::buffer::PacketBuffer;
+
 // Caution: do not implement Clone for `TestBuffer`.
 // Clone would significantly deviate from the actual mechanics of a DPDK mbuf.
 /// Toy data structure which implements [`PacketBuffer`]

--- a/net/src/buffer/test_buffer.rs
+++ b/net/src/buffer/test_buffer.rs
@@ -132,6 +132,9 @@ impl TrimFromStart for TestBuffer {
     type Error = MemoryBufferNotLongEnough;
     fn trim_from_start(&mut self, len: u16) -> Result<&mut [u8], MemoryBufferNotLongEnough> {
         debug_assert!((self.headroom + self.tailroom) as usize <= self.buffer.len());
+        debug_assert!(
+            (self.headroom + self.tailroom) as usize + self.as_ref().len() == self.buffer.len()
+        );
         if (self.headroom + self.tailroom + len) as usize > self.buffer.len() {
             return Err(MemoryBufferNotLongEnough);
         }
@@ -144,6 +147,9 @@ impl TrimFromEnd for TestBuffer {
     type Error = MemoryBufferNotLongEnough;
     fn trim_from_end(&mut self, len: u16) -> Result<&mut [u8], MemoryBufferNotLongEnough> {
         debug_assert!((self.headroom + self.tailroom) as usize <= self.buffer.len());
+        debug_assert!(
+            (self.headroom + self.tailroom) as usize + self.as_ref().len() == self.buffer.len()
+        );
         if (self.headroom + self.tailroom + len) as usize > self.buffer.len() {
             return Err(MemoryBufferNotLongEnough);
         }

--- a/net/src/buffer/test_buffer.rs
+++ b/net/src/buffer/test_buffer.rs
@@ -132,7 +132,7 @@ impl TrimFromStart for TestBuffer {
     type Error = MemoryBufferNotLongEnough;
     fn trim_from_start(&mut self, len: u16) -> Result<&mut [u8], MemoryBufferNotLongEnough> {
         debug_assert!((self.headroom + self.tailroom) as usize <= self.buffer.len());
-        if (self.headroom + self.tailroom + len) as usize >= self.buffer.len() {
+        if (self.headroom + self.tailroom + len) as usize > self.buffer.len() {
             return Err(MemoryBufferNotLongEnough);
         }
         self.headroom += len;
@@ -144,7 +144,7 @@ impl TrimFromEnd for TestBuffer {
     type Error = MemoryBufferNotLongEnough;
     fn trim_from_end(&mut self, len: u16) -> Result<&mut [u8], MemoryBufferNotLongEnough> {
         debug_assert!((self.headroom + self.tailroom) as usize <= self.buffer.len());
-        if (self.headroom + self.tailroom + len) as usize >= self.buffer.len() {
+        if (self.headroom + self.tailroom + len) as usize > self.buffer.len() {
             return Err(MemoryBufferNotLongEnough);
         }
         self.tailroom += len;

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -834,6 +834,7 @@ pub trait AbstractHeaders:
     + TryIcmp6
     + TryTransport
     + TryVxlan
+    + DeParse
 {
 }
 
@@ -849,11 +850,13 @@ impl<T> AbstractHeaders for T where
         + TryIcmp6
         + TryTransport
         + TryVxlan
+        + DeParse
 {
 }
 
 pub trait AbstractHeadersMut:
-    TryEthMut
+    AbstractHeaders
+    + TryEthMut
     + TryIpv4Mut
     + TryIpv6Mut
     + TryIpMut
@@ -865,8 +868,10 @@ pub trait AbstractHeadersMut:
     + TryVxlanMut
 {
 }
+
 impl<T> AbstractHeadersMut for T where
-    T: TryEthMut
+    T: AbstractHeaders
+        + TryEthMut
         + TryIpv4Mut
         + TryIpv6Mut
         + TryIpMut

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -371,7 +371,7 @@ impl Headers {
     /// Returns [`None`] if no [`Vlan`]s are on the stack.
     ///
     /// If `Some` is returned, the popped [`Vlan`]s ethtype is assigned to the `eth` header to
-    /// preserve structure.
+    /// preserve the structure.
     ///
     /// If `None` is returned, the [`Headers`] is not modified.
     pub fn pop_vlan(&mut self) -> Result<Option<Vlan>, PopVlanError> {

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -29,7 +29,7 @@ const MAX_VLANS: usize = 4;
 const MAX_NET_EXTENSIONS: usize = 2;
 
 // TODO: remove `pub` from all fields
-#[derive(Debug, PartialEq, Eq, Default, Builder)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Builder)]
 #[builder(default)]
 pub struct Headers {
     pub eth: Option<Eth>,

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -27,8 +27,9 @@ pub mod flow_label;
 pub use contract::*;
 
 /// An IPv6 header
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Ipv6(Ipv6Header);
+
 impl Ipv6 {
     /// The minimum length (in bytes) of an [`Ipv6`] header.
     #[allow(clippy::unwrap_used)] // safe due to const eval

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -107,6 +107,20 @@ impl Ipv6 {
         self
     }
 
+    /// Set the payload length.
+    ///
+    /// # Safety
+    ///
+    /// This method does not (and cannot) check that the length is correct in the context of the
+    /// packet as a whole.
+    #[allow(unsafe_code)] // requirements documented
+    pub unsafe fn set_payload_length(&mut self, length: u16) -> &mut Self {
+        self.0
+            .set_payload_length(length as usize)
+            .unwrap_or_else(|_| unreachable!());
+        self
+    }
+
     /// Set the destination ip address of this header
     ///
     /// # Safety

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -14,9 +14,6 @@
 )]
 #![allow(clippy::should_panic_without_expect)] // we panic in contract checks with simple unwrap()
 
-extern crate alloc;
-extern crate core;
-
 pub mod buffer;
 pub mod eth;
 pub mod headers;

--- a/net/src/packet/hash.rs
+++ b/net/src/packet/hash.rs
@@ -3,9 +3,9 @@
 
 //! Module to compute packet hashes
 
-use super::Packet;
 use crate::buffer::PacketBufferMut;
 use crate::headers::{Net, Transport, TryHeaders, TryIp, TryTransport};
+use crate::packet::Packet;
 use ahash::AHasher;
 use std::hash::{Hash, Hasher};
 

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+#![allow(missing_docs)] // TODO
+
 use std::collections::HashMap;
 use std::net::IpAddr;
 

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -9,8 +9,9 @@
     clippy::missing_errors_doc
 )]
 #![allow(clippy::double_must_use)]
+#![allow(missing_docs)]
 
-pub use crate::buffer::TestBuffer;
+use crate::buffer::TestBuffer;
 use crate::eth::Eth;
 use crate::eth::ethtype::EthType;
 use crate::eth::mac::{DestinationMac, Mac, SourceMac};

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -46,6 +46,17 @@ impl Udp {
         })
     }
 
+    #[allow(missing_docs)] // TODO
+    #[must_use]
+    pub fn new(source: UdpPort, destination: UdpPort) -> Udp {
+        let header = UdpHeader {
+            source_port: source.into(),
+            destination_port: destination.into(),
+            ..Default::default()
+        };
+        Udp(header)
+    }
+
     /// Get the header's source port
     #[must_use]
     pub const fn source(&self) -> UdpPort {

--- a/net/src/vxlan/encap.rs
+++ b/net/src/vxlan/encap.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use crate::headers::{Headers, TryIp, TryUdp, TryVxlan};
+use tracing::error;
+
+/// Configuration for [`VxlanEncap`] operation
+///
+/// This struct is a safety measure designed to check that the enclosed [`Headers`] really do
+/// describe a vxlan packet.
+pub struct VxlanEncap {
+    headers: Headers,
+}
+
+impl AsRef<Headers> for VxlanEncap {
+    fn as_ref(&self) -> &Headers {
+        &self.headers
+    }
+}
+
+/// Errors which may occur when encapsulating a packet with VXLAN headers.
+#[derive(Debug, thiserror::Error)]
+pub enum VxlanEncapError {
+    /// supplied headers have no IP layer
+    #[error("supplied headers have no IP layer")]
+    Ip,
+    /// supplied headers have no UDP layer
+    #[error("supplied headers have no UDP layer")]
+    Udp,
+    /// supplied headers have no VXLAN layer
+    #[error("supplied headers have no VXLAN layer")]
+    Vxlan,
+}
+
+impl VxlanEncap {
+    /// Create a new [`VxlanEncap`] configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`VxlanEncapError`] if the supplied [`Headers`] are not a legal VXLAN header.
+    pub fn new(headers: Headers) -> Result<VxlanEncap, VxlanEncapError> {
+        match (headers.try_ip(), headers.try_udp(), headers.try_vxlan()) {
+            (None, _, _) => Err(VxlanEncapError::Ip),
+            (_, None, _) => Err(VxlanEncapError::Udp),
+            (_, _, None) => Err(VxlanEncapError::Vxlan),
+            (Some(_), Some(_), Some(_)) => Ok(Self { headers }),
+        }
+    }
+
+    /// Get the headers to be used to fill in the VXLAN parameters on encap.
+    #[must_use]
+    pub fn headers(&self) -> &Headers {
+        &self.headers
+    }
+}

--- a/net/src/vxlan/mod.rs
+++ b/net/src/vxlan/mod.rs
@@ -46,7 +46,7 @@ impl Vxlan {
     /// > Flags (8-bits): where the I flag MUST be set to 1 for a valid VXLAN Network ID (VNI).
     /// > The other 7-bits (designated "R") are reserved fields and MUST be set to zero on
     /// > transmission and ignored on receipt.
-    pub const LEGAL_FLAGS: u8 = 0b0000_1000;
+    const LEGAL_FLAGS: u8 = 0b0000_1000;
 
     /// Create a new VXLAN header.
     #[must_use]

--- a/net/src/vxlan/mod.rs
+++ b/net/src/vxlan/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! [RFC7348]: https://datatracker.ietf.org/doc/html/rfc7348#section-5
 
+mod encap;
 mod vni;
 
 use crate::parse::{
@@ -12,6 +13,7 @@ use crate::parse::{
 };
 use crate::udp::port::UdpPort;
 use core::num::NonZero;
+pub use encap::{VxlanEncap, VxlanEncapError};
 use tracing::trace;
 pub use vni::{InvalidVni, Vni};
 

--- a/net/src/vxlan/vni.rs
+++ b/net/src/vxlan/vni.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use core::fmt::{Display, Formatter};
 use std::num::NonZero;
 
 #[allow(unused_imports)] // re-export
@@ -43,6 +44,12 @@ pub use contract::*;
 #[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 #[repr(transparent)]
 pub struct Vni(NonZero<u32>);
+
+impl Display for Vni {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0.get())
+    }
+}
 
 impl Vni {
     /// The minimum legal [`Vni`] value (1).

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 arc-swap = { workspace = true }
 dyn-iter = { workspace = true }
 id = { workspace = true }
-net = { workspace = true }
+net = { workspace = true, features = ["test_buffer"] }
 ordermap = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -28,7 +28,7 @@
 //! use pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders};
 //! use net::buffer::PacketBufferMut;
 //! use net::packet::Packet;
-//! use net::packet::test_utils::TestBuffer;
+//! use net::buffer::TestBuffer;
 //!
 //! /// This creates a chain of functions that first does a `debug!` on the packet contents then
 //! /// sets the destination mac to the broadcast mac address then decrements the TTL value of the
@@ -57,7 +57,7 @@
 //! ```rust
 //! use pipeline::DynPipeline;
 //! use pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders};
-//! use net::packet::test_utils::TestBuffer;
+//! use net::buffer::TestBuffer;
 //!
 //! let mut pipeline = DynPipeline::<TestBuffer>::new();
 //! pipeline = pipeline.add_stage(InspectHeaders);
@@ -78,7 +78,7 @@
 //! ```rust
 //! use pipeline::{DynPipeline, NetworkFunction, StaticChain};
 //! use pipeline::sample_nfs::{BroadcastMacs, DecrementTtl, InspectHeaders};
-//! use net::packet::test_utils::TestBuffer;
+//! use net::buffer::TestBuffer;
 //!
 //! let mut pipeline: DynPipeline<TestBuffer> = DynPipeline::new();
 //! // Add a dynamic stage that is the static chain of `InspectHeaders` and `BroadcastMacs`


### PR DESCRIPTION
> [!NOTE]
> ~~This is now on rebased top of #383 which should go in first~~ mission complete

This patch series is aimed at two major goals

1. implement vxlan encap / decap
2. unify the packet and pipeline and net functionality to the point where we can implement the next set of tasks (i.e. interface manager and routing crates)