### PR TITLE
CI tune up (deal with flaky tests)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -131,3 +131,8 @@ store-success-output = true
 # Note that if a description can be extracted from the output, it is always stored in the
 # <description> element.
 store-failure-output = true
+
+# See https://github.com/githedgehog/dataplane/issues/446
+[[profile.default.overrides]]
+filter = 'test(reconcile_fuzz)'
+retries = 3

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -95,7 +95,7 @@ slow-timeout = { period = "60s" }
 # handles, but doesn't clean the child process up (especially when it fails).
 #
 # See <https://nexte.st/docs/features/leaky-tests> for more information.
-leak-timeout = "100ms"
+leak-timeout = "500ms"
 
 # `nextest archive` automatically includes any build output required by a standard build.
 # However sometimes extra non-standard files are required.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -51,7 +51,7 @@ run-extra-args = []
 status-level = "all"
 
 # Similar to status-level, show these test statuses at the end of the run.
-final-status-level = "all"
+final-status-level = "skip"
 
 # "failure-output" defines when standard output and standard error for failing tests are produced.
 # Accepted values are

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -93,8 +93,7 @@ jobs:
         debug_justfile:
           - "${{ inputs.debug_justfile || false }}"
     outputs:
-      result: |
-        ${{ matrix.rust.optional || (steps.debug_test.conclusion == 'success' && steps.release_test.conclusion == 'success' && steps.clippy.conclusion == 'success') }}
+      result: "${{ matrix.rust.optional || (steps.debug_test.conclusion == 'success' && steps.release_test.conclusion == 'success' && steps.docs.conclusion == 'success' && steps.clippy.conclusion == 'success') }}"
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -207,6 +206,22 @@ jobs:
         run: |
           just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} \
             cargo clippy --all-targets --all-features -- -D warnings
+
+      - id: "docs"
+        name: "run rustdoc"
+        run: |
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            rust=${{matrix.rust.version}} \
+            profile=debug \
+            target=x86_64-unknown-linux-gnu \
+            cargo doc
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            rust=${{matrix.rust.version}} \
+            profile=release \
+            target=x86_64-unknown-linux-gnu \
+            cargo doc
 
       - id: "build_each_commit"
         continue-on-error: true

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -201,6 +201,33 @@ jobs:
           message: |
             ${{ env.FLAKY_TESTS_DEBUG }}${{ env.FLAKY_TESTS_RELEASE }}
 
+      - name: "publish dev/release test report"
+        uses: "mikepenz/action-junit-report@v5"
+        if: "${{ always() }}"
+        with:
+          annotate_notice: 'false'
+          annotate_only: 'false'
+          check_annotations: 'true'
+          check_retries: 'false'
+          comment: 'false'
+          detailed_summary: 'true'
+          fail_on_failure: 'false'
+          fail_on_parse_error: 'true'
+          flaky_summary: 'true'
+          include_empty_in_summary: 'true'
+          include_passed: 'true'
+          include_time_in_summary: 'true'
+          report_paths: 'target/nextest/default/*junit.xml'
+          require_passed_tests: 'true'
+          require_tests: 'true'
+          simplified_summary: 'true'
+          truncate_stack_traces: 'false'
+          group_reports: 'true'
+          check_name: 'test-report-${{matrix.rust.version}}'
+          skip_success_summary: 'false'
+          job_summary: 'true'
+          verbose_summary: 'false'
+
       - id: "clippy"
         name: "run clippy"
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -80,7 +80,7 @@ jobs:
             version: "nightly"
             optional: true
         debug_justfile:
-          - "${{inputs.debug_justfile || false}}"
+          - "${{ inputs.debug_justfile || false }}"
     outputs:
       result: "${{ matrix.rust.optional || (steps.gnu_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' && steps.clippy.conclusion == 'success') }}"
     name: "Developer build"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -73,12 +73,17 @@ jobs:
           - # failures on stable block release
             version: "stable"
             optional: false
+            # HACK: we sleep for a different time in each job to avoid provoking DDoS mitigations in cargo binstall
+            #       resulting from launching multiple binstall tasks at (very nearly) the same time.
+            sleep: "0.0"
           - # failures on beta block release
             version: "beta"
             optional: false
+            sleep: "0.2"
           - # failures on the nightly channel are a clear "yellow" flag
             version: "nightly"
             optional: true
