### PR TITLE
feat(mgmt): no import routemap in peeringless VPC

### DIFF
--- a/mgmt/src/models/external/overlay/vpc.rs
+++ b/mgmt/src/models/external/overlay/vpc.rs
@@ -102,6 +102,10 @@ impl Vpc {
             debug!("Vpc '{}' has {} peerings", self.name, self.peerings.len());
         }
     }
+    /// Tell how many peerings this VPC has
+    pub fn num_peerings(&self) -> usize {
+        self.peerings.len()
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -111,7 +111,9 @@ fn vpc_ipv4_imports(vpc: &Vpc) -> VrfImports {
 /// Build AF Ipv4 unicast config for a VPC VRF
 fn vpc_bgp_af_ipv4(vpc: &Vpc) -> AfIpv4Ucast {
     let mut af = AfIpv4Ucast::new();
-    af.set_vrf_imports(vpc_ipv4_imports(vpc));
+    if vpc.num_peerings() > 0 {
+        af.set_vrf_imports(vpc_ipv4_imports(vpc));
+    }
     af
 }
 


### PR DESCRIPTION
When building the configuration of FRR, do not add an import route- map if the VPC has no peerings. In principle, it should not harm. However, such a route-map is useless and we speculate it may confuse frr-reload.