### PR TITLE
Management cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ name = "mgmt"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "derive_builder",
  "gateway_config",
  "net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +436,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1050,6 +1083,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1157,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1201,6 +1268,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "chrono",
  "derive_builder",
  "gateway_config",
  "net",
@@ -2347,6 +2415,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2493,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ async-trait = { version = "0.1"}
 bindgen = { version = "0.71.1", default-features = false, features = [] }
 bolero = { version = "0.13.2", default-features = false, features = [] }
 bytes = { version = "1.10.1", default-features = false, features = [] }
+chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
 clap = { version = "4.5.37", default-features = true, features = [] }
 ctrlc = { version = "3.4.6", default-features = false, features = [] }
 derive_builder = { version = "0.20.2", default-features = false, features = ["default"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ rtnetlink = { version = "0.16.0", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
 thiserror = { version = "2.0.12", default-features = false, features = [] }
-tokio = { version = "1.44.2", default-features = false, features = [] }
+tokio = { version = "1.44.2", default-features = false, features = ["full"] }
 tonic = { version = "0.13", default-features = false, features = ["transport", "codegen"] }
 tracing = { version = "0.1.41", default-features = false, features = ["attributes"] } # attribute feature is so commonly used that we should just leave it on globally
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [] }

--- a/dataplane/src/drivers/kernel.rs
+++ b/dataplane/src/drivers/kernel.rs
@@ -217,7 +217,9 @@ impl DriverKernel {
                     pkts.push(incoming);
                 }
                 Err(e) => {
-                    error!("Failed to parse packet!!:\n{e}");
+                    if interface.name != "lo" {
+                        error!("Failed to parse packet!!:\n{e}");
+                    }
                 }
             }
         }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -25,6 +25,7 @@ fn init_logging() {
         .with_thread_ids(true)
         .with_line_number(true)
         .with_thread_names(true)
+        .with_env_filter(EnvFilter::new("debug,tonic=off,h2=off"))
         .init();
 }
 
@@ -47,6 +48,7 @@ fn setup_pipeline<Buf: PacketBufferMut>() -> DynPipeline<Buf> {
 }
 
 use mgmt::processor::proc::start_mgmt;
+use tracing_subscriber::EnvFilter;
 
 fn main() {
     init_logging();

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -18,6 +18,7 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-test = { workspace = true }
 nix = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 routing = { workspace = true, features = ["testing"] }

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = { workspace = true }
+bytes = { workspace = true }
 derive_builder = { workspace = true }
 gateway_config = { workspace = true }
 net = { workspace = true }

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -12,7 +12,7 @@ gateway_config = { workspace = true }
 net = { workspace = true }
 routing = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }    
+tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-test = { workspace = true }

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -18,3 +18,6 @@ tracing = { workspace = true }
 tracing-test = { workspace = true }
 nix = { workspace = true }
 
+[dev-dependencies]
+routing = { workspace = true, features = ["testing"] }
+

--- a/mgmt/src/frr/frrmi/mod.rs
+++ b/mgmt/src/frr/frrmi/mod.rs
@@ -8,7 +8,7 @@ use std::str;
 use tokio::time::{Duration, timeout};
 
 use crate::frr::renderer::builder::ConfigBuilder;
-use crate::models::external::configdb::gwconfig::GenId;
+use crate::models::external::gwconfig::GenId;
 
 use std::fs;
 use std::net::Shutdown;
