### PR TITLE
fix(routing): Move mac_address dependency to toplevel Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ futures = { version = "0.3.31", default-features = false, features = [] }
 ipnet = { version = "2.11.0", default-features = false, features = [] }
 iptrie = { version = "0.10.3", default-features = false, features = [] }
 left-right = { version = "0.11.5" }
-
+mac_address= { version = "1.1.7", default-features = false, features = [] }
 mio = { version = "1.0.4", default-features = false, features = [] }
 multi_index_map = { version = "0.15.0", default-features = false, features = [] }
 netdev = { version = "0.35.1", default-features = false, features = [] }

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -16,7 +16,7 @@ ipnet = { workspace = true }
 iptrie = { workspace = true }
 left-right = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
-mac_address= {version = "1.1.7"}
+mac_address= { workspace = true }
 net = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
Move the declaration of the mac_address dependency (with its version and features) from routing/Cargo.toml to the toplevel Cargo.toml, for consistency.

This issue was found because it broke the bump.yml GitHub workflow, given that it's the routing/Cargo.toml file that gets updated, and we don't "git add" it which results in no added changes to commit.

Link: https://github.com/githedgehog/dataplane/actions/runs/15457829853/job/43513283734
Fixes: 31a7771f2b9d
