### PR TITLE
NAT: Hook NAT table construction into `mgmt`

### DIFF
--- a/mgmt/src/models/internal/mod.rs
+++ b/mgmt/src/models/internal/mod.rs
@@ -19,6 +19,7 @@ use crate::models::external::gwconfig::GenId;
 
 use crate::models::internal::device::DeviceConfig;
 use crate::models::internal::interfaces::interface::{InterfaceConfig, InterfaceConfigTable};
+use crate::models::internal::nat::tables::NatTables;
 use crate::models::internal::routing::evpn::VtepConfig;
 use crate::models::internal::routing::frr::Frr;
 use crate::models::internal::routing::prefixlist::{PrefixList, PrefixListTable};
@@ -36,6 +37,7 @@ pub struct InternalConfig {
     pub vrfs: VrfConfigTable,
     pub plist_table: PrefixListTable,
     pub rmap_table: RouteMapTable,
+    pub nat_table: Option<NatTables>,
 }
 
 impl InternalConfig {
@@ -52,6 +54,7 @@ impl InternalConfig {
             vrfs: VrfConfigTable::new(),
             plist_table: PrefixListTable::new(),
             rmap_table: RouteMapTable::new(),
+            nat_table: None,
         }
     }
     pub fn set_vtep(&mut self, vtep: VtepConfig) {
@@ -68,5 +71,8 @@ impl InternalConfig {
     }
     pub fn add_route_map(&mut self, rmap: RouteMap) {
         self.rmap_table.add_route_map(rmap);
+    }
+    pub fn add_nat_tables(&mut self, nat_tables: NatTables) {
+        self.nat_table = Some(nat_tables);
     }
 }

--- a/mgmt/src/models/internal/nat/tables.rs
+++ b/mgmt/src/models/internal/nat/tables.rs
@@ -10,7 +10,7 @@ use std::net::IpAddr;
 /// An object containing the rules for the NAT pipeline stage, not in terms of states for the
 /// different connections established, but instead holding the base rules for stateful or static
 /// NAT.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NatTables {
     pub tables: HashMap<u32, PerVniTable>,
 }
@@ -38,7 +38,7 @@ impl Default for NatTables {
 
 /// A table containing all rules for both source and destination static NAT, for packets with a
 /// given source VNI.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PerVniTable {
     pub(crate) dst_nat: NatPrefixRuleTable,
     pub(crate) src_nat_peers: NatPeerRuleTable,
@@ -103,7 +103,7 @@ pub struct NatPrefixRuleTable {
 
 /// From a current address prefix, find the relevant [`NatPrefixRuleTable`] for the target prefix
 /// lookup.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NatPeerRuleTable {
     pub rules: PrefixTrie<usize>,
 }


### PR DESCRIPTION
Based on #470

- **feat(nat): Optimize peerings before adding them to NAT tables**
- **chore(nat): Derive Clone trait for NAT tables**
- **feat(nat): Hook NAT tables creation into internal config build**

Fixes: #472