### PR TITLE
feat(mgmt): empty peering table & move validations

### DIFF
--- a/mgmt/src/models/external/overlay/mod.rs
+++ b/mgmt/src/models/external/overlay/mod.rs
@@ -39,8 +39,10 @@ impl Overlay {
     }
     pub fn validate(&mut self) -> ConfigResult {
         debug!("Validating overlay configuration...");
-        /* check if the VPCs referred in a peering exist */
+
+        /* validate peerings and check if referred VPCs exist */
         for peering in self.peering_table.values() {
+            peering.validate()?;
             self.check_peering_vpc(&peering.name, &peering.left)?;
             self.check_peering_vpc(&peering.name, &peering.right)?;
         }
@@ -55,6 +57,10 @@ impl Overlay {
         /* collect peerings of every VPC */
         self.vpc_table
             .collect_peerings(&self.peering_table, &id_map);
+
+        /* empty peering table: we no longer need it since we have collected
+        all of the peerings and added them to the corresponding VPCs */
+        self.peering_table.clear();
 
         debug!("Overlay configuration is VALID");
         Ok(())


### PR DESCRIPTION
The vpc peering table holds the VPC peerings desired for a certain overlay configuration. Soon in the processing of a config, the peerings are validated and moved to each of the VPCs participating. Therefore, we can empty it since it is no longer needed.

The gRPC server uses the VpcPeering builders to deserialize the peerings into them. Since this happens before the config is actually processed (other than building it from gRPC), validation should occur later, be it for the sake of clarity in logs.

Logs before this change:
```
2025-05-14T11:06:41.344642Z DEBUG mgmt ThreadId(03) dataplane_mgmt::grpc::server: 151: Received request to apply new config
2025-05-14T11:06:41.344798Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpcpeering: 79: Validating VPC peering 'VPC-1--VPC-2'...  <---- This is confusing
2025-05-14T11:06:41.344857Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpcpeering: 79: Validating VPC peering 'VPC-1--VPC-3'...
2025-05-14T11:06:41.345030Z DEBUG mgmt ThreadId(03) dataplane_mgmt::processor::proc: 120: ━━━━━━ Handling apply configuration request. Genid 2 ━━━━━━   <--- because we start processing the config here
2025-05-14T11:06:41.345060Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::gwconfig: 132: Validating external config with genid 2 ..    <---- and we validate stuff here
2025-05-14T11:06:41.345074Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::internal::device: 28: Validating device configuration..
2025-05-14T11:06:41.345087Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::gwconfig: 33: Validating underlay configuration...
2025-05-14T11:06:41.345104Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay: 41: Validating overlay configuration...
2025-05-14T11:06:41.345138Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpc: 157: Collecting peerings for all VPCs..

```

Logs after:

```
2025-05-14T11:11:12.096276Z DEBUG mgmt ThreadId(03) dataplane_mgmt::grpc::server: 151: Received request to apply new config
2025-05-14T11:11:12.096982Z DEBUG mgmt ThreadId(03) dataplane_mgmt::processor::proc: 120: ━━━━━━ Handling apply configuration request. Genid 2 ━━━━━━
2025-05-14T11:11:12.097057Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::gwconfig: 132: Validating external config with genid 2 ..
2025-05-14T11:11:12.097096Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::internal::device: 28: Validating device configuration..
2025-05-14T11:11:12.097128Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::gwconfig: 33: Validating underlay configuration...
2025-05-14T11:11:12.097168Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay: 41: Validating overlay configuration...
2025-05-14T11:11:12.097203Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpcpeering: 79: Validating VPC peering 'VPC-1--VPC-2'... <---- this is better in terms of logging
2025-05-14T11:11:12.097238Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpcpeering: 79: Validating VPC peering 'VPC-1--VPC-3'...
2025-05-14T11:11:12.097303Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpc: 157: Collecting peerings for all VPCs..
2025-05-14T11:11:12.097342Z DEBUG mgmt ThreadId(03) dataplane_mgmt::models::external::overlay::vpc: 84: Collecting peerings for vpc 'VPC-1'...


```



