### PR TITLE
ci(deny): Allow multiple crates versions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -126,7 +126,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "deny"
+multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
 allow-wildcard-paths = true


### PR DESCRIPTION
In CI, we run "cargo deny check" to check a number of things regarding licensing and dependencies. One of the checks consist in reporting duplicate versions of crates loaded as dependencies. So far, we've "denied" these, meaning we have been rejected changes that led to rely on multiple versions of a given crate.

The expected benefit is easier debugging (less confusion as to what code is actually running). This also comes with a number of drawbacks: it makes it harder to pull in new dependencies, or even to upgrade dependencies when not all dependencies are in sync regarding recursive dependencies versions.

We have spent too much time struggling around this. We need to pull the dependencies we want to use, we can't afford bumping versions for multiple projects, sometimes not reactive, every time an issue shows up. As of this writing, the bump.yml workflow to update our dependencies has been failing for two weeks because of concurrent crate versions being pulled. Let's put an end to it.

This commit make the check return a warning in CI logs. Note that we won't get any notification when multiple versions of a crate are pulled: the workflow will succeed, because GitHub workflows don't do warnings. This will only show up if we go and read the logs for the "cargo deny check" step in CI.