@@ -243,7 +243,7 @@ impl FrrMi {
 pub mod tests {
     use super::*;
     use crate::frr::renderer::builder::Render;
-    use crate::models::external::configdb::gwconfig::GwConfig;
+    use crate::models::external::gwconfig::GwConfig;
     use crate::processor::tests::test::sample_external_config;
     use tokio::task::JoinHandle;
     use tracing_test::traced_test;

--- a/mgmt/src/frr/frrmi/mod.rs
+++ b/mgmt/src/frr/frrmi/mod.rs
@@ -3,235 +3,262 @@
 
 // FRRMI: FRR management interface
 
-use crate::frr::renderer::builder::ConfigBuilder;
-use crate::models::external::gwconfig::GenId;
-use nix::sys::socket::{setsockopt, sockopt};
-use std::str;
+#![cfg(unix)]
+use bytes::Buf;
+use bytes::BytesMut;
+
+use tokio::io::{AsyncWriteExt, ErrorKind};
+use tokio::net::UnixStream;
 use tokio::time::{Duration, timeout};
 
-use std::fs;
-use std::net::Shutdown;
-use std::os::fd::BorrowedFd;
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::io::AsRawFd;
+use std::io::Cursor;
 use std::path::Path;
+use std::str;
+use std::str::from_utf8;
 use thiserror::Error;
-use tracing::{debug, error, info};
+#[allow(unused)]
+use tracing::{debug, error, info, warn};
 
-use tokio::net::UnixDatagram;
+use crate::frr::renderer::builder::ConfigBuilder;
+use crate::models::external::gwconfig::GenId;
 
 #[derive(Error, Debug)]
 pub enum FrrErr {
-    #[error("Failed to open FrrMi: {0}")]
-    FailOpen(&'static str),
+    #[error("Failed to connect FrrMi: {0}")]
+    ConnectFailed(&'static str),
 
     #[error("No connection to frr-agent exists")]
     NotConnected,
 
-    #[error("Frr-agent is down or unreachable")]
-    FrrAgentDown,
-
-    #[error("Failed to communicate with frr-agent: {0}")]
-    FailCommFrrAgent(String),
-
     #[error("Timeout: did not receive response in time")]
     TimeOut,
 
+    #[error("Peer left")]
+    PeerLeft,
+
+    #[error("Receive failure {0}")]
+    RxFail(String),
+
+    #[error("Send failure {0}")]
+    TxFail(String),
+
     #[error("Reloading error: {0}")]
     ReloadErr(String),
+
+    #[error("Decoding error")]
+    DecodeError(&'static str),
 }
 
-pub fn open_unix_sock_async<P: AsRef<Path> + ?Sized + std::fmt::Display>(
-    bind_addr: &P,
-) -> Result<UnixDatagram, &'static str> {
-    debug!("Opening sock at {bind_addr}...");
-
-    /* remove entry from filesystem */
-    let _ = std::fs::remove_file(bind_addr);
-
-    /* create intermediate directories */
-    let path = Path::new(bind_addr.as_ref());
-    if let Some(parent_dir) = path.parent() {
-        debug!("Creating directory at {parent_dir:?}...");
-        fs::create_dir_all(parent_dir)
-            .map_err(|_| "Failed to create path to unix sock local address")?;
-    }
-
-    /* create sock */
-    let sock = UnixDatagram::bind(bind_addr).map_err(|_| "Failed to bind socket")?;
-    let raw_fd = sock.as_raw_fd();
-    let send_buf_size = 8 * 1024 * 1024;
-    let borrowed_fd = unsafe { BorrowedFd::borrow_raw(raw_fd) };
-    setsockopt(&borrowed_fd, sockopt::SndBuf, &send_buf_size)
-        .map_err(|_| "Failed to set send buffer size")?;
-    let recv_buf_size = 8 * 1024 * 1024;
-    setsockopt(&borrowed_fd, sockopt::RcvBuf, &recv_buf_size)
-        .map_err(|_| "Failed to set receive buffer size")?;
-    let mut perms = fs::metadata(bind_addr)
-        .map_err(|_| "Failed to retrieve path metadata")?
-        .permissions();
-    perms.set_mode(0o777); // fixme: make this more restrictive
-    fs::set_permissions(bind_addr, perms).map_err(|_| "Failure setting permissions")?;
-    debug!("Created unix sock and bound to {bind_addr}");
+/// Connect to the specified remote path and provide a [`UnixStream`] socket.
+/// Will fail if connection does not succeed in the indicated timeout specified as a [`Duration`].
+pub async fn connect_sock_stream<P: AsRef<Path> + ?Sized + std::fmt::Display>(
+    remote: &P,
+    tout: Duration,
+) -> Result<UnixStream, FrrErr> {
+    debug!("Connecting to frr-agent at {}...", remote);
+    let sock = timeout(tout, UnixStream::connect(remote))
+        .await
+        .map_err(|_| FrrErr::TimeOut)?
+        .map_err(|_| {
+            error!("Failed to connect to {}", remote);
+            FrrErr::ConnectFailed("Failed to connect")
+        })?;
+    debug!("Connected to {}", remote);
     Ok(sock)
 }
 
+/// Receive **EXACTLY** len octets of data over the specified [`UnixStream`] socket
+async fn do_recv(sock: &mut UnixStream, len: usize) -> Result<Vec<u8>, FrrErr> {
+    let mut data = BytesMut::with_capacity(len);
+    let mut chunk_buffer = vec![0u8; len];
+    while data.len() < len {
+        sock.readable()
+            .await
+            .map_err(|e| FrrErr::RxFail(e.to_string()))?;
+        match sock.try_read(&mut chunk_buffer) {
+            Ok(0) => return Err(FrrErr::PeerLeft),
+            Ok(n) => data.extend_from_slice(&chunk_buffer[..n]),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                continue;
+            }
+            Err(e) => return Err(FrrErr::RxFail(e.to_string())),
+        };
+    }
+    Ok(data.into())
+}
+
+/// Receive a message made of |length|genid|data. This applies to both requests and responses.
+async fn receive_msg(sock: &mut UnixStream) -> Result<(GenId, String), FrrErr> {
+    /* data length as 8 octets*/
+    let len_buf = do_recv(sock, 8).await?;
+    let len_buf: [u8; 8] = len_buf
+        .try_into()
+        .map_err(|_| FrrErr::DecodeError("Error decoding msg length"))?;
+    let msg_len = u64::from_ne_bytes(len_buf) as usize;
+
+    /* genid */
+    let genid_buf = do_recv(sock, 8).await?;
+    let genid_buf: [u8; 8] = genid_buf
+        .try_into()
+        .map_err(|_| FrrErr::DecodeError("Error decoding genid"))?;
+    let genid = i64::from_ne_bytes(genid_buf) as GenId;
+
+    /* data with length msg_len */
+    let buf = do_recv(sock, msg_len).await?;
+    let message = from_utf8(&buf).map_err(|_| FrrErr::DecodeError("Error decoding message"))?;
+    debug!("Got message with {msg_len} octets for genid {genid}");
+    Ok((genid, message.to_string()))
+}
+
+/// Receive a (response) message over the [`FrrMi`] with the provided timeout.
+/// Fails if no **COMPLETE** message is received in the indicated timeout.
+async fn receive_msg_timed(
+    sock: &mut UnixStream,
+    tout: Duration,
+) -> Result<(GenId, String), FrrErr> {
+    timeout(tout, receive_msg(sock)).await.map_err(|_| {
+        let peer = sock.peer_addr();
+        error!("No response from agent at {peer:?} in {tout:?}");
+        FrrErr::TimeOut
+    })?
+}
+
+/// Send a buffer over the provided [`UnixStream`]
+async fn send_buf(sock: &mut UnixStream, buf: &[u8]) -> Result<(), FrrErr> {
+    let mut cursor = Cursor::new(buf);
+    while cursor.has_remaining() {
+        sock.write_buf(&mut cursor).await.map_err(|e| {
+            error!("Failed to send buffer: {e}");
+            FrrErr::TxFail(e.to_string())
+        })?;
+    }
+    Ok(())
+}
+
+/// Send a message over the provided [`UnixStream`]. Messages are structured as
+///    |length(8)|genid(8)|data(variable)|
+/// where the numbers indicate the number of octets.
+async fn send_msg(sock: &mut UnixStream, genid: GenId, msg: &[u8]) -> Result<(), FrrErr> {
+    /* length of data */
+    let length = msg.len() as u64;
+
+    debug!("Sending message. Genid: {genid} size: {length}");
+
+    /* assemble wire message: |length|genid|data| */
+    let mut wire_msg = BytesMut::with_capacity(msg.len() + 16);
+    wire_msg.extend_from_slice(&length.to_ne_bytes());
+    wire_msg.extend_from_slice(&genid.to_ne_bytes());
+    wire_msg.extend_from_slice(msg);
+
+    /* send wire message */
+    send_buf(sock, &wire_msg).await?;
+    debug!("Successfully sent msg. data-len: {length} genid: {genid}");
+    Ok(())
+}
+
 pub struct FrrMi {
-    sock: UnixDatagram,
-    local: String,
+    sock: Option<UnixStream>,
     remote: String,
-    connected: bool,
-    up: bool,
     timeout: Duration,
 }
 impl FrrMi {
     const FRRMI_TIMEOUT: u64 = 10;
 
     /// Create an frrmi to talk to an frr-agent.
-    pub async fn new(bind_addr: &str, remote_addr: &str) -> Result<FrrMi, FrrErr> {
-        let sock = open_unix_sock_async(bind_addr).map_err(FrrErr::FailOpen)?;
+    pub async fn new(remote_addr: &str) -> Result<FrrMi, FrrErr> {
         let mut frrmi = Self {
-            sock,
-            local: bind_addr.to_string(),
+            sock: None,
             remote: remote_addr.to_string(),
-            connected: false,
-            up: false,
             timeout: Duration::from_secs(Self::FRRMI_TIMEOUT),
         };
-        /* attempt connect to frr-agent. If successful, probe the frr-agent */
-        frrmi.connect();
+        frrmi.connect().await;
         if frrmi.is_connected() {
             frrmi.probe().await;
         }
         info!(
-            "Successfully opened frrmi. Local:{} remote:{} connected:{} up:{}",
-            &frrmi.local, &frrmi.remote, frrmi.connected, frrmi.up
+            "Created frrmi. remote: {} connected: {}",
+            &frrmi.remote,
+            frrmi.is_connected(),
         );
         Ok(frrmi)
     }
-    /// Close the socket of this frrmi. Currently UNUSED
-    pub fn close(&mut self) {
-        info!("Shutting down frrmi...");
-        let _ = self.sock.shutdown(Shutdown::Both);
-    }
-    /// Tell if the frrmi is connected to the remote address
-    pub fn is_connected(&self) -> bool {
-        self.connected
-    }
-
-    /// Tell if according to the frrmi, the frr-agent is up or not
-    pub fn is_up(&self) -> bool {
-        self.up
-    }
-    /// Connect the frrmi to the configured remote address
-    pub fn connect(&mut self) {
-        debug!("Connecting frrmi to {}...", &self.remote);
-        match self.sock.connect(&self.remote) {
-            Ok(_) => {
-                debug!("Connected to frr-agent at {}", self.remote);
-                self.connected = true;
-            }
-            Err(e) => {
-                error!("Can't connect to frr-agent at {}: {e}", self.remote);
-            }
+    pub async fn connect(&mut self) {
+        let timeout = Duration::from_secs(Self::FRRMI_TIMEOUT);
+        if let Ok(stream) = connect_sock_stream(&self.remote, timeout).await {
+            self.sock = Some(stream);
         }
     }
+    pub fn is_connected(&self) -> bool {
+        self.sock.is_some()
+    }
+
     /// Probe the frr-agent with this [`FrrMi`] by sending a keepalive message
+    /// FIXME: decide if we need probing with stream sockets
     pub async fn probe(&mut self) {
         if !self.is_connected() {
-            self.connect();
+            self.connect().await;
         }
         if self.is_connected() {
             debug!("Probing frr-agent...");
-            let up = self.send_receive(0, "KEEPALIVE").await.is_ok();
-            if up != self.up {
-                info!("Frr-agent at {} is up", self.remote);
-                self.up = up
+            if self.send_receive(0, "KEEPALIVE").await.is_ok() {
+                info!("Contacted Frr-agent at {}", self.remote);
             }
         }
     }
 
     /// Receive a response
-    async fn receive_response(&self) -> Result<(), FrrErr> {
+    async fn receive_response(&mut self) -> Result<(), FrrErr> {
         debug!("Awaiting reply from frr-agent at {}...", self.remote);
-
-        /* start a timeout for the reception of the response */
-        let mut rx_buff = vec![0u8; 1024];
-        let result = match timeout(self.timeout, self.sock.recv(&mut rx_buff)).await {
-            Ok(result) => result,
-            Err(_) => {
-                error!(
-                    "Got no response from frr-agent in {:?} seconds",
-                    self.timeout
-                );
-                return Err(FrrErr::TimeOut);
+        if let Some(stream) = &mut self.sock {
+            let (genid, response) = receive_msg_timed(stream, self.timeout).await?;
+            debug!(
+                "Got response from frr-agent at {} for genid {genid}: {response}",
+                self.remote
+            );
+            match response.as_str() {
+                "Ok" => Ok(()),
+                _ => Err(FrrErr::ReloadErr(response)),
             }
-        };
-
-        /* we received response in time. Check it */
-        match result {
-            Ok(len) => {
-                /* decode response as a string */
-                if let Ok(response) = String::from_utf8(rx_buff[0..len].to_vec()) {
-                    debug!("Frr-agent answered: {response}");
-                    match response.as_str() {
-                        "Ok" => Ok(()),
-                        _ => Err(FrrErr::ReloadErr(response)),
-                    }
-                } else {
-                    Err(FrrErr::ReloadErr("Failed to parse response".to_string()))
-                }
-            }
-            Err(e) => {
-                error!("Error receiving over frrmi: {e}");
-                Err(FrrErr::FailCommFrrAgent(e.to_string()))
-            }
+        } else {
+            Err(FrrErr::NotConnected)
         }
     }
 
-    /// Send a message over this [`FrrMi`], such as a config or a keepalive
-    /// and receive the response.
-    ///
+    /// Send a message over this [`FrrMi`], such as a config or a keepalive and receive the response.
     /// Returns error if message could not be sent, or the response could not
     /// be received, or a response was received but it was not "Ok"
-    async fn send_receive(&self, genid: GenId, msg: &str) -> Result<(), FrrErr> {
-        if !self.is_connected() || !self.is_up() {
-            /* // FIXME: this requires frrmi to be mutable
-                       self.probe();
-                       if !self.is_connected() {
-                           return Err(FrrErr::NotConnected);
-                       }
-                       if !self.is_up() {
-                           return Err(FrrErr::FrrAgentDown);
-                       }
-            */
+    async fn send_receive(&mut self, genid: GenId, msg: &str) -> Result<(), FrrErr> {
+        if !self.is_connected() {
+            debug!("Frmmi is not connected to agent...");
+            self.connect().await;
+            if !self.is_connected() {
+                return Err(FrrErr::NotConnected);
+            }
         }
 
-        /* send length of message */
-        let length = msg.len() as u64;
-        self.sock.send(&length.to_ne_bytes()).await.map_err(|e| {
-            error!("Fatal: Failed to send message length: {e}");
-            FrrErr::FailCommFrrAgent(e.to_string())
-        })?;
-
-        /* send genid (0 in keepalives) */
-        self.sock.send(&genid.to_ne_bytes()).await.map_err(|e| {
-            error!("Fatal: Failed to send genid: {e}");
-            FrrErr::FailCommFrrAgent(e.to_string())
-        })?;
-
-        /* send message (e.g. a config or a keepalive) */
-        self.sock.send(msg.as_bytes()).await.map_err(|e| {
-            error!("Fatal: Failed to send message: {e}");
-            FrrErr::FailCommFrrAgent(e.to_string())
-        })?;
-
-        /* receive reply from frr-agent and check its contents */
-        self.receive_response().await
+        if let Some(sock) = &mut self.sock {
+            /* send the request: if sending fails, we may disconnect */
+            if let Err(e) = send_msg(sock, genid, msg.as_bytes()).await {
+                if matches!(e, FrrErr::PeerLeft | FrrErr::RxFail(_) | FrrErr::TxFail(_)) {
+                    warn!("Got error: {e}. Disconnecting frrmi...");
+                    let _ = sock.shutdown().await;
+                    self.sock.take();
+                    return Err(e);
+                }
+            }
+            /* we could send the request: receive the response */
+            self.receive_response().await
+        } else {
+            unreachable!()
+        }
     }
 
     /// Apply the config in FRR represented by [`ConfigBuilder`] using this [`FrrMi`]
-    pub async fn apply_config(&self, genid: GenId, config: &ConfigBuilder) -> Result<(), FrrErr> {
+    pub async fn apply_config(
+        &mut self,
+        genid: GenId,
+        config: &ConfigBuilder,
+    ) -> Result<(), FrrErr> {
         info!("Applying FRR config. Genid={genid} agent={}", &self.remote);
         let conf_str = config.to_string();
         if let Err(e) = self.send_receive(genid, &conf_str).await {
@@ -250,30 +277,43 @@ pub mod tests {
     use crate::frr::renderer::builder::Render;
     use crate::models::external::gwconfig::GwConfig;
     use crate::processor::tests::test::sample_external_config;
+    use tokio::fs;
+    use tokio::net::UnixListener;
     use tokio::task::JoinHandle;
     use tracing_test::traced_test;
 
     /// Create a fake frr-agent async task for testing.
     /// The agent can be stopped by calling abort() on the returned handle.
     pub async fn fake_frr_agent(agent_address: &str) -> JoinHandle<()> {
-        /* N.B: socknames include name of test to avoid issues with other tests running concurrently */
-        let sock = open_unix_sock_async(agent_address).expect("Should succeed");
-        tokio::spawn(async move {
+        debug!("Starting fake frr-agent at {agent_address}...");
+
+        /* remove stale entries in FS and create new */
+        let _ = std::fs::remove_file(agent_address);
+        let bind_path = Path::new(agent_address);
+        if let Some(parent_dir) = bind_path.parent() {
+            debug!("Creating directory at {parent_dir:?}...");
+            fs::create_dir_all(parent_dir).await.unwrap();
+        }
+        let listener = UnixListener::bind(bind_path).unwrap();
+
+        /* spawn */
+        let task = tokio::spawn(async move {
+            debug!("frr-agent will accept connections now");
+            let (mut sock, peer) = listener.accept().await.unwrap();
+            debug!("frr-agent got connection from {peer:?}");
             loop {
-                let mut rx_buff = vec![0u8; 8192];
-                let (_, _) = sock.recv_from(&mut rx_buff).await.unwrap();
-                let (_, requestor) = sock.recv_from(&mut rx_buff).await.unwrap();
-                sock.send_to(
-                    "Ok".to_string().as_bytes(),
-                    requestor.as_pathname().unwrap(),
-                )
-                .await
-                .unwrap();
+                let (genid, request) = receive_msg(&mut sock).await.unwrap();
+                debug!("frr-agent got request:\n{request}");
+                send_msg(&mut sock, genid, "Ok".to_string().as_bytes())
+                    .await
+                    .unwrap();
             }
-        })
+        });
+        debug!("Spawned fake frr-agent");
+        task
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[traced_test]
     async fn test_frrmi() {
         /* build some sample config */
@@ -287,12 +327,7 @@ pub mod tests {
         let frr_agent = fake_frr_agent("/tmp/frrmi-test/frr-agent.sock").await;
 
         /* open frrmi */
-        let frrmi = FrrMi::new(
-            "/tmp/frrmi-test/frrmi.sock",
-            "/tmp/frrmi-test/frr-agent.sock",
-        )
-        .await
-        .unwrap();
+        let mut frrmi = FrrMi::new("/tmp/frrmi-test/frr-agent.sock").await.unwrap();
 
         /* apply config over frrmi */
         if let Err(e) = frrmi.apply_config(config.genid(), &rendered).await {

--- a/mgmt/src/frr/renderer/mod.rs
+++ b/mgmt/src/frr/renderer/mod.rs
@@ -14,7 +14,7 @@ pub mod statics;
 pub mod vrf;
 
 use crate::frr::renderer::builder::{ConfigBuilder, Render};
-use crate::models::external::configdb::gwconfig::GwConfig;
+use crate::models::external::gwconfig::GwConfig;
 use crate::models::internal::InternalConfig;
 
 fn render_metadata(config: &GwConfig) -> String {

--- a/mgmt/src/grpc/converter.rs
+++ b/mgmt/src/grpc/converter.rs
@@ -83,9 +83,7 @@ pub fn create_gw_config(external_config: ExternalConfig) -> GwConfig {
 //--------------------------------------------------------------------------------
 
 /// Convert from GatewayConfig (gRPC) to ExternalConfig
-pub async fn convert_from_grpc_config(
-    grpc_config: &GatewayConfig,
-) -> Result<ExternalConfig, String> {
+pub fn convert_from_grpc_config(grpc_config: &GatewayConfig) -> Result<ExternalConfig, String> {
     // Extract required components
     let device = grpc_config
         .device
@@ -917,9 +915,7 @@ pub fn convert_overlay_to_grpc(overlay: &Overlay) -> Result<gateway_config::Over
 }
 
 /// Convert from ExternalConfig to GatewayConfig (gRPC)
-pub async fn convert_to_grpc_config(
-    external_config: &ExternalConfig,
-) -> Result<GatewayConfig, String> {
+pub fn convert_to_grpc_config(external_config: &ExternalConfig) -> Result<GatewayConfig, String> {
     // Convert device config
     let device = convert_device_to_grpc(&external_config.device)?;
 

--- a/mgmt/src/grpc/converter.rs
+++ b/mgmt/src/grpc/converter.rs
@@ -6,7 +6,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 use tracing::Level;
 
-use crate::models::external::configdb::gwconfig::{
+use crate::models::external::gwconfig::{
     ExternalConfig, ExternalConfigBuilder, GwConfig, Underlay,
 };
 use crate::models::external::overlay::Overlay;

--- a/mgmt/src/grpc/converter.rs
+++ b/mgmt/src/grpc/converter.rs
@@ -490,13 +490,17 @@ pub fn convert_expose_from_grpc(expose: &gateway_config::Expose) -> Result<VpcEx
                     // Parse CIDR into IP and netmask
                     let (ip_str, netmask) = parse_cidr(cidr)?;
                     // Add as an include rule
-                    vpc_expose = vpc_expose.ip(Prefix::from((ip_str.as_str(), netmask)));
+                    vpc_expose = vpc_expose.ip(Prefix::try_from_tuple((ip_str.as_str(), netmask))
+                        .map_err(|e| e.to_string())?);
                 }
                 gateway_config::config::peering_i_ps::Rule::Not(not) => {
                     // Parse CIDR into IP and netmask for exclude rule
                     let (ip_str, netmask) = parse_cidr(not)?;
                     // Add as an exclude rule
-                    vpc_expose = vpc_expose.not(Prefix::from((ip_str.as_str(), netmask)));
+                    vpc_expose = vpc_expose.not(
+                        Prefix::try_from_tuple((ip_str.as_str(), netmask))
+                            .map_err(|e| e.to_string())?,
+                    );
                 }
             }
         } else {
@@ -512,13 +516,19 @@ pub fn convert_expose_from_grpc(expose: &gateway_config::Expose) -> Result<VpcEx
                     // Parse CIDR into IP and netmask
                     let (ip_str, netmask) = parse_cidr(cidr)?;
                     // Add as an include rule for AS
-                    vpc_expose = vpc_expose.as_range(Prefix::from((ip_str.as_str(), netmask)));
+                    vpc_expose = vpc_expose.as_range(
+                        Prefix::try_from_tuple((ip_str.as_str(), netmask))
+                            .map_err(|e| e.to_string())?,
+                    );
                 }
                 gateway_config::config::peering_as::Rule::Not(ip_exclude) => {
                     // Parse CIDR into IP and netmask for exclude rule
                     let (ip_str, netmask) = parse_cidr(ip_exclude)?;
                     // Add as an exclude rule for AS
-                    vpc_expose = vpc_expose.not_as(Prefix::from((ip_str.as_str(), netmask)));
+                    vpc_expose = vpc_expose.not_as(
+                        Prefix::try_from_tuple((ip_str.as_str(), netmask))
+                            .map_err(|e| e.to_string())?,
+                    );
                 }
             }
         } else {

--- a/mgmt/src/grpc/server.rs
+++ b/mgmt/src/grpc/server.rs
@@ -7,24 +7,17 @@ use async_trait::async_trait;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tracing::error;
+
+use crate::grpc::converter::convert_to_grpc_config;
+use crate::models::external::gwconfig::GwConfig;
+use crate::processor::proc::{ConfigRequest, ConfigResponse};
+use crate::{grpc::converter, models::external::gwconfig::GenId};
 
 // Import proto-generated types
 use gateway_config::{
     ConfigService, ConfigServiceServer, Error, GatewayConfig, GetConfigGenerationRequest,
     GetConfigGenerationResponse, GetConfigRequest, UpdateConfigRequest, UpdateConfigResponse,
 };
-
-use crate::frr::frrmi::FrrMi;
-use crate::processor::proc::new_gw_config;
-
-// Import database access
-use crate::processor::gwconfigdb::GwConfigDatabase;
-use tokio::sync::RwLock;
-
-// Import converter module for async functions
-use crate::grpc::converter;
-use crate::models::external::gwconfig::GwConfig;
 
 /// Trait for configuration management
 #[async_trait]
@@ -99,13 +92,12 @@ impl ConfigService for ConfigServiceImpl {
 
 /// Basic configuration manager implementation
 pub struct BasicConfigManager {
-    config_db: Arc<RwLock<GwConfigDatabase>>,
-    frrmi: FrrMi,
+    channel_tx: Sender<ConfigChannelRequest>,
 }
 
 impl BasicConfigManager {
-    pub fn new(config_db: Arc<RwLock<GwConfigDatabase>>, frrmi: FrrMi) -> Self {
-        Self { config_db, frrmi }
+    pub fn new(channel_tx: Sender<ConfigChannelRequest>) -> Self {
+        Self { channel_tx }
     }
 
     // Example function showing how to use TryFrom conversions for components
@@ -161,21 +153,44 @@ impl BasicConfigManager {
 #[async_trait]
 impl ConfigManager for BasicConfigManager {
     async fn get_current_config(&self) -> Result<GatewayConfig, String> {
-        let config_db = self.config_db.read().await;
-        let gw_config = config_db
-            .get_current_config()
-            .ok_or_else(|| "No configuration found".to_string())?;
-
-        // Use the async converter function
-        converter::convert_to_grpc_config(&gw_config.external).await
+        // build a request to the config processor, send it and get the response
+        let (req, rx) = ConfigChannelRequest::new(ConfigRequest::GetCurrentConfig);
+        self.channel_tx
+            .send(req)
+            .await
+            .map_err(|_| "Failure relaying request".to_string())?;
+        let response = rx
+            .await
+            .map_err(|_| "Failure receiving from config processor".to_string())?;
+        match response {
+            ConfigResponse::GetCurrentConfig(opt_config) => {
+                if let Some(config) = &opt_config {
+                    Ok(convert_to_grpc_config(&config.external)
+                        .await
+                        .expect("Failed to convert to gRPC"))
+                } else {
+                    Err("No config is currently applied".to_string())
+                }
+            }
+            _ => unreachable!(),
+        }
     }
 
-    async fn get_generation(&self) -> Result<i64, String> {
-        let config_db = self.config_db.read().await;
-        if let Some(gw_config_gen) = config_db.get_current_gen() {
-            Ok(gw_config_gen)
-        } else {
-            Err("No config is currently applied".to_string())
+    async fn get_generation(&self) -> Result<GenId, String> {
+        // build a request to the config processor, send it and get the response
+        let (req, rx) = ConfigChannelRequest::new(ConfigRequest::GetGeneration);
+        self.channel_tx
+            .send(req)
+            .await
+            .map_err(|_| "Failure relaying request".to_string())?;
+        let response = rx
+            .await
+            .map_err(|_| "Failure receiving from config processor".to_string())?;
+        match response {
+            ConfigResponse::GetGeneration(opt_genid) => {
+                opt_genid.ok_or_else(|| "No config is currently applied".to_string())
+            }
+            _ => unreachable!(),
         }
     }
 
@@ -199,25 +214,32 @@ impl ConfigManager for BasicConfigManager {
         // Create a new GwConfig
         let gw_config = GwConfig::new(external_config);
 
-        // Get a write lock on the DB
-        let mut config_db = self.config_db.write().await;
-
-        // Process the config
-        new_gw_config(&mut config_db, gw_config, &self.frrmi)
+        // build a request to the config processor, send it and get the response
+        let (req, rx) = ConfigChannelRequest::new(ConfigRequest::ApplyConfig(gw_config));
+        self.channel_tx
+            .send(req)
             .await
-            .map_err(|e| {
-                error!("Applying config failed: {e}");
-                e.to_string()
-            })
+            .map_err(|_| "Failure relaying request".to_string())?;
+        let response = rx
+            .await
+            .map_err(|_| "Failure receiving from config processor".to_string())?;
+        match response {
+            ConfigResponse::ApplyConfig(result) => {
+                result.map_err(|e| format!("Failed to apply config: {e}"))
+            }
+            _ => unreachable!(),
+        }
     }
 }
 
+use crate::processor::proc::ConfigChannelRequest;
+use tokio::sync::mpsc::Sender;
+
 /// Function to create the gRPC service
 pub fn create_config_service(
-    config_db: Arc<RwLock<GwConfigDatabase>>,
-    frrmi: FrrMi,
+    channel_tx: Sender<ConfigChannelRequest>,
 ) -> ConfigServiceServer<ConfigServiceImpl> {
-    let config_manager = Arc::new(BasicConfigManager::new(config_db, frrmi));
+    let config_manager = Arc::new(BasicConfigManager::new(channel_tx));
     let service = ConfigServiceImpl::new(config_manager);
     ConfigServiceServer::new(service)
 }

--- a/mgmt/src/grpc/server.rs
+++ b/mgmt/src/grpc/server.rs
@@ -19,12 +19,12 @@ use crate::frr::frrmi::FrrMi;
 use crate::processor::proc::new_gw_config;
 
 // Import database access
-use crate::models::external::configdb::gwconfigdb::GwConfigDatabase;
+use crate::processor::gwconfigdb::GwConfigDatabase;
 use tokio::sync::RwLock;
 
 // Import converter module for async functions
 use crate::grpc::converter;
-use crate::models::external::configdb::gwconfig::GwConfig;
+use crate::models::external::gwconfig::GwConfig;
 
 /// Trait for configuration management
 #[async_trait]

--- a/mgmt/src/grpc/server.rs
+++ b/mgmt/src/grpc/server.rs
@@ -101,22 +101,6 @@ impl BasicConfigManager {
         Self { channel_tx }
     }
 
-    // Example function showing how to use TryFrom conversions for components
-    // This is not part of the ConfigManager trait but shows how to use TryFrom
-    fn validate_device(&self, device: &gateway_config::Device) -> Result<(), String> {
-        // Use TryFrom to convert to internal type
-        let device_config = crate::models::internal::device::DeviceConfig::try_from(device)?;
-
-        // Perform validation on internal type
-        if device_config.settings.hostname.is_empty() {
-            return Err("Device hostname cannot be empty".to_string());
-        }
-
-        // Could do more validation here
-
-        Ok(())
-    }
-
     // Example function showing how to use TryFrom for interface validation
     fn validate_interfaces(&self, interfaces: &[gateway_config::Interface]) -> Result<(), String> {
         // Convert and validate all interfaces
@@ -196,11 +180,6 @@ impl ConfigManager for BasicConfigManager {
 
     async fn apply_config(&self, grpc_config: GatewayConfig) -> Result<(), String> {
         debug!("Received request to apply new config");
-
-        // Example: Validate components using TryFrom conversions
-        if let Some(device) = &grpc_config.device {
-            self.validate_device(device)?;
-        }
 
         // Validate interfaces in all VRFs
         if let Some(underlay) = &grpc_config.underlay {

--- a/mgmt/src/grpc/server.rs
+++ b/mgmt/src/grpc/server.rs
@@ -165,9 +165,10 @@ impl ConfigManager for BasicConfigManager {
         match response {
             ConfigResponse::GetCurrentConfig(opt_config) => {
                 if let Some(config) = *opt_config {
-                    Ok(convert_to_grpc_config(&config.external)
-                        .await
-                        .expect("Failed to convert to gRPC"))
+                    Ok(
+                        convert_to_grpc_config(&config.external)
+                            .expect("Failed to convert to gRPC"),
+                    )
                 } else {
                     Err("No config is currently applied".to_string())
                 }
@@ -209,7 +210,7 @@ impl ConfigManager for BasicConfigManager {
 
         // Continue with conversion and applying config
         // Use the async converter function
-        let external_config = converter::convert_from_grpc_config(&grpc_config).await?;
+        let external_config = converter::convert_from_grpc_config(&grpc_config)?;
 
         // Create a new GwConfig with this ExternalConfig
         let gw_config = Box::new(GwConfig::new(external_config));

--- a/mgmt/src/grpc/server.rs
+++ b/mgmt/src/grpc/server.rs
@@ -164,7 +164,7 @@ impl ConfigManager for BasicConfigManager {
             .map_err(|_| "Failure receiving from config processor".to_string())?;
         match response {
             ConfigResponse::GetCurrentConfig(opt_config) => {
-                if let Some(config) = &opt_config {
+                if let Some(config) = *opt_config {
                     Ok(convert_to_grpc_config(&config.external)
                         .await
                         .expect("Failed to convert to gRPC"))
@@ -211,8 +211,8 @@ impl ConfigManager for BasicConfigManager {
         // Use the async converter function
         let external_config = converter::convert_from_grpc_config(&grpc_config).await?;
 
-        // Create a new GwConfig
-        let gw_config = GwConfig::new(external_config);
+        // Create a new GwConfig with this ExternalConfig
+        let gw_config = Box::new(GwConfig::new(external_config));
 
         // build a request to the config processor, send it and get the response
         let (req, rx) = ConfigChannelRequest::new(ConfigRequest::ApplyConfig(gw_config));

--- a/mgmt/src/grpc/test.rs
+++ b/mgmt/src/grpc/test.rs
@@ -195,7 +195,7 @@ mod tests {
         let grpc_config = create_test_gateway_config();
         // Call the conversion function (gRPC -> ExternalConfig)
         // Using standalone function instead of manager method
-        let result = converter::convert_from_grpc_config(&grpc_config).await;
+        let result = converter::convert_from_grpc_config(&grpc_config);
 
         // Verify result
         assert!(
@@ -207,7 +207,7 @@ mod tests {
 
         // Call the conversion function (ExternalConfig -> gRPC)
         // Using standalone function instead of manager method
-        let result = converter::convert_to_grpc_config(&external_config).await;
+        let result = converter::convert_to_grpc_config(&external_config);
 
         // Verify result
         assert!(

--- a/mgmt/src/grpc/test.rs
+++ b/mgmt/src/grpc/test.rs
@@ -4,6 +4,7 @@
 #[cfg(test)]
 #[allow(clippy::uninlined_format_args)]
 mod tests {
+    // Import proto-generated types
     use gateway_config::GatewayConfig;
     use std::collections::HashMap;
     use std::convert::TryFrom;
@@ -190,8 +191,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_convert_to_grpc_config() {
-        // Create a mock database
-        #[allow(unused_variables)]
         // Create test data
         let grpc_config = create_test_gateway_config();
         // Call the conversion function (gRPC -> ExternalConfig)

--- a/mgmt/src/grpc/test.rs
+++ b/mgmt/src/grpc/test.rs
@@ -189,8 +189,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_convert_to_grpc_config() {
+    #[test]
+    fn test_convert_to_grpc_config() {
         // Create test data
         let grpc_config = create_test_gateway_config();
         // Call the conversion function (gRPC -> ExternalConfig)
@@ -591,8 +591,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_tryfrom_conversions() {
+    #[test]
+    fn test_tryfrom_conversions() {
         // Create test data with specific components
         let device = gateway_config::Device {
             driver: 0,   // Kernel

--- a/mgmt/src/models/external/configdb/mod.rs
+++ b/mgmt/src/models/external/configdb/mod.rs
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Open Network Fabric Authors
-
-pub mod gwconfig;
-pub mod gwconfigdb;

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -53,7 +53,7 @@ impl GwConfigMeta {
 }
 
 /// The configuration object as seen by the gRPC server
-#[derive(Builder)]
+#[derive(Builder, Clone)]
 pub struct ExternalConfig {
     pub genid: GenId,         /* configuration generation id (version) */
     pub device: DeviceConfig, /* goes as-is into the internal config */
@@ -78,6 +78,7 @@ impl ExternalConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct GwConfig {
     pub meta: GwConfigMeta,               /* config metadata */
     pub external: ExternalConfig,         /* external config: received */

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -8,7 +8,7 @@ use derive_builder::Builder;
 use std::time::SystemTime;
 use tracing::{debug, info};
 
-use crate::models::external::{ConfigError, ConfigResult};
+use crate::models::external::ConfigResult;
 use crate::models::internal::InternalConfig;
 use crate::models::internal::device::DeviceConfig;
 use crate::models::internal::routing::vrf::VrfConfig;
@@ -136,16 +136,9 @@ impl GwConfig {
         }
 
         /* Apply this gw config */
-        match apply_gw_config(self, frrmi).await {
-            Ok(()) => {
-                self.meta.applied = Some(SystemTime::now());
-                self.meta.is_applied = true;
-                Ok(())
-            }
-            Err(e) => {
-                info!("Failed to apply config {}: {e}", self.genid());
-                Err(ConfigError::FailureApply)
-            }
-        }
+        apply_gw_config(self, frrmi).await?;
+        self.meta.applied = Some(SystemTime::now());
+        self.meta.is_applied = true;
+        Ok(())
     }
 }

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -8,7 +8,7 @@ use derive_builder::Builder;
 use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
-use crate::models::external::{ApiError, ApiResult};
+use crate::models::external::{ConfigError, ConfigResult};
 use crate::models::internal::InternalConfig;
 use crate::models::internal::device::DeviceConfig;
 use crate::models::internal::routing::vrf::VrfConfig;
@@ -29,7 +29,7 @@ impl Underlay {
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn validate(&self) -> ApiResult {
+    pub fn validate(&self) -> ConfigResult {
         warn!("Validating underlay configuration (TODO)");
         Ok(())
     }
@@ -70,7 +70,7 @@ impl ExternalConfig {
             overlay: Overlay::default(),
         }
     }
-    pub fn validate(&mut self) -> ApiResult {
+    pub fn validate(&mut self) -> ConfigResult {
         self.device.validate()?;
         self.underlay.validate()?;
         self.overlay.validate()?;
@@ -98,20 +98,20 @@ impl GwConfig {
     }
 
     /// Validate a [`GwConfig`]
-    pub fn validate(&mut self) -> ApiResult {
+    pub fn validate(&mut self) -> ConfigResult {
         debug!("Validating external config with genid {} ..", self.genid());
         self.external.validate()
     }
 
     /// Build the [`InternalConfig`] for this [`GwConfig`]
-    pub fn build_internal_config(&mut self) -> ApiResult {
+    pub fn build_internal_config(&mut self) -> ConfigResult {
         /* build and set internal config */
         self.internal = Some(build_internal_config(self)?);
         Ok(())
     }
 
     /// Apply a [`GwConfig`]
-    pub async fn apply(&mut self, frrmi: &FrrMi) -> ApiResult {
+    pub async fn apply(&mut self, frrmi: &FrrMi) -> ConfigResult {
         info!("Applying config with genid {}...", self.genid());
         if self.internal.is_none() {
             debug!("Config has no internal config...");
@@ -127,7 +127,7 @@ impl GwConfig {
             }
             Err(e) => {
                 info!("Failed to apply config {}: {e}", self.genid());
-                Err(ApiError::FailureApply)
+                Err(ConfigError::FailureApply)
             }
         }
     }

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -6,7 +6,7 @@
 
 use derive_builder::Builder;
 use std::time::SystemTime;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::models::external::{ConfigError, ConfigResult};
 use crate::models::internal::InternalConfig;
@@ -30,7 +30,14 @@ impl Underlay {
         Self::default()
     }
     pub fn validate(&self) -> ConfigResult {
-        warn!("Validating underlay configuration (TODO)");
+        debug!("Validating underlay configuration...");
+
+        // validate interfaces
+        self.vrf
+            .interfaces
+            .values()
+            .try_for_each(|iface| iface.validate())?;
+
         Ok(())
     }
 }

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -45,15 +45,17 @@ impl Underlay {
 #[derive(Clone)]
 /// Configuration metadata. Every config object stored by the dataplane has metadata
 pub struct GwConfigMeta {
-    pub created: SystemTime,         /* time when config was built (received) */
-    pub applied: Option<SystemTime>, /* last time when config was applied successfully */
-    pub is_applied: bool,            /* True if the config is currently applied */
+    pub created: SystemTime,           /* time when config was built (received) */
+    pub applied: Option<SystemTime>,   /* last time when config was applied successfully */
+    pub unapplied: Option<SystemTime>, /* time when config was un-applied */
+    pub is_applied: bool,              /* True if the config is currently applied */
 }
 impl GwConfigMeta {
     fn new() -> Self {
         Self {
             created: SystemTime::now(),
             applied: None,
+            unapplied: None,
             is_applied: false,
         }
     }
@@ -112,6 +114,17 @@ impl GwConfig {
     /// Return the [`GenId`] of a [`GwConfig`] object.
     pub fn genid(&self) -> GenId {
         self.external.genid
+    }
+
+    /// Mark/unmark config as applied
+    pub fn set_applied(&mut self, value: bool) {
+        if value {
+            self.meta.applied = Some(SystemTime::now());
+            self.meta.unapplied.take();
+        } else {
+            self.meta.unapplied = Some(SystemTime::now());
+        }
+        self.meta.is_applied = value;
     }
 
     /// Validate a [`GwConfig`].

--- a/mgmt/src/models/external/gwconfig/mod.rs
+++ b/mgmt/src/models/external/gwconfig/mod.rs
@@ -128,7 +128,7 @@ impl GwConfig {
     }
 
     /// Apply a [`GwConfig`].
-    pub async fn apply(&mut self, frrmi: &FrrMi) -> ConfigResult {
+    pub async fn apply(&mut self, frrmi: &mut FrrMi) -> ConfigResult {
         info!("Applying config with genid {}...", self.genid());
         if self.internal.is_none() {
             debug!("Config has no internal config...");

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -6,7 +6,6 @@ pub mod overlay;
 
 use crate::models::external::gwconfig::GenId;
 use crate::models::external::overlay::vpc::VpcId;
-
 use thiserror::Error;
 
 /// The reasons why we may reject a configuration
@@ -34,13 +33,23 @@ pub enum ConfigError {
     Forbidden(&'static str),
     #[error("Bad VPC Id")]
     BadVpcId(String),
-    #[error("Error applying FRR config {0}")]
+    #[error("Error applying FRR config: {0}")]
     FrrApplyError(String),
     #[error("Missing identifier: {0}")]
     MissingIdentifier(&'static str),
     #[error("Missing mandatory parameter: {0}")]
     MissingParameter(&'static str),
+
+    #[error("Frr agent is unreachable")]
+    FrrAgentUnreachable,
 }
 
 /// Result-like type for configurations
 pub type ConfigResult = Result<(), ConfigError>;
+
+pub fn stringify(conf_result: &ConfigResult) -> String {
+    match conf_result {
+        Ok(()) => "Ok".to_string(),
+        Err(e) => format!("FAILED: {e}"),
+    }
+}

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -30,8 +30,8 @@ pub enum ConfigError {
     ConfigAlreadyExists(GenId),
     #[error("Failure applying config")]
     FailureApply,
-    #[error("Forbidden")]
-    Forbidden,
+    #[error("Forbidden: {0}")]
+    Forbidden(&'static str),
     #[error("Bad VPC Id")]
     BadVpcId(String),
     #[error("Incomplete configuration {0}")]

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-pub mod configdb;
+pub mod gwconfig;
 pub mod overlay;
 
-use crate::models::external::configdb::gwconfig::GenId;
+use crate::models::external::gwconfig::GenId;
 use crate::models::external::overlay::vpc::VpcId;
 
 use thiserror::Error;

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -24,8 +24,6 @@ pub enum ConfigError {
     NoSuchVpc(String),
     #[error("'{0}' is not a valid VNI")]
     InvalidVpcVni(u32),
-    #[error("VPC peering name is missing")]
-    MissingPeeringName,
     #[error("Config with id {0} not found")]
     NoSuchConfig(GenId),
     #[error("A config with id {0} already exists")]
@@ -42,6 +40,8 @@ pub enum ConfigError {
     FrrApplyError(String),
     #[error("Missing identifier: {0}")]
     MissingIdentifier(&'static str),
+    #[error("Missing mandatory parameter: {0}")]
+    MissingParameter(&'static str),
 }
 
 /// Result-like type for configurations

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 /// The reasons why we may reject a configuration
 #[derive(Debug, Error, PartialEq)]
-pub enum ApiError {
+pub enum ConfigError {
     #[error("A VPC with name '{0}' already exists")]
     DuplicateVpcName(String),
     #[error("A VPC with id '{0}' already exists")]
@@ -20,8 +20,6 @@ pub enum ApiError {
     DuplicateVpcVni(u32),
     #[error("A VPC peering with id '{0}' already exists")]
     DuplicateVpcPeeringId(String),
-    #[error("The VPC peering '{0}' is incomplete")]
-    IncompletePeeringData(String),
     #[error("A VPC peering object refers to non-existent VPC '{0}'")]
     NoSuchVpc(String),
     #[error("'{0}' is not a valid VNI")]
@@ -45,4 +43,4 @@ pub enum ApiError {
 }
 
 /// Result-like type for configurations
-pub type ApiResult = Result<(), ApiError>;
+pub type ConfigResult = Result<(), ConfigError>;

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -40,6 +40,8 @@ pub enum ConfigError {
     IncompleteConfig(String),
     #[error("Error applying FRR config {0}")]
     FrrApplyError(String),
+    #[error("Missing identifier: {0}")]
+    MissingIdentifier(&'static str),
 }
 
 /// Result-like type for configurations

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -34,8 +34,6 @@ pub enum ConfigError {
     Forbidden(&'static str),
     #[error("Bad VPC Id")]
     BadVpcId(String),
-    #[error("Incomplete configuration {0}")]
-    IncompleteConfig(String),
     #[error("Error applying FRR config {0}")]
     FrrApplyError(String),
     #[error("Missing identifier: {0}")]

--- a/mgmt/src/models/external/overlay/mod.rs
+++ b/mgmt/src/models/external/overlay/mod.rs
@@ -15,7 +15,7 @@ use crate::models::external::overlay::vpcpeering::VpcPeeringTable;
 
 use tracing::{debug, error};
 
-use super::{ApiError, ApiResult};
+use super::{ConfigError, ConfigResult};
 
 #[derive(Clone, Debug, Default)]
 pub struct Overlay {
@@ -30,14 +30,14 @@ impl Overlay {
             peering_table,
         }
     }
-    fn check_peering_vpc(&self, peering: &str, manifest: &VpcManifest) -> ApiResult {
+    fn check_peering_vpc(&self, peering: &str, manifest: &VpcManifest) -> ConfigResult {
         if self.vpc_table.get_vpc(&manifest.name).is_none() {
             error!("peering '{}': unknown VPC '{}'", peering, manifest.name);
-            return Err(ApiError::NoSuchVpc(manifest.name.clone()));
+            return Err(ConfigError::NoSuchVpc(manifest.name.clone()));
         }
         Ok(())
     }
-    pub fn validate(&mut self) -> ApiResult {
+    pub fn validate(&mut self) -> ConfigResult {
         debug!("Validating overlay configuration...");
         /* check if the VPCs referred in a peering exist */
         for peering in self.peering_table.values() {

--- a/mgmt/src/models/external/overlay/tests.rs
+++ b/mgmt/src/models/external/overlay/tests.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 #[allow(dead_code)]
 pub mod test {
-    use crate::models::external::ApiError;
+    use crate::models::external::ConfigError;
     use crate::models::external::overlay::Overlay;
     use crate::models::external::overlay::VpcIdMap;
     use crate::models::external::overlay::display::VpcDetailed;
@@ -55,7 +55,7 @@ pub mod test {
 
         /* invalid vni should be rejected */
         let vpc1 = Vpc::new("VPC-1", "AAAAA", 0);
-        assert_eq!(vpc1, Err(ApiError::InvalidVpcVni(0)));
+        assert_eq!(vpc1, Err(ConfigError::InvalidVpcVni(0)));
 
         /* add vpc with valid vni 3000 */
         let vpc1 = Vpc::new("VPC-1", "AAAAA", 3000).expect("Should succeed");
@@ -65,27 +65,27 @@ pub mod test {
         let bad = Vpc::new("VPC-1", "BBBBB", 2000).expect("Should succeed");
         assert_eq!(
             vpc_table.add(bad),
-            Err(ApiError::DuplicateVpcName("VPC-1".to_string()))
+            Err(ConfigError::DuplicateVpcName("VPC-1".to_string()))
         );
 
         /* vpc with colliding VNI should be rejected */
         let bad = Vpc::new("VPC-2", "CCCCC", 3000).expect("Should succeed");
-        assert_eq!(vpc_table.add(bad), Err(ApiError::DuplicateVpcVni(3000)));
+        assert_eq!(vpc_table.add(bad), Err(ConfigError::DuplicateVpcVni(3000)));
 
         /* vpc with colliding Id should be rejected */
         let bad = Vpc::new("VPC-2", "AAAAA", 9000).expect("Should succeed");
         assert_eq!(
             vpc_table.add(bad),
-            Err(ApiError::DuplicateVpcId("AAAAA".try_into().unwrap()))
+            Err(ConfigError::DuplicateVpcId("AAAAA".try_into().unwrap()))
         );
 
         /* vpc with bad Id should not build */
         let bad = Vpc::new("VPC-2", "AAA", 9000);
-        assert_eq!(bad, Err(ApiError::BadVpcId("AAA".to_string())));
+        assert_eq!(bad, Err(ConfigError::BadVpcId("AAA".to_string())));
 
         /* vpc with bad Id should not build */
         let bad = Vpc::new("VPC-2", "!1234", 9000);
-        assert_eq!(bad, Err(ApiError::BadVpcId("!1234".to_string())));
+        assert_eq!(bad, Err(ConfigError::BadVpcId("!1234".to_string())));
     }
 
     #[test]
@@ -108,7 +108,7 @@ pub mod test {
         let mut overlay = Overlay::new(vpc_table, peering_table);
         assert_eq!(
             overlay.validate(),
-            Err(ApiError::NoSuchVpc("VPC-2".to_owned()))
+            Err(ConfigError::NoSuchVpc("VPC-2".to_owned()))
         );
     }
 

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -76,7 +76,7 @@ impl VpcPeering {
     }
     pub fn validate(&self) -> ConfigResult {
         if self.name.is_empty() {
-            return Err(ConfigError::MissingPeeringName);
+            return Err(ConfigError::MissingIdentifier("Peering name"));
         }
         Ok(())
     }

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -7,7 +7,7 @@ use routing::prefix::Prefix;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use crate::models::external::{ApiError, ApiResult};
+use crate::models::external::{ConfigError, ConfigResult};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct VpcExpose {
     pub ips: BTreeSet<Prefix>,
@@ -35,7 +35,7 @@ impl VpcExpose {
         self.not_as.insert(prefix);
         self
     }
-    pub fn validate(&self) -> ApiResult {
+    pub fn validate(&self) -> ConfigResult {
         // TODO
         Ok(())
     }
@@ -53,7 +53,7 @@ impl VpcManifest {
             ..Default::default()
         }
     }
-    pub fn add_expose(&mut self, expose: VpcExpose) -> ApiResult {
+    pub fn add_expose(&mut self, expose: VpcExpose) -> ConfigResult {
         expose.validate()?;
         self.exposes.push(expose);
         Ok(())
@@ -74,9 +74,9 @@ impl VpcPeering {
             right,
         }
     }
-    pub fn validate(&self) -> ApiResult {
+    pub fn validate(&self) -> ConfigResult {
         if self.name.is_empty() {
-            return Err(ApiError::MissingPeeringName);
+            return Err(ConfigError::MissingPeeringName);
         }
         Ok(())
     }
@@ -107,10 +107,10 @@ impl VpcPeeringTable {
     }
 
     /// Add a [`VpcPeering`] to a [`VpcPeeringTable`]
-    pub fn add(&mut self, peering: VpcPeering) -> ApiResult {
+    pub fn add(&mut self, peering: VpcPeering) -> ConfigResult {
         peering.validate()?;
         if let Some(peering) = self.0.insert(peering.name.to_owned(), peering) {
-            Err(ApiError::DuplicateVpcPeeringId(peering.name.clone()))
+            Err(ConfigError::DuplicateVpcPeeringId(peering.name.clone()))
         } else {
             Ok(())
         }

--- a/mgmt/src/models/internal/device/mod.rs
+++ b/mgmt/src/models/internal/device/mod.rs
@@ -10,7 +10,7 @@ use ports::PortConfig;
 use settings::DeviceSettings;
 use tracing::warn;
 
-use crate::models::external::ApiResult;
+use crate::models::external::ConfigResult;
 
 #[derive(Clone, Debug)]
 pub struct DeviceConfig {
@@ -24,7 +24,7 @@ impl DeviceConfig {
             ports: vec![],
         }
     }
-    pub fn validate(&self) -> ApiResult {
+    pub fn validate(&self) -> ConfigResult {
         warn!("Validating device configuration (TODO)");
         Ok(())
     }

--- a/mgmt/src/models/internal/device/mod.rs
+++ b/mgmt/src/models/internal/device/mod.rs
@@ -8,9 +8,9 @@ pub mod settings;
 
 use ports::PortConfig;
 use settings::DeviceSettings;
-use tracing::warn;
+use tracing::{debug, error};
 
-use crate::models::external::ConfigResult;
+use crate::models::external::{ConfigError, ConfigResult};
 
 #[derive(Clone, Debug)]
 pub struct DeviceConfig {
@@ -25,7 +25,10 @@ impl DeviceConfig {
         }
     }
     pub fn validate(&self) -> ConfigResult {
-        warn!("Validating device configuration (TODO)");
+        debug!("Validating device configuration..");
+        if self.settings.hostname.is_empty() {
+            return Err(ConfigError::MissingIdentifier("Device hostname"));
+        }
         Ok(())
     }
 }

--- a/mgmt/src/models/internal/interfaces/interface.rs
+++ b/mgmt/src/models/internal/interfaces/interface.rs
@@ -13,6 +13,8 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
 
+use crate::models::external::ConfigError;
+use crate::models::external::ConfigResult;
 use crate::models::internal::routing::ospf::OspfInterface;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -118,6 +120,18 @@ impl InterfaceConfig {
     pub fn set_ospf(mut self, ospf: OspfInterface) -> Self {
         self.ospf = Some(ospf);
         self
+    }
+    pub fn validate(&self) -> ConfigResult {
+        // name is mandatory
+        if self.name.is_empty() {
+            return Err(ConfigError::MissingIdentifier("interface name"));
+        }
+        // Ip address is mandatory on VTEP
+        if matches!(self.iftype, InterfaceType::Vtep(_)) && self.addresses.is_empty() {
+            return Err(ConfigError::MissingParameter("Ip address"));
+        }
+
+        Ok(())
     }
 }
 

--- a/mgmt/src/models/internal/mod.rs
+++ b/mgmt/src/models/internal/mod.rs
@@ -14,7 +14,7 @@ pub mod routing;
 
 use derive_builder::Builder;
 
-use crate::models::external::configdb::gwconfig::GenId;
+use crate::models::external::gwconfig::GenId;
 
 use crate::models::internal::device::DeviceConfig;
 use crate::models::internal::interfaces::interface::{InterfaceConfig, InterfaceConfigTable};
@@ -24,7 +24,7 @@ use crate::models::internal::routing::prefixlist::{PrefixList, PrefixListTable};
 use crate::models::internal::routing::routemap::{RouteMap, RouteMapTable};
 use crate::models::internal::routing::vrf::{VrfConfig, VrfConfigTable};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /* Main internal GW configuration */
 pub struct InternalConfig {
     pub dev_cfg: DeviceConfig,

--- a/mgmt/src/models/internal/routing/evpn.rs
+++ b/mgmt/src/models/internal/routing/evpn.rs
@@ -6,7 +6,7 @@
 use net::eth::mac::Mac;
 use std::net::IpAddr;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VtepConfig {
     pub address: IpAddr,
     pub mac: Mac,

--- a/mgmt/src/models/internal/routing/frr.rs
+++ b/mgmt/src/models/internal/routing/frr.rs
@@ -5,14 +5,14 @@
 
 use std::fmt::Display;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub enum FrrProfile {
     #[default]
     Datacenter,
     Traditional,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Frr {
     pub profile: FrrProfile,
     pub hostname: String,

--- a/mgmt/src/models/internal/routing/prefixlist.rs
+++ b/mgmt/src/models/internal/routing/prefixlist.rs
@@ -6,25 +6,25 @@
 use routing::prefix::Prefix;
 use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(Debug, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Ord, Eq, PartialOrd, PartialEq)]
 pub enum PrefixListAction {
     Deny,
     Permit,
 }
 
-#[derive(Debug, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Ord, Eq, PartialOrd, PartialEq)]
 pub enum PrefixListPrefix {
     Prefix(Prefix),
     Any,
 }
 
-#[derive(Debug, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Ord, Eq, PartialOrd, PartialEq)]
 pub enum PrefixListMatchLen {
     Ge(u8),
     Le(u8),
 }
 
-#[derive(Debug, Ord, Eq, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Ord, Eq, PartialOrd, PartialEq)]
 pub struct PrefixListEntry {
     pub seq: u32,
     pub action: PrefixListAction,
@@ -32,14 +32,14 @@ pub struct PrefixListEntry {
     pub len_match: Option<PrefixListMatchLen>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PrefixList {
     pub name: String,
     pub description: Option<String>,
     pub entries: BTreeSet<PrefixListEntry>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PrefixListTable(BTreeMap<String, PrefixList>);
 
 /* Impl basic ops */

--- a/mgmt/src/models/internal/routing/routemap.rs
+++ b/mgmt/src/models/internal/routing/routemap.rs
@@ -6,13 +6,13 @@
 use net::vxlan::Vni;
 use std::collections::{BTreeMap, BTreeSet};
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum MatchingPolicy {
     Deny,
     Permit,
 }
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum RouteMapMatch {
     SrcVrf(String),
     Ipv4AddressPrefixList(String),
@@ -27,7 +27,7 @@ pub enum RouteMapMatch {
     // TODO: complete as needed
 }
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum RouteMapSetAction {
     Tag(u32),
     Distance(u8),
@@ -37,7 +37,7 @@ pub enum RouteMapSetAction {
     //TODO: complete as needed
 }
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Community {
     None,
     ASNVAL(u16, u16),
@@ -51,7 +51,7 @@ pub enum Community {
     //TODO: complete as needed
 }
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub struct RouteMapEntry {
     pub seq: u32,
     pub policy: MatchingPolicy,
@@ -59,13 +59,13 @@ pub struct RouteMapEntry {
     pub actions: Vec<RouteMapSetAction>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RouteMap {
     pub name: String,
     pub entries: BTreeSet<RouteMapEntry>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RouteMapTable(BTreeMap<String, RouteMap>);
 
 /* Impl basic ops */

--- a/mgmt/src/models/internal/routing/vrf.rs
+++ b/mgmt/src/models/internal/routing/vrf.rs
@@ -67,7 +67,7 @@ impl VrfConfig {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VrfConfigTable(Vec<VrfConfig>);
 
 impl VrfConfigTable {

--- a/mgmt/src/models/internal/routing/vrf.rs
+++ b/mgmt/src/models/internal/routing/vrf.rs
@@ -13,7 +13,7 @@ use super::bgp::BgpConfig;
 use super::ospf::Ospf;
 use super::statics::StaticRoute;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 
 pub struct VrfConfig {
     pub name: String,
@@ -27,6 +27,22 @@ pub struct VrfConfig {
     pub ospf: Option<Ospf>,
 }
 
+impl Default for VrfConfig {
+    fn default() -> Self {
+        Self {
+            name: "default".to_owned(),
+            default: true,
+            tableid: None,
+            vni: None,
+            subnets: BTreeSet::new(),
+            static_routes: BTreeSet::new(),
+            bgp: None,
+            interfaces: InterfaceConfigTable::new(),
+            ospf: None,
+        }
+    }
+}
+
 impl VrfConfig {
     pub fn new(name: &str, vni: Option<Vni>, default: bool) -> Self {
         Self {
@@ -34,11 +50,7 @@ impl VrfConfig {
             default,
             tableid: None,
             vni,
-            subnets: BTreeSet::new(),
-            static_routes: BTreeSet::new(),
-            bgp: None,
-            interfaces: InterfaceConfigTable::new(),
-            ospf: None,
+            ..Default::default()
         }
     }
     pub fn set_table_id(mut self, tableid: u32) -> Self {

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -9,7 +9,7 @@ use crate::models::external::overlay::vpc::Vpc;
 use crate::models::external::overlay::vpcpeering::VpcManifest;
 use crate::models::external::{ApiError, overlay::Overlay};
 
-use crate::models::external::configdb::gwconfig::GwConfig;
+use crate::models::external::gwconfig::GwConfig;
 
 use crate::models::internal::InternalConfig;
 use crate::models::internal::routing::bgp::{AfIpv4Ucast, AfL2vpnEvpn};

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -2,7 +2,7 @@
 // Copyright Open Network Fabric Authors
 
 #[allow(unused)]
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use routing::prefix::Prefix;
 use std::net::Ipv4Addr;
@@ -224,11 +224,9 @@ pub fn build_internal_config(config: &GwConfig) -> Result<InternalConfig, Config
         let router_id = bgp.router_id;
         build_internal_overlay_config(&external.overlay, asn, router_id, &mut internal);
     } else if config.genid() != ExternalConfig::BLANK_GENID {
-        error!("Config has no BGP configuration");
-        return Err(ConfigError::IncompleteConfig(
-            "Missing BGP config".to_string(),
-        ));
+        warn!("Config has no BGP configuration");
     }
+
     debug!(
         "Successfully built internal config for genid {}",
         config.genid()

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 
 use crate::models::external::overlay::vpc::Vpc;
 use crate::models::external::overlay::vpcpeering::VpcManifest;
-use crate::models::external::{ApiError, overlay::Overlay};
+use crate::models::external::{ConfigError, overlay::Overlay};
 
 use crate::models::external::gwconfig::GwConfig;
 
@@ -209,7 +209,7 @@ fn build_internal_overlay_config(
 }
 
 /// Top-level function to build internal config from external config
-pub fn build_internal_config(config: &GwConfig) -> Result<InternalConfig, ApiError> {
+pub fn build_internal_config(config: &GwConfig) -> Result<InternalConfig, ConfigError> {
     debug!("Building internal config for gen {}", config.genid());
     let external = &config.external;
 
@@ -222,7 +222,9 @@ pub fn build_internal_config(config: &GwConfig) -> Result<InternalConfig, ApiErr
         let router_id = bgp.router_id;
         build_internal_overlay_config(&external.overlay, asn, router_id, &mut internal);
     } else {
-        return Err(ApiError::IncompleteConfig("Missing BGP config".to_string()));
+        return Err(ConfigError::IncompleteConfig(
+            "Missing BGP config".to_string(),
+        ));
     }
     debug!(
         "Successfully built internal config for genid {}",

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+#[allow(unused)]
+use tracing::{debug, error};
+
 use routing::prefix::Prefix;
 use std::net::Ipv4Addr;
-use tracing::debug;
 
 use crate::models::external::overlay::vpc::Vpc;
 use crate::models::external::overlay::vpcpeering::VpcManifest;
 use crate::models::external::{ConfigError, overlay::Overlay};
 
-use crate::models::external::gwconfig::GwConfig;
+use crate::models::external::gwconfig::{ExternalConfig, GwConfig};
 
 use crate::models::internal::InternalConfig;
 use crate::models::internal::routing::bgp::{AfIpv4Ucast, AfL2vpnEvpn};
@@ -221,7 +223,8 @@ pub fn build_internal_config(config: &GwConfig) -> Result<InternalConfig, Config
         let asn = bgp.asn;
         let router_id = bgp.router_id;
         build_internal_overlay_config(&external.overlay, asn, router_id, &mut internal);
-    } else {
+    } else if config.genid() != ExternalConfig::BLANK_GENID {
+        error!("Config has no BGP configuration");
         return Err(ConfigError::IncompleteConfig(
             "Missing BGP config".to_string(),
         ));

--- a/mgmt/src/processor/display.rs
+++ b/mgmt/src/processor/display.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use chrono::{DateTime, Utc};
+use routing::pretty_utils::Heading;
+use std::fmt::Display;
+
+use crate::models::external::gwconfig::ExternalConfig;
+use crate::models::external::gwconfig::GenId;
+use crate::models::external::gwconfig::GwConfig;
+use crate::models::external::gwconfig::GwConfigMeta;
+
+use crate::models::internal::InternalConfig;
+use crate::processor::gwconfigdb::GwConfigDatabase;
+
+macro_rules! CONFIGDB_TBL_FMT {
+    () => {
+        " {:>6} {:<25} {:<25} {:<25} {:<10}"
+    };
+}
+fn fmt_configdb_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            CONFIGDB_TBL_FMT!(),
+            "GenId", "created", "applied", "replaced", "active"
+        )
+    )
+}
+fn fmt_gwconfig_summary(
+    meta: &GwConfigMeta,
+    genid: GenId,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    let created = DateTime::<Utc>::from(meta.created).format("%H:%M:%S on %Y/%m/%d");
+    let apply_time = if let Some(time) = meta.applied {
+        let time = DateTime::<Utc>::from(time).format("%H:%M:%S on %Y/%m/%d");
+        format!("{time}")
+    } else {
+        "--".to_string()
+    };
+    let unapply_time = if let Some(time) = meta.unapplied {
+        let time = DateTime::<Utc>::from(time).format("%H:%M:%S on %Y/%m/%d");
+        format!("{time}")
+    } else {
+        "--".to_string()
+    };
+
+    let applied = if meta.is_applied { "yes" } else { "no" };
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            CONFIGDB_TBL_FMT!(),
+            genid, created, apply_time, unapply_time, applied
+        )
+    )
+}
+
+pub struct GwConfigDatabaseSummary<'a>(pub &'a GwConfigDatabase);
+impl Display for GwConfigDatabaseSummary<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading(format!(
+            "Configuration database summary ({} configs)",
+            self.0.len()
+        ))
+        .fmt(f)?;
+        if let Some(curr) = self.0.get_current_gen() {
+            writeln!(f, " current generation: {curr}")?;
+        } else {
+            writeln!(f, " current generation: --")?;
+        }
+        fmt_configdb_summary_heading(f)?;
+        for (genid, gwconfig) in self.0.iter() {
+            fmt_gwconfig_summary(&gwconfig.meta, *genid, f)?;
+        }
+        Ok(())
+    }
+}
+
+// TODO(fredi)
+impl Display for GwConfigMeta {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO
+        Ok(())
+    }
+}
+// TODO(fredi)
+impl Display for ExternalConfig {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO
+        Ok(())
+    }
+}
+// TODO(fredi)
+impl Display for InternalConfig {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // TODO
+        Ok(())
+    }
+}
+// TODO(fredi)
+impl Display for GwConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.meta.fmt(f)?;
+        self.external.fmt(f)?;
+        if let Some(internal) = &self.internal {
+            internal.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+// TODO(fredi)
+impl Display for GwConfigDatabase {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -43,9 +43,9 @@ impl GwConfigDatabase {
         self.configs.get_mut(&generation)
     }
     pub fn remove(&mut self, genid: GenId) -> ConfigResult {
-        debug!("Removing config '{}' from config db...", genid);
+        debug!("Removing config '{genid}' from config db...");
         if genid == ExternalConfig::BLANK_GENID {
-            error!("Can't remove config {}: forbidden", genid);
+            error!("Can't remove config {genid}: forbidden");
             return Err(ConfigError::Forbidden("Cannot delete initial config"));
         }
         if let Some(config) = &self.configs.get(&genid) {
@@ -94,8 +94,8 @@ impl GwConfigDatabase {
             self.current = Some(genid);
         } else {
             /* delete the config we wanted to apply */
-            debug!("Deleting config with id {genid}");
-            let _ = self.configs.remove(&genid);
+            debug!("Deleting config with id {genid}..");
+            let _ = self.remove(genid);
             /* roll-back */
             if let Some(current) = last {
                 info!("Rolling back to prior config '{}'", current);

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -99,8 +99,10 @@ impl GwConfigDatabase {
                     }
                 }
             } else {
-                info!("There was no current config. Flushing system...");
-                /* To do: build a dummy config and apply it for the purpose of flushing */
+                // This should not happen if we apply upfront the blank config and we
+                // succeed. That is not guaranteed, though since we may fail to communicate
+                // to FRR an initial, blank config.
+                info!("There was no config applied");
             }
         }
         res

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -63,7 +63,7 @@ impl GwConfigDatabase {
         }
     }
 
-    pub async fn apply(&mut self, genid: GenId, frrmi: &FrrMi) -> ConfigResult {
+    pub async fn apply(&mut self, genid: GenId, frrmi: &mut FrrMi) -> ConfigResult {
         debug!("Applying config with genid '{}'...", genid);
 
         /* get the generation (id) of the currently applied config, if any */

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -7,7 +7,7 @@ use crate::frr::frrmi::FrrMi;
 use std::collections::BTreeMap;
 use tracing::{debug, error, info};
 
-use crate::models::external::configdb::gwconfig::{GenId, GwConfig};
+use crate::models::external::gwconfig::{GenId, GwConfig};
 use crate::models::external::{ApiError, ApiResult};
 
 #[derive(Default)]

--- a/mgmt/src/processor/mod.rs
+++ b/mgmt/src/processor/mod.rs
@@ -5,6 +5,7 @@
 //! This module implements the core logic to determine and build internal configurations.
 
 pub mod confbuild;
+mod display;
 pub mod gwconfigdb;
 mod namegen;
 pub mod proc;

--- a/mgmt/src/processor/mod.rs
+++ b/mgmt/src/processor/mod.rs
@@ -5,6 +5,7 @@
 //! This module implements the core logic to determine and build internal configurations.
 
 pub mod confbuild;
+pub mod gwconfigdb;
 mod namegen;
 pub mod proc;
 pub mod tests;

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -103,7 +103,7 @@ impl ConfigProcessor {
         self.config_db.add(config);
 
         /* apply the configuration just stored */
-        self.config_db.apply(genid, &self.frrmi).await?;
+        self.config_db.apply(genid, &mut self.frrmi).await?;
 
         Ok(())
     }
@@ -111,7 +111,7 @@ impl ConfigProcessor {
     /// Method to apply a blank configuration
     async fn apply_blank_config(&mut self) -> ConfigResult {
         self.config_db
-            .apply(ExternalConfig::BLANK_GENID, &self.frrmi)
+            .apply(ExternalConfig::BLANK_GENID, &mut self.frrmi)
             .await
     }
 
@@ -170,7 +170,7 @@ impl ConfigProcessor {
     }
 }
 
-pub async fn apply_gw_config(config: &mut GwConfig, frrmi: &FrrMi) -> ConfigResult {
+pub async fn apply_gw_config(config: &mut GwConfig, frrmi: &mut FrrMi) -> ConfigResult {
     /* apply in interface manager - async (TODO) */
 
     /* apply in frr: need to render and call frr-reload */
@@ -202,8 +202,7 @@ async fn start_grpc_server(addr: SocketAddr, channel_tx: Sender<ConfigChannelReq
 
 async fn start_frrmi() -> Result<FrrMi, Error> {
     /* create frrmi to talk to frr-agent */
-    let Ok(frrmi) = FrrMi::new("/var/run/frr/frrmi.sock", "/var/run/frr/frr-agent.sock").await
-    else {
+    let Ok(frrmi) = FrrMi::new("/var/run/frr/frr-agent.sock").await else {
         error!("Failed to start frrmi");
         return Err(Error::other("Failed to start frrmi"));
     };

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -1,23 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+#![allow(unused)] // TEMPORARY
+
 use std::io::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::thread;
 use tokio::sync::RwLock;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc, oneshot};
 use tonic::transport::Server;
 
-use crate::frr::renderer::builder::Render;
 use crate::models::external::gwconfig::ExternalConfig;
 use crate::models::external::{ApiResult, gwconfig::GwConfig};
 use crate::processor::gwconfigdb::GwConfigDatabase;
 use crate::{frr::frrmi::FrrMi, models::external::ApiError};
-use tracing::{debug, error, info};
+use crate::{frr::renderer::builder::Render, models::external::gwconfig::GenId};
+use tracing::{debug, error, info, warn};
 
 use crate::grpc::server::create_config_service;
 
-#[allow(unused)]
+
 /// Build an empty config and apply it
 async fn blank_config_apply(configdb: &mut GwConfigDatabase, frrmi: &FrrMi) {
     let external = ExternalConfig::new();
@@ -31,13 +35,10 @@ pub async fn new_gw_config(
     mut config: GwConfig,
     frrmi: &FrrMi,
 ) -> ApiResult {
-    debug!(
-        "Processing received configuration. Genid:'{}'..",
-        config.genid()
-    );
 
     /* get id of incoming config */
     let genid = config.genid();
+    debug!("Processing config with id:'{genid}'..");
 
     /* reject config if it uses id of existing one */
     if configdb.contains(genid) {
@@ -58,6 +59,82 @@ pub async fn new_gw_config(
     configdb.apply(genid, frrmi).await?;
 
     Ok(())
+}
+
+/// A request type to the [`ConfigProcessor`]
+pub(crate) enum ConfigRequest {
+    ApplyConfig(GwConfig),
+    GetCurrentConfig,
+    GetGeneration,
+}
+
+/// A response from the [`ConfigProcessor`]
+pub(crate) enum ConfigResponse {
+    ApplyConfig(ApiResult),
+    GetCurrentConfig(Option<GwConfig>),
+    GetGeneration(Option<GenId>),
+}
+type ConfigResponseChannel = oneshot::Sender<ConfigResponse>;
+
+/// A type that includes a request to the [`ConfigProcessor`] and a channel to
+/// issue the response back
+struct ConfigChannelRequest {
+    request: ConfigRequest,          /* a request to the mgmt processor */
+    reply_tx: ConfigResponseChannel, /* the one-shot channel to respond */
+}
+
+/// A configuration processor entity. This is the RPC-independent entity responsible for
+/// accepting/rejecting configurations, storing them in the configuration database and
+/// applying them.
+struct ConfigProcessor {
+    config_db: GwConfigDatabase,
+    rx: mpsc::Receiver<ConfigChannelRequest>,
+    frrmi: FrrMi,
+}
+
+impl ConfigProcessor {
+    fn new(frrmi: FrrMi) -> (Self, Sender<ConfigChannelRequest>) {
+        let (tx, rx) = mpsc::channel(1);
+        let processor = Self {
+            config_db: GwConfigDatabase::new(),
+            rx,
+            frrmi,
+        };
+        (processor, tx)
+    }
+    async fn handle_apply_config(&mut self, config: GwConfig) -> ConfigResponse {
+        ConfigResponse::ApplyConfig(new_gw_config(&mut self.config_db, config, &self.frrmi).await)
+    }
+    fn handle_get_generation(&self) -> ConfigResponse {
+        ConfigResponse::GetGeneration(self.config_db.get_current_gen())
+    }
+    fn handle_get_config(&self) -> ConfigResponse {
+        if let Some(current) = self.config_db.get_current_config() {
+            ConfigResponse::GetCurrentConfig(Some(current.clone()))
+        } else {
+            ConfigResponse::GetCurrentConfig(None)
+        }
+    }
+    /// Run the configuration processor
+    async fn run(&mut self) {
+        debug!("Starting config processor...");
+        loop {
+            match self.rx.recv().await {
+                Some(req) => {
+                    let response = match req.request {
+                        ConfigRequest::ApplyConfig(config) => self.handle_apply_config(config).await,
+                        ConfigRequest::GetCurrentConfig => self.handle_get_config(),
+                        ConfigRequest::GetGeneration => self.handle_get_generation(),
+                    };
+                    // check error
+                    req.reply_tx.send(response);
+                }
+                None => {
+                    warn!("Channel to config processor was closed!");
+                }
+            }
+        }
+    }
 }
 
 /// Main logic to apply a [`GwConfig`]. This is called from GwConfig::apply()

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -86,7 +86,6 @@ impl ConfigProcessor {
     pub(crate) async fn process_incoming_config(&mut self, mut config: GwConfig) -> ConfigResult {
         /* get id of incoming config */
         let genid = config.genid();
-        debug!("Processing config with id:'{genid}'..");
 
         /* reject config if it uses id of existing one */
         if genid != ExternalConfig::BLANK_GENID && self.config_db.contains(genid) {
@@ -106,8 +105,6 @@ impl ConfigProcessor {
         /* apply the configuration just stored */
         self.config_db.apply(genid, &self.frrmi).await?;
 
-        debug!("Current config is {:?}", self.config_db.get_current_gen());
-
         Ok(())
     }
 
@@ -120,19 +117,22 @@ impl ConfigProcessor {
 
     /// RPC handler to apply a config
     async fn handle_apply_config(&mut self, config: GwConfig) -> ConfigResponse {
-        debug!("Handling apply configuration request...");
+        debug!(
+            "━━━━━━ Handling apply configuration request. Genid {} ━━━━━━",
+            config.genid()
+        );
         ConfigResponse::ApplyConfig(self.process_incoming_config(config).await)
     }
 
     /// RPC handler to get current config generation id
     fn handle_get_generation(&self) -> ConfigResponse {
-        debug!("Handling get generation request...");
+        debug!("Handling get generation request");
         ConfigResponse::GetGeneration(self.config_db.get_current_gen())
     }
 
     /// RPC handler to get the currently applied config
     fn handle_get_config(&self) -> ConfigResponse {
-        debug!("Handling get running configuration request...");
+        debug!("Handling get running configuration request");
         let cfg = Box::new(self.config_db.get_current_config().cloned());
         ConfigResponse::GetCurrentConfig(cfg)
     }

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -161,8 +161,9 @@ impl ConfigProcessor {
                         ConfigRequest::GetCurrentConfig => self.handle_get_config(),
                         ConfigRequest::GetGeneration => self.handle_get_generation(),
                     };
-                    // check error
-                    let _ = req.reply_tx.send(response);
+                    if req.reply_tx.send(response).is_err() {
+                        warn!("Failed to send reply from config processor: receiver dropped?");
+                    }
                 }
                 None => {
                     warn!("Channel to config processor was closed!");

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -12,7 +12,6 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::{spawn, sync::mpsc::Sender};
 use tonic::transport::Server;
 
-use crate::models::external::gwconfig::ExternalConfig;
 use crate::models::external::{ConfigResult, gwconfig::GwConfig};
 use crate::processor::gwconfigdb::GwConfigDatabase;
 use crate::{frr::frrmi::FrrMi, models::external::ConfigError};
@@ -25,8 +24,7 @@ use crate::grpc::server::create_config_service;
 #[allow(unused)]
 async fn blank_config_apply(configdb: &mut GwConfigDatabase, frrmi: &FrrMi) {
     debug!("Applying empty configuration...");
-    let external = ExternalConfig::new();
-    let blank = GwConfig::new(external);
+    let blank = GwConfig::blank();
     let _ = new_gw_config(configdb, blank, frrmi).await;
 }
 

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -9,9 +9,9 @@ use tokio::sync::RwLock;
 use tonic::transport::Server;
 
 use crate::frr::renderer::builder::Render;
-use crate::models::external::configdb::gwconfig::ExternalConfig;
-use crate::models::external::configdb::gwconfigdb::GwConfigDatabase;
-use crate::models::external::{ApiResult, configdb::gwconfig::GwConfig};
+use crate::models::external::gwconfig::ExternalConfig;
+use crate::models::external::{ApiResult, gwconfig::GwConfig};
+use crate::processor::gwconfigdb::GwConfigDatabase;
 use crate::{frr::frrmi::FrrMi, models::external::ApiError};
 use tracing::{debug, error, info};
 

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -173,6 +173,13 @@ impl ConfigProcessor {
 }
 
 pub async fn apply_gw_config(config: &mut GwConfig, frrmi: &mut FrrMi) -> ConfigResult {
+    /* probe the FRR agent. If unreachable, there's no point in trying to apply
+    a configuration, either in interface manager or frr */
+    frrmi
+        .probe()
+        .await
+        .map_err(|_| ConfigError::FrrAgentUnreachable)?;
+
     /* apply in interface manager - async (TODO) */
 
     /* apply in frr: need to render and call frr-reload */

--- a/mgmt/src/processor/tests.rs
+++ b/mgmt/src/processor/tests.rs
@@ -289,9 +289,7 @@ pub mod test {
         let frr_agent = fake_frr_agent("/tmp/frr-agent.sock").await;
 
         /* open frrmi and connect to the faked frr-agent */
-        let frrmi = FrrMi::new("/tmp/frrmi.sock", "/tmp/frr-agent.sock")
-            .await
-            .unwrap();
+        let frrmi = FrrMi::new("/tmp/frr-agent.sock").await.unwrap();
 
         /* build sample external config */
         let external = sample_external_config();

--- a/mgmt/src/processor/tests.rs
+++ b/mgmt/src/processor/tests.rs
@@ -12,8 +12,10 @@ pub mod test {
     use std::str::FromStr;
     use tracing::Level;
 
+    use crate::models::internal::device::settings::DeviceSettings;
     use crate::models::internal::device::settings::KernelPacketConfig;
     use crate::models::internal::device::settings::PacketDriver;
+    use crate::models::internal::interfaces::interface::InterfaceConfig;
     use crate::models::internal::interfaces::interface::*;
     use crate::models::internal::routing::bgp::AfIpv4Ucast;
     use crate::models::internal::routing::bgp::AfL2vpnEvpn;
@@ -25,18 +27,13 @@ pub mod test {
     use crate::models::internal::routing::ospf::{OspfInterface, OspfNetwork};
     use crate::models::internal::routing::vrf::VrfConfig;
     use crate::models::internal::{device::DeviceConfig, routing::ospf::Ospf};
-    use crate::models::{
-        external::configdb::gwconfigdb::GwConfigDatabase,
-        internal::device::settings::DeviceSettings,
-    };
-
-    use crate::models::internal::interfaces::interface::InterfaceConfig;
+    use crate::processor::gwconfigdb::GwConfigDatabase;
     //    use crate::models::internal::routing::evpn::VtepConfig;
 
-    use crate::models::external::configdb::gwconfig::ExternalConfig;
-    use crate::models::external::configdb::gwconfig::ExternalConfigBuilder;
-    use crate::models::external::configdb::gwconfig::GwConfig;
-    use crate::models::external::configdb::gwconfig::Underlay;
+    use crate::models::external::gwconfig::ExternalConfig;
+    use crate::models::external::gwconfig::ExternalConfigBuilder;
+    use crate::models::external::gwconfig::GwConfig;
+    use crate::models::external::gwconfig::Underlay;
     // use crate::models::external::configdb::gwconfigdb::GwConfigDatabase;
 
     use crate::models::external::overlay::Overlay;

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [features]
 auto-learn = []
+testing = []
 
 [dependencies]
 ipnet = { workspace = true }

--- a/routing/src/prefix.rs
+++ b/routing/src/prefix.rs
@@ -171,6 +171,7 @@ impl From<Ipv6Prefix> for Prefix {
 }
 
 /// Only for testing. Will panic with badly formed address strings
+#[cfg(test)]
 impl From<(&str, u8)> for Prefix {
     fn from(tuple: (&str, u8)) -> Self {
         let a = IpAddr::from_str(tuple.0).expect("Bad address");

--- a/routing/src/prefix.rs
+++ b/routing/src/prefix.rs
@@ -171,7 +171,7 @@ impl From<Ipv6Prefix> for Prefix {
 }
 
 /// Only for testing. Will panic with badly formed address strings
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 impl From<(&str, u8)> for Prefix {
     fn from(tuple: (&str, u8)) -> Self {
         let a = IpAddr::from_str(tuple.0).expect("Bad address");


### PR DESCRIPTION
~This rides on https://github.com/githedgehog/dataplane/pull/434~
This rides on https://github.com/githedgehog/dataplane/pull/427

* reorganizes code and tidies it up
* refactors integration to decouple gRPC from database and interface to frr-agent, which simplifies setup of gRPC code, tests and removes the need for a RWLock.
* handles frr-agent reconnects (WIP).

Assigning this to @daniel-noland since it targets and modifies https://github.com/githedgehog/dataplane/pull/434