### PR TITLE
chore(codecov): Add Codecov config file to disable comments in PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Comments in Pull Requests discussions from the Codecov bots are intrusive, in the sense that they break the flow of the conversation, and they also generate email notifications to all contributors subscribed to the Pull Request.

Let's disable the comments. The status check at the bottom of the Pull Requests are enough to get some signal about the change in coverage.

I wish there was a way to configure this in Codecov's online interface, or at least to hide the config file under `.github/` or as a dotfile, but it seems that none of these is possible :cry. The toplevel config file seems to be our only option.

Link: https://docs.codecov.com/docs/pull-request-comments#disable-comment
