### PR TITLE
CI: Make bump not bump on bump bumps

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -4,9 +4,6 @@
 name: "bump.yml"
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/bump.yml"
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
This reverts commit f6198c0f26d7f239cc8be9086c2942ebc1c12834.

The workflow is broken when running on PRs, and I don't have the time to fix it. Remove the run on PRs for now, to avoid failing worfklows in CI when we update the file.

In other words, make bump not bump on bump bumps.
