### PR TITLE
fix(net): Fix build warnings (dead_code false positives)

### DIFF
--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -376,6 +376,7 @@ mod contract {
         }
     }
 
+    #[allow(dead_code)] // rustc not able to infer we construct this through .with_generator()
     /// Generate valid MAC address strings in format XX:XX:XX:XX:XX:XX
     pub struct MacTestStringGenerator;
     impl ValueGenerator for MacTestStringGenerator {

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -1135,6 +1135,7 @@ mod contract {
         }
     }
 
+    #[allow(dead_code)] // rustc not able to infer we construct this through .with_generator()
     #[repr(transparent)]
     pub struct CommonHeaders;
 


### PR DESCRIPTION
:rotating_light: **Required to fix current CI failures** on dev.yml with nightly toolchain

It seems that rustc is not able to tell we're using `MacTestStringGenerator` and `CommonHeaders` through the `.with_generator()` method. Let's tell it to ignore dead code for these structs.

Fixes: 613cf78ef5da ("feat(net): Add Mac::try_from::<&str>()")
Fixes: e1b81987d3b6 ("test(net): Add fuzz tests for parsing packet headers")
