### PR TITLE
ci: Reorder steps in bump.yml workflow to fix upgrades from Git

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -107,6 +107,13 @@ jobs:
           git config user.email '<41898282+github-actions[bot]@users.noreply.github.com>'
           BASE="$(git rev-parse HEAD)"
 
+          # Run "cargo update"
+          cargo update
+          if ! git diff --quiet; then
+              git add Cargo.lock
+              git commit -sm "bump(cargo)!: bump dependencies (cargo update)"
+          fi
+
           # Check updates available with "cargo upgrade",
           # then bump each package individually through separate commits
           cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
@@ -123,13 +130,6 @@ jobs:
               git add Cargo.toml Cargo.lock
               git commit -sF commit_msg.txt
           done < list_packages.txt
-
-          # Run "cargo update"
-          cargo update
-          if ! git diff --quiet; then
-              git add Cargo.lock
-              git commit -sm "bump(cargo)!: bump dependencies (cargo update)"
-          fi
 
           # If we didn't create any commits, we don't need to create a PR message
           if [[ "$(git rev-parse HEAD)" = "${BASE}" ]]; then


### PR DESCRIPTION
We have an issue in the bump.yml workflow. It fails to update recursive dependencies for the project when these dependencies are passed as links to Git repositories (for example, a branch name and an URL to a GitHub repository).

I'm not sure what happens exactly, but there seems to be an issue with the `cargo upgrade` command: it expects some local index to be populated when running the upgrade for the Git-based dependency, and calls `cargo update` under the hood with the `--offline` option, but this command fails.

We've opened a GitHub issue for the upstream `cargo-edit` project (providing `cargo upgrade`), but in the meantime, let's re-order the commands we run: if we do the `cargo update` first, this should populate whatever index `cargo upgrade` seems to rely on when we try to bump the dependencies in Cargo.toml.

See https://github.com/githedgehog/dataplane/issues/491 for more context.

Fixes: #491
