### PR TITLE
ci: Fix bump.yml workflow for CLI

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -127,7 +127,7 @@ jobs:
               echo "bump(cargo)!: bump $package (cargo upgrade)" | tee commit_msg.txt
               echo '' | tee -a commit_msg.txt
               cargo upgrade --incompatible=allow --package "$package" | tee -a commit_msg.txt
-              git add Cargo.toml Cargo.lock
+              git add Cargo.lock Cargo.toml cli/Cargo.toml
               git commit -sF commit_msg.txt
           done < list_packages.txt
 


### PR DESCRIPTION
We recently adjusted our bump.yml workflow to account for upgrades in the CLI repository (cli), but forgot to "git add" the related Cargo.toml file, making the workflow fail when toplevel Cargo files are not modified (because there's nothing to commit - the change is in cli/Cargo.toml). Let's add it.

Fixes: e3522a0e664d (ci: Fix generation of list of packages to update)
