### PR TITLE
Dataplane configuration display

### DIFF
--- a/mgmt/src/rpc/overlay/display.rs
+++ b/mgmt/src/rpc/overlay/display.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use crate::rpc::overlay::vpc::Vpc;
+use routing::pretty_utils::Heading;
+use std::fmt::Display;
+
+use crate::rpc::overlay::VpcManifest;
+use crate::rpc::overlay::vpc::Peering;
+use crate::rpc::overlay::vpc::VpcTable;
+use crate::rpc::overlay::vpcpeering::{VpcExpose, VpcPeering, VpcPeeringTable};
+
+const SEP: &str = "       ";
+
+impl Display for VpcExpose {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut carriage = false;
+        if !self.ips.is_empty() {
+            write!(f, "{SEP} prefixes:")?;
+            self.ips.iter().for_each(|x| {
+                let _ = write!(f, " {x}");
+            });
+        }
+        if !self.nots.is_empty() {
+            write!(f, ", except")?;
+            self.nots.iter().for_each(|x| {
+                let _ = write!(f, " {x}");
+            });
+        }
+
+        writeln!(f)?;
+
+        if !self.as_range.is_empty() {
+            write!(f, "{SEP}       as:")?;
+            self.as_range.iter().for_each(|x| {
+                let _ = write!(f, " {x}");
+            });
+            carriage = true;
+        }
+
+        if !self.not_as.is_empty() {
+            write!(f, ", excluding")?;
+            self.not_as.iter().for_each(|x| {
+                let _ = write!(f, " {x}");
+            });
+            carriage = true;
+        }
+        if carriage { writeln!(f) } else { Ok(()) }
+    }
+}
+
+// Vpc manifest is common to VpcPeering and Peering
+fn fmt_manifest(
+    f: &mut std::fmt::Formatter<'_>,
+    is_local: bool,
+
+    manifest: &VpcManifest,
+) -> std::fmt::Result {
+    if is_local {
+        writeln!(f, "     local:")?;
+    } else {
+        writeln!(f, "     remote, {}:", manifest.name)?;
+    }
+
+    for e in &manifest.exposes {
+        e.fmt(f)?;
+    }
+    Ok(())
+}
+
+impl Display for Peering {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "  ■ {}:", self.name)?;
+        fmt_manifest(f, true, &self.local)?;
+        writeln!(f)?;
+        fmt_manifest(f, false, &self.remote)?;
+        writeln!(f)
+    }
+}
+
+/* ========= VPCs =========*/
+
+macro_rules! VPC_TBL_FMT {
+    () => {
+        " {:<18} {:<8} {:<9} {:<18} {:<18}"
+    };
+}
+fn fmt_vpc_table_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            VPC_TBL_FMT!(),
+            "VPC", "VNI", "peers", "remote", "peering name"
+        )
+    )
+}
+
+// Auxiliary type to implement detailed VPC display
+pub struct VpcDetailed<'a>(pub &'a Vpc);
+impl Display for VpcDetailed<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vpc = self.0;
+        Heading(format!("vpc: {}", vpc.name)).fmt(f)?;
+        writeln!(f, " name: {}", vpc.name)?;
+        writeln!(f, " vni : {}", vpc.vni)?;
+        writeln!(f, " peerings: {}", vpc.peerings.len())?;
+        Heading(format!("Peerings of {}", vpc.name)).fmt(f)?;
+        for peering in &vpc.peerings {
+            peering.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for Vpc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // VPC that has no peerings
+        if self.peerings.is_empty() {
+            writeln!(
+                f,
+                "{}",
+                format_args!(VPC_TBL_FMT!(), &self.name, self.vni, "", "", "")
+            )?;
+        } else {
+            // VPC that has peerings
+            for (num, peering) in self.peerings.iter().enumerate() {
+                let (name, vni, num_peers) = if num == 0 {
+                    (
+                        self.name.as_str(),
+                        self.vni.to_string(),
+                        self.peerings.len().to_string(),
+                    )
+                } else {
+                    ("", "".to_string(), "".to_string())
+                };
+                writeln!(
+                    f,
+                    "{}",
+                    format_args!(
+                        VPC_TBL_FMT!(),
+                        name, vni, num_peers, peering.remote.name, peering.name
+                    )
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+impl Display for VpcTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading(format!("VPCs ({})", self.len())).fmt(f)?;
+        fmt_vpc_table_heading(f)?;
+        for vpc in self.values() {
+            vpc.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+/* ===== VPC peerings =====*/
+
+fn fmt_peering_manifest(
+    f: &mut std::fmt::Formatter<'_>,
+    manifest: &VpcManifest,
+) -> std::fmt::Result {
+    writeln!(f, "    {}:", manifest.name)?;
+    for e in &manifest.exposes {
+        e.fmt(f)?;
+    }
+    Ok(())
+}
+
+impl Display for VpcPeering {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, " ■ {}:", self.name)?;
+        fmt_peering_manifest(f, &self.left)?;
+        writeln!(f)?;
+        fmt_peering_manifest(f, &self.right)?;
+        writeln!(f)
+    }
+}
+impl Display for VpcPeeringTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading(format!("VPC Peering Table ({})", self.len())).fmt(f)?;
+        for peering in self.values() {
+            peering.fmt(f)?;
+        }
+        Ok(())
+    }
+}

--- a/mgmt/src/rpc/overlay/mod.rs
+++ b/mgmt/src/rpc/overlay/mod.rs
@@ -3,6 +3,7 @@
 
 //! Dataplane configuration model: overlay configuration
 
+pub mod display;
 pub mod tests;
 pub mod vpc;
 pub mod vpcpeering;

--- a/mgmt/src/rpc/overlay/tests.rs
+++ b/mgmt/src/rpc/overlay/tests.rs
@@ -8,6 +8,7 @@
 pub mod test {
     use crate::rpc::ApiError;
     use crate::rpc::overlay::Overlay;
+    use crate::rpc::overlay::display::VpcDetailed;
     use crate::rpc::overlay::vpc::{Vpc, VpcTable};
     use crate::rpc::overlay::vpcpeering::VpcExpose;
     use crate::rpc::overlay::vpcpeering::VpcManifest;
@@ -17,7 +18,7 @@ pub mod test {
 
     /* Build sample manifests for a peering */
     fn build_manifest_vpc1() -> VpcManifest {
-        let mut vpc1 = VpcManifest::new("VPC-1");
+        let mut m1 = VpcManifest::new("VPC-1");
         let expose = VpcExpose::empty()
             .ip(Prefix::from(("10.0.0.0", 25)))
             .ip(Prefix::from(("10.0.2.128", 25)))
@@ -25,17 +26,17 @@ pub mod test {
             .not(Prefix::from(("10.0.2.130", 32)))
             .as_range(Prefix::from(("100.64.1.0", 24)))
             .not_as(Prefix::from(("100.64.1.13", 32)));
-        vpc1.add_expose(expose).expect("Should succeed");
-        vpc1
+        m1.add_expose(expose).expect("Should succeed");
+        m1
     }
     fn build_manifest_vpc2() -> VpcManifest {
-        let mut vpc1 = VpcManifest::new("VPC-2");
+        let mut m2 = VpcManifest::new("VPC-2");
         let expose = VpcExpose::empty()
             .ip(Prefix::from(("10.0.0.0", 24)))
             .as_range(Prefix::from(("100.64.2.0", 24)));
 
-        vpc1.add_expose(expose).expect("Should succeed");
-        vpc1
+        m2.add_expose(expose).expect("Should succeed");
+        m2
     }
 
     /* build sample peering between VPC-1 and VPC-2 */
@@ -44,7 +45,7 @@ pub mod test {
         let m1 = build_manifest_vpc1();
         let m2 = build_manifest_vpc2();
         // build vpc peering with the manifests
-        VpcPeering::new("VPC-1-to-VPC-2", m1, m2)
+        VpcPeering::new("VPC-1--VPC-2", m1, m2)
     }
 
     #[test]
@@ -113,10 +114,11 @@ pub mod test {
         let mut peering_table = VpcPeeringTable::new();
         peering_table.add(peering).expect("Should succeed");
 
+        println!("{peering_table}");
+
         /* build overlay object and validate it */
         let overlay = Overlay::new(vpc_table, peering_table);
         assert_eq!(overlay.validate(), Ok(()));
-        println!("{overlay:#?}");
     }
 
     #[test]
@@ -153,5 +155,130 @@ pub mod test {
         assert!(x.contains(&"Peering-2".to_owned()));
         assert!(x.contains(&"Peering-4".to_owned()));
         assert!(!x.contains(&"Peering-3".to_owned()), "not there");
+    }
+
+    #[test]
+    fn test_vpc_collect_peerings() {
+        fn man_vpc1_with_vpc2() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-1");
+            let expose = VpcExpose::empty()
+                .ip(Prefix::from(("192.168.50.0", 24)))
+                .not(Prefix::from(("192.168.50.13", 32)));
+            m1.add_expose(expose).expect("Should succeed");
+
+            let expose = VpcExpose::empty()
+                .ip(Prefix::from(("192.168.111.0", 24)))
+                .not(Prefix::from(("192.168.111.2", 32)))
+                .not(Prefix::from(("192.168.111.254", 32)))
+                .as_range(Prefix::from(("100.64.200.0", 24)))
+                .not_as(Prefix::from(("100.64.200.13", 32)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc1_with_vpc3() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-1");
+            let expose = VpcExpose::empty().ip(Prefix::from(("192.168.60.0", 24)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc1_with_vpc4() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-1");
+            let expose = VpcExpose::empty().ip(Prefix::from(("192.168.60.0", 24)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc2() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-2");
+            let expose = VpcExpose::empty().ip(Prefix::from(("192.168.80.0", 24)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc2_with_vpc3() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-2");
+            let expose = VpcExpose::empty().ip(Prefix::from(("192.168.80.0", 24)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc3() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-3");
+            let expose = VpcExpose::empty().ip(Prefix::from(("192.168.128.0", 27)));
+            m1.add_expose(expose).expect("Should succeed");
+            m1
+        }
+        fn man_vpc4() -> VpcManifest {
+            let mut m1 = VpcManifest::new("VPC-4");
+            let expose = VpcExpose::empty()
+                .ip(Prefix::from(("192.168.201.1", 32)))
+                .ip(Prefix::from(("192.168.202.2", 32)))
+                .ip(Prefix::from(("192.168.203.3", 32)));
+            m1.add_expose(expose).expect("Should succeed");
+
+            let expose = VpcExpose::empty()
+                .ip(Prefix::from(("192.168.204.4", 32)))
+                .as_range(Prefix::from(("100.64.204.4", 32)));
+            m1.add_expose(expose).expect("Should succeed");
+
+            let expose = VpcExpose::empty()
+                .ip(Prefix::from(("192.168.210.0", 29)))
+                .not(Prefix::from(("192.168.210.1", 32)));
+            m1.add_expose(expose).expect("Should succeed");
+
+            m1
+        }
+
+        /* build VPC table with 3 vpcs */
+        let mut vpc_table = VpcTable::new();
+        let _ = vpc_table.add(Vpc::new("VPC-1", 3000).expect("Should succeed"));
+        let _ = vpc_table.add(Vpc::new("VPC-2", 4000).expect("Should succeed"));
+        let _ = vpc_table.add(Vpc::new("VPC-3", 2000).expect("Should succeed"));
+        let _ = vpc_table.add(Vpc::new("VPC-4", 6000).expect("Should succeed"));
+
+        /* build peering table with 3 peerings */
+        let mut peering_table = VpcPeeringTable::new();
+        peering_table
+            .add(VpcPeering::new(
+                "VPC-1--VPC-2",
+                man_vpc1_with_vpc2(),
+                man_vpc2(),
+            ))
+            .expect("Should succeed");
+
+        peering_table
+            .add(VpcPeering::new(
+                "VPC-1--VPC-3",
+                man_vpc1_with_vpc3(),
+                man_vpc3(),
+            ))
+            .expect("Should succeed");
+
+        peering_table
+            .add(VpcPeering::new(
+                "VPC-1--VPC-4",
+                man_vpc1_with_vpc4(),
+                man_vpc4(),
+            ))
+            .expect("Should succeed");
+
+        peering_table
+            .add(VpcPeering::new(
+                "VPC-2--VPC-3",
+                man_vpc2_with_vpc3(),
+                man_vpc3(),
+            ))
+            .expect("Should succeed");
+
+        /* display peering table */
+        println!("{peering_table}");
+
+        /* collect the peerings for each VPC */
+        vpc_table.collect_peerings(&peering_table);
+
+        /* display VPC table */
+        println!("{vpc_table}");
+
+        /* get vpc VPC1 */
+        if let Some(vpc) = vpc_table.get_vpc("VPC-1") {
+            println!("{}", VpcDetailed(vpc));
+        }
     }
 }

--- a/mgmt/src/rpc/overlay/vpc.rs
+++ b/mgmt/src/rpc/overlay/vpc.rs
@@ -63,6 +63,15 @@ impl VpcTable {
     pub fn new() -> Self {
         Self::default()
     }
+    /// Number of VPCs in [`VpcTable`]
+    pub fn len(&self) -> usize {
+        self.vpcs.len()
+    }
+    /// Tells if [`VpcTable`] is empty
+    pub fn is_empty(&self) -> bool {
+        self.vpcs.is_empty()
+    }
+
     /// Add a [`Vpc`] to the vpc table
     pub fn add(&mut self, vpc: Vpc) -> ApiResult {
         // Vni must have not been used before

--- a/mgmt/src/rpc/overlay/vpc.rs
+++ b/mgmt/src/rpc/overlay/vpc.rs
@@ -14,6 +14,9 @@ use crate::rpc::overlay::VpcManifest;
 use crate::rpc::overlay::VpcPeeringTable;
 use crate::rpc::{ApiError, ApiResult};
 
+/// This is nearly identical to [`VpcPeering`], but with some subtle differences.
+/// [`Peering`] is owned by a Vpc while [`VpcPeering`] remains in the [`VpcPeeringTable`].
+/// Most importantly, [`Peering`] has a notion of local and remote, while [`VpcPeering`] is symmetrical.
 #[derive(Debug, PartialEq)]
 pub struct Peering {
     pub name: String,        /* name of peering */

--- a/mgmt/src/rpc/overlay/vpcpeering.rs
+++ b/mgmt/src/rpc/overlay/vpcpeering.rs
@@ -98,6 +98,15 @@ impl VpcPeeringTable {
     pub fn new() -> Self {
         Self::default()
     }
+    /// Number of peerings in [`VpcPeeringTable`]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    /// Tells if [`VpcPeeringTable`] contains peerings or not
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Add a [`VpcPeering`] to a [`VpcPeeringTable`]
     pub fn add(&mut self, peering: VpcPeering) -> ApiResult {
         peering.validate()?;

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -14,7 +14,7 @@ mod errors;
 pub mod interface;
 mod nexthop;
 pub mod prefix;
-mod pretty_utils;
+pub mod pretty_utils;
 mod rmac;
 mod routingdb;
 mod rpc_adapt;

--- a/routing/src/pretty_utils.rs
+++ b/routing/src/pretty_utils.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 
 const LINE_WIDTH: usize = 81;
 
-pub struct Frame(pub(crate) String);
+pub struct Frame(pub String);
 impl Display for Frame {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let len = self.0.len() + 2;
@@ -16,7 +16,7 @@ impl Display for Frame {
         writeln!(f, "┗{:━<width$}┛", "━", width = len)
     }
 }
-pub struct Heading(pub(crate) String);
+pub struct Heading(pub String);
 impl Display for Heading {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let len = (LINE_WIDTH - (self.0.len() + 2)) / 2;


### PR DESCRIPTION
on https://github.com/githedgehog/dataplane/pull/391

Implements Display for Overlay config.

**Sample:** Vpc table summary showing what vpcs peer with each other

```
 ─────────────────────────────────── VPCs (4)  ───────────────────────────────────
 VPC                VNI      peers     remote             peering name      
 VPC-1              3000     3         VPC-2              VPC-1--VPC-2      
                                       VPC-3              VPC-1--VPC-3      
                                       VPC-4              VPC-1--VPC-4      
 VPC-2              4000     2         VPC-1              VPC-1--VPC-2      
                                       VPC-3              VPC-2--VPC-3      
 VPC-3              2000     2         VPC-1              VPC-1--VPC-3      
                                       VPC-2              VPC-2--VPC-3      
 VPC-4              6000     1         VPC-1              VPC-1--VPC-4      
```

**Sample**: full Vpc peering table

```
 ───────────────────────────── VPC Peering Table (4)  ─────────────────────────────
 ■ VPC-1--VPC-2
    VPC-1:
        prefixes: 192.168.50.0/24, except 192.168.50.13/32
        prefixes: 192.168.111.0/24, except 192.168.111.2/32 192.168.111.254/32
              as: 100.64.200.0/24, excluding 100.64.200.13/32

    VPC-2:
        prefixes: 192.168.80.0/24

 ■ VPC-1--VPC-3
    VPC-1:
        prefixes: 192.168.60.0/24

    VPC-3:
        prefixes: 192.168.128.0/27

 ■ VPC-1--VPC-4
    VPC-1:
        prefixes: 192.168.60.0/24

    VPC-4:
        prefixes: 192.168.201.1/32 192.168.202.2/32 192.168.203.3/32
        prefixes: 192.168.204.4/32
              as: 100.64.204.4/32
        prefixes: 192.168.210.0/29, except 192.168.210.1/32

 ■ VPC-2--VPC-3
    VPC-2:
        prefixes: 192.168.80.0/24

    VPC-3:
        prefixes: 192.168.128.0/27
```

**Sample:** Detailed view of a single VPC and its peerings
```
 ────────────────────────────────── vpc: VPC-1  ──────────────────────────────────
 name: VPC-1
 vni : 3000
 peerings: 3
 ─────────────────────────────── Peerings of VPC-1  ───────────────────────────────
  ■ VPC-1--VPC-2:
     local:
        prefixes: 192.168.50.0/24, except 192.168.50.13/32
        prefixes: 192.168.111.0/24, except 192.168.111.2/32 192.168.111.254/32
              as: 100.64.200.0/24, excluding 100.64.200.13/32

     remote, VPC-2:
        prefixes: 192.168.80.0/24

  ■ VPC-1--VPC-3:
     local:
        prefixes: 192.168.60.0/24

     remote, VPC-3:
        prefixes: 192.168.128.0/27

  ■ VPC-1--VPC-4:
     local:
        prefixes: 192.168.60.0/24

     remote, VPC-4:
        prefixes: 192.168.201.1/32 192.168.202.2/32 192.168.203.3/32
        prefixes: 192.168.204.4/32
              as: 100.64.204.4/32
        prefixes: 192.168.210.0/29, except 192.168.210.1/32

```


