### PR TITLE
test(test-runner): Per-package opt-in for test runner

### DIFF
--- a/net/src/packet/hash.rs
+++ b/net/src/packet/hash.rs
@@ -97,14 +97,14 @@ mod tests {
             let hash_value = hash_ip_packet(packet);
             vals.insert(u16::try_from(n).expect("Conversion failed"), hash_value);
         }
-        let mut file = File::create("net/artifacts/ahash_fingerprint.txt")
+        let mut file = File::create("artifacts/ahash_fingerprint.txt")
             .expect("Failed to open ahash fingerprint file");
         file.write_all(format!("{vals:#?}").as_bytes())
             .expect("Failed to write fingerprint");
     }
 
     // hashes the test packets storing the results in an ordermap and then compares
-    // the whole ordermap with a reference stored in net/artifacts/ahash_fingerprint.
+    // the whole ordermap with a reference stored in artifacts/ahash_fingerprint.txt.
     // This test should fail if ahash changes to produce distinct output.
     // If that happens, set update_fingerprint to true and commit the fingerprint
     // file.
@@ -121,7 +121,7 @@ mod tests {
             vals.insert(u16::try_from(n).expect("Conversion failed"), hash_value);
         }
         let fingerprint = format!("{vals:#?}");
-        let reference = fs::read_to_string("net/artifacts/ahash_fingerprint.txt")
+        let reference = fs::read_to_string("artifacts/ahash_fingerprint.txt")
             .expect("Missing fingerprint file");
         assert_eq!(fingerprint, reference);
     }

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -103,6 +103,27 @@ check_if_reasonable "${test_exe}"
 # This lets us pick the correct libc container.
 source "${script_dir}/dpdk-sys.env"
 
+declare -ra WRAPPED_TEST_SUITES=(
+  "dataplane"
+  "dataplane-interface-manager"
+  "dataplane-vpc-manager"
+  "integration-fixtures"
+)
+
+declare -i SHOULD_WRAP=0
+declare test_suite
+for test_suite in "${WRAPPED_TEST_SUITES[@]}"; do
+  if [ "${CARGO_PKG_NAME-CARGO_PKG_NAME_NOT_SET}" == "${test_suite}" ]; then
+    SHOULD_WRAP=1
+    break
+  fi
+done
+declare -ri SHOULD_WRAP
+
+if [ "${SHOULD_WRAP}" -eq 0 ]; then
+  exec "${@}"
+fi
+
 # Now we can run the docker container
 #
 # Notes about this command:


### PR DESCRIPTION
The test runner that makes unit tests run inside of a Docker container tend to make it harder to run and debug tests. Only use the container for packages that do require specific configuration or elevated privileges, not for the other packages.

Code from Daniel.