+            sleep: "0.4"
         debug_justfile:
           - "${{ inputs.debug_justfile || false }}"
     outputs:
@@ -108,12 +113,15 @@ jobs:
           fetch-depth: "0"
       - name: "install just"
         run: |
+          sleep ${{matrix.rust.sleep}}
           cargo binstall --no-confirm just
       - name: "install cargo-deny"
         run: |
+          sleep ${{matrix.rust.sleep}}
           cargo binstall --no-confirm cargo-deny
       - name: "install cargo-nextest"
         run: |
+          sleep ${{matrix.rust.sleep}}
           cargo binstall --no-confirm cargo-nextest
       - name: refresh-compile-env
         run: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,6 +66,12 @@ jobs:
   build:
     needs: [ check_changes ]
     if: "${{ needs.check_changes.outputs.devfiles == 'true' }}"
+    permissions:
+      checks: "write"
+      pull-requests: "write"
+      contents: "read"
+      packages: "write"
+      id-token: "write"
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +93,8 @@ jobs:
         debug_justfile:
           - "${{ inputs.debug_justfile || false }}"
     outputs:
-      result: "${{ matrix.rust.optional || (steps.gnu_dev_test.conclusion == 'success' && steps.gnu_release_test.conclusion == 'success' && steps.clippy.conclusion == 'success') }}"
+      result: |
+        ${{ matrix.rust.optional || (steps.debug_test.conclusion == 'success' && steps.release_test.conclusion == 'success' && steps.clippy.conclusion == 'success') }}
     name: "Developer build"
     runs-on: "lab"
     timeout-minutes: 45
@@ -123,7 +130,8 @@ jobs:
         run: |
           sleep ${{matrix.rust.sleep}}
           cargo binstall --no-confirm cargo-nextest
-      - name: refresh-compile-env
+          mkdir -p target/nextest
+      - name: "refresh-compile-env"
         run: |
           just --yes debug_justfile="${{matrix.debug_justfile}}" refresh-compile-env
       - run: |
@@ -131,21 +139,68 @@ jobs:
       - run: |
           just --yes debug_justfile="${{matrix.debug_justfile}}" fake-nix
 
-      - id: "gnu_dev_test"
-        name: "test gnu dev"
+      - id: "debug_test"
+        name: "test debug"
         run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-gnu \
-            cargo nextest run
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=dev target=x86_64-unknown-linux-gnu \
-            cargo doc
+          set -euo pipefail
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            rust=${{matrix.rust.version}} \
+            profile=debug \
+            target=x86_64-unknown-linux-gnu \
+            cargo nextest run --status-level=none --final-status-level=skip --message-format=libtest-json-plus > ./target/nextest/debug.json
+          mv ./target/nextest/default/junit.xml ./target/nextest/default/debug.junit.xml
+          jq \
+            --raw-output \
+            --slurp '.[] | select(.type == "test" and (.name | test(".*#\\d+"))) | ( .name | split("#") ) | 
+                     [.[0], (.[1] | tonumber)] | @csv
+          ' ./target/nextest/debug.json > ./target/nextest/debug.flakes.csv
+          if [ -s ./target/nextest/debug.flakes.csv ]; then
+            cargo binstall --no-confirm csview
+            { 
+              echo "FLAKY_TESTS_DEBUG<<EOF"
+              echo -e "### :warning: Flaky tests (debug run, ${{ matrix.rust.version }})\n";
+              echo "| test | retries |"
+              echo "|------|---------|"
+              csview --style=markdown --no-headers --body-align=left ./target/nextest/debug.flakes.csv;
+              echo "EOF"
+            } >> "${GITHUB_ENV}"
+          fi
 
