### PR TITLE
Remove nom dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,6 @@ dependencies = [
  "bolero",
  "derive_builder",
  "etherparse",
- "nom",
  "ordermap",
  "serde",
  "thiserror 2.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ ordermap = { version = "0.5.6", default-features = false, features = [] }
 ipnet = { version = "2.11.0", default-features = false, features = [] }
 iptrie = { version = "0.10.2", default-features = false, features = [] }
 mio = { version = "1.0.3", default-features = false, features = [] }
-nom = { version = "7.1.3", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
 thiserror = { version = "2.0.12", default-features = false, features = [] }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -18,7 +18,6 @@ arrayvec = { workspace = true }
 bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 derive_builder = { workspace = true, features = [] }
 etherparse = { workspace = true, features = ["std"] }
-nom = { workspace = true, features = ["std"]  }
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -136,7 +136,7 @@ impl Display for Mac {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{:<02X}:{:<02X}:{:<02X}:{:<02X}:{:<02X}:{:<02X}",
+            "{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}",
             self.0[0], self.0[1], self.0[2], self.0[3], self.0[4], self.0[5]
         )
     }


### PR DESCRIPTION
Reason:
* We only use it to dump in hex buffers
* It attempts to dump packet contents in utf, producing most of the time useless outputs. E.g.
```
                                                                       // this is useless
00000000	98 fa 9b 0c 86 6d 60 8d 26 bf cf 7c 08 00 45 00 	���.�m`�&��|..E.
00000010	00 36 00 00 40 00 37 11 2a 1f 8e fa c8 8a c0 a8 	.6..@.7.*.��Ȋ��
00000020	01 6b 01 bb aa 57 00 22 63 9b 42 d4 90 d6 6e 6f 	.k.��W."c�BԐ�no
00000030	30 ab 57 9b 0a ea cf 78 dc 8d b4 ab e2 79 c7 c7 	0�W�.��x܍���y��
00000040	97 51 5e d3                                     	�Q^�
```

Add instead our own dumper which does not display the former. The extra room allows us to dump 32 octets per row (instead of 16). Also, on the leftmost side, we show octet ranges, instead of just the starting octet in hex.
We can then dump larger packets with less rows.
```
───────────────────────────────────────────────────────────────────────────────────────────────────────────
[0000-0031] 98 fa 9b 0c 86 6d 60 8d 26 bf cf 7c 08 00 45 00 05 aa 68 3d 40 00 31 06 16 45 0d 6b f6 4d c0 a8 
[0032-0063] 01 6b 01 bb 97 16 2b ed 5c 16 ff cb bb c8 80 18 00 53 c8 f0 00 00 01 01 08 0a 23 0c 36 56 ef 62 
[0064-0095] c8 20 57 55 85 d4 64 47 17 23 52 e3 18 95 a4 9b 49 d1 d6 64 34 18 ed 19 f0 70 5a 58 ee b3 20 b7 
[0096-0127] d5 13 61 92 ed 3c 55 5f 73 56 98 0a 0c 73 92 af 23 da c9 52 fb 0a 4e be 79 e2 06 5a fb 12 c6 28 
[0128-0159] 11 88 20 59 29 78 cb fa d2 d2 a9 4c 81 7d ae d9 d0 78 07 be 3e a8 65 be 8f 1a b9 f7 53 c5 91 42 
[0160-0191] 8c 35 24 1a 66 9c 48 ea 54 f1 5f 7b 76 f8 6e 02 a8 59 91 b3 fd 4a 9b 84 98 44 b5 b5 9e a6 ae 70 
[0192-0223] af f8 25 ab c3 f7 82 80 d8 91 6c 8e 7a ab c3 5b 4b 9c 19 dc ed 7c e5 dd 5d 28 56 8e 9d 26 e5 0b 
[0224-0255] 38 8b 0f 94 c6 12 4b 1e d3 74 93 8a a8 d5 78 17 42 f6 c0 de 2e 6c 9d 9e b5 be 80 5c 32 d0 77 cb 
[0256-0287] 3e 07 be 09 18 6c 01 1a f6 e6 94 eb bc 41 74 b2 70 39 7d c6 97 92 cb 52 d4 55 41 03 c9 40 f9 69 
[0288-0319] c9 b2 74 47 35 cf 4f 8f a0 51 f7 df 69 2a b9 19 03 2d af 37 ec e3 2e a8 81 25 4b a1 0f dc 71 3c 
[0320-0351] a2 87 14 bf 20 6f 2c 0b 49 29 c5 ce 4e 99 e1 88 96 c8 17 9b ea 0e 24 61 8a a4 45 64 18 6b e8 cf 
[0352-0383] d8 9e a4 fb a2 72 24 1b 79 0d 17 75 ed d7 c0 77 85 37 07 65 62 2c aa 3e 69 b6 45 9f 71 70 f6 d7 
[0384-0415] 95 06 ce de cc a0 aa 16 03 2a ed ae 95 a4 df ff d6 d5 8d 76 53 7a 0f 5c 25 36 63 96 76 aa 37 08 
[0416-0447] 71 91 e1 12 6d fe c9 e8 b2 21 00 56 43 24 37 69 9b de 1e d1 27 7a 6e f5 a3 fa 1e 77 e1 bd 5e 24 
[0448-0479] 14 58 b3 6a b4 19 94 2b 67 f7 97 b6 74 82 c6 a9 4c 75 b4 29 7d 1d 14 10 05 ff 23 0c 93 e7 0c 40 
[0480-0511] 4e 56 f1 31 7c 28 2f fa 7d 94 a1 a3 5d 5f fc 26 2a 12 e5 d0 94 e2 8a b3 fc ef 54 8b 6e 3b 15 47 
[0512-0543] 0c 77 73 56 4e 1c 29 50 bb 5e da 92 03 43 20 5b 7d cd f6 f1 4e e3 f2 fb d5 22 21 88 4f b4 9a 1b 
[0544-0575] a7 b1 c4 11 46 e2 cd 40 37 e2 e2 a6 dc 65 48 fe 14 74 c1 b2 7c 82 2d bc 76 31 1b 20 2d 94 81 e9 
[0576-0607] a7 72 2b 3c c4 61 8d 8c 1b c7 55 d8 0b 6b 57 3f 55 d8 3b 6d d2 e4 49 e9 a6 07 ef 96 56 5c c8 ac 
[0608-0639] 71 da bc a2 d3 61 5b 8e 83 8f d8 84 64 c3 75 45 4c 08 b2 a5 d0 6f a2 42 e6 8e 80 97 21 6a da b9 
[0640-0671] 37 b2 ae 6c 6f 29 cf 10 be 0c a6 27 5a 4e cf 27 7c d1 91 eb 24 0f 08 56 d6 26 28 94 7d c4 93 5e 
[0672-0703] 07 93 66 f6 e9 e2 d6 21 89 09 33 ee 61 05 8b 1a 13 b4 18 83 90 99 13 b6 02 c6 e5 32 47 d3 29 79 
[0704-0735] 57 08 de 73 5b 21 c2 26 0e d0 20 35 23 f7 5a e9 b3 11 d3 26 db c8 76 00 c2 7d 95 03 9a a1 c5 76 
[0736-0767] 27 1f fd 49 e4 b5 1c 0b 34 32 f0 f7 16 53 8f 3e cf d2 6f 9f 9f 2b 0d 0e 5f 3a 54 47 80 e7 ec 1d 
[0768-0799] be 8d 2e 6a ba 84 d1 fa 5e d8 10 91 52 91 2f 7c 19 b5 58 ba a0 9a 81 fe e1 bb 19 b3 aa 68 ca bf 
[0800-0831] f0 14 a1 6b 8e d6 23 24 06 1a 38 2b 9b ee 5d a1 8d 5b 79 27 cc dd 11 1d 3b 26 7b 30 93 70 6f b4 
[0832-0863] be ea 91 23 ff 9f 2b bb 6d 34 88 50 36 84 1a 0a d1 82 9e 5b a6 5c ae 15 a3 ef 22 aa 13 fc 6d a6 
[0864-0895] cb 1d 57 92 9a b5 4f 8c d8 13 a2 73 46 4d 2d 25 5e db 41 c1 c7 fe 3f e9 c4 52 aa 39 3d 66 47 08 
[0896-0927] 22 60 df 54 3f a1 ab b8 e5 ac 5b 9e c5 f1 7b 86 1e be 82 80 fa 61 df e3 82 97 3b 90 71 97 7a 10 
[0928-0959] 95 57 52 e0 16 78 1d f1 de 81 8d 0b 84 0c 77 69 d6 3b 54 9f 1c f1 8f dc 77 36 25 b0 6d a5 46 b5 
[0960-0991] 1d b1 70 b6 5a fe 2d c9 2b ea ca c4 4f 2d 38 2d e2 3e c9 da 95 a9 19 bc 2a 84 2f c9 52 e0 9f b6 
[0992-1023] 36 0a dc 10 8d ee ae af 4e 94 26 41 36 d7 f7 9e 29 ca 8a 63 b0 8b f9 c8 96 41 c7 6a 23 fc cb 5b 
[1024-1055] 16 fc f7 9f 79 a7 ca 09 b8 3e 2f 70 56 41 1c f1 65 a9 72 2e 32 75 78 40 12 0a 08 bd 8e ff 8a 9b 
[1056-1087] 7a f3 7a f0 a7 10 22 2c 74 66 ae 76 ab b7 4b 29 97 8e 82 87 55 74 37 e3 68 57 15 35 7d 77 e1 84 
[1088-1119] 8e 99 26 b3 43 c6 90 37 df 2d a0 a5 91 2f a4 23 8a 39 94 61 91 36 50 56 7c 5c 15 32 10 0c 9e 89 
[1120-1151] bb 58 9b 6c 90 b5 7a 82 d7 c8 7e 12 18 87 b0 75 df 54 04 c8 02 24 4a eb 6f ed a5 3c 74 a7 c8 34 
[1152-1183] 87 4f d9 ba 6b 66 bc 00 a4 68 5d 82 f0 44 30 8e ca 8f e2 8d 19 78 7d d9 cd a5 86 a6 a5 f3 7a 25 
[1184-1215] 2f ad 8d dd 31 56 18 eb e0 75 45 bc 37 ba fa 53 4b 67 b0 db 91 0e e1 1c 60 86 9d 9b 91 62 21 25 
[1216-1247] 09 34 a9 f8 23 af 23 65 c3 9d 16 7a a3 1a 56 96 c5 0b 81 28 6f c6 cc 50 4a 9b 98 17 0e 38 56 3d 
[1248-1279] f2 87 bc 13 b7 a8 da d2 cb 98 c4 d4 f8 fd 65 9a 18 52 f1 35 08 73 f8 cd cd b0 6b 53 e3 23 08 12 
[1280-1311] c8 78 21 c9 ce d8 53 cb 6b 9c 72 9c 36 93 13 6c 76 0d 55 1b 1c 5a 25 5d af f7 ed 30 ed 94 38 fc 
[1312-1343] 1a bf 14 01 70 81 b9 6f 14 fb 9c a0 c7 f2 61 29 4f 13 e6 3a e8 64 33 87 8f b1 79 8b 84 bb 6b 7a 
[1344-1375] aa 94 4d 3d 89 29 16 e6 e3 05 33 61 e2 0c 13 c6 f6 da 45 3e 80 60 17 b8 f3 e5 e0 49 40 0a 9f 23 
[1376-1407] 9f f4 b1 47 6c 1e 04 2f ad 2a da 11 7d 50 43 e8 b7 83 4d 08 bc e0 c9 85 c8 85 8a d2 58 23 21 70 
[1408-1439] 5b 29 b2 78 73 77 80 1f b5 01 e3 7b ec 38 cf 0b 80 1e c9 77 fe 86 21 a2 d7 e7 bd ca bd 73 cf c4 
[1440-1463] c6 95 7b 85 31 c3 23 dc 2f 46 d2 a8 c6 84 41 3d a9 27 b9 fb 7f 54 25 c5 
───────────────────────────────────────────────────────────────────────────────────────────────────────────
```


