### PR TITLE
chore(mgmt): Bump gateway-proto to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,8 +1235,8 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.3"
-source = "git+https://github.com/githedgehog/gateway-proto#7859015d1326cee10719ddac75b62b4a3602b1e1"
+version = "0.2.4"
+source = "git+https://github.com/githedgehog/gateway-proto#87ce7a9e6429d082fc8c5735b15e157a99ddb0d9"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dpdk-sys = { path = "./dpdk-sys", package = "dataplane-dpdk-sys" }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpdk-sysroot-helper" }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = "1.0.1" }
 errno = { path = "./errno", package = "dataplane-errno" }
-gateway_config = { git = "https://github.com/githedgehog/gateway-proto", version = "0.2.3" }
+gateway_config = { git = "https://github.com/githedgehog/gateway-proto", version = "0.2.4" }
 id = { path = "./id", package = "dataplane-id" }
 interface-manager = { path = "./interface-manager", package = "dataplane-interface-manager" }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt"}


### PR DESCRIPTION
Do not merge until [gateway-proto#29](https://github.com/githedgehog/gateway-proto/pull/29) is merged.

Now that dataplane uses Rust 1.87.0 we can use
gateway-proto 0.2.4 code that requires Rust 1.87.0