### PR TITLE
docs(README.md): Fix Rust version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ managed by the Fabric, or to communicate with endpoints outside of the Fabric.
 - [Docker][docker] (install through your package manager)
 - Cargo / Rust (install via [`rustup`][rustup])
 
-  * :warning: You need a recent version of rust (1.85.0 or better) to build the project.
+  * :warning: You need a recent version of rust (1.86.0 or better) to build the project.
 
     ```bash
     rustup update


### PR DESCRIPTION
We need Rust 1.86+ for running the dataplane. We switched to the beta toolchain for some time because of this requirement. Let's fix the warning in the README.md.
