### PR TITLE
Miscellaneous CLI fixes for dataplane

### DIFF
--- a/dataplane/src/args.rs
+++ b/dataplane/src/args.rs
@@ -42,7 +42,7 @@ pub(crate) struct CmdArgs {
         long,
         value_name = "ADDRESS",
         default_value = "[::1]:50051",
-        help = "IP Address and port or UNIX socket path to listen for managment connections"
+        help = "IP Address and port or UNIX socket path to listen for management connections"
     )]
     grpc_address: String,
 
@@ -55,21 +55,21 @@ pub(crate) struct CmdArgs {
         value_name = "Unix socket for FRR to send messages to the dataplane control plane interface",
         default_value = DEFAULT_DP_UX_PATH
     )]
-    cpi_sock_path: Option<String>,
+    cpi_sock_path: String,
 
     #[arg(
         long,
         value_name = "Unix socket to listen for dataplane cli connections",
         default_value = DEFAULT_DP_UX_PATH_CLI
     )]
-    cli_sock_path: Option<String>,
+    cli_sock_path: String,
 
     #[arg(
         long,
         value_name = "Unix socket to connect to FRR agent that controls FRR configuration reload",
         default_value = DEFAULT_FRR_AGENT_PATH
     )]
-    frr_agent_path: Option<String>,
+    frr_agent_path: String,
 }
 
 impl CmdArgs {
@@ -162,18 +162,12 @@ impl CmdArgs {
     }
 
     pub fn cpi_sock_path(&self) -> String {
-        self.cpi_sock_path
-            .clone()
-            .unwrap_or(DEFAULT_DP_UX_PATH.to_string())
+        self.cpi_sock_path.clone()
     }
     pub fn cli_sock_path(&self) -> String {
-        self.cli_sock_path
-            .clone()
-            .unwrap_or(DEFAULT_DP_UX_PATH_CLI.to_string())
+        self.cli_sock_path.clone()
     }
     pub fn frr_agent_path(&self) -> String {
-        self.frr_agent_path
-            .clone()
-            .unwrap_or(DEFAULT_FRR_AGENT_PATH.to_string())
+        self.frr_agent_path.clone()
     }
 }

--- a/dataplane/src/args.rs
+++ b/dataplane/src/args.rs
@@ -52,21 +52,24 @@ pub(crate) struct CmdArgs {
 
     #[arg(
         long,
-        value_name = "Unix socket for FRR to send messages to the dataplane control plane interface",
+        value_name = "CPI Unix socket path",
+        help = "Unix socket for FRR to send route update messages to the dataplane",
         default_value = DEFAULT_DP_UX_PATH
     )]
     cpi_sock_path: String,
 
     #[arg(
         long,
-        value_name = "Unix socket to listen for dataplane cli connections",
+        value_name = "CLI Unix socket path",
+        help = "Unix socket to listen for dataplane cli connections",
         default_value = DEFAULT_DP_UX_PATH_CLI
     )]
     cli_sock_path: String,
 
     #[arg(
         long,
-        value_name = "Unix socket to connect to FRR agent that controls FRR configuration reload",
+        value_name = "FRR Agent Unix socket path",
+        help = "Unix socket to connect to FRR agent that controls FRR configuration reload",
         default_value = DEFAULT_FRR_AGENT_PATH
     )]
     frr_agent_path: String,

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -172,7 +172,7 @@ fi
 "${SUDO}" --preserve-env docker run \
   --rm \
   --interactive \
-  --mount "type=bind,source=${1},target=${1},readonly=true,bind-propagation=rprivate" \
+  --mount "type=bind,source=$(readlink -e "${1}"),target=$(readlink -e "${1}"),readonly=true,bind-propagation=rprivate" \
   --mount "type=bind,source=${project_dir},target=${project_dir},readonly=true,bind-propagation=rprivate" \
   --mount "type=bind,source=${project_dir}/target,target=${project_dir}/target,readonly=false,bind-propagation=rprivate" \
   --mount "type=bind,source=$(get_docker_sock),target=$(get_docker_sock),readonly=false,bind-propagation=rprivate" \


### PR DESCRIPTION
* Address all copilot comments from #601 
* Fix path bug in `test-runner.sh` so that `just cargo run -p dataplane` works as expected
* Fix help messages for cli arguments.