### PR TITLE
ci: Fix generation of list of packages to update

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -110,8 +110,11 @@ jobs:
           # Check updates available with "cargo upgrade",
           # then bump each package individually through separate commits
           cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
-          sed '0,/^====/d; s/ .*//' upgrade_output.txt > list_packages.txt
+          sed '/^====/d; /^name .* new req$/d; s/ .*//' upgrade_output.txt > list_packages.txt
           nb_upgrades=$(wc -l < list_packages.txt)
+
+          echo "Found the following ${nb_upgrades} upgrade(s) available:"
+          cat list_packages.txt
 
           while read -r package; do
               echo "bump(cargo)!: bump $package (cargo upgrade)" | tee commit_msg.txt


### PR DESCRIPTION
Workflow bump.yml performs a dry run of the "cargo upgrade" command, and processes its output to determine the list of packages to upgrade (then upgrades them as individual commits). It expects the output to be a Markdown array, of this kind:

    name     old req compatible latest new req
    ====     ======= ========== ====== =======
    netdev   0.34.0  0.34.1     0.34.1 0.34.1
    smallvec 1.14.0  1.15.0     1.15.0 1.15.0

However, the recent introduction of the dataplane CLI with a separate binary, and in particular, a set of dependency crates that are not managed from the toplevel Cargo.toml, caused "cargo upgrade" to process two files and to produce two different tables:

    $ cargo upgrade --incompatible=allow --dry-run 2>/dev/null
    name     old req compatible latest new req
    ====     ======= ========== ====== =======
    netdev   0.34.0  0.34.1     0.34.1 0.34.1
    smallvec 1.14.0  1.15.0     1.15.0 1.15.0
    name old req compatible latest new req
    ==== ======= ========== ====== =======
    log  ^0.4.25 0.4.27     0.4.27 ^0.4.27

This is obviously an issue for the workflow, that expects a single table when parsing the output.

One solution is to move all dependencies for the CLI to the toplevel crate. This is a separate discussion. In any case, we don't want the workflow to break when processing multiple Cargo.toml. Fix the sed expression to remove all heading and separator lines from the output (it appears that we can collapse dependencies from all Cargo.toml into a single list and treat the packages irrespective of the binary using them when running "cargo upgrade"; version conflicts have not happened yet, and are assumed to be solved by moving the dependency to the toplevel Cargo.toml).

This is not expected to solve the issues currently observed with the bump.yml workflow, but should improve resilience anyway.
