### PR TITLE
Fix bugs, extend tests, and refactor gRPC converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -1235,10 +1235,11 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.2"
-source = "git+https://github.com/githedgehog/gateway-proto#aa8a6e50eab0b18f2ba5cacc564d90067d94db68"
+version = "0.2.3"
+source = "git+https://github.com/githedgehog/gateway-proto#7859015d1326cee10719ddac75b62b4a3602b1e1"
 dependencies = [
  "async-trait",
+ "bolero",
  "futures",
  "prost",
  "serde",
@@ -1505,15 +1506,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2151,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dpdk-sys = { path = "./dpdk-sys", package = "dataplane-dpdk-sys" }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpdk-sysroot-helper" }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = "1.0.1" }
 errno = { path = "./errno", package = "dataplane-errno" }
-gateway_config = { git = "https://github.com/githedgehog/gateway-proto", version = "0.2.2" }
+gateway_config = { git = "https://github.com/githedgehog/gateway-proto", version = "0.2.3" }
 id = { path = "./id", package = "dataplane-id" }
 interface-manager = { path = "./interface-manager", package = "dataplane-interface-manager" }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt"}

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -48,11 +48,12 @@ fixin = { workspace = true }
 id = { workspace = true, features = ["bolero"] }
 interface-manager = { workspace = true, features = ["bolero"] }
 net = { workspace = true, features = ["arbitrary"] }
-pretty_assertions = { workspace = true }
 routing = { workspace = true, features = ["testing"] }
 test-utils = { workspace = true }
 
 # external
 bolero = { workspace = true, default-features = false, features = ["alloc"] }
+gateway_config = { workspace = true, features = ["bolero"] }
+pretty_assertions = { workspace = true }
 tracing-test = { workspace = true, features = [] }
 caps = { workspace = true }

--- a/mgmt/src/grpc/converter/mod.rs
+++ b/mgmt/src/grpc/converter/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::must_use_candidate)] // Do not want to remove pub methods yet
+
+mod old_impl;
+pub use old_impl::*;

--- a/mgmt/src/grpc/converter/mod.rs
+++ b/mgmt/src/grpc/converter/mod.rs
@@ -7,3 +7,63 @@
 
 mod old_impl;
 pub use old_impl::*;
+
+#[cfg(test)]
+mod test {
+    use gateway_config::GatewayConfig;
+    use pretty_assertions::assert_eq;
+
+    use crate::grpc::converter::{convert_from_grpc_config, convert_to_grpc_config};
+
+    fn normalize_order(config: &GatewayConfig) -> GatewayConfig {
+        let mut config = config.clone();
+        if let Some(overlay) = &mut config.overlay {
+            overlay.vpcs.sort_by_key(|vpc| vpc.name.clone());
+            overlay.vpcs.iter_mut().for_each(|vpc| {
+                vpc.interfaces.sort_by_key(|iface| iface.name.clone());
+                vpc.interfaces.iter_mut().for_each(|iface| {
+                    iface.ipaddrs.sort_by_key(String::clone);
+                });
+            });
+            overlay.peerings.sort_by_key(|peering| peering.name.clone());
+            overlay.peerings.iter_mut().for_each(|peering| {
+                peering.r#for.iter_mut().for_each(|peering_config| {
+                    peering_config.expose.iter_mut().for_each(|expose| {
+                        expose.ips.sort_by_key(|pip| format!("{pip:?}"));
+                        expose
+                            .r#as
+                            .sort_by_key(|as_config| format!("{as_config:?}"));
+                    });
+                });
+            });
+        }
+
+        if let Some(underlay) = &mut config.underlay {
+            underlay.vrfs.sort_by_key(|vrf| vrf.name.clone());
+            underlay.vrfs.iter_mut().for_each(|vrf| {
+                vrf.interfaces.sort_by_key(|iface| iface.name.clone());
+                vrf.interfaces.iter_mut().for_each(|iface| {
+                    iface.ipaddrs.sort_by_key(String::clone);
+                });
+                if let Some(router) = &mut vrf.router {
+                    router.neighbors.iter_mut().for_each(|neighbor| {
+                        neighbor.af_activate.sort_by_key(|af| *af);
+                    });
+                }
+            });
+        }
+
+        config
+    }
+
+    #[test]
+    fn test_bolero_gateway_config_to_external() {
+        bolero::check!()
+            .with_type::<GatewayConfig>()
+            .for_each(|config| {
+                let external = convert_from_grpc_config(config).unwrap();
+                let reserialized = convert_to_grpc_config(&external).unwrap();
+                assert_eq!(normalize_order(config), normalize_order(&reserialized));
+            });
+    }
+}

