### PR TITLE
chore(dependabot): Make Dependabot ignore gateway_config updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
       - "automated"
       - "dependencies"
     versioning-strategy: "lockfile-only"
+    ignore:
+      - dependency-name: "gateway_config"
     groups:
       dependencies:
         applies-to: "version-updates"


### PR DESCRIPTION
Updates for gateway_config require manual adjustments in our code for now, we need someone to take care of them. Attempts from the bot to autmatically bump the version number (or commit SHA) are unlikely to be correct, so let's discharge Dependabot of the task.
