### PR TITLE
test(routing): Re-implement From<&str> trait for Prefix

### DIFF
--- a/routing/src/prefix.rs
+++ b/routing/src/prefix.rs
@@ -224,6 +224,19 @@ impl<'a> From<&'a Prefix> for &'a Ipv6Prefix {
         }
     }
 }
+/// Only for testing. Will panic with badly formatted prefix strings
+#[cfg(any(test, feature = "testing"))]
+impl From<&str> for Prefix {
+    fn from(s: &str) -> Self {
+        if let Ok(p) = Ipv4Net::from_str(s) {
+            Prefix::IPV4(Ipv4Prefix::from(p))
+        } else if let Ok(p) = Ipv6Net::from_str(s) {
+            Prefix::IPV6(Ipv6Prefix::from(p))
+        } else {
+            panic!("Not a valid IP prefix")
+        }
+    }
+}
 
 impl Display for Prefix {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -349,32 +362,36 @@ mod tests {
     #[test]
     fn test_prefix_try_from() {
         let prefix_v4_1 = Prefix::expect_from(("1.2.3.0", 24));
-        let prefix_v4_2: Prefix = Prefix::expect_from(PrefixString("1.2.3.0/24"));
-        let prefix_v4_3: Prefix = Ipv4Prefix::from_str("1.2.3.0/24")
+        let prefix_v4_2: Prefix = "1.2.3.0/24".into();
+        let prefix_v4_3: Prefix = Prefix::expect_from(PrefixString("1.2.3.0/24"));
+        let prefix_v4_4: Prefix = Ipv4Prefix::from_str("1.2.3.0/24")
             .expect("Invalid IPv4 prefix")
             .into();
-        let prefix_v4_4 = Prefix::expect_from(("1.2.3.0", 24));
-        let prefix_v4_5: Prefix = Ipv4Net::from_str("1.2.3.0/24")
+        let prefix_v4_5 = Prefix::expect_from(("1.2.3.0", 24));
+        let prefix_v4_6: Prefix = Ipv4Net::from_str("1.2.3.0/24")
             .expect("Invalid IPv4 prefix")
             .into();
         assert_eq!(prefix_v4_1, prefix_v4_2);
         assert_eq!(prefix_v4_1, prefix_v4_3);
         assert_eq!(prefix_v4_1, prefix_v4_4);
         assert_eq!(prefix_v4_1, prefix_v4_5);
+        assert_eq!(prefix_v4_1, prefix_v4_6);
 
         let prefix_v6_1 = Prefix::expect_from(("2001:a:b:c::", 64));
-        let prefix_v6_2: Prefix = Prefix::expect_from(PrefixString("2001:a:b:c::/64"));
-        let prefix_v6_3: Prefix = Ipv6Prefix::from_str("2001:a:b:c::/64")
+        let prefix_v6_2: Prefix = "2001:a:b:c::/64".into();
+        let prefix_v6_3: Prefix = Prefix::expect_from(PrefixString("2001:a:b:c::/64"));
+        let prefix_v6_4: Prefix = Ipv6Prefix::from_str("2001:a:b:c::/64")
             .expect("Invalid IPv6 prefix")
             .into();
-        let prefix_v6_4 = Prefix::expect_from(("2001:a:b:c::", 64));
-        let prefix_v6_5: Prefix = Ipv6Net::from_str("2001:a:b:c::/64")
+        let prefix_v6_5 = Prefix::expect_from(("2001:a:b:c::", 64));
+        let prefix_v6_6: Prefix = Ipv6Net::from_str("2001:a:b:c::/64")
             .expect("Invalid IPv6 prefix")
             .into();
         assert_eq!(prefix_v6_1, prefix_v6_2);
         assert_eq!(prefix_v6_1, prefix_v6_3);
         assert_eq!(prefix_v6_1, prefix_v6_4);
         assert_eq!(prefix_v6_1, prefix_v6_5);
+        assert_eq!(prefix_v6_1, prefix_v6_6);
     }
 
     #[test]


### PR DESCRIPTION
The trait was first implemented in commit 39abac4465e9. It was later removed in commit 4caec75ebb02, seemingly because the introduction of the `PrefixString` struct made it less relevant to build prefixes from strings. But it remains faster, and easier to read, to use the `"1.2.3.4/24".into()` notation to build numerous prefixes for unit tests, so let's re-add support for it.

Used in #445, #470, #529.