### PR TITLE
fix(net): serde should not be optional

### DIFF
--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -15,7 +15,7 @@ iptrie = { workspace = true }
 default-net = { workspace = true }
 dyn-iter = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
-net = { workspace = true, features = ["serde", "test_buffer"] }
+net = { workspace = true, features = ["test_buffer"] }
 ordermap = { workspace = true, features = ["std"] }
 pipeline = { workspace = true }
 routing = { workspace = true }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [features]
 default = []
-serde = ["dep:serde"]
 arbitrary = ["dep:bolero"]
 test_buffer = []
 
@@ -18,7 +17,7 @@ bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional 
 derive_builder = { workspace = true, features = [] }
 etherparse = { workspace = true, features = ["std"] }
 ordermap = { workspace = true }
-serde = { workspace = true, optional = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/net/src/eth/ethtype.rs
+++ b/net/src/eth/ethtype.rs
@@ -17,8 +17,8 @@ use etherparse::EtherType;
 /// 2. Permit the implementation of the `TypeGenerator` trait on this type
 ///    to allow us to property test the rest of our code.
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(from = "u16", into = "u16"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(from = "u16", into = "u16")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EthType(pub(crate) EtherType);
 

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -13,8 +13,9 @@ use std::fmt::Display;
 /// [MAC Address]: https://en.wikipedia.org/wiki/MAC_address
 #[repr(transparent)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct Mac(pub [u8; 6]);
 
 impl From<[u8; 6]> for Mac {

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -11,8 +11,8 @@ use std::fmt::{Debug, Display, Formatter};
 /// You can't generally meaningfully persist or assign them.
 /// They don't typically mean anything "between" machines or even reboots.
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "u32", into = "u32")]
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InterfaceIndex(u32);
 
@@ -64,8 +64,8 @@ const MAX_LEN: usize = 16;
 /// The maximum legal length of an `InterfaceName` is 16 bytes (including the terminating null).
 /// Thus, the _effective_ maximum length is 15 bytes (not characters).
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "String", into = "String")]
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct InterfaceName(String);
 

--- a/net/src/ipv4/addr.rs
+++ b/net/src/ipv4/addr.rs
@@ -13,7 +13,9 @@ use std::net::Ipv4Addr;
 /// This wrapper is zero cost save for the need to check that the [`Ipv4Addr`] is in fact unicast.
 #[non_exhaustive]
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct UnicastIpv4Addr(Ipv4Addr);
 
 impl UnicastIpv4Addr {

--- a/net/src/ipv6/flow_label.rs
+++ b/net/src/ipv6/flow_label.rs
@@ -14,8 +14,8 @@ use etherparse::Ipv6FlowLabel;
 /// [flow label]: https://www.rfc-editor.org/rfc/rfc6437.html
 /// [`Ipv6`]: crate::ipv6::Ipv6
 #[allow(clippy::unsafe_derive_deserialize)] // safety: no (non-const eval) unsafe code used
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "u32", into = "u32")]
 #[derive(Copy, Clone, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct FlowLabel(pub(crate) Ipv6FlowLabel);
 

--- a/net/src/tcp/checksum.rs
+++ b/net/src/tcp/checksum.rs
@@ -9,7 +9,7 @@ use core::fmt::{Display, Formatter};
 ///
 /// [checksum]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Checksum_computation
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
 pub struct TcpChecksum(pub(crate) u16);

