### PR TITLE
fix: temporary fix to bgp neigh update-source

### DIFF
--- a/mgmt/src/grpc/converter.rs
+++ b/mgmt/src/grpc/converter.rs
@@ -408,7 +408,7 @@ pub fn convert_bgp_neighbor(neighbor: &gateway_config::BgpNeighbor) -> Result<Bg
     // Create the neighbor config
     let neigh = BgpNeighbor::new_host(neighbor_addr)
         .set_remote_as(remote_as)
-        .set_update_source_address(neighbor_addr)
+        .set_update_source_interface("lo")
         .set_capabilities(BgpNeighCapabilities::default())
         .set_send_community(NeighSendCommunities::Both)
         .ipv4_unicast_activate(ipv4_unicast)


### PR DESCRIPTION
**Temporary** fix to bgp neigh update-source

The fix hard-codes the name of the loopback interface and should be replaced by a proper method that uses the information coming from the gRPC config model.

See: https://github.com/githedgehog/gateway-proto/compare/pr/fredi/augment-proto-bgp-update-source?expand=1