### PR TITLE
mgmt: Validate VpcPeering & friends

### DIFF
--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -22,6 +22,8 @@ pub enum ConfigError {
     DuplicateVpcVni(u32),
     #[error("A VPC peering with id '{0}' already exists")]
     DuplicateVpcPeeringId(String),
+    #[error("Peering '{0}' refers to a VPC for which a peering already exists")]
+    DuplicateVpcPeerings(String),
     #[error("A VPC peering object refers to non-existent VPC '{0}'")]
     NoSuchVpc(String),
     #[error("'{0}' is not a valid VNI")]

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -6,6 +6,9 @@ pub mod overlay;
 
 use crate::models::external::gwconfig::GenId;
 use crate::models::external::overlay::vpc::VpcId;
+use crate::models::external::overlay::vpcpeering::VpcExpose;
+
+use routing::prefix::Prefix;
 use thiserror::Error;
 
 /// The reasons why we may reject a configuration
@@ -41,6 +44,19 @@ pub enum ConfigError {
     FrrAgentUnreachable,
     #[error("Internal error: {0}")]
     InternalFailure(&'static str),
+
+    // Peering and VpcExpose validation
+    #[error("All prefixes are excluded in VpcExpose: {0}")]
+    ExcludedAllPrefixes(VpcExpose),
+    #[error("Exclusion prefix {0} not contained within existing allowed prefix")]
+    OutOfRangeExclusionPrefix(Prefix),
+    #[error("VPC prefixes overlap: {0} and {1}")]
+    OverlappingPrefixes(Prefix, Prefix),
+    #[error("Inconsistent IP version in VpcExpose: {0}")]
+    InconsistentIpVersion(VpcExpose),
+    // NAT-specific
+    #[error("Mismatched prefixes sizes for static NAT: {0} and {1}")]
+    MismatchedPrefixSizes(u128, u128),
 }
 
 /// Result-like type for configurations

--- a/mgmt/src/models/external/overlay/mod.rs
+++ b/mgmt/src/models/external/overlay/mod.rs
@@ -57,6 +57,7 @@ impl Overlay {
         /* collect peerings of every VPC */
         self.vpc_table
             .collect_peerings(&self.peering_table, &id_map);
+        self.vpc_table.validate()?;
 
         debug!(
             "Overlay configuration is VALID and looks as:\n{}\n{}",

--- a/mgmt/src/models/external/overlay/tests.rs
+++ b/mgmt/src/models/external/overlay/tests.rs
@@ -264,6 +264,40 @@ pub mod test {
     }
 
     #[test]
+    fn test_overlay_duplicate_peering() {
+        /* build VPCs */
+        let vpc1 = Vpc::new("VPC-1", "AAAAA", 3000).expect("Should succeed");
+        let vpc2 = Vpc::new("VPC-2", "BBBBB", 4000).expect("Should succeed");
+
+        /* build VPC table */
+        let mut vpc_table = VpcTable::new();
+        vpc_table.add(vpc1).expect("Should succeed");
+        vpc_table.add(vpc2).expect("Should succeed");
+
+        /* build peerings */
+        let peering1 = build_vpc_peering();
+        let mut peering2 = build_vpc_peering();
+        peering2.name = "Peering-2".to_owned();
+
+        let name1 = peering1.name.clone();
+
+        assert_eq!(peering1.validate(), Ok(()));
+        assert_eq!(peering2.validate(), Ok(()));
+
+        /* build peering table */
+        let mut peering_table = VpcPeeringTable::new();
+        peering_table.add(peering1).expect("Should succeed");
+        peering_table.add(peering2).expect("Should succeed");
+
+        /* build overlay object and validate it */
+        let mut overlay = Overlay::new(vpc_table, peering_table);
+        assert_eq!(
+            overlay.validate(),
+            Err(ConfigError::DuplicateVpcPeerings(name1))
+        );
+    }
+
+    #[test]
     fn test_overlay() {
         /* build VPCs */
         let vpc1 = Vpc::new("VPC-1", "AAAAA", 3000).expect("Should succeed");

--- a/mgmt/src/models/external/overlay/tests.rs
+++ b/mgmt/src/models/external/overlay/tests.rs
@@ -400,7 +400,7 @@ pub mod test {
         let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 2000).expect("Should succeed"));
         let _ = vpc_table.add(Vpc::new("VPC-4", "DDDDD", 6000).expect("Should succeed"));
 
-        /* build peering table with 3 peerings */
+        /* build peering table with 4 peerings */
         let mut peering_table = VpcPeeringTable::new();
         peering_table
             .add(VpcPeering::new(
@@ -433,6 +433,29 @@ pub mod test {
                 man_vpc3(),
             ))
             .expect("Should succeed");
+
+        assert_eq!(peering_table.len(), 4);
+
+        /* peering with empty name cannot be added to the table */
+        let peering_empty_name = VpcPeering::new("", man_vpc1_with_vpc2(), man_vpc2());
+        assert_eq!(
+            peering_table.add(peering_empty_name),
+            Err(ConfigError::MissingIdentifier("Peering name"))
+        );
+        assert_eq!(peering_table.len(), 4);
+
+        /* peering with duplicate name cannot be added to the table */
+        let peering_duplicate_name =
+            VpcPeering::new("VPC-1--VPC-2", man_vpc1_with_vpc2(), man_vpc2());
+        assert_eq!(
+            peering_table.add(peering_duplicate_name),
+            Err(ConfigError::DuplicateVpcPeeringId(
+                "VPC-1--VPC-2".to_string()
+            ))
+        );
+
+        /* make sure erroneous entries were not inserted */
+        assert_eq!(peering_table.len(), 4);
 
         /* display peering table */
         println!("{peering_table}");

--- a/mgmt/src/models/external/overlay/vpc.rs
+++ b/mgmt/src/models/external/overlay/vpc.rs
@@ -170,4 +170,21 @@ impl VpcTable {
     pub fn clear_ids(&mut self) {
         self.ids.clear();
     }
+    /// Validate the [`VpcTable`]
+    pub fn validate(&self) -> ConfigResult {
+        for vpc in self.values() {
+            let mut peers = BTreeSet::new();
+            // For each VPC, loop over all peerings
+            for peering in &vpc.peerings {
+                // Check whether we have duplicate remote VPCs between peerings.
+                // If we fail to insert, this means the remote VPC ID is already in our set,
+                // and we have a duplicate peering: this is a configuration error.
+                if (!peers.insert(peering.remote_id.clone())) {
+                    return Err(ConfigError::DuplicateVpcPeerings(peering.name.clone()));
+                }
+            }
+            peers.clear();
+        }
+        Ok(())
+    }
 }

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -142,8 +142,16 @@ impl VpcManifest {
         }
     }
     pub fn add_expose(&mut self, expose: VpcExpose) -> ConfigResult {
-        expose.validate()?;
         self.exposes.push(expose);
+        Ok(())
+    }
+    pub fn validate(&self) -> ConfigResult {
+        if self.name.is_empty() {
+            return Err(ConfigError::MissingIdentifier("Manifest name"));
+        }
+        for expose in &self.exposes {
+            expose.validate()?;
+        }
         Ok(())
     }
 }
@@ -164,6 +172,8 @@ impl VpcPeering {
     }
     pub fn validate(&self) -> ConfigResult {
         debug!("Validating VPC peering '{}'...", &self.name);
+        self.left.validate()?;
+        self.right.validate()?;
         Ok(())
     }
     /// Given a peering fetch the manifests, orderly depending on the provided vpc name

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -6,6 +6,7 @@
 use routing::prefix::Prefix;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::ops::Bound::{Excluded, Unbounded};
 use tracing::debug;
 
 use crate::models::external::{ConfigError, ConfigResult};
@@ -36,8 +37,94 @@ impl VpcExpose {
         self.not_as.insert(prefix);
         self
     }
+    /// Validate the [`VpcExpose`]:
+    ///
+    /// 1. Make sure that all prefixes and exclusion prefixes for this [`VpcExpose`] are of the same
+    ///    IP version.
+    /// 2. Make sure that all prefixes (or exclusion prefixes) in each list
+    ///    (ips/nots/as_range/not_as) don't overlap with other prefixes (or exclusion prefixes,
+    ///    respectively) of this list.
+    /// 3. Make sure that all exclusion prefixes are contained within existing prefixes, unless the
+    ///    list of allowed prefixes is empty.
+    /// 4. Make sure exclusion prefixes in a list don't exclude all of the prefixes in the
+    ///    associated prefixes list.
+    /// 5. Make sure we have the same number of addresses available on each side (public/private),
+    ///    taking exclusion prefixes into account.
     pub fn validate(&self) -> ConfigResult {
-        // TODO
+        // 1. Static NAT: Check that all prefixes in a list are of the same IP version, as we don't
+        // support NAT46 or NAT64 at the moment.
+        //
+        // TODO: We can loosen this restriction in the future. When we do, some additional
+        //       considerations might be required to validate independently the IPv4 and the IPv6
+        //       prefixes and exclusion prefixes in the rest of this function.
+        let mut is_ipv4_opt = None;
+        for prefixes in [&self.ips, &self.nots, &self.as_range, &self.not_as] {
+            if prefixes.iter().any(|p| {
+                if let Some(is_ipv4) = is_ipv4_opt {
+                    p.is_ipv4() != is_ipv4
+                } else {
+                    is_ipv4_opt = Some(p.is_ipv4());
+                    false
+                }
+            }) {
+                return Err(ConfigError::InconsistentIpVersion(self.clone()));
+            }
+        }
+
+        // 2. Check that items in prefix lists of each kind don't overlap
+        for prefixes in [&self.ips, &self.nots, &self.as_range, &self.not_as] {
+            for prefix in prefixes.iter() {
+                // Loop over the remaining prefixes in the tree
+                for other_prefix in prefixes.range((Excluded(prefix), Unbounded)) {
+                    if prefix.covers(other_prefix) || other_prefix.covers(prefix) {
+                        return Err(ConfigError::OverlappingPrefixes(*prefix, *other_prefix));
+                    }
+                }
+            }
+        }
+
+        // 3. Ensure all exclusion prefixes are contained within existing allowed prefixes,
+        // unless the list of allowed prefixes is empty.
+        for (prefixes, excludes) in [(&self.ips, &self.nots), (&self.as_range, &self.not_as)] {
+            if prefixes.is_empty() {
+                continue;
+            }
+            for exclude in excludes.iter() {
+                if !prefixes.iter().any(|p| p.covers(exclude)) {
+                    return Err(ConfigError::OutOfRangeExclusionPrefix(*exclude));
+                }
+            }
+        }
+
+        fn prefixes_size(prefixes: &BTreeSet<Prefix>) -> u128 {
+            prefixes.iter().map(|p| p.size()).sum()
+        }
+
+        // 4. Ensure we don't exclude all of the allowed prefixes
+        let ips_sizes = prefixes_size(&self.ips);
+        let nots_sizes = prefixes_size(&self.nots);
+        if ips_sizes > 0 && ips_sizes <= nots_sizes {
+            return Err(ConfigError::ExcludedAllPrefixes(self.clone()));
+        }
+
+        let as_range_sizes = prefixes_size(&self.as_range);
+        let not_as_sizes = prefixes_size(&self.not_as);
+        if as_range_sizes > 0 && as_range_sizes <= not_as_sizes {
+            return Err(ConfigError::ExcludedAllPrefixes(self.clone()));
+        }
+
+        // 5. Static NAT: Ensure that, if the list of publicly-exposed addresses is not empty, then
+        //    we have the same number of address on each side
+        //
+        // TODO: We need a way to disable this check (or move it elsewhere) when we add support
+        //       for stateful NAT.
+        if as_range_sizes > 0 && ips_sizes - nots_sizes != as_range_sizes - not_as_sizes {
+            return Err(ConfigError::MismatchedPrefixSizes(
+                ips_sizes - nots_sizes,
+                as_range_sizes - not_as_sizes,
+            ));
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
This Pull Request implements some validation for `VpcExpose`, `VpcManifest`, `VpcPeering`, and `VpcTable` objects received from the gRPC server.

Fixes: #442

Please refer to individual commit descriptions for details.