### PR TITLE
net: Fix serde traits derivation (only available when "serde" feature is enabled)

### DIFF
--- a/net/src/eth/ethtype.rs
+++ b/net/src/eth/ethtype.rs
@@ -17,10 +17,9 @@ use etherparse::EtherType;
 /// 2. Permit the implementation of the `TypeGenerator` trait on this type
 ///    to allow us to property test the rest of our code.
 #[repr(transparent)]
-#[derive(
-    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
-#[serde(from = "u16", into = "u16")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(from = "u16", into = "u16"))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EthType(pub(crate) EtherType);
 
 impl EthType {

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -11,8 +11,8 @@ use std::fmt::{Debug, Display, Formatter};
 /// You can't generally meaningfully persist or assign them.
 /// They don't typically mean anything "between" machines or even reboots.
 #[repr(transparent)]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(try_from = "u32", into = "u32")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InterfaceIndex(u32);
 
@@ -64,8 +64,8 @@ const MAX_LEN: usize = 16;
 /// The maximum legal length of an `InterfaceName` is 16 bytes (including the terminating null).
 /// Thus, the _effective_ maximum length is 15 bytes (not characters).
 #[repr(transparent)]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(try_from = "String", into = "String")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct InterfaceName(String);
 


### PR DESCRIPTION
The use of dependency crate `serde` in the `net` package is optional, based on the `serde` feature for the package. As a consequence, we cannot always derive the serde traits without taking precautions inside of the package.

This issue has crept in in spite of the CI checks, because CI does not build every package independently. We observed the build failure with:

    $ just cargo build -p net

We then found the relevant commit that introduced the issue by bissecting, and observed we could fix the issue, on top of that commit, by enabling `serde` by running instead:

    $ just cargo build -p net -F serde

However, the issue doesn't appear at all by running only:

    $ just cargo build

This is likely because when building from the root of the repository, we must address requirements from all packages, including the `dataplane` package that requires the `net` package to be built with its `serde` feature, thus masking the issue.

Anyway, fix the bug by making traits derivation conditional to the use of the `serde` feature in ethtype.rs, then in interface/mod.rs.
