### PR TITLE
ci: Fix summary step for dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -90,7 +90,7 @@ jobs:
         debug_justfile:
           - "${{inputs.debug_justfile || false}}"
     outputs:
-      result: "${{ matrix.rust.optional || steps.gnu_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' }}"
+      result: "${{ matrix.rust.optional || (steps.gnu_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' && steps.clippy.conclusion == 'success' && (steps.build_each_commit.conclusion == 'success' || steps.build_each_commit.conclusion == 'skipped')) }}"
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -163,7 +163,7 @@ jobs:
 
       - name: "Note failure of optional steps"
         uses: "actions/github-script@v7"
-        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success') }}
+        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success' || (steps.build_each_commit.outcome != 'success' && steps.build_each_commit.outcome != 'skipped')) }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |


### PR DESCRIPTION
The summary step fails to detect failures at the Clippy or "build-each-commit" steps, because it's not looking for the conditions of these steps at the end of the run. Update the condition to ensure that we look at these results.
