### PR TITLE
Have gRPC conversion respect mac addresses for Vtep interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -1236,8 +1236,8 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.5"
-source = "git+https://github.com/githedgehog/gateway-proto#ee2154588bfd0ba214ac292300cdca678b160dad"
+version = "0.2.6"
+source = "git+https://github.com/githedgehog/gateway-proto?tag=v0.2.6#e17833b6a1403aa76a8fe1415f10608b5bca6aec"
 dependencies = [
  "async-trait",
  "bolero",
@@ -1507,15 +1507,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2153,7 +2144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.102",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dpdk-sys = { path = "./dpdk-sys", package = "dataplane-dpdk-sys" }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpdk-sysroot-helper" }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = "1.0.1" }
 errno = { path = "./errno", package = "dataplane-errno" }
-gateway_config = { git = "https://github.com/githedgehog/gateway-proto", version = "0.2.5" }
+gateway_config = { git = "https://github.com/githedgehog/gateway-proto", tag="v0.2.6", version = "0.2.5" }
 id = { path = "./id", package = "dataplane-id" }
 interface-manager = { path = "./interface-manager", package = "dataplane-interface-manager" }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt"}

--- a/mgmt/src/grpc/converter/interface.rs
+++ b/mgmt/src/grpc/converter/interface.rs
@@ -112,7 +112,9 @@ impl TryFrom<&gateway_config::Interface> for InterfaceConfig {
                         let addr_mask = addr.parse::<InterfaceAddress>().map_err(|e| {
                             format!("Invalid interface address \"{addr}\" for VTEP interface: {e}",)
                         })?;
-                        if addr_mask.mask_len == 32 {
+                        if !addr_mask.address.is_ipv4() {
+                            Err("VTEP interface requires an IPv4 address".to_string())
+                        } else if addr_mask.mask_len == 32 {
                             Ok(addr_mask.address)
                         } else {
                             Err("VTEP interface requires a /32 IP address".to_string())

--- a/mgmt/src/grpc/converter/interface.rs
+++ b/mgmt/src/grpc/converter/interface.rs
@@ -109,7 +109,7 @@ impl TryFrom<&gateway_config::Interface> for InterfaceConfig {
                 }?;
 
                 InterfaceType::Vtep(IfVtepConfig {
-                    mac: None,
+                    mac: mac.map(|mac| mac.inner()),
                     vni: None,
                     ttl: None,
                     local,


### PR DESCRIPTION
* Respect Vtep mac addresses from gRPC
* Make sure that interface mac addresses are valid unicast, non-zero, source macs

Fixes #581