### PR TITLE
Set bridge mac

### DIFF
--- a/mgmt/src/models/internal/routing/evpn.rs
+++ b/mgmt/src/models/internal/routing/evpn.rs
@@ -3,16 +3,21 @@
 
 //! Dataplane configuration model: EVPN
 
-use net::eth::mac::Mac;
-use std::net::IpAddr;
+use net::eth::mac::{Mac, SourceMac};
+use net::ip::UnicastIpAddr;
 
+/// The configuration of a VTEP (virtual tunnel endpoint) for the Hedgehog EVPN router.
 #[derive(Clone, Debug)]
 pub struct VtepConfig {
-    pub address: IpAddr,
-    pub mac: Mac,
+    /// The source IP address to be used by vxlan packets originating from this router.
+    pub address: UnicastIpAddr,
+    /// The source MAC address to be used by vxlan packets originating from this router.
+    pub mac: SourceMac,
 }
+
 impl VtepConfig {
-    pub fn new(address: IpAddr, mac: Mac) -> Self {
+    /// Creates a new VTEP configuration.
+    pub fn new(address: UnicastIpAddr, mac: SourceMac) -> Self {
         Self { address, mac }
     }
 }

--- a/mgmt/src/models/internal/routing/evpn.rs
+++ b/mgmt/src/models/internal/routing/evpn.rs
@@ -16,6 +16,9 @@ pub struct VtepConfig {
 }
 
 impl VtepConfig {
+    /// The TTL to be used by VTEPs.
+    pub const TTL: u8 = 64;
+
     /// Creates a new VTEP configuration.
     pub fn new(address: UnicastIpAddr, mac: SourceMac) -> Self {
         Self { address, mac }

--- a/mgmt/src/models/internal/routing/vrf.rs
+++ b/mgmt/src/models/internal/routing/vrf.rs
@@ -100,6 +100,15 @@ impl VrfConfigTable {
     pub fn new() -> Self {
         VrfConfigTable::default()
     }
+
+    pub fn default_vrf_config(&self) -> Option<&VrfConfig> {
+        self.iter_by_name().find(|vrf| vrf.default)
+    }
+
+    pub fn vpc_vrfs(&self) -> impl Iterator<Item = &VrfConfig> {
+        self.iter_by_name().filter(|vrf| vrf.vni.is_some())
+    }
+
     pub fn add_vrf_config(&mut self, vrf_cfg: VrfConfig) -> ConfigResult {
         let name = vrf_cfg.name.clone();
         debug!(

--- a/mgmt/src/processor/tests.rs
+++ b/mgmt/src/processor/tests.rs
@@ -27,7 +27,7 @@ pub mod test {
     use std::net::Ipv4Addr;
     use std::str::FromStr;
     use test_utils::with_caps;
-    use tracing::Level;
+    use tracing::{Level, error};
     //    use crate::models::internal::routing::evpn::VtepConfig;
 
     use crate::models::external::gwconfig::ExternalConfig;
@@ -304,10 +304,13 @@ pub mod test {
         let (mut processor, _sender) = ConfigProcessor::new(frrmi);
 
         /* let the processor process the config */
-        processor
-            .process_incoming_config(config)
-            .await
-            .expect("Faked frr-agent should answer ok");
+        match processor.process_incoming_config(config).await {
+            Ok(()) => {}
+            Err(e) => {
+                error!("{e}");
+                panic!("{e}");
+            }
+        }
 
         /* stop the faked frr-agent */
         frr_agent.abort();

--- a/mgmt/src/vpc_manager/mod.rs
+++ b/mgmt/src/vpc_manager/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::models::internal::InternalConfig;
 use crate::models::internal::interfaces::interface::InterfaceType;
+use crate::models::internal::routing::evpn::VtepConfig;
 use derive_builder::Builder;
 use futures::TryStreamExt;
 use interface_manager::Manager;
@@ -379,7 +380,7 @@ impl TryFrom<&InternalConfig> for RequiredInformationBase {
                     vtep.properties(InterfacePropertiesSpec::Vtep(VtepPropertiesSpec {
                         vni: config.vni.expect("vni not set"),
                         local: UnicastIpv4Addr::new(vtep_ip).unwrap(),
-                        ttl: 64,
+                        ttl: VtepConfig::TTL,
                         port: Vxlan::PORT,
                     }));
                 }

--- a/mgmt/src/vpc_manager/mod.rs
+++ b/mgmt/src/vpc_manager/mod.rs
@@ -358,6 +358,9 @@ impl TryFrom<&InternalConfig> for RequiredInformationBase {
                         ttl: VtepConfig::TTL,
                         port: Vxlan::PORT,
                     }));
+                    vrf.mac(Some(main_vtep.mac));
+                    bridge.mac(Some(main_vtep.mac));
+                    vtep.mac(Some(main_vtep.mac));
                 }
             }
             match (vrf.build(), bridge.build(), vtep.build()) {

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -3,7 +3,10 @@
 
 //! Helper methods and types which are common between IPv4 and IPv6
 
+use crate::ipv4::UnicastIpv4Addr;
+use crate::ipv6::UnicastIpv6Addr;
 use etherparse::IpNumber;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Thin wrapper around [`IpNumber`]
 ///
@@ -54,6 +57,82 @@ impl NextHeader {
     }
 }
 
+/// A union type for IPv4 and IPv6 unicast addresses
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(bolero::TypeGenerator))]
+pub enum UnicastIpAddr {
+    /// A unicast Ipv4 address
+    V4(UnicastIpv4Addr),
+    /// A unicast Ipv6 address
+    V6(UnicastIpv6Addr),
+}
+
+impl UnicastIpAddr {
+    /// Get the inner (wrapped) [`IpAddr`] type
+    #[must_use]
+    pub fn inner(&self) -> IpAddr {
+        match self {
+            UnicastIpAddr::V4(ip) => IpAddr::V4(ip.inner()),
+            UnicastIpAddr::V6(ip) => IpAddr::V6(ip.inner()),
+        }
+    }
+}
+
+impl TryFrom<IpAddr> for UnicastIpAddr {
+    type Error = IpAddr;
+
+    fn try_from(value: IpAddr) -> Result<UnicastIpAddr, IpAddr> {
+        match value {
+            IpAddr::V4(ip) => Ok(UnicastIpAddr::V4(
+                UnicastIpv4Addr::new(ip).map_err(IpAddr::V4)?,
+            )),
+            IpAddr::V6(ip) => Ok(UnicastIpAddr::V6(
+                UnicastIpv6Addr::new(ip).map_err(IpAddr::V6)?,
+            )),
+        }
+    }
+}
+
+impl From<UnicastIpAddr> for IpAddr {
+    fn from(value: UnicastIpAddr) -> Self {
+        match value {
+            UnicastIpAddr::V4(ip) => IpAddr::V4(ip.inner()),
+            UnicastIpAddr::V6(ip) => IpAddr::V6(ip.inner()),
+        }
+    }
+}
+
+impl From<UnicastIpv4Addr> for UnicastIpAddr {
+    fn from(value: UnicastIpv4Addr) -> Self {
+        UnicastIpAddr::V4(value)
+    }
+}
+
+impl From<UnicastIpv6Addr> for UnicastIpAddr {
+    fn from(value: UnicastIpv6Addr) -> Self {
+        UnicastIpAddr::V6(value)
+    }
+}
+
+impl TryFrom<Ipv4Addr> for UnicastIpAddr {
+    type Error = Ipv4Addr;
+
+    fn try_from(value: Ipv4Addr) -> Result<Self, Self::Error> {
+        Ok(UnicastIpAddr::V4(UnicastIpv4Addr::new(value)?))
+    }
+}
+
+impl TryFrom<Ipv6Addr> for UnicastIpAddr {
+    type Error = Ipv6Addr;
+
+    fn try_from(value: Ipv6Addr) -> Result<Self, Self::Error> {
+        Ok(UnicastIpAddr::V6(UnicastIpv6Addr::new(value)?))
+    }
+}
+
 #[cfg(any(test, feature = "arbitrary"))]
 mod contract {
     use crate::ip::NextHeader;
@@ -63,5 +142,69 @@ mod contract {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
             Some(NextHeader::new(driver.produce()?))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ip::UnicastIpAddr;
+    use crate::ipv4::UnicastIpv4Addr;
+    use crate::ipv6::UnicastIpv6Addr;
+    use std::net::IpAddr;
+
+    #[test]
+    fn generated_unicast_ip_address_is_unicast() {
+        bolero::check!()
+            .with_type()
+            .for_each(|ip: &UnicastIpAddr| match ip {
+                UnicastIpAddr::V4(ip) => assert!(!ip.inner().is_multicast()),
+                UnicastIpAddr::V6(ip) => assert!(!ip.inner().is_multicast()),
+            });
+    }
+
+    #[test]
+    fn unicast_ipv4_is_unicast_ip() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|ipv4: UnicastIpv4Addr| {
+                let ip: UnicastIpAddr = ipv4.inner().try_into().unwrap();
+                match ip {
+                    UnicastIpAddr::V4(ip) => assert_eq!(ip, ipv4),
+                    UnicastIpAddr::V6(_) => unreachable!(),
+                }
+            });
+    }
+
+    #[test]
+    fn unicast_ipv6_is_unicast_ip() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|ipv6: UnicastIpv6Addr| {
+                let ip: UnicastIpAddr = ipv6.inner().try_into().unwrap();
+                match ip {
+                    UnicastIpAddr::V4(_) => unreachable!(),
+                    UnicastIpAddr::V6(ip) => assert_eq!(ip, ipv6),
+                }
+            });
+    }
+
+    #[test]
+    fn try_from_obeys_contract() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|ip: IpAddr| {
+                if ip.is_multicast() {
+                    let multicast_ip = UnicastIpAddr::try_from(ip).unwrap_err();
+                    assert!(multicast_ip.is_multicast());
+                    assert_eq!(ip, multicast_ip);
+                } else {
+                    let unicast_ip = UnicastIpAddr::try_from(ip).unwrap();
+                    assert!(!unicast_ip.inner().is_multicast());
+                    assert_eq!(ip, IpAddr::from(unicast_ip));
+                }
+            });
     }
 }

--- a/net/src/ipv4/addr.rs
+++ b/net/src/ipv4/addr.rs
@@ -16,6 +16,7 @@ use std::net::Ipv4Addr;
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
+#[serde(transparent)]
 pub struct UnicastIpv4Addr(Ipv4Addr);
 
 impl UnicastIpv4Addr {

--- a/net/src/ipv6/addr.rs
+++ b/net/src/ipv6/addr.rs
@@ -11,7 +11,10 @@ use std::net::Ipv6Addr;
 /// A type representing the set of unicast ipv6 addresses.
 #[non_exhaustive]
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
 pub struct UnicastIpv6Addr(Ipv6Addr);
 
 impl UnicastIpv6Addr {


### PR DESCRIPTION
This PR sets the bridge (and vtep + vrf) MAC to a consistent value, as well as adding infrastructure to allow specifying the VTEP ip more logically.

Doing so requires a bit of plumbing, but not a lot of new logic.