-      - id: "gnu_release_test"
-        name: "test gnu release"
+      - id: "release_test"
+        name: "test release"
         run: |
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
-            cargo nextest run
-          just debug_justfile="${{matrix.debug_justfile}}" rust=${{matrix.rust.version}} profile=release target=x86_64-unknown-linux-gnu \
-            cargo doc
+          set -euo pipefail
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            rust=${{matrix.rust.version}} \
+            profile=debug \
+            target=x86_64-unknown-linux-gnu \
+            cargo nextest run --status-level=none --final-status-level=skip --message-format=libtest-json-plus > ./target/nextest/release.json
+          mv ./target/nextest/default/junit.xml ./target/nextest/default/release.junit.xml
+          jq \
+            --raw-output \
+            --slurp '.[] | select(.type == "test" and (.name | test(".*#\\d+"))) | ( .name | split("#") ) | 
+                     [.[0], (.[1] | tonumber)] | @csv
+          ' ./target/nextest/release.json > ./target/nextest/release.flakes.csv
+          if [ -s ./target/nextest/release.flakes.csv ]; then
+            cargo binstall --no-confirm csview
+            { 
+              echo "FLAKY_TESTS_RELEASE<<EOF"
+              echo -e "\n### :warning: Flaky tests (release run, ${{ matrix.rust.version }})\n";
+              echo "| test | retries |"
+              echo "|------|---------|"
+              csview --style=markdown --no-headers --body-align=left ./target/nextest/release.flakes.csv;
+              echo "EOF"
+            } >> "${GITHUB_ENV}"
+          fi
+
+      - uses: "marocchino/sticky-pull-request-comment@v2"
+        with:
+          header: "flakes_${{matrix.rust.version}}"
+          ignore_empty: 'true'
+          message: |
+            ${{ env.FLAKY_TESTS_DEBUG }}${{ env.FLAKY_TESTS_RELEASE }}
 
       - id: "clippy"
         name: "run clippy"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -159,9 +159,7 @@ jobs:
         if: "${{ github.event.pull_request || github.event.merge_group }}"
         run: |
           BASE="${{ github.event.pull_request.base.sha || github.event.merge_group.base.sha }}"
-          just debug_justfile="${{matrix.debug_justfile}}" rust="${{matrix.rust.version}}" \
-            build-sweep ${BASE}
-          printf "::notice::HEAD back to %s\n" "$(git log --oneline --no-decorate -n 1)"
+          just build-sweep "${BASE}"
 
       - name: "Setup tmate session for debug"
         if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}

--- a/justfile
+++ b/justfile
@@ -420,18 +420,11 @@ rustdoc-serve:
 
 # Build for each separate commit (for "pull_request") or for the HEAD of the branch (other events)
 [script]
-build-sweep start="main":
+build-sweep start="main" command="{ git log --oneline --no-decorate -n 1 && just cargo build; }":
     {{ _just_debuggable_ }}
-    set -euo pipefail
-    if [ {{ _clean }} != "clean" ]; then
-      >&2 echo "can not build-sweep with dirty branch (would risk data loss)"
-      exit 1
+    # Check for uncommitted changes
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Error: Uncommitted changes detected. Please commit or stash your changes before running this script."
+        exit 1
     fi
-    INIT_HEAD=$(git rev-parse --abbrev-ref HEAD)
-    # Get all commits since {{ start }}, in chronological order
-    while read -r commit; do
-      git -c advice.detachedHead=false checkout "${commit}" || exit 1
-      { just debug_justfile={{ debug_justfile }} cargo +{{ rust }} build --locked --profile=dev --target=x86_64-unknown-linux-gnu; } || exit 1
-    done < <(git rev-list --reverse "{{ start }}".."$(git rev-parse HEAD)")
-    # Return to the initial branch if any (exit "detached HEAD" state)
-    git checkout "${INIT_HEAD}"
+    git rebase --keep-base "{{ start }}" --no-autosquash --exec "{{ command }}"

--- a/scripts/rust.env
+++ b/scripts/rust.env
@@ -1,3 +1,4 @@
+NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1
 LINKER="-C linker=./compile-env/bin/clang -C link-arg=--ld-path=./compile-env/bin/ld.lld"
 RELRO="-C relro-level=full"
 CRT_STATIC="-C target-feature=+crt-static"


### PR DESCRIPTION
CI tune up time!

This is all basically in service of making flaky tests (specifically flaky fuzz tests) visible in CI, while not punishing PRs which have nothing to do with that flake.

Finding new flakes is just part of fuzzing the codebase.

We should just create an issue to investigate and move on (assuming that the issue really isn't caused by the PR in question).


> [!NOTE]
> This PR does not address flakes in the sterile environment.  I'll get to that in a future PR.

See https://github.com/githedgehog/dataplane/pull/533 for examples of the types of messages this new functionality generates.

See also issue #446 for motivation