--- a/net/src/tcp/port.rs
+++ b/net/src/tcp/port.rs
@@ -6,14 +6,25 @@ use std::num::NonZero;
 #[repr(transparent)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
 #[allow(clippy::unsafe_derive_deserialize)] // both try_from and into u16 are safe for this type
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "u16", into = "u16")]
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct TcpPort(NonZero<u16>);
 
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, thiserror::Error)]
+#[derive(
+    Copy,
+    Clone,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+    Debug,
+    thiserror::Error,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum TcpPortError {
     #[error("port must be non-zero")]
     Zero,

--- a/net/src/udp/checksum.rs
+++ b/net/src/udp/checksum.rs
@@ -10,7 +10,7 @@ use core::fmt::{Display, Formatter};
 /// [checksum]: https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Checksum_computation
 /// [`Udp`]: crate::udp::Udp
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(serde::Serialize, serde::Deserialize)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
 pub struct UdpChecksum(pub(crate) u16);

--- a/net/src/udp/port.rs
+++ b/net/src/udp/port.rs
@@ -12,16 +12,27 @@ use std::num::NonZero;
 #[repr(transparent)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
 #[allow(clippy::unsafe_derive_deserialize)] // both try_from and into u16 are safe for this type
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(
+    Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(try_from = "u16", into = "u16")]
 pub struct UdpPort(NonZero<u16>);
 
 /// Errors which may occur in the creation or parsing of a [`UdpPort`].
 #[repr(transparent)]
-#[derive(Debug, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(
+    Debug,
+    thiserror::Error,
+    serde::Serialize,
+    serde::Deserialize,
+    Copy,
+    Clone,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    Hash,
+)]
 pub enum UdpPortError {
     /// The spec reserves zero to mean "any port."  It isn't valid in the context of a packet parser.
     #[error("port must be non-zero")]

--- a/net/src/vlan/mod.rs
+++ b/net/src/vlan/mod.rs
@@ -27,14 +27,15 @@ use etherparse::{SingleVlanHeader, VlanId, VlanPcp};
 /// (which we should generally be doing anyway).
 #[repr(transparent)]
 #[allow(clippy::unsafe_derive_deserialize)] // use of unsafe in trivially sound const expression
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u16", into = "u16"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "u16", into = "u16")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Vid(NonZero<u16>);
 
 /// Errors which can occur when converting a `u16` to a validated [`Vid`]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, thiserror::Error, serde::Serialize, serde::Deserialize,
+)]
 #[must_use]
 pub enum InvalidVid {
     /// 0 is a reserved [`Vid`] which basically means "the native vlan."
@@ -125,8 +126,8 @@ impl core::fmt::Display for Vid {
 
 /// A Priority Code Point.
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u8", into = "u8"))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "u8", into = "u8")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct Pcp(u8);
 
@@ -152,8 +153,8 @@ impl Display for Pcp {
 
 /// Error type for invalid [`Pcp`] values.
 #[repr(transparent)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
 #[error("Invalid PCP value: {0} (3-bit max)")]
 pub struct InvalidPcp(u8);

--- a/net/src/vxlan/mod.rs
+++ b/net/src/vxlan/mod.rs
@@ -24,8 +24,8 @@ pub use vni::{InvalidVni, Vni};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
 #[allow(clippy::unsafe_derive_deserialize)] // all uses of unsafe are compile time and trivial
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct Vxlan {
     vni: Vni,
 }

--- a/net/src/vxlan/vni.rs
+++ b/net/src/vxlan/vni.rs
@@ -40,9 +40,10 @@ pub use contract::*;
 /// [RFC7348]: https://datatracker.ietf.org/doc/html/rfc7348#section-5
 /// [overlay network]: https://en.wikipedia.org/wiki/Overlay_network
 /// [transparent]: https://doc.rust-lang.org/reference/type-layout.html#the-transparent-representation
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(try_from = "u32", into = "u32"))]
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+#[serde(try_from = "u32", into = "u32")]
 #[repr(transparent)]
 pub struct Vni(NonZero<u32>);
 
@@ -89,8 +90,19 @@ impl AsRef<NonZero<u32>> for Vni {
 
 /// Errors that can occur when converting a `u32` to a [`Vni`]
 #[must_use]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, thiserror::Error)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    thiserror::Error,
+    serde::Deserialize,
+    serde::Serialize,
+)]
 pub enum InvalidVni {
     /// Zero is not a legal Vni in many EVPN / VXLAN implementations.  Don't use it.
     #[error("Zero is not a legal Vni")]


### PR DESCRIPTION
I originally had dreams of making the net crate fully support no-std and limited resource environments. As a result, I made things optional which, in retrospect, have no need to be. Serde is one of those things.

So here ya go, with appologies to @qmonnet who just fixed this feature I'm removing.