### PR TITLE
chore: Sync version of gateway-proto to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,8 +1236,8 @@ dependencies = [
 
 [[package]]
 name = "gateway_config"
-version = "0.2.6"
-source = "git+https://github.com/githedgehog/gateway-proto?tag=v0.2.6#e17833b6a1403aa76a8fe1415f10608b5bca6aec"
+version = "0.9.0"
+source = "git+https://github.com/githedgehog/gateway-proto?tag=v0.9.0#de785f6082d5c708304cfb95d15cbeeb7196f78b"
 dependencies = [
  "async-trait",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dpdk-sys = { path = "./dpdk-sys", package = "dataplane-dpdk-sys" }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpdk-sysroot-helper" }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", version = "1.0.1" }
 errno = { path = "./errno", package = "dataplane-errno" }
-gateway_config = { git = "https://github.com/githedgehog/gateway-proto", tag="v0.2.6", version = "0.2.5" }
+gateway_config = { git = "https://github.com/githedgehog/gateway-proto", tag="v0.9.0", version = "0.9.0" }
 id = { path = "./id", package = "dataplane-id" }
 interface-manager = { path = "./interface-manager", package = "dataplane-interface-manager" }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt"}


### PR DESCRIPTION
gateway-proto cargo crate version was not synced with repo version. Now it is synced and the version is 0.9.0