--- a/mgmt/src/grpc/converter/old_impl.rs
+++ b/mgmt/src/grpc/converter/old_impl.rs
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-#![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::must_use_candidate)] // Do not want to remove pub methods yet
-
 use net::eth::mac::Mac;
 use net::vlan::Vid;
 use std::net::{IpAddr, Ipv4Addr};

--- a/mgmt/src/grpc/converter/old_impl.rs
+++ b/mgmt/src/grpc/converter/old_impl.rs
@@ -730,7 +730,13 @@ pub fn convert_interface_to_grpc(
 ) -> Result<gateway_config::Interface, String> {
     // Get IP address safely
     //let ipaddr = get_primary_address(interface)?;
-    let interface_addresses = interface_prefixes_to_strings(interface);
+    let interface_addresses = match &interface.iftype {
+        InterfaceType::Ethernet(_) | InterfaceType::Vlan(_) | InterfaceType::Loopback => {
+            interface_prefixes_to_strings(interface)
+        }
+        InterfaceType::Vtep(vtep) => vec![format!("{}/32", vtep.local.to_string())],
+        _ => vec![],
+    };
 
     // Convert interface type
     let if_type = match &interface.iftype {

--- a/mgmt/src/grpc/converter/old_impl.rs
+++ b/mgmt/src/grpc/converter/old_impl.rs
@@ -430,7 +430,7 @@ pub fn convert_router_config_to_bgp_config(
     }
 
     let af_l2vpnevpn = AfL2vpnEvpn::new()
-        .set_adv_all_vni(true)
+        .set_adv_all_vni(router.l2vpn_evpn.is_none_or(|evpn| evpn.advertise_all_vni))
         .set_adv_default_gw(true)
         .set_adv_svi_ip(true)
         .set_adv_ipv4_unicast(true)

--- a/mgmt/src/models/external/overlay/vpc.rs
+++ b/mgmt/src/models/external/overlay/vpc.rs
@@ -34,21 +34,25 @@ pub struct Peering {
 /// Type for a fixed-sized VPC unique id
 pub struct VpcId(pub(crate) [char; 5]);
 impl VpcId {
-    pub fn new(a: char, b: char, c: char, d: char, e: char) -> Self {
-        Self([a, b, c, d, e])
+    pub fn new(chars: [char; 5]) -> Self {
+        Self(chars)
     }
 }
 impl TryFrom<&str> for VpcId {
     type Error = ConfigError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if value.len() != 5 {
+        const ID_LEN: usize = 5;
+        if value.len() != ID_LEN {
             return Err(ConfigError::BadVpcId(value.to_owned()));
         }
         if !value.chars().all(|c| c.is_ascii_alphanumeric()) {
             return Err(ConfigError::BadVpcId(value.to_owned()));
         }
-        let chars: Vec<char> = value.chars().collect();
-        Ok(VpcId::new(chars[0], chars[1], chars[2], chars[3], chars[4]))
+        let mut chars = value.chars().take(ID_LEN);
+        // unwrap cannot fail here because we checked the length earlier
+        Ok(VpcId::new(
+            [(); 5].map(|i| chars.next().unwrap_or_else(|| unreachable!())),
+        ))
     }
 }
 

--- a/mgmt/src/models/internal/routing/bgp.rs
+++ b/mgmt/src/models/internal/routing/bgp.rs
@@ -11,7 +11,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 // FRR defaults {datacenter | traditional}
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Protocol {
     #[default]
     Connected,


### PR DESCRIPTION
This PR does the following:

1. It has fuzz testing now for the converter
2. It has bug fixes/extensions for the problems the fuzzer found
3. The converter implementation has been moved from a single file to a directory
4. Updates to gateway-proto 0.2.3

Left to do in future PRs

1.  Move implementation to separate files
2. Remove `convert_*` functions and just implement in the `TryFrom` interfaces
