### PR TITLE
Re-enable Clippy with the nightly toolchain

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -145,9 +145,6 @@ jobs:
         continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "clippy"
-        # Disable on nightly because cargo clippy is broken there,
-        # see https://github.com/githedgehog/dataplane/issues/309
-        if: "${{ matrix.rust.version != 'nightly' }}"
         name: "run clippy"
         run: |
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} \
@@ -166,7 +163,7 @@ jobs:
 
       - name: "Note failure of optional steps"
         uses: "actions/github-script@v7"
-        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || (steps.clippy.outcome != 'success' && steps.clippy.outcome != 'skipped')) }}
+        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |

--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -73,8 +73,10 @@ impl Eq for Pool {}
 impl PartialEq for PoolInner {
     fn eq(&self, other: &Self) -> bool {
         self.config == other.config
-            && core::ptr::from_ref(unsafe { self.as_ref() })
-                == core::ptr::from_ref(unsafe { other.as_ref() })
+            && std::ptr::eq(
+                core::ptr::from_ref(unsafe { self.as_ref() }),
+                core::ptr::from_ref(unsafe { other.as_ref() }),
+            )
     }
 }
 


### PR DESCRIPTION
- **style(dpdk): Fix Clippy report about raw pointers comparison**
- **Revert "ci: Disable "cargo clippy" with Nightly toolchain in dev workflow"**

It looks like whatever compiler bug affected us before has been solved, we can use Clippy with the nightly toolchain again.