### PR TITLE
Implement Display for Invalid Packet

### DIFF
--- a/dataplane/src/drivers/kernel.rs
+++ b/dataplane/src/drivers/kernel.rs
@@ -217,7 +217,7 @@ impl DriverKernel {
                     pkts.push(incoming);
                 }
                 Err(e) => {
-                    error!("Failed to parse packet!!: e");
+                    error!("Failed to parse packet!!:\n{e}");
                 }
             }
         }


### PR DESCRIPTION
Implement Display for invalid packet as the Debug display is hard to read. This also fixes the kernel driver log.

**Sample output:**
```
2025-05-07T17:34:22.727791Z ERROR main ThreadId(01) dataplane::drivers::kernel: 220: Failed to parse packet!!:
Invalid packet
────────────────────────────────────────────────────────────────────────────────────────────────────
[0000-0031] 00 00 00 00 00 00 00 00 00 00 00 00 86 dd 60 0e 50 ad 00 20 06 40 00 00 00 00 00 00 00 00 00 00 
[0032-0063] 00 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 9c ae c3 83 25 72 9a 53 50 53 
[0064-0085] c5 e8 80 10 02 00 00 28 00 00 01 01 08 0a c5 13 21 2e c5 13 21 01 
────────────────────────────────────────────────────────────────────────────────────────────────────
buffer: 86 data octets (headroom: 96 tailroom: 96))
error: invalid destination mac address: zero mac is illegal as destination mac
```
**Note:**
I don't think we should be worried about the actuall error (Invalid destination Mac) since the packet was captured by the kernel driver on the loopback interface. Therefore, it is normal that it does not have a destination mac (yet).