### PR TITLE
CI: Remove comments on Nightly job failures

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,11 +66,6 @@ jobs:
   build:
     needs: [ check_changes ]
     if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
-    permissions:
-      issues: "write"
-      pull-requests: "write"
-      contents: "write"
-      id-token: "write"
     strategy:
       fail-fast: false
       matrix:
@@ -153,21 +148,6 @@ jobs:
           just debug_justfile="${{matrix.debug_justfile}}" rust="${{matrix.rust.version}}" \
             build-sweep ${BASE}
           printf "::notice::HEAD back to %s\n" "$(git log --oneline --no-decorate -n 1)"
-
-      - name: "Note failure of optional steps"
-        uses: "actions/github-script@v7"
-        if: ${{ matrix.rust.optional && (steps.gnu_dev_test.outcome != 'success' || steps.gnu_release_test.outcome != 'success' || steps.clippy.outcome != 'success' || (steps.build_each_commit.outcome != 'success' && steps.build_each_commit.outcome != 'skipped')) }}
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            let body = "### :warning: One or more optional CI steps have failed!\n\n";
-            body += "_[click here to lament thy folly](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_"
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -130,7 +130,6 @@ jobs:
             cargo test
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-gnu \
             cargo doc
-        continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "gnu_release_test"
         name: "test gnu release"
@@ -139,14 +138,12 @@ jobs:
             cargo test
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
             cargo doc
-        continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "clippy"
         name: "run clippy"
         run: |
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} \
             cargo clippy --all-targets --all-features -- -D warnings
-        continue-on-error: ${{ matrix.rust.optional }}
 
       - id: "build_each_commit"
         name: "build each commit"
@@ -156,7 +153,6 @@ jobs:
           just debug_justfile="${{matrix.debug_justfile}}" rust="${{matrix.rust.version}}" \
             build-sweep ${BASE}
           printf "::notice::HEAD back to %s\n" "$(git log --oneline --no-decorate -n 1)"
-        continue-on-error: ${{ matrix.rust.optional }}
 
       - name: "Note failure of optional steps"
         uses: "actions/github-script@v7"


### PR DESCRIPTION
I don't like the comments generated by the CI workflow when the job with the Nightly toolchain fails, I find them disruptive when trying to follow a conversation on a GitHub Pull Request page. Plus given that the job is optional, we barely ever click the links from the comments anyway. A failed status check draws more attention to the actual issue, in my opinion.

Motivation:
- My objective here is to remove the creation of the comments when an optional step fails
- To get some feedback on failure instead, we remove the `continue-on-error` directives: I expect this to make the job using the Nightly toolchain fail on errors (which should show up in the list of status checks at the bottom of the page).

Will a job failure block the CI or the merge queue?
- The individual jobs for the dev.yml workflow are not marked as required, only the last `Summary` step is required
- The job with Nightly still has an `optional` attribute in the Matrix, and as a consequence its status is ignored when building the `Summary`, so I don't expect it to block CI/merge queue.