### PR TITLE
Make eth optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "dataplane"
 version = "0.1.0"
 dependencies = [
@@ -437,6 +472,37 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.100",
 ]
 
@@ -536,6 +602,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +648,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -736,6 +814,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bolero",
+ "derive_builder",
  "etherparse",
  "nom",
  "ordermap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ arrayvec = { version = "0.7.6", default-features = false, features = [] }
 bindgen = { version = "0.71.1", default-features = false, features = [] }
 bolero = { version = "0.13.0", default-features = false, features = [] }
 bytes = { version = "1.10.1", default-features = false, features = [] }
-# std feature currently globally required for clap
 clap = { version = "4.5.32", default-features = true, features = [] }
 ctrlc = { version = "3.4.5", default-features = false, features = [] }
 doxygen-rs = { version = "0.4.2", default-features = false, features = [] }
@@ -59,7 +58,6 @@ nom = { version = "7.1.3", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
 thiserror = { version = "2.0.12", default-features = false, features = [] }
-# attribute feature is so commonly used that we should just leave it on globally
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [] }
 tracing-test = { version = "0.2.5", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ bolero = { version = "0.13.0", default-features = false, features = [] }
 bytes = { version = "1.10.1", default-features = false, features = [] }
 clap = { version = "4.5.32", default-features = true, features = [] }
 ctrlc = { version = "3.4.5", default-features = false, features = [] }
+derive_builder = { version = "0.20.2", default-features = false, features = ["default"] }
 doxygen-rs = { version = "0.4.2", default-features = false, features = [] }
 dyn-iter = { version = "1.0.1", default-features = false, features = [] }
 etherparse = { version = "0.17.0", default-features = false, features = [] }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -16,6 +16,7 @@ ahash = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 arrayvec = { workspace = true }
 bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
+derive_builder = { workspace = true, features = [] }
 etherparse = { workspace = true, features = ["std"] }
 nom = { workspace = true, features = ["std"]  }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -14,9 +14,8 @@ test_buffer = []
 [dependencies]
 ahash = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
-bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 arrayvec = { workspace = true }
-# ideally, we would do without "std" for etherparse, but we need it for error types.
+bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 etherparse = { workspace = true, features = ["std"] }
 nom = { workspace = true, features = ["std"]  }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -314,14 +314,7 @@ pub enum PopVlanError {
 impl Headers {
     /// Create a new [`Headers`] with the supplied `Eth` header.
     pub fn new() -> Headers {
-        Headers {
-            eth: None,
-            vlan: ArrayVec::default(),
-            net: None,
-            net_ext: ArrayVec::default(),
-            transport: None,
-            udp_encap: None,
-        }
+        Headers::default()
     }
 
     /// Push a VLAN header to the top of the stack.

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -313,9 +313,9 @@ pub enum PopVlanError {
 
 impl Headers {
     /// Create a new [`Headers`] with the supplied `Eth` header.
-    pub fn new(eth: Eth) -> Headers {
+    pub fn new() -> Headers {
         Headers {
-            eth: Some(eth),
+            eth: None,
             vlan: ArrayVec::default(),
             net: None,
             net_ext: ArrayVec::default(),

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -21,6 +21,7 @@ use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::Vxlan;
 use arrayvec::ArrayVec;
 use core::fmt::Debug;
+use derive_builder::Builder;
 use std::num::NonZero;
 use tracing::debug;
 
@@ -28,7 +29,8 @@ const MAX_VLANS: usize = 4;
 const MAX_NET_EXTENSIONS: usize = 2;
 
 // TODO: remove `pub` from all fields
-#[derive(Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Default, Builder)]
+#[builder(default)]
 pub struct Headers {
     pub eth: Option<Eth>,
     pub vlan: ArrayVec<Vlan, MAX_VLANS>,

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -28,7 +28,7 @@ const MAX_VLANS: usize = 4;
 const MAX_NET_EXTENSIONS: usize = 2;
 
 // TODO: remove `pub` from all fields
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct Headers {
     pub eth: Option<Eth>,
     pub vlan: ArrayVec<Vlan, MAX_VLANS>,
@@ -360,9 +360,7 @@ impl Headers {
             return Err(PushVlanError::TooManyVlans);
         }
         match &mut self.eth {
-            None => {
-                Err(PushVlanError::NoEthernetHeader)
-            }
+            None => Err(PushVlanError::NoEthernetHeader),
             Some(eth) => {
                 let old_eth_type = eth.ether_type();
                 eth.set_ether_type(EthType::VLAN);
@@ -383,16 +381,14 @@ impl Headers {
     /// If `None` is returned, the [`Headers`] is not modified.
     pub fn pop_vlan(&mut self) -> Result<Option<Vlan>, PopVlanError> {
         match &mut self.eth {
-            None => {
-                Err(PopVlanError::NoEthernetHeader)
-            }
+            None => Err(PopVlanError::NoEthernetHeader),
             Some(eth) => match self.vlan.pop() {
                 None => Ok(None),
                 Some(vlan) => {
                     eth.set_ether_type(vlan.inner_ethtype());
                     Ok(Some(vlan))
                 }
-            }
+            },
         }
     }
 }
@@ -423,7 +419,7 @@ impl TryEth for Headers {
 
 impl TryEthMut for Headers {
     fn try_eth_mut(&mut self) -> Option<&mut Eth> {
-       self.eth.as_mut() 
+        self.eth.as_mut()
     }
 }
 

--- a/net/src/packet/display.rs
+++ b/net/src/packet/display.rs
@@ -171,7 +171,10 @@ impl Display for Transport {
 
 impl Display for Headers {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "\n{}", self.eth)?;
+        writeln!(f)?;
+        if let Some(eth) = &self.eth {
+            write!(f, "{eth}")?;
+        }
         if let Some(net) = &self.net {
             write!(f, "{net}")?;
         }

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -38,7 +38,9 @@ pub fn build_test_ipv4_packet(ttl: u8) -> Result<Packet<TestBuffer>, InvalidPack
     ipv4.set_destination(Ipv4Addr::new(1, 2, 3, 4));
     ipv4.set_ttl(ttl);
 
-    let mut headers = Headers::new(Eth::new(
+    let mut headers = Headers::new();
+
+    headers.eth = Some(Eth::new(
         SourceMac::new(Mac([0x2, 0, 0, 0, 0, 1])).unwrap(),
         DestinationMac::new(Mac([0x2, 0, 0, 0, 0, 2])).unwrap(),
         EthType::IPV4,
@@ -76,7 +78,9 @@ pub fn build_test_udp_ipv4_frame(
         ipv4.set_next_header(NextHeader::UDP);
     }
 
-    let mut headers = Headers::new(Eth::new(
+    let mut headers = Headers::new();
+
+    headers.eth = Some(Eth::new(
         SourceMac::new(src_mac).unwrap(),
         DestinationMac::new(dst_mac).unwrap(),
         EthType::IPV4,


### PR DESCRIPTION
It turns out that (upcoming) vxlan encap / decap benefit from making eth an optional field.
Specifically, at one point in the pipeline we simply don't know the ethernet header we want to use yet.

It is also entirely possible that we will use layer 3 tunneling for other protocols in the future so making eth required is not generally wise.