### PR TITLE
Integration mgmt-routing - part-1

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -23,7 +23,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::packet_processor::start_router;
 use mgmt::processor::launch::start_mgmt;
-use routing::RouterConfigBuilder;
+use routing::RouterParamsBuilder;
 
 fn init_logging() {
     tracing_subscriber::fmt()
@@ -74,7 +74,7 @@ fn main() {
     };
 
     /* router configuration */
-    let Ok(config) = RouterConfigBuilder::default()
+    let Ok(config) = RouterParamsBuilder::default()
         .cli_sock_path(args.cli_sock_path())
         .cpi_sock_path(args.cpi_sock_path())
         .frr_agent_path(args.frr_agent_path())

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -17,7 +17,7 @@ use pipeline::sample_nfs::PacketDumper;
 use routing::atable::atablerw::AtableReader;
 use routing::fib::fibtable::FibTableReader;
 use routing::interfaces::iftablerw::IfTableReader;
-use routing::{Router, RouterConfig, RouterError};
+use routing::{Router, RouterError, RouterParams};
 
 /// Build the pipeline for a router. The composition of the pipeline (in stages)
 /// is currently hard-coded.
@@ -45,9 +45,9 @@ fn setup_routing_pipeline<Buf: PacketBufferMut>(
 /// Start a router and provide the associated pipeline
 #[allow(unused)]
 pub fn start_router<Buf: PacketBufferMut>(
-    config: RouterConfig,
+    params: RouterParams,
 ) -> Result<(Router, DynPipeline<Buf>), RouterError> {
-    let router = Router::new(config)?;
+    let router = Router::new(params)?;
     let pipeline = setup_routing_pipeline(
         router.get_iftabler(),
         router.get_fibtr(),

--- a/mgmt/src/frr/frrmi/mod.rs
+++ b/mgmt/src/frr/frrmi/mod.rs
@@ -318,7 +318,7 @@ pub mod tests {
         let mut config = GwConfig::new(external);
         config.validate().expect("Validation should succeed");
         config.build_internal_config().expect("Should succeed");
-        let rendered = config.internal.as_ref().unwrap().render(&config);
+        let rendered = config.internal.as_ref().unwrap().render(&config.genid());
 
         /* start faked frr-agent */
         let frr_agent = fake_frr_agent("/tmp/frrmi-test/frr-agent.sock").await;

--- a/mgmt/src/frr/renderer/bgp.rs
+++ b/mgmt/src/frr/renderer/bgp.rs
@@ -199,7 +199,7 @@ fn bgp_neigh_bool_switches(neigh: &BgpNeighbor, prefix: &str) -> ConfigBuilder {
 
     /* extended link bw */
     if neigh.extended_link_bandwidth {
-        cfg += format!(" {} allowas-in", &prefix);
+        cfg += format!(" {} extended-link-bandwidth", &prefix);
     }
 
     /* extended link bw */

--- a/mgmt/src/frr/renderer/mod.rs
+++ b/mgmt/src/frr/renderer/mod.rs
@@ -14,15 +14,15 @@ pub mod statics;
 pub mod vrf;
 
 use crate::frr::renderer::builder::{ConfigBuilder, Render};
-use crate::models::external::gwconfig::GwConfig;
+use crate::models::external::gwconfig::GenId;
 use crate::models::internal::InternalConfig;
 
-fn render_metadata(config: &GwConfig) -> String {
-    format!("! config for gen {}", config.external.genid)
+fn render_metadata(genid: &GenId) -> String {
+    format!("! config for gen {}", genid)
 }
 
 impl Render for InternalConfig {
-    type Context = GwConfig;
+    type Context = GenId;
     type Output = ConfigBuilder;
     fn render(&self, config: &Self::Context) -> Self::Output {
         let mut cfg = ConfigBuilder::new();

--- a/mgmt/src/models/external/overlay/mod.rs
+++ b/mgmt/src/models/external/overlay/mod.rs
@@ -70,7 +70,6 @@ impl Overlay {
 
         /* empty collections used for validation */
         self.vpc_table.clear_vnis();
-        self.vpc_table.clear_ids();
 
         Ok(())
     }

--- a/mgmt/src/models/internal/routing/vrf.rs
+++ b/mgmt/src/models/internal/routing/vrf.rs
@@ -31,6 +31,7 @@ pub struct VrfConfig {
     pub ospf: Option<Ospf>,
     #[multi_index(ordered_unique)]
     pub vpc_id: Option<VpcId>,
+    pub description: Option<String>, /* informational */
 }
 
 impl Default for VrfConfig {
@@ -46,6 +47,7 @@ impl Default for VrfConfig {
             interfaces: InterfaceConfigTable::new(),
             vpc_id: None,
             ospf: None,
+            description: None,
         }
     }
 }
@@ -65,6 +67,10 @@ impl VrfConfig {
             panic!("Can't set vpc_id for default vrf");
         }
         self.vpc_id = Some(vpc_id);
+        self
+    }
+    pub fn set_description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_owned());
         self
     }
     pub fn set_table_id(mut self, tableid: RouteTableId) -> Self {

--- a/mgmt/src/processor/confbuild.rs
+++ b/mgmt/src/processor/confbuild.rs
@@ -156,8 +156,9 @@ fn vpc_vrf_bgp_config(vpc: &Vpc, asn: u32, router_id: Option<Ipv4Addr>) -> BgpCo
 fn vpc_vrf_config(vpc: &Vpc, asn: u32, router_id: Option<Ipv4Addr>) -> VrfConfig {
     debug!("Building VRF config for vpc '{}'", vpc.name);
     /* build vrf config */
-    let mut vrf_cfg =
-        VrfConfig::new(&vpc.vrf_name(), Some(vpc.vni), false).set_vpc_id(vpc.id.clone());
+    let mut vrf_cfg = VrfConfig::new(&vpc.vrf_name(), Some(vpc.vni), false)
+        .set_vpc_id(vpc.id.clone())
+        .set_description(&vpc.name);
 
     /* set table-id: table ids should be unique per VRF. We should track them and pick unused ones.
     Setting this to the VNI is not too bad atm, except that we should avoid picking reserved values

--- a/mgmt/src/processor/display.rs
+++ b/mgmt/src/processor/display.rs
@@ -15,7 +15,7 @@ use crate::processor::gwconfigdb::GwConfigDatabase;
 
 macro_rules! CONFIGDB_TBL_FMT {
     () => {
-        " {:>6} {:<25} {:<25} {:<25} {:<10}"
+        " {:>6} {:<25} {:<25} {:<25} {:>6} {:<10}"
     };
 }
 fn fmt_configdb_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -24,7 +24,7 @@ fn fmt_configdb_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Re
         "{}",
         format_args!(
             CONFIGDB_TBL_FMT!(),
-            "GenId", "created", "applied", "replaced", "active"
+            "GenId", "created", "applied", "replaced", "by", "active"
         )
     )
 }
@@ -33,14 +33,14 @@ fn fmt_gwconfig_summary(
     genid: GenId,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    let created = DateTime::<Utc>::from(meta.created).format("%H:%M:%S on %Y/%m/%d");
-    let apply_time = if let Some(time) = meta.applied {
+    let created = DateTime::<Utc>::from(meta.create_t).format("%H:%M:%S on %Y/%m/%d");
+    let apply_time = if let Some(time) = meta.apply_t {
         let time = DateTime::<Utc>::from(time).format("%H:%M:%S on %Y/%m/%d");
         format!("{time}")
     } else {
         "--".to_string()
     };
-    let unapply_time = if let Some(time) = meta.unapplied {
+    let replace_time = if let Some(time) = meta.replace_t {
         let time = DateTime::<Utc>::from(time).format("%H:%M:%S on %Y/%m/%d");
         format!("{time}")
     } else {
@@ -48,12 +48,16 @@ fn fmt_gwconfig_summary(
     };
 
     let applied = if meta.is_applied { "yes" } else { "no" };
+    let replacement = meta
+        .replacement
+        .map(|genid| genid.to_string())
+        .unwrap_or("--".to_string());
     writeln!(
         f,
         "{}",
         format_args!(
             CONFIGDB_TBL_FMT!(),
-            genid, created, apply_time, unapply_time, applied
+            genid, created, apply_time, replace_time, replacement, applied
         )
     )
 }

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -29,7 +29,7 @@ impl GwConfigDatabase {
         configdb
     }
     pub fn add(&mut self, config: GwConfig) {
-        debug!("Adding config '{}' to config db...", config.genid());
+        debug!("Storing config '{}' in config db...", config.genid());
         self.configs.insert(config.external.genid, config);
     }
     #[allow(clippy::len_without_is_empty)]
@@ -47,15 +47,6 @@ impl GwConfigDatabase {
     }
     pub fn get_mut(&mut self, generation: GenId) -> Option<&mut GwConfig> {
         self.configs.get_mut(&generation)
-    }
-    pub fn unmark_current(&mut self) {
-        #[allow(clippy::collapsible_if)]
-        if let Some(genid) = &self.current {
-            if let Some(config) = self.configs.get_mut(genid) {
-                config.set_applied(false);
-                debug!("Marked config with genid {genid} as inactive");
-            }
-        }
     }
     pub fn remove(&mut self, genid: GenId) -> ConfigResult {
         if genid == ExternalConfig::BLANK_GENID {
@@ -90,10 +81,11 @@ impl GwConfigDatabase {
     }
     /// Get a reference to the config currently applied, if any.
     pub fn get_current_config(&self) -> Option<&GwConfig> {
-        if let Some(genid) = self.current {
-            self.get(genid)
-        } else {
-            None
-        }
+        self.current.and_then(|genid| self.get(genid))
+    }
+
+    /// Get a mutable reference to the config currently applied, if any.
+    pub fn get_current_config_mut(&mut self) -> Option<&mut GwConfig> {
+        self.current.and_then(|genid| self.get_mut(genid))
     }
 }

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -341,7 +341,7 @@ fn generate_router_vrf_config(
             .map(|p| p.route_table_id)
             .unwrap_or_else(|| unreachable!());
         let vrfconfig = RouterVrfConfig::new(kvrf.index.into(), kvrf.name.as_ref())
-            .set_vni_opt(vrf.vni)
+            .set_vni(vrf.vni)
             .set_description(&vrf.description.clone().unwrap_or_else(|| "--".to_string()))
             .set_tableid(tableid);
         router_config.add_vrf(vrfconfig);

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -289,17 +289,15 @@ impl VpcManager<RequiredInformationBase> {
 /// Apply config over frrmi with frr-agent
 async fn apply_config_frr(
     frrmi: &mut FrrMi,
-    config: &GwConfig,
+    genid: GenId,
     internal: &InternalConfig,
 ) -> ConfigResult {
-    let genid = config.genid();
-
     debug!("Generating FRR config for genid {genid}...");
 
-    let rendered = internal.render(config);
+    let rendered = internal.render(&genid);
 
     frrmi
-        .apply_config(config.genid(), &rendered)
+        .apply_config(genid, &rendered)
         .await
         .map_err(|e| ConfigError::FailureApply(format!("Error applying FRR config: {e}")))?;
 
@@ -341,7 +339,7 @@ async fn apply_gw_config(
     vpc_mgr.apply_config(internal, genid).await?;
 
     /* apply config with frrmi to frr-agent */
-    apply_config_frr(frrmi, config, internal).await?;
+    apply_config_frr(frrmi, genid, internal).await?;
 
     /* tell router about vtep as it won't learn it from frr */
     if let Some(vconfig) = internal.get_vtep() {

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -28,7 +28,6 @@ use tracing::{debug, error, info, warn};
 use net::interface::Interface;
 use net::interface::display::MultiIndexInterfaceMapView;
 use routing::ctl::RouterCtlSender;
-use routing::evpn::Vtep;
 
 /// A request type to the `ConfigProcessor`
 #[derive(Debug)]
@@ -341,11 +340,6 @@ async fn apply_gw_config(
     /* apply config with frrmi to frr-agent */
     apply_config_frr(frrmi, genid, internal).await?;
 
-    /* tell router about vtep as it won't learn it from frr */
-    if let Some(vconfig) = internal.get_vtep() {
-        let vtep = Vtep::with_ip_and_mac(vconfig.address.into(), vconfig.mac.into());
-        router_ctl.set_vtep(vtep).await;
-    }
     info!("Successfully applied config for genid {genid}");
     Ok(())
 }

--- a/mgmt/src/processor/tests.rs
+++ b/mgmt/src/processor/tests.rs
@@ -47,7 +47,7 @@ pub mod test {
     use crate::frr::frrmi::FrrMi;
     use crate::frr::frrmi::tests::fake_frr_agent;
     use crate::processor::proc::ConfigProcessor;
-    use routing::{Router, RouterConfigBuilder};
+    use routing::{Router, RouterParamsBuilder};
     use tracing::debug;
 
     /* OVERLAY config sample builders */
@@ -315,7 +315,7 @@ pub mod test {
         let config = GwConfig::new(external);
 
         /* build router config */
-        let router_config = RouterConfigBuilder::default()
+        let router_config = RouterParamsBuilder::default()
             .cpi_sock_path("/tmp/cpi.sock")
             .cli_sock_path("/tmp/cli.sock")
             .frr_agent_path("/tmp/frr-agent.sock")

--- a/mgmt/src/vpc_manager/mod.rs
+++ b/mgmt/src/vpc_manager/mod.rs
@@ -299,7 +299,7 @@ impl Vpc {
 impl TryFrom<&InternalConfig> for RequiredInformationBase {
     type Error = RequiredInformationBaseBuilderError;
 
-    #[tracing::instrument(level = "debug", ret)]
+    #[tracing::instrument(level = "trace", ret)]
     fn try_from(internal: &InternalConfig) -> Result<Self, Self::Error> {
         let mut rib = RequiredInformationBaseBuilder::default();
         let mut interfaces = MultiIndexInterfaceSpecMap::default();

--- a/net/src/interface/display.rs
+++ b/net/src/interface/display.rs
@@ -132,3 +132,22 @@ impl Display for MultiIndexInterfaceMap {
         Ok(())
     }
 }
+
+pub struct MultiIndexInterfaceMapView<'a, F>
+where
+    F: Fn(&Interface) -> bool,
+{
+    pub map: &'a MultiIndexInterfaceMap,
+    pub filter: &'a F,
+}
+
+impl<F: for<'a> Fn(&'a Interface) -> bool> Display for MultiIndexInterfaceMapView<'_, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_kernel_interface_heading(f)?;
+        let interfaces = self.map.iter().filter(|(_, iface)| (self.filter)(iface));
+        for (_, iface) in interfaces {
+            iface.fmt(f)?;
+        }
+        Ok(())
+    }
+}

--- a/net/src/interface/display.rs
+++ b/net/src/interface/display.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Display trait implementations
+
+use crate::interface::MultiIndexInterfaceMap;
+use crate::interface::{AdminState, OperationalState};
+use crate::interface::{
+    BridgeProperties, Interface, InterfaceProperties, VrfProperties, VtepProperties,
+};
+use std::fmt::Display;
+use std::string::ToString;
+
+macro_rules! KERNEL_INTERFACE_FMT {
+    () => {
+        " {:>8} {:>8} {:>16} {:>8} {:>20} {:>8} {:>8} {:>8} {:}"
+    };
+}
+fn fmt_kernel_interface_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            KERNEL_INTERFACE_FMT!(),
+            "index", "contrl", "name", "mtu", "mac", "Adm", "Oper", "type", "properties"
+        )
+    )
+}
+
+impl Display for AdminState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdminState::Down => write!(f, "down"),
+            AdminState::Up => write!(f, "up"),
+        }
+    }
+}
+impl Display for OperationalState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OperationalState::Down => write!(f, "down"),
+            OperationalState::Up => write!(f, "up"),
+            OperationalState::Unknown => write!(f, "unknown"),
+            OperationalState::Complex => write!(f, "complex"),
+        }
+    }
+}
+
+impl Display for BridgeProperties {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "vlan_filtering: {} vlan-proto: {:?}",
+            self.vlan_filtering, self.vlan_protocol,
+        )
+    }
+}
+impl Display for VtepProperties {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vni = self
+            .vni
+            .as_ref()
+            .map_or("--".to_string(), ToString::to_string);
+        let ttl = self
+            .ttl
+            .as_ref()
+            .map_or("--".to_string(), ToString::to_string);
+        let local = self
+            .local
+            .as_ref()
+            .map_or("--".to_string(), ToString::to_string);
+        write!(f, "vni: {vni} ttl: {ttl} local: {local}")
+    }
+}
+impl Display for VrfProperties {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "table-id: {}", self.route_table_id)
+    }
+}
+impl Display for InterfaceProperties {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InterfaceProperties::Bridge(bridge) => bridge.fmt(f),
+            InterfaceProperties::Vrf(vrf) => vrf.fmt(f),
+            InterfaceProperties::Vtep(vtep) => vtep.fmt(f),
+            InterfaceProperties::Other => write!(f, "other"),
+        }
+    }
+}
+
+fn ifproperty_to_str(properties: &InterfaceProperties) -> &'static str {
+    match properties {
+        InterfaceProperties::Bridge(_) => "bridge",
+        InterfaceProperties::Vrf(_) => "vrf",
+        InterfaceProperties::Vtep(_) => "vtep",
+        InterfaceProperties::Other => "other",
+    }
+}
+
+impl Display for Interface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mac = self.mac.map(|mac| mac.to_string()).unwrap_or_default();
+        let ctl = self
+            .controller
+            .map(|mac| mac.to_string())
+            .unwrap_or_default();
+        let mtu = self.mtu.map(|mtu| mtu.to_string()).unwrap_or_default();
+        writeln!(
+            f,
+            "{}",
+            format_args!(
+                KERNEL_INTERFACE_FMT!(),
+                self.index.to_string(),
+                ctl,
+                self.name.to_string(),
+                mtu,
+                mac,
+                self.admin_state.to_string(),
+                self.operational_state.to_string(),
+                ifproperty_to_str(&self.properties),
+                self.properties.to_string(),
+            )
+        )
+    }
+}
+impl Display for MultiIndexInterfaceMap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_kernel_interface_heading(f)?;
+        for iface in self.iter_by_index() {
+            iface.fmt(f)?;
+        }
+        Ok(())
+    }
+}

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -18,7 +18,7 @@ use std::fmt::{Debug, Display, Formatter};
 use tracing::error;
 
 mod bridge;
-mod display;
+pub mod display;
 mod vrf;
 mod vtep;
 

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -316,6 +316,15 @@ impl Interface {
     pub fn is_bridge(&self) -> bool {
         matches!(self.properties, InterfaceProperties::Bridge(_))
     }
+    /// Provide a reference to [`VrfProperties`] if the interface has
+    /// such a property
+    #[must_use]
+    pub fn get_vrf_properties(&self) -> Option<&VrfProperties> {
+        match &self.properties {
+            InterfaceProperties::Vrf(properties) => Some(properties),
+            _ => None,
+        }
+    }
 }
 
 /// Interface-specific properties.

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -18,6 +18,7 @@ use std::fmt::{Debug, Display, Formatter};
 use tracing::error;
 
 mod bridge;
+mod display;
 mod vrf;
 mod vtep;
 

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -299,6 +299,24 @@ pub struct Interface {
     pub properties: InterfaceProperties,
 }
 
+impl Interface {
+    /// Tell if [`Interface`] is a VRF
+    #[must_use]
+    pub fn is_vrf(&self) -> bool {
+        matches!(self.properties, InterfaceProperties::Vrf(_))
+    }
+    /// Tell if [`Interface`] is a vxlan interface
+    #[must_use]
+    pub fn is_vtep(&self) -> bool {
+        matches!(self.properties, InterfaceProperties::Vtep(_))
+    }
+    /// Tell if [`Interface`] is a bridge interface
+    #[must_use]
+    pub fn is_bridge(&self) -> bool {
+        matches!(self.properties, InterfaceProperties::Bridge(_))
+    }
+}
+
 /// Interface-specific properties.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub enum InterfaceProperties {

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -20,7 +20,7 @@ mac_address= { workspace = true }
 net = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 dplane-rpc = { workspace = true }

--- a/routing/src/config/interface.rs
+++ b/routing/src/config/interface.rs
@@ -112,7 +112,11 @@ impl ReconfigInterfacePlan {
         iftw: &mut IfTableWriter,
         vrftable: &VrfTable,
     ) -> Result<(), RouterError> {
-        self.enforce_deletions(iftw)?;
+        if false {
+            // disabled because we still auto-learn interfaces. If we'd do this
+            // we'd delete auto-learnt interfaces which is not what we want
+            self.enforce_deletions(iftw)?;
+        }
         self.enforce_changes(iftw, vrftable)?;
         self.enforce_additions(iftw, vrftable)?;
         debug!("Successfully applied Interface configurations");

--- a/routing/src/config/interface.rs
+++ b/routing/src/config/interface.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Router interface configuration
+
+#[allow(unused)]
+use tracing::debug;
+
+use crate::RouterError;
+use crate::config::RouterConfig;
+use crate::interfaces::iftable::IfTable;
+use crate::interfaces::interface::IfIndex;
+
+use crate::interfaces::iftablerw::IfTableWriter;
+use crate::interfaces::interface::{AttachConfig, Attachment};
+use crate::interfaces::interface::{Interface, RouterInterfaceConfig};
+use crate::rib::VrfTable;
+///////////////////////////////////////////////////////////////////////////////////////
+/// Structure used to summarize a plan for reconfiguring [`Interface`]s
+///////////////////////////////////////////////////////////////////////////////////////
+pub(crate) struct ReconfigInterfacePlan {
+    #[allow(unused)]
+    to_keep: Vec<IfIndex>, /* interfaces to keep as is */
+    to_delete: Vec<IfIndex>,               /* interfaces to delete */
+    to_modify: Vec<RouterInterfaceConfig>, /* interfaces to change */
+    to_add: Vec<RouterInterfaceConfig>,    /* interfaces to add */
+}
+
+impl ReconfigInterfacePlan {
+    ///////////////////////////////////////////////////////////////////////////////////
+    /// Build a [`ReconfigInterfacePlan`] given a [`RouterConfig`] and an [`IfTable`]
+    ///////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    pub(crate) fn generate(config: &RouterConfig, iftable: &IfTable) -> Self {
+        let mut to_delete: Vec<IfIndex> = vec![];
+        let mut to_keep: Vec<IfIndex> = vec![];
+        let mut to_modify: Vec<RouterInterfaceConfig> = vec![];
+        let mut to_add: Vec<RouterInterfaceConfig> = vec![];
+
+        for iface in iftable.values() {
+            let ifindex = iface.ifindex;
+            if let Some(cfg) = config.get_interface(ifindex) {
+                if iface.as_config() != *cfg {
+                    to_modify.push(cfg.clone());
+                } else {
+                    to_keep.push(ifindex);
+                }
+            } else {
+                to_delete.push(ifindex);
+            }
+        }
+        for cfg in config.interfaces() {
+            if !iftable.contains(cfg.ifindex.into()) {
+                to_add.push(cfg.clone());
+            }
+        }
+        ReconfigInterfacePlan {
+            to_keep,
+            to_delete,
+            to_modify,
+            to_add,
+        }
+    }
+
+    fn enforce_deletions(&self, iftw: &mut IfTableWriter) -> Result<(), RouterError> {
+        for ifindex in &self.to_delete {
+            iftw.del_interface((*ifindex).into());
+        }
+        Ok(())
+    }
+    fn enforce_additions(
+        &self,
+        iftw: &mut IfTableWriter,
+        vrftable: &VrfTable,
+    ) -> Result<(), RouterError> {
+        for ifconfig in &self.to_add {
+            iftw.add_interface(ifconfig.clone())?;
+            // attach
+            match ifconfig.attach_cfg {
+                Some(AttachConfig::VRF(vrfid)) => {
+                    iftw.attach_interface_to_vrf(ifconfig.ifindex, vrfid, vrftable)?
+                }
+                Some(AttachConfig::BD) => todo!(),
+                _ => {}
+            };
+        }
+        Ok(())
+    }
+    fn enforce_changes(
+        &self,
+        iftw: &mut IfTableWriter,
+        vrftable: &VrfTable,
+    ) -> Result<(), RouterError> {
+        for ifconfig in &self.to_modify {
+            debug!("Interface w/ ifindex {} requires changes", ifconfig.ifindex);
+            iftw.mod_interface(ifconfig.clone())?;
+            // attach / re-attach / detach
+            match ifconfig.attach_cfg {
+                None => iftw.detach_interface(ifconfig.ifindex),
+                Some(AttachConfig::VRF(vrfid)) => {
+                    iftw.attach_interface_to_vrf(ifconfig.ifindex, vrfid, vrftable)?
+                }
+                Some(AttachConfig::BD) => todo!(),
+            };
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub(crate) fn apply(
+        &self,
+        iftw: &mut IfTableWriter,
+        vrftable: &VrfTable,
+    ) -> Result<(), RouterError> {
+        self.enforce_deletions(iftw)?;
+        self.enforce_changes(iftw, vrftable)?;
+        self.enforce_additions(iftw, vrftable)?;
+        debug!("Successfully applied Interface configurations");
+        Ok(())
+    }
+}
+
+impl Interface {
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    /// Build the [`RouterInterfaceConfig`] object that would lead to having a certain [`Interface`]
+    /// in its current state.
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    pub(crate) fn as_config(&self) -> RouterInterfaceConfig {
+        RouterInterfaceConfig {
+            ifindex: self.ifindex,
+            name: self.name.clone(),
+            description: self.description.to_owned(),
+            iftype: self.iftype.clone(),
+            admin_state: self.admin_state,
+            attach_cfg: self
+                .attachment
+                .as_ref()
+                .map(|attachment| attachment.as_config()),
+        }
+    }
+}
+
+impl Attachment {
+    #[must_use]
+    pub(crate) fn as_config(&self) -> AttachConfig {
+        match self {
+            Attachment::VRF(fibr) => {
+                AttachConfig::VRF(fibr.get_id().unwrap().as_u32()) // FIXME
+            }
+            Attachment::BD => AttachConfig::BD,
+        }
+    }
+}

--- a/routing/src/config/mod.rs
+++ b/routing/src/config/mod.rs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Router configuration
+
+#![allow(unused)]
+
+mod interface;
+mod vrf;
+
+use net::vxlan::Vni;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::format,
+};
+use tracing::{debug, error};
+
+use crate::RouterError;
+use crate::interfaces::iftable::IfTable;
+use crate::interfaces::interface::IfIndex;
+use crate::interfaces::interface::RouterInterfaceConfig;
+use crate::rib::VrfTable;
+use crate::rib::vrf::{RouterVrfConfig, VrfId};
+use crate::routingdb::RoutingDb;
+
+use crate::config::interface::ReconfigInterfacePlan;
+use crate::config::vrf::ReconfigVrfPlan;
+
+//////////////////////////////////////////////////////////////////////////////////
+/// The main configuration object for a router
+//////////////////////////////////////////////////////////////////////////////////
+#[derive(Debug)]
+pub struct RouterConfig {
+    genid: i64, /* not using mgmt GenId to avoid circ dependencies */
+    vrfs: BTreeMap<VrfId, RouterVrfConfig>,
+    interfaces: BTreeMap<IfIndex, RouterInterfaceConfig>,
+}
+
+/// Builder methods
+impl RouterConfig {
+    pub fn new(genid: i64) -> Self {
+        Self {
+            genid,
+            vrfs: BTreeMap::new(),
+            interfaces: BTreeMap::new(),
+        }
+    }
+    pub fn add_vrf(&mut self, vrfconfig: RouterVrfConfig) {
+        self.vrfs.insert(vrfconfig.vrfid, vrfconfig);
+    }
+    pub fn add_interface(&mut self, ifconfig: RouterInterfaceConfig) {
+        self.interfaces.insert(ifconfig.ifindex, ifconfig);
+    }
+    pub fn validate(&self) -> Result<(), RouterError> {
+        let mut num_vnis = 0;
+        let vnis = self
+            .vrfs()
+            .filter_map(|vrf| {
+                if vrf.vni.is_some() {
+                    num_vnis += 1;
+                }
+                vrf.vni
+            })
+            .collect::<BTreeSet<Vni>>();
+        if vnis.len() != num_vnis {
+            return Err(RouterError::InvalidConfig("Duplicated vnis"));
+        }
+        Ok(())
+    }
+}
+
+/// Lookup and iterators
+impl RouterConfig {
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Get the config for a Vrf with a given [`VrfId`]
+    //////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    fn get_vrf(&self, vrfid: VrfId) -> Option<&RouterVrfConfig> {
+        self.vrfs.get(&vrfid)
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Mutably get the config for a Vrf with a given [`VrfId`]
+    //////////////////////////////////////////////////////////////////////////////////
+    #[cfg(test)]
+    #[must_use]
+    fn get_vrf_mut(&mut self, vrfid: VrfId) -> Option<&mut RouterVrfConfig> {
+        self.vrfs.get_mut(&vrfid)
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Iterate over the [`RouterVrfConfig`]s in this [`RouterConfig`]
+    //////////////////////////////////////////////////////////////////////////////////
+    fn vrfs(&self) -> impl Iterator<Item = &RouterVrfConfig> {
+        self.vrfs.values()
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Get the config for an interface with a given [`IfIndex`]
+    //////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    fn get_interface(&self, ifindex: IfIndex) -> Option<&RouterInterfaceConfig> {
+        self.interfaces.get(&ifindex)
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Mutably get the config for an interface with a given [`IfIndex`]
+    //////////////////////////////////////////////////////////////////////////////////
+    #[cfg(test)]
+    #[must_use]
+    fn get_interface_mut(&mut self, ifindex: IfIndex) -> Option<&mut RouterInterfaceConfig> {
+        self.interfaces.get_mut(&ifindex)
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Iterate over the [`RouterInterfaceConfig`]s in this [`RouterConfig`]
+    //////////////////////////////////////////////////////////////////////////////////
+    fn interfaces(&self) -> impl Iterator<Item = &RouterInterfaceConfig> {
+        self.interfaces.values()
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////
+    /// Apply a configuration
+    //////////////////////////////////////////////////////////////////////////////////
+    pub(crate) fn apply(&self, db: &mut RoutingDb) -> Result<(), RouterError> {
+        let genid = self.genid;
+        self.validate()?; /* validate the config */
+        ReconfigVrfPlan::generate(self, &mut db.vrftable).apply(&mut db.vrftable)?;
+        let iftabler = db.iftw.enter().unwrap_or_else(|| unreachable!());
+        let reconfig_ifaces = ReconfigInterfacePlan::generate(self, &iftabler);
+        drop(iftabler);
+        reconfig_ifaces.apply(&mut db.iftw, &mut db.vrftable)?;
+        debug!("Successfully applied router config for generation {genid}");
+        self.verify(&db)?;
+        Ok(())
+    }
+}
+
+/// Verification
+impl RouterConfig {
+    fn verify_vrf(vrf_cfg: &RouterVrfConfig, vrftable: &VrfTable) -> Result<(), RouterError> {
+        debug!("Verifying vrf {}...", &vrf_cfg.name);
+        let vrf = vrftable.get_vrf(vrf_cfg.vrfid)?;
+        if vrf.as_config() != *vrf_cfg {
+            error!("Vrf {} has not been correctly reconfigured!:", vrf.name);
+            error!("Config:\n{vrf_cfg:#?}");
+            error!("Vrf:\n{vrf}");
+            return Err(RouterError::VerifyFailure(format!(
+                "Vrf with id {}",
+                vrf.vrfid
+            )));
+        }
+        if vrf.vni.is_some() {
+            vrftable.check_vni(vrf.vrfid)?;
+        }
+        Ok(())
+    }
+    fn verify_vrfs(&self, db: &RoutingDb) -> Result<(), RouterError> {
+        for vrf_cfg in self.vrfs() {
+            Self::verify_vrf(vrf_cfg, &db.vrftable)?;
+        }
+        Ok(())
+    }
+    fn verify_interface(
+        ifconfig: &RouterInterfaceConfig,
+        iftable: &IfTable,
+    ) -> Result<(), RouterError> {
+        debug!("Verifying interface {}...", &ifconfig.name);
+        let iface = iftable.get_interface(ifconfig.ifindex).ok_or_else(|| {
+            RouterError::VerifyFailure(format!("interface {}: no such interface", ifconfig.ifindex))
+        })?;
+        let ifindex = ifconfig.ifindex;
+        let built = iface.as_config();
+        if built != *ifconfig {
+            error!("Verification of interface {ifindex} failed!");
+            error!("Requested config:\n{ifconfig:#?}");
+            error!("Applied config:\n{built:#?}");
+            return Err(RouterError::VerifyFailure(format!(
+                "interface with ifindex {ifindex}"
+            )));
+        }
+        Ok(())
+    }
+    fn verify_interfaces(&self, db: &RoutingDb) -> Result<(), RouterError> {
+        let iftable = &*db.iftw.enter().unwrap_or_else(|| unreachable!());
+        for ifconfig in self.interfaces() {
+            Self::verify_interface(ifconfig, iftable)?;
+        }
+        Ok(())
+    }
+    fn verify(&self, db: &RoutingDb) -> Result<(), RouterError> {
+        let genid = self.genid;
+        debug!("Verifying config {genid}...");
+        self.verify_vrfs(db)?;
+        self.verify_interfaces(db)?;
+        debug!("Successfully verified router config for generation {genid}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[rustfmt::skip]
+mod tests {
+    use tracing_test::traced_test;
+    use tracing::debug;
+    use net::{route::RouteTableId, vxlan::Vni};
+    use net::eth::mac::Mac;
+    use crate::{config::RouterConfig, interfaces::interface::{AttachConfig, RouterInterfaceConfig}, rib::vrf::RouterVrfConfig};
+    use crate::interfaces::interface::IfState;
+    use crate::interfaces::interface::IfType;
+    use crate::interfaces::interface::IfDataEthernet;
+
+    use crate::RouterError;
+    use crate::routingdb::RoutingDb;
+    use crate::interfaces::iftablerw::IfTableWriter;
+    use crate::fib::fibtable::FibTableWriter;
+    use crate::atable::resolver::AtResolver;
+
+
+    fn mk_vni(vni: u32) -> Vni {
+        vni.try_into().expect("Bad vni")
+    }
+    fn mk_tableid(id: u32) -> RouteTableId {
+        id.try_into().expect("Bad table-id")
+    }
+
+    fn add_router_vrf_configs(config: &mut RouterConfig) {
+        // N.B. default VRF is automatically created
+
+        // VRF for VPC-1
+        let vrf = RouterVrfConfig::new(100, "AAAAA-vrf")
+            .set_description("VRF for VPC-1")
+            .set_tableid(mk_tableid(1000))
+            .set_vni(mk_vni(3000));
+        config.add_vrf(vrf);
+
+        // VRF for VPC-2
+        let vrf = RouterVrfConfig::new(101, "BBBBB-vrf")
+            .set_description("VRF for VPC-2")
+            .set_tableid(mk_tableid(1001))
+            .set_vni(mk_vni(4000));
+        config.add_vrf(vrf);
+
+        // VRF for VPC-2
+        let vrf = RouterVrfConfig::new(102, "CCCCC-vrf")
+            .set_description("VRF for VPC-3")
+            .set_tableid(mk_tableid(1002))
+            .set_vni(mk_vni(6000));
+        config.add_vrf(vrf);
+
+    }
+    fn add_router_interface_configs(config: &mut RouterConfig) {
+        let mut ifconfig = RouterInterfaceConfig::new("Loopback", 1);
+        ifconfig.set_description("main loopback interface");
+        ifconfig.set_iftype(IfType::Loopback);
+        ifconfig.set_admin_state(IfState::Up);
+        config.add_interface(ifconfig);
+
+        let mut ifconfig = RouterInterfaceConfig::new("Eth0", 10);
+        ifconfig.set_description("Interface to Spine-1");
+        ifconfig.set_admin_state(IfState::Up);
+        ifconfig.set_iftype(IfType::Ethernet(IfDataEthernet {
+            mac: Mac::from([0x0, 0xaa, 0x0, 0x0, 0x0, 0x2]),
+        }));
+        ifconfig.set_attach_cfg(Some(AttachConfig::VRF(100)));
+        config.add_interface(ifconfig);
+
+        let mut ifconfig = RouterInterfaceConfig::new("Eth1", 11);
+        ifconfig.set_description("Interface to Spine-2");
+        ifconfig.set_admin_state(IfState::Up);
+        ifconfig.set_iftype(IfType::Ethernet(IfDataEthernet {
+            mac: Mac::from([0x0, 0xbb, 0x0, 0x0, 0x0, 0x2]),
+        }));
+        config.add_interface(ifconfig);
+
+    }
+    fn build_router_config() -> RouterConfig {
+        let mut config = RouterConfig::new(1);
+        add_router_vrf_configs(&mut config);
+        add_router_interface_configs(&mut config);
+        config
+    }
+    fn create_routing_database() -> RoutingDb {
+        let (iftw, _iftr) = IfTableWriter::new();
+        let (fibtw, _fibtr) = FibTableWriter::new();
+        let (_resolver, atabler) = AtResolver::new(false);
+        RoutingDb::new(fibtw, iftw, atabler)
+    }
+    fn test_apply_config(config: &RouterConfig, db: &mut RoutingDb) -> Result<(), RouterError> {
+        config.apply(db)?;
+        let iftr = db.iftw.enter().unwrap();
+        println!("\n{}", &db.vrftable);
+        println!("\n{}", *iftr);
+        println!("\n ████████ SUCCESSFULLY applied and verified config {} ███████\n", config.genid);
+        Ok(())
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_initial() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_invalid() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+
+        // modify the config to make it invalid: let two vrfs have the same vni
+        let conf1 = config.get_vrf(100).expect("Should find vrf config");
+        assert!(conf1.vni.is_some());
+        let duped_vni = conf1.vni.clone();
+
+        let conf2 = config.get_vrf_mut(101).expect("Should find vrf config");
+        conf2.reset_vni(duped_vni);
+
+        let result = test_apply_config(&config, &mut db);
+        assert!(result.is_err_and(|e| matches!(e, RouterError::InvalidConfig(_))));
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_reapply() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+        config.genid = 2;
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_reconfig_vrf_name_and_vni() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+
+        config.genid = 3;
+        let new_vni = mk_vni(666);
+        let vrfid = 100;
+        debug!("━━━━Test: Change name of vrf {vrfid} and its vni to {new_vni}");
+        let vrf = config.get_vrf_mut(100).expect("Should find it");
+        vrf.set_name("CHANGED");
+        vrf.reset_vni(Some(new_vni));
+
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_reconfig_vnis() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+
+        config.genid = 4;
+        let new_vni = mk_vni(6000);
+        debug!("━━━━━━━━ Test: Remove vni {new_vni} from one vrf and associate it to another");
+        let vrf = config.get_vrf_mut(101).expect("Should find it");
+        vrf.reset_vni(Some(mk_vni(6000)));
+        let vrf = config.get_vrf_mut(102).expect("Should find it");
+        vrf.reset_vni(None);
+
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_config_swap_vrf_vnis() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+
+        debug!("━━━━━━━━ Test: Swap the vnis of two vrfs");
+        config.genid = 5;
+        let vrf1 = db.vrftable.get_vrf(100).expect("Should find vrf");
+        let vrf2 = db.vrftable.get_vrf(101).expect("Should find vrf");
+        let vni1 = vrf1.vni.expect("Should have vni");
+        let vni2 = vrf2.vni.expect("Should have vni");
+
+        let vrf = config.get_vrf_mut(100).expect("Should find config");
+        vrf.reset_vni(Some(vni2));
+
+        let vrf = config.get_vrf_mut(101).expect("Should find config");
+        vrf.reset_vni(Some(vni1));
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+
+
+    #[traced_test]
+    #[test]
+    fn test_config_change_interface() {
+        let mut db = create_routing_database();
+        let mut config = build_router_config();
+        test_apply_config(&config, &mut db).expect("Should succeed");
+
+        debug!("━━━━━━━━ Test: Change interface name, mac, admin state and attach it to another vrf");
+        config.genid = 6;
+        let ifconfig = config.get_interface_mut(10).expect("Should find config");
+        ifconfig.set_name("CHANGED-NAME");
+        ifconfig.set_description("Interface with changed config");
+        ifconfig.set_admin_state(IfState::Down);
+        ifconfig.set_iftype(IfType::Ethernet(IfDataEthernet {
+            mac: Mac::from([0x0, 0xFF, 0xaa, 0xbb, 0xcc, 0xdd]),
+        }));
+        ifconfig.set_attach_cfg(Some(AttachConfig::VRF(101)));
+        test_apply_config(&config, &mut db).expect("Should succeed");
+
+        debug!("━━━━━━━━ Test: Detach interface");
+        config.genid = 7;
+        let ifconfig = config.get_interface_mut(10).expect("Should find config");
+        ifconfig.set_attach_cfg(None);
+        test_apply_config(&config, &mut db).expect("Should succeed");
+    }
+}

--- a/routing/src/config/mod.rs
+++ b/routing/src/config/mod.rs
@@ -250,21 +250,21 @@ mod tests {
         let vrf = RouterVrfConfig::new(100, "AAAAA-vrf")
             .set_description("VRF for VPC-1")
             .set_tableid(mk_tableid(1000))
-            .set_vni(mk_vni(3000));
+            .set_vni(Some(mk_vni(3000)));
         config.add_vrf(vrf);
 
         // VRF for VPC-2
         let vrf = RouterVrfConfig::new(101, "BBBBB-vrf")
             .set_description("VRF for VPC-2")
             .set_tableid(mk_tableid(1001))
-            .set_vni(mk_vni(4000));
+            .set_vni(Some(mk_vni(4000)));
         config.add_vrf(vrf);
 
         // VRF for VPC-2
         let vrf = RouterVrfConfig::new(102, "CCCCC-vrf")
             .set_description("VRF for VPC-3")
             .set_tableid(mk_tableid(1002))
-            .set_vni(mk_vni(6000));
+            .set_vni(Some(mk_vni(6000)));
         config.add_vrf(vrf);
 
     }

--- a/routing/src/config/mod.rs
+++ b/routing/src/config/mod.rs
@@ -139,7 +139,7 @@ impl RouterConfig {
     pub(crate) fn apply(&self, db: &mut RoutingDb) -> Result<(), RouterError> {
         let genid = self.genid;
         self.validate()?; /* validate the config */
-        ReconfigVrfPlan::generate(self, &mut db.vrftable).apply(&mut db.vrftable)?;
+        ReconfigVrfPlan::generate(self, &mut db.vrftable).apply(&mut db.vrftable, &mut db.iftw)?;
         let iftabler = db.iftw.enter().unwrap_or_else(|| unreachable!());
         let reconfig_ifaces = ReconfigInterfacePlan::generate(self, &iftabler);
         drop(iftabler);

--- a/routing/src/config/vrf.rs
+++ b/routing/src/config/vrf.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Router VRF configuration
+
+use std::collections::VecDeque;
+use std::fmt::Display;
+use tracing::debug;
+
+use net::vxlan::Vni;
+
+use crate::RouterError;
+use crate::config::RouterConfig;
+use crate::rib::vrf::{RouterVrfConfig, VrfId, VrfStatus};
+use crate::rib::{Vrf, VrfTable};
+
+/////////////////////////////////////////////////////////////////////////////////////////
+/// An operation to set / unset a  [`Vni`] to / from a [`Vrf`]
+/////////////////////////////////////////////////////////////////////////////////////////
+#[derive(Debug)]
+enum VniOp {
+    Add(Vni),
+    Del(Vni),
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+/// An object to represent a programmed change on the [`Vni`] associated to a [`Vrf`]
+/////////////////////////////////////////////////////////////////////////////////////////
+#[derive(Debug)]
+struct VniChange {
+    vrfid: VrfId,
+    op: VniOp,
+}
+impl VniChange {
+    fn new(vrfid: VrfId, op: VniOp) -> Self {
+        Self { vrfid, op }
+    }
+}
+impl Display for VniChange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.op {
+            VniOp::Add(vni) => writeln!(f, " - Add vni {vni} to vrf {}", self.vrfid),
+            VniOp::Del(vni) => writeln!(f, " - Remove vni {vni} from vrf {}", self.vrfid),
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+/// A sequence of [`VniChange`]s to be applied in a certain order
+/////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+struct VniChangePlan(VecDeque<VniChange>);
+impl VniChangePlan {
+    fn new() -> Self {
+        Self(VecDeque::new())
+    }
+    fn push_front(&mut self, c: VniChange) {
+        self.0.push_front(c);
+    }
+    fn push_back(&mut self, c: VniChange) {
+        self.0.push_back(c);
+    }
+    fn apply(&mut self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        if self.0.is_empty() {
+            debug!("No Vni reconfigurations are required");
+            return Ok(());
+        }
+        debug!("Will apply {} Vni changes...", self.0.len());
+        debug!("\n{self}");
+        while let Some(change) = self.0.pop_front() {
+            match change.op {
+                VniOp::Add(vni) => vrftable.set_vni(change.vrfid, vni)?,
+                VniOp::Del(_curr) => vrftable.unset_vni(change.vrfid)?,
+            }
+        }
+        Ok(())
+    }
+}
+impl Display for VniChangePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for change in self.0.iter() {
+            change.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+///////////////////////////////////////////////////////////////////////////////////////
+/// Structure used to summarize a plan for reconfiguring [`Vrfs`] given a configuration
+/// and the current set of [`Vrf`]s in the [`VrfTable`].
+///////////////////////////////////////////////////////////////////////////////////////
+pub(crate) struct ReconfigVrfPlan {
+    to_keep: Vec<VrfId>,             /* vrfs to keep as is */
+    to_delete: Vec<VrfId>,           /* vrfs to delete */
+    to_change: Vec<RouterVrfConfig>, /* vrfs to change */
+    to_add: Vec<RouterVrfConfig>,    /* vrfs to add */
+}
+
+impl ReconfigVrfPlan {
+    ///////////////////////////////////////////////////////////////////////////////////
+    /// Build a [`ReconfigVrfPlan`] given a [`RouterConfig`] and a [`VrfTable`]
+    ///////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    pub(crate) fn generate(config: &RouterConfig, vrftable: &VrfTable) -> Self {
+        let mut to_delete: Vec<VrfId> = vec![];
+        let mut to_keep: Vec<VrfId> = vec![];
+        let mut to_modify: Vec<RouterVrfConfig> = vec![];
+        let mut to_add: Vec<RouterVrfConfig> = vec![];
+
+        for vrf in vrftable.values() {
+            let vrfid = vrf.vrfid;
+            if let Some(cfg) = config.get_vrf(vrfid) {
+                if vrf.as_config() != *cfg {
+                    to_modify.push(cfg.clone());
+                } else {
+                    to_keep.push(vrfid);
+                }
+            } else if vrfid != 0 {
+                // default has vrfid of 0 and should not be deleted
+                // if anything, interfaces should be detached
+                to_delete.push(vrfid);
+            }
+        }
+        for cfg in config.vrfs() {
+            if !vrftable.contains(cfg.vrfid) {
+                to_add.push(cfg.clone());
+            }
+        }
+        ReconfigVrfPlan {
+            to_keep,
+            to_delete,
+            to_change: to_modify,
+            to_add,
+        }
+    }
+
+    #[must_use]
+    fn enforce_deletions(&self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        for vrfid in &self.to_delete {
+            let vrf = vrftable.get_vrf_mut(*vrfid)?;
+            if vrf.status != VrfStatus::Deleted {
+                vrf.set_status(VrfStatus::Deleting);
+            }
+            vrftable.unset_vni(*vrfid)?;
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    fn enforce_keeps(&self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        for vrfid in &self.to_keep {
+            let vrf = vrftable.get_vrf_mut(*vrfid)?;
+            if vrf.status != VrfStatus::Active {
+                vrf.set_status(VrfStatus::Active);
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    fn enforce_changes(&self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        let mut vni_changes = VniChangePlan::new();
+        for cfg in &self.to_change {
+            if let Ok(vrf) = vrftable.get_vrf_mut(cfg.vrfid) {
+                let vrfid = vrf.vrfid;
+                // update name if needed
+                if vrf.name != cfg.name {
+                    vrf.name = cfg.name.clone();
+                }
+                // update description if needed
+                if vrf.description != cfg.description {
+                    vrf.description = cfg.description.clone();
+                }
+                // update table-id id needed
+                if vrf.tableid != cfg.tableid {
+                    vrf.tableid = cfg.tableid;
+                }
+                // update vni. This is trickier since Vrfs may be swapping Vnis and there
+                // can only be one Vrf with a given vni in the vrftable. Therefore, when
+                // a Vrf has to have a vni, we need to make sure that no other vrf that
+                // we have not yet updated (reconfigured) has it. For this reason, we need
+                // to collect the changes first and apply them in a deferred fashion. The
+                // recollection of vni changes is such that removals will be enforced first
+                // to ensure that the vni associated to a VRF, configured later, is not in
+                // use. Correctness is guaranteed by the fact that no two VPCs in the config
+                // can have the same Vni.
+                if vrf.vni != cfg.vni {
+                    match (vrf.vni, cfg.vni) {
+                        (Some(curr), Some(new)) => {
+                            vni_changes.push_front(VniChange::new(vrfid, VniOp::Del(curr)));
+                            vni_changes.push_back(VniChange::new(vrfid, VniOp::Add(new)));
+                        }
+                        (None, Some(new)) => {
+                            vni_changes.push_back(VniChange::new(vrfid, VniOp::Add(new)));
+                        }
+                        (Some(curr), None) => {
+                            vni_changes.push_front(VniChange::new(vrfid, VniOp::Del(curr)));
+                        }
+                        (None, None) => {}
+                    }
+                }
+            }
+        }
+        // apply the required Vni changes
+        vni_changes.apply(vrftable)?;
+        Ok(())
+    }
+
+    #[must_use]
+    fn enforce_additions(&self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        for cfg in &self.to_add {
+            vrftable.add_vrf(&cfg)?;
+            if let Ok(vrf) = vrftable.get_vrf_mut(cfg.vrfid) {
+                if let Some(descr) = &cfg.description {
+                    vrf.set_description(descr);
+                } else {
+                    vrf.description.take();
+                }
+                if let Some(tableid) = cfg.tableid {
+                    vrf.set_tableid(tableid);
+                } else {
+                    vrf.tableid.take();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub(crate) fn apply(&self, vrftable: &mut VrfTable) -> Result<(), RouterError> {
+        self.enforce_deletions(vrftable)?;
+        self.enforce_keeps(vrftable)?;
+        self.enforce_changes(vrftable)?;
+        self.enforce_additions(vrftable)?;
+        debug!("Successfully applied VRF configurations");
+        Ok(())
+    }
+}
+
+impl Vrf {
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    /// Build the [`RouterVrfConfig`] object that would lead to having a certain [`Vrf`]
+    /// in its current state.
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    #[must_use]
+    pub(crate) fn as_config(&self) -> RouterVrfConfig {
+        RouterVrfConfig {
+            vrfid: self.vrfid,
+            name: self.name.to_owned(),
+            description: self.description.to_owned(),
+            tableid: self.tableid,
+            vni: self.vni,
+        }
+    }
+}

--- a/routing/src/config/vtep.rs
+++ b/routing/src/config/vtep.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Router VTEP configuration
+
+use crate::RouterError;
+use crate::{evpn::Vtep, routingdb::RoutingDb};
+use tracing::info;
+
+impl Vtep {
+    // Apply a vtep configuration. This method can't fail because
+    // we validate that the config has a correct vtep
+    pub(crate) fn apply(&self, db: &mut RoutingDb) {
+        let vtep = &mut db.vtep;
+        let (ip) = self.get_ip().unwrap_or_else(|| unreachable!());
+        if Some(ip) != vtep.get_ip() {
+            vtep.set_ip(ip);
+            info!("Updated VTEP ip address set to {ip}");
+        }
+        let mac = self.get_mac().unwrap_or_else(|| unreachable!());
+        if Some(mac) != vtep.get_mac() {
+            vtep.set_mac(mac);
+            info!("Updated VTEP mac to {mac}");
+        }
+
+        // refresh all VRFs
+        db.vrftable
+            .values_mut()
+            .filter(|vrf| {
+                let vtep = vrf.get_vtep();
+                vrf.vni.is_some() && (vtep != Some(self.clone()))
+            })
+            .for_each(|vrf| vrf.set_vtep(vtep))
+    }
+}

--- a/routing/src/cpi.rs
+++ b/routing/src/cpi.rs
@@ -27,7 +27,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixDatagram;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use tokio::sync::mpsc::{Sender, channel};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tracing::{debug, error, info};
 
 // capacity of cpi control channel. This should have very little impact on performance.
@@ -96,7 +96,79 @@ fn open_unix_sock(path: &String) -> Result<UnixDatagram, RouterError> {
     Ok(sock)
 }
 
-#[allow(clippy::too_many_lines)]
+pub(crate) const CPSOCK: Token = Token(0);
+pub(crate) const CLISOCK: Token = Token(1);
+
+pub(crate) struct Cpi {
+    pub(crate) run: bool,
+    pub(crate) frozen: bool,
+    pub(crate) cp_sock_path: String,
+    pub(crate) cli_sock_path: String,
+    pub(crate) poller: Poll,
+    pub(crate) clisock: UnixDatagram,
+    pub(crate) cached_sock: RpcCachedSock,
+    pub(crate) ctl_tx: Sender<CpiCtlMsg>,
+    pub(crate) ctl_rx: Receiver<CpiCtlMsg>,
+}
+impl Cpi {
+    fn new(conf: &CpiConf) -> Result<Cpi, RouterError> {
+        /* path to bind to for routing function */
+        let cp_sock_path = conf.cpi_sock_path.as_ref().map_or_else(
+            || DEFAULT_DP_UX_PATH.to_owned(),
+            std::borrow::ToOwned::to_owned,
+        );
+
+        /* path to bind to for cli */
+        let cli_sock_path = conf.cli_sock_path.as_ref().map_or_else(
+            || DEFAULT_DP_UX_PATH_CLI.to_owned(),
+            std::borrow::ToOwned::to_owned,
+        );
+
+        /* create unix sock for routing function and bind it */
+        let cpsock = open_unix_sock(&cp_sock_path)?;
+
+        /* create unix sock for cli and bind it */
+        let clisock = open_unix_sock(&cli_sock_path)?;
+
+        /* internal ctl channel */
+        let (ctl_tx, ctl_rx) = channel::<CpiCtlMsg>(CTL_CHANNEL_CAPACITY);
+
+        /* Routing socket */
+        let cpsock_fd = cpsock.as_raw_fd();
+        let mut ev_cpsock = SourceFd(&cpsock_fd);
+
+        /* Build a cached socket */
+        let cached_sock = RpcCachedSock::from_sock(cpsock);
+
+        /* cli socket */
+        let clisock_fd = clisock.as_raw_fd();
+        let mut ev_clisock = SourceFd(&clisock_fd);
+
+        /* create poller and register cp_sock and cli_sock */
+        let poller = Poll::new().map_err(|_| RouterError::Internal("Poll creation failed"))?;
+        poller
+            .registry()
+            .register(&mut ev_cpsock, CPSOCK, Interest::READABLE)
+            .map_err(|_| RouterError::Internal("Failed to register CPI sock"))?;
+        poller
+            .registry()
+            .register(&mut ev_clisock, CLISOCK, Interest::READABLE)
+            .map_err(|_| RouterError::Internal("Failed to register CLI sock"))?;
+
+        Ok(Cpi {
+            run: true,
+            frozen: false,
+            cp_sock_path,
+            cli_sock_path,
+            poller,
+            clisock,
+            cached_sock,
+            ctl_tx,
+            ctl_rx,
+        })
+    }
+}
+
 #[allow(clippy::missing_errors_doc)]
 pub fn start_cpi(
     conf: &CpiConf,
@@ -104,65 +176,22 @@ pub fn start_cpi(
     iftw: IfTableWriter,
     atabler: AtableReader,
 ) -> Result<CpiHandle, RouterError> {
-    /* path to bind to for routing function */
-    let cp_sock_path = conf.cpi_sock_path.as_ref().map_or_else(
-        || DEFAULT_DP_UX_PATH.to_owned(),
-        std::borrow::ToOwned::to_owned,
-    );
-
-    /* path to bind to for cli */
-    let cli_sock_path = conf.cli_sock_path.as_ref().map_or_else(
-        || DEFAULT_DP_UX_PATH_CLI.to_owned(),
-        std::borrow::ToOwned::to_owned,
-    );
-
-    /* create unix sock for routing function and bind it */
-    let cpsock = open_unix_sock(&cp_sock_path)?;
-
-    /* create unix sock for cli and bind it */
-    let clisock = open_unix_sock(&cli_sock_path)?;
-
-    /* internal ctl channel */
-    let (tx, mut rx) = channel::<CpiCtlMsg>(CTL_CHANNEL_CAPACITY);
-
-    /* Routing socket */
-    const CPSOCK: Token = Token(0);
-    let cpsock_fd = cpsock.as_raw_fd();
-    let mut ev_cpsock = SourceFd(&cpsock_fd);
-
-    /* Build a cached socket */
-    let mut cached_sock = RpcCachedSock::from_sock(cpsock);
-
-    /* cli socket */
-    const CLISOCK: Token = Token(1);
-    let clisock_fd = clisock.as_raw_fd();
-    let mut ev_clisock = SourceFd(&clisock_fd);
-
-    /* create poller and register cp_sock and cli_sock */
-    let mut poller = Poll::new().map_err(|_| RouterError::Internal("Poll creation failed"))?;
-    poller
-        .registry()
-        .register(&mut ev_cpsock, CPSOCK, Interest::READABLE)
-        .map_err(|_| RouterError::Internal("Failed to register CPI sock"))?;
-    poller
-        .registry()
-        .register(&mut ev_clisock, CLISOCK, Interest::READABLE)
-        .map_err(|_| RouterError::Internal("Failed to register CLI sock"))?;
+    let mut cpi = Cpi::new(conf)?;
+    let ctl_tx = cpi.ctl_tx.clone();
 
     /* CPI & CLI loop */
     let cpi_loop = move || {
-        info!("CPI Listening at {}.", cp_sock_path);
-        info!("CLI Listening at {}.", cli_sock_path);
+        info!("CPI Listening at {}.", &cpi.cp_sock_path);
+        info!("CLI Listening at {}.", &cpi.cli_sock_path);
         let mut events = Events::with_capacity(64);
         let mut buf = vec![0; 1024];
-        let mut run = true;
 
         /* create routing database: this is fully owned by the CPI */
         let mut db = RoutingDb::new(fibtw, iftw, atabler);
 
         info!("Entering CPI IO loop....");
-        while run {
-            if let Err(e) = poller.poll(&mut events, Some(Duration::from_secs(1))) {
+        while cpi.run {
+            if let Err(e) = cpi.poller.poll(&mut events, Some(Duration::from_secs(1))) {
                 error!("Poller error!: {e}");
                 continue;
             }
@@ -172,30 +201,30 @@ pub fn start_cpi(
                 match event.token() {
                     CPSOCK => {
                         while event.is_readable() {
-                            if let Ok((len, peer)) = cached_sock.recv_from(buf.as_mut_slice()) {
-                                process_rx_data(&mut cached_sock, &peer, &buf[..len], &mut db);
+                            if let Ok((len, peer)) = cpi.cached_sock.recv_from(buf.as_mut_slice()) {
+                                process_rx_data(&mut cpi.cached_sock, &peer, &buf[..len], &mut db);
                             } else {
                                 break;
                             }
                         }
-                        if event.is_writable() {
-                            cached_sock.flush_out_fast();
-                            if !cached_sock.interests().is_writable() {
-                                if let Err(e) = poller.registry().reregister(
-                                    &mut SourceFd(&cached_sock.get_raw_fd()),
+                        if event.is_writable() && !cpi.frozen {
+                            cpi.cached_sock.flush_out_fast();
+                            if !cpi.cached_sock.interests().is_writable() {
+                                if let Err(e) = cpi.poller.registry().reregister(
+                                    &mut SourceFd(&cpi.cached_sock.get_raw_fd()),
                                     CPSOCK,
-                                    cached_sock.interests(),
+                                    cpi.cached_sock.interests(),
                                 ) {
-                                    error!("Too bad: poller registry failed: {e}");
+                                    error!("Poller reregister failed for CPI: {e} !!!");
                                 }
                             }
                         }
                     }
                     CLISOCK => {
                         while event.is_readable() {
-                            if let Ok((len, peer)) = clisock.recv_from(buf.as_mut_slice()) {
+                            if let Ok((len, peer)) = cpi.clisock.recv_from(buf.as_mut_slice()) {
                                 if let Ok(request) = CliRequest::deserialize(&buf[0..len]) {
-                                    handle_cli_request(&clisock, &peer, request, &db);
+                                    handle_cli_request(&cpi.clisock, &peer, request, &db);
                                 }
                             } else {
                                 break;
@@ -206,8 +235,8 @@ pub fn start_cpi(
                 }
             }
 
-            /* handle control channel messages */
-            handle_ctl_msg(&mut rx, &mut run, &mut db);
+            /* handle control-channel messages */
+            handle_ctl_msg(&mut cpi, &mut db);
         }
     };
     let handle = thread::Builder::new()
@@ -216,7 +245,7 @@ pub fn start_cpi(
         .map_err(|_| RouterError::Internal("Failure spawning thread"))?;
 
     Ok(CpiHandle {
-        ctl: tx,
+        ctl: ctl_tx,
         handle: Some(handle),
     })
 }

--- a/routing/src/cpi.rs
+++ b/routing/src/cpi.rs
@@ -158,7 +158,7 @@ pub fn start_cpi(
         let mut run = true;
 
         /* create routing database: this is fully owned by the CPI */
-        let mut db = RoutingDb::new(Some(fibtw), iftw, atabler);
+        let mut db = RoutingDb::new(fibtw, iftw, atabler);
 
         info!("Entering CPI IO loop....");
         while run {

--- a/routing/src/cpi_process.rs
+++ b/routing/src/cpi_process.rs
@@ -125,8 +125,8 @@ fn auto_learn_vrf(
         };
 
         let mut vrf_cfg = RouterVrfConfig::new(route.vrfid, name);
-        if let Some(vni) = vni {
-            vrf_cfg.set_vni(vni);
+        if vni.is_some() {
+            vrf_cfg.reset_vni(vni);
         }
 
         // add the vrf

--- a/routing/src/cpi_process.rs
+++ b/routing/src/cpi_process.rs
@@ -197,6 +197,11 @@ impl RpcOperation for IpRoute {
         let vrftable = &mut db.vrftable;
         if let Ok(vrf) = vrftable.get_vrf_mut(self.vrfid) {
             vrf.del_route_rpc(self);
+            if vrf.can_be_deleted() {
+                if let Err(e) = vrftable.remove_vrf(self.vrfid, &mut db.iftw) {
+                    warn!("Failed to delete vrf {}: {e}", self.vrfid);
+                }
+            }
             RpcResultCode::Ok
         } else {
             error!("Unable to find VRF with id {}", self.vrfid);

--- a/routing/src/cpi_process.rs
+++ b/routing/src/cpi_process.rs
@@ -14,11 +14,9 @@ use crate::interfaces::iftablerw::IfTableWriter;
 #[cfg(feature = "auto-learn")]
 use crate::interfaces::interface::IfDataEthernet;
 #[cfg(feature = "auto-learn")]
-use crate::interfaces::interface::IfState;
-#[cfg(feature = "auto-learn")]
 use crate::interfaces::interface::IfType;
 #[cfg(feature = "auto-learn")]
-use crate::interfaces::interface::Interface;
+use crate::interfaces::interface::RouterInterfaceConfig;
 #[cfg(feature = "auto-learn")]
 use crate::rib::vrftable::VrfTable;
 #[cfg(feature = "auto-learn")]
@@ -236,22 +234,20 @@ fn auto_learn_interface(a: &IfAddress, iftw: &mut IfTableWriter, vrftable: &VrfT
             a.ifindex
         );
 
-        /* create interface */
-        let mut iface = Interface::new(a.ifname.as_str(), a.ifindex);
-        iface.set_admin_state(IfState::Up);
-        iface.set_oper_state(IfState::Up);
+        /* create interface config */
+        let mut ifconfig = RouterInterfaceConfig::new(a.ifname.as_str(), a.ifindex);
         if a.ifindex == 1 {
-            iface.set_iftype(IfType::Loopback);
+            ifconfig.set_iftype(IfType::Loopback);
         } else if let Ok(res) = mac_address_by_name(a.ifname.as_str()) {
             if let Some(mac) = &res {
-                iface.set_iftype(IfType::Ethernet(IfDataEthernet {
+                ifconfig.set_iftype(IfType::Ethernet(IfDataEthernet {
                     mac: Mac::from(mac.bytes()),
                 }));
             }
         }
 
         /* add to interface table */
-        iftw.add_interface(iface);
+        iftw.add_interface(ifconfig);
 
         /* attach to default vrf */
 

--- a/routing/src/cpi_process.rs
+++ b/routing/src/cpi_process.rs
@@ -254,10 +254,11 @@ fn auto_learn_interface(a: &IfAddress, iftw: &mut IfTableWriter, vrftable: &VrfT
         }
 
         /* add to interface table */
-        iftw.add_interface(ifconfig);
+        if let Err(e) = iftw.add_interface(ifconfig.clone()) {
+            error!("Failed to add interface {}: {e}", ifconfig.name);
+        }
 
         /* attach to default vrf */
-
         debug!("Attaching {} to default VRF", a.ifname.as_str());
         let _ = iftw.attach_interface_to_vrf(a.ifindex, 0, vrftable);
     }

--- a/routing/src/cpi_process.rs
+++ b/routing/src/cpi_process.rs
@@ -113,7 +113,7 @@ fn auto_learn_vrf(
         for nh in &route.nhops {
             if let Some(NextHopEncap::VXLAN(vxlan)) = &nh.encap {
                 if nh.vrfid == route.vrfid {
-                    vni = Some(vxlan.vni);
+                    vni = Some(vxlan.vni.try_into().expect("Bad vni"));
                     break;
                 }
             }
@@ -135,7 +135,7 @@ fn auto_learn_vrf(
             if let Some(duped_vni) = vni {
                 if matches!(e, RouterError::VniInUse(_)) {
                     if let Ok(other_vrfid) = vrftable.get_vrfid_by_vni(duped_vni) {
-                        let _ = vrftable.remove_vrf_good(other_vrfid, iftablew);
+                        let _ = vrftable.remove_vrf(other_vrfid, iftablew);
                         // add the new one
                         if let Err(e) = vrftable.add_vrf(name, route.vrfid, vni) {
                             error!(

--- a/routing/src/ctl.rs
+++ b/routing/src/ctl.rs
@@ -3,16 +3,44 @@
 
 //! Control channel for the CPI
 
+use mio::Interest;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::error::TryRecvError;
-use tokio::sync::mpsc::{Receiver, Sender};
-use tracing::{error, info, warn};
+use tokio::sync::oneshot;
+use tokio::sync::oneshot::Sender as AsyncSender;
+use tokio::task;
+#[allow(unused)]
+use tracing::{debug, error, info, warn};
 
+use crate::RouterError;
+use crate::cpi::{CPSOCK, Cpi};
 use crate::evpn::Vtep;
 use crate::routingdb::RoutingDb;
+use mio::unix::SourceFd;
+
+type CpiCtlReplyTx = AsyncSender<Result<(), RouterError>>;
+
+#[repr(transparent)]
+pub struct LockGuard(Option<Sender<CpiCtlMsg>>);
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let tx = self.0.take();
+        if let Some(tx) = tx {
+            task::spawn(async move {
+                if let Err(e) = tx.send(CpiCtlMsg::GuardedUnlock).await {
+                    error!("Fatal: could not send unlock request!!: {e}");
+                }
+            });
+        }
+    }
+}
 
 pub enum CpiCtlMsg {
     Finish,
     SetVtep(Vtep),
+    Lock(CpiCtlReplyTx),
+    Unlock(CpiCtlReplyTx),
+    GuardedUnlock,
 }
 
 // An object to send control messages to the cpi/router
@@ -21,15 +49,49 @@ impl RouterCtlSender {
     pub(crate) fn new(tx: Sender<CpiCtlMsg>) -> Self {
         Self(tx)
     }
+    pub(crate) fn as_lock_guard(&self) -> LockGuard {
+        LockGuard(Some(self.0.clone()))
+    }
     pub async fn set_vtep(&mut self, vtep: Vtep) {
         if let Err(e) = self.0.send(CpiCtlMsg::SetVtep(vtep)).await {
             error!("Failed to send vtep data: {e} !");
         }
     }
+    #[must_use]
+    pub async fn lock(&mut self) -> Result<LockGuard, RouterError> {
+        debug!("Requesting CPI lock...");
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let msg = CpiCtlMsg::Lock(reply_tx);
+        self.0
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send lock request"))?;
+        let reply = reply_rx
+            .await
+            .map_err(|_| RouterError::Internal("Failed to receive lock reply"))?;
+        reply?;
+        Ok(self.as_lock_guard())
+    }
+    #[allow(unused)]
+    #[must_use]
+    pub async fn unlock(&mut self) -> Result<(), RouterError> {
+        debug!("Requesting CPI lock...");
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let msg = CpiCtlMsg::Unlock(reply_tx);
+        self.0
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send unlock request"))?;
+        let reply = reply_rx
+            .await
+            .map_err(|_| RouterError::Internal("Failed to receive unlock reply"))?;
+        reply?;
+        Ok(())
+    }
 }
 
 /// Handle a control request to set the VTEP ip address and MAC
-fn set_vtep(db: &mut RoutingDb, vtep_data: &Vtep) {
+fn handle_set_vtep(db: &mut RoutingDb, vtep_data: &Vtep) {
     let vtep = &mut db.vtep;
 
     if let Some(ip) = vtep_data.get_ip() {
@@ -53,14 +115,50 @@ fn set_vtep(db: &mut RoutingDb, vtep_data: &Vtep) {
         .for_each(|vrf| vrf.set_vtep(vtep));
 }
 
+/// Handle a lock request for the indicated CPI
+fn handle_lock(cpi: &mut Cpi, lock: bool, reply_to: Option<CpiCtlReplyTx>) {
+    let action = if lock { "lock" } else { "unlock" };
+    let interests = if lock {
+        cpi.frozen = true;
+        Interest::WRITABLE
+    } else {
+        cpi.frozen = false;
+        Interest::WRITABLE | Interest::READABLE
+    };
+    let result = cpi
+        .poller
+        .registry()
+        .reregister(
+            &mut SourceFd(&cpi.cached_sock.get_raw_fd()),
+            CPSOCK,
+            interests,
+        )
+        .map_err(|_| RouterError::Internal("(un)-locking failed"));
+
+    if result.is_ok() {
+        debug!("The CPI is now {action}ed");
+    } else {
+        error!("Failed to {action} CPI");
+    }
+
+    if let Some(reply_to) = reply_to {
+        if let Err(e) = reply_to.send(result) {
+            error!("Fatal: could not reply to lock/unlock request: {e:?}");
+        }
+    }
+}
+
 /// Handle a request from the control channel
-pub(crate) fn handle_ctl_msg(rx: &mut Receiver<CpiCtlMsg>, run: &mut bool, db: &mut RoutingDb) {
-    match rx.try_recv() {
+pub(crate) fn handle_ctl_msg(cpi: &mut Cpi, db: &mut RoutingDb) {
+    match cpi.ctl_rx.try_recv() {
         Ok(CpiCtlMsg::Finish) => {
             info!("Got request to shutdown. Au revoir ...");
-            *run = false;
+            cpi.run = false;
         }
-        Ok(CpiCtlMsg::SetVtep(vtep_data)) => set_vtep(db, &vtep_data),
+        Ok(CpiCtlMsg::SetVtep(vtep_data)) => handle_set_vtep(db, &vtep_data),
+        Ok(CpiCtlMsg::Lock(reply_to)) => handle_lock(cpi, true, Some(reply_to)),
+        Ok(CpiCtlMsg::Unlock(reply_to)) => handle_lock(cpi, false, Some(reply_to)),
+        Ok(CpiCtlMsg::GuardedUnlock) => handle_lock(cpi, false, None),
         Err(TryRecvError::Empty) => {}
         Err(e) => {
             error!("Error receiving from ctl channel {e:?}");

--- a/routing/src/ctl.rs
+++ b/routing/src/ctl.rs
@@ -82,6 +82,20 @@ impl RouterCtlSender {
         reply?;
         Ok(())
     }
+    pub async fn configure(&mut self, config: RouterConfig) -> Result<(), RouterError> {
+        debug!("Requesting router to apply configuration...");
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let msg = CpiCtlMsg::Configure(config, reply_tx);
+        self.0
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send configure request"))?;
+        let reply = reply_rx
+            .await
+            .map_err(|_| RouterError::Internal("Failed to receive configure reply"))?;
+        reply?;
+        Ok(())
+    }
 }
 
 /// Handle a lock request for the indicated CPI

--- a/routing/src/display.rs
+++ b/routing/src/display.rs
@@ -338,7 +338,7 @@ impl Display for VrfV6Nexthops<'_> {
 
 macro_rules! VRF_TBL_FMT {
     () => {
-        "{:>16} {:>8} {:>8} {:>12} {:>12} {:>8} {:>8}"
+        "{:>16} {:>8} {:>8} {:>12} {:>12} {:>8} {:>8} {:<}"
     };
 }
 fn fmt_vrf_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -347,7 +347,7 @@ fn fmt_vrf_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result 
         "{}",
         format_args!(
             VRF_TBL_FMT!(),
-            "name", "id", "vni", "Ipv4-routes", "Ipv6-routes", "status", "table-id"
+            "name", "id", "vni", "Ipv4-routes", "Ipv6-routes", "status", "table-id", "description"
         )
     )
 }
@@ -364,7 +364,8 @@ fn fmt_vrf_summary(f: &mut std::fmt::Formatter<'_>, vrf: &Vrf) -> std::fmt::Resu
             vrf.routesv6.len(),
             vrf.status.to_string(),
             vrf.tableid
-                .map_or_else(|| "--".to_owned(), |t| t.to_string())
+                .map_or_else(|| "--".to_owned(), |t| t.to_string()),
+            &vrf.description.as_ref().map_or_else(|| "", |t| t.as_str())
         )
     )
 }

--- a/routing/src/display.rs
+++ b/routing/src/display.rs
@@ -210,6 +210,16 @@ impl Display for VrfStatus {
     }
 }
 
+fn fmt_vrf_oneline(vrf: &Vrf, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let description = vrf.description.clone().unwrap_or_else(|| "--".to_string());
+    writeln!(
+        f,
+        "\n ━━━━━━━━━\n Vrf: '{}' (id: {}) description: {description}",
+        vrf.name, vrf.vrfid
+    )?;
+    Ok(())
+}
+
 impl Display for Vrf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
@@ -241,12 +251,7 @@ impl<F: for<'a> Fn(&'a (&Ipv4Prefix, &Route)) -> bool> Display for VrfViewV4<'_,
         // displayed routes
         let mut displayed = 0;
 
-        // display !
-        writeln!(
-            f,
-            "\n ━━━━━━━━━\n Vrf: '{}' (id: {})",
-            self.vrf.name, self.vrf.vrfid
-        )?;
+        fmt_vrf_oneline(&self.vrf, f)?;
         Heading(format!("Ipv4 routes ({total_routes})")).fmt(f)?;
         for (prefix, route) in rt_iter {
             write!(f, "  {prefix:?} {route}")?;
@@ -280,12 +285,7 @@ impl<F: for<'a> Fn(&'a (&Ipv6Prefix, &Route)) -> bool> Display for VrfViewV6<'_,
         // displayed routes
         let mut displayed = 0;
 
-        // display !
-        writeln!(
-            f,
-            "\n ━━━━━━━━━\n Vrf: '{}' (id: {})",
-            self.vrf.name, self.vrf.vrfid
-        )?;
+        fmt_vrf_oneline(&self.vrf, f)?;
         Heading(format!("Ipv6 routes ({total_routes})")).fmt(f)?;
         for (prefix, route) in rt_iter {
             write!(f, "  {prefix:?} {route}")?;
@@ -306,7 +306,7 @@ impl<F: for<'a> Fn(&'a (&Ipv6Prefix, &Route)) -> bool> Display for VrfViewV6<'_,
 pub struct VrfV4Nexthops<'a>(pub &'a Vrf);
 impl Display for VrfV4Nexthops<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, " Vrf: '{}' (id: {})", self.0.name, self.0.vrfid)?;
+        fmt_vrf_oneline(&self.0, f)?;
         Heading("Ipv4 Next-hops".to_string()).fmt(f)?;
         let iter =
             self.0.nhstore.iter().filter(|nh| {
@@ -322,7 +322,7 @@ impl Display for VrfV4Nexthops<'_> {
 pub struct VrfV6Nexthops<'a>(pub &'a Vrf);
 impl Display for VrfV6Nexthops<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, " Vrf: '{}' (id: {})", self.0.name, self.0.vrfid)?;
+        fmt_vrf_oneline(&self.0, f)?;
         Heading("Ipv6 Next-hops".to_string()).fmt(f)?;
         let iter =
             self.0.nhstore.iter().filter(|nh| {
@@ -721,11 +721,7 @@ impl<F: for<'a> Fn(&'a (&Ipv4Prefix, &Rc<FibGroup>)) -> bool> Display for FibVie
                 let total_entries = fibr.len_v4();
                 let mut displayed = 0;
 
-                writeln!(
-                    f,
-                    "\n ━━━━━━━━━\n Vrf: '{}' (id: {})",
-                    self.vrf.name, self.vrf.vrfid
-                )?;
+                fmt_vrf_oneline(&self.vrf, f)?;
                 Heading(format!("Ipv4 FIB ({total_entries} destinations)")).fmt(f)?;
                 for (prefix, group) in rt_iter {
                     write!(f, "  {prefix:?} {group}")?;
@@ -761,11 +757,7 @@ impl<F: for<'a> Fn(&'a (&Ipv6Prefix, &Rc<FibGroup>)) -> bool> Display for FibVie
                 let total_entries = fibr.len_v6();
                 let mut displayed = 0;
 
-                writeln!(
-                    f,
-                    "\n ━━━━━━━━━\n Vrf: '{}' (id: {})",
-                    self.vrf.name, self.vrf.vrfid
-                )?;
+                fmt_vrf_oneline(&self.vrf, f)?;
                 Heading(format!("Ipv6 FIB ({total_entries} destinations)")).fmt(f)?;
                 for (prefix, group) in rt_iter {
                     write!(f, "  {prefix:?} {group}")?;

--- a/routing/src/display.rs
+++ b/routing/src/display.rs
@@ -410,7 +410,7 @@ fn fmt_interface_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         "{}",
         format_args!(
             INTERFACE_TBL_FMT!(),
-            "name", "id", "OpStatus", "AdmStatus", "attachment", "type"
+            "name", "id", "AdmStatus", "OpStatus", "attachment", "type"
         )
     )
 }

--- a/routing/src/display.rs
+++ b/routing/src/display.rs
@@ -338,7 +338,7 @@ impl Display for VrfV6Nexthops<'_> {
 
 macro_rules! VRF_TBL_FMT {
     () => {
-        "{:>16} {:>8} {:>8} {:>12} {:>12} {:>8}"
+        "{:>16} {:>8} {:>8} {:>12} {:>12} {:>8} {:>8}"
     };
 }
 fn fmt_vrf_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -347,7 +347,7 @@ fn fmt_vrf_summary_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result 
         "{}",
         format_args!(
             VRF_TBL_FMT!(),
-            "name", "id", "vni", "Ipv4-routes", "Ipv6-routes", "status"
+            "name", "id", "vni", "Ipv4-routes", "Ipv6-routes", "status", "table-id"
         )
     )
 }
@@ -363,6 +363,8 @@ fn fmt_vrf_summary(f: &mut std::fmt::Formatter<'_>, vrf: &Vrf) -> std::fmt::Resu
             vrf.routesv4.len(),
             vrf.routesv6.len(),
             vrf.status.to_string(),
+            vrf.tableid
+                .map_or_else(|| "--".to_owned(), |t| t.to_string())
         )
     )
 }

--- a/routing/src/errors.rs
+++ b/routing/src/errors.rs
@@ -31,6 +31,12 @@ pub enum RouterError {
     #[error("Internal error: {0}")]
     Internal(&'static str),
 
+    #[error("Verify failure for {0}")]
+    VerifyFailure(String),
+
     #[error("Permission errors")]
     PermError,
+
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(&'static str),
 }

--- a/routing/src/errors.rs
+++ b/routing/src/errors.rs
@@ -22,8 +22,8 @@ pub enum RouterError {
     #[error("Invalid VNI value: {0}")]
     VniInvalid(u32),
 
-    #[error("The interface is already attached to a distinct entity")]
-    AlreadyAttached,
+    #[error("An interface with ifindex {0} already exists")]
+    InterfaceExists(u32),
 
     #[error("Invalid socket path '{0}'")]
     InvalidPath(String),

--- a/routing/src/evpn/vtep.rs
+++ b/routing/src/evpn/vtep.rs
@@ -7,7 +7,7 @@ use net::eth::mac::Mac;
 use std::net::IpAddr;
 
 /// Type that represents a VTEP
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vtep {
     ip: Option<IpAddr>,
     mac: Option<Mac>,

--- a/routing/src/fib/fibtable.rs
+++ b/routing/src/fib/fibtable.rs
@@ -21,7 +21,7 @@ impl FibTable {
     }
     /// Del a Fib ([`FibReader`])
     pub fn del_fib(&mut self, id: &FibId) {
-        debug!("Deleting FIB with id {id}");
+        debug!("Deleting FIB reference with id {id}");
         self.0.remove(id);
     }
     /// Register a Fib ([`FibReader`]) with a given [`Vni`]
@@ -37,7 +37,9 @@ impl FibTable {
 
     /// Remove any entry referring to the given Vni
     pub fn unregister_vni(&mut self, vni: &Vni) {
-        self.0.remove(&FibId::Vni(*vni));
+        let id = FibId::Vni(*vni);
+        debug!("Deleting FIB reference with id {id}");
+        self.0.remove(&id);
     }
 
     /// Get the [`FibReader`] for the fib with the given [`FibId`]

--- a/routing/src/fib/fibtype.rs
+++ b/routing/src/fib/fibtype.rs
@@ -347,6 +347,10 @@ impl FibWriter {
         self.0.append(FibChange::SetVtep(vtep));
         self.0.publish();
     }
+    pub fn get_vtep(&self) -> Vtep {
+        let fib = self.enter().unwrap_or_else(|| unreachable!());
+        fib.vtep.clone()
+    }
     #[must_use]
     pub fn as_fibreader(&self) -> FibReader {
         FibReader::new(self.0.clone())

--- a/routing/src/interfaces/iftable.rs
+++ b/routing/src/interfaces/iftable.rs
@@ -5,7 +5,7 @@
 
 use crate::errors::RouterError;
 use crate::fib::fibtype::{FibId, FibReader};
-use crate::interfaces::interface::{IfAddress, IfIndex, IfState, Interface};
+use crate::interfaces::interface::{IfAddress, IfIndex, IfState, Interface, RouterInterfaceConfig};
 use ahash::RandomState;
 use std::collections::HashMap;
 
@@ -49,7 +49,9 @@ impl IfTable {
     /// Add an [`Interface`] to the table. Interfaces are univocally
     /// identified by an [`IfIndex`], which acts as the master hash key.
     //////////////////////////////////////////////////////////////////
-    pub fn add_interface(&mut self, iface: Interface) {
+    pub fn add_interface(&mut self, config: &RouterInterfaceConfig) {
+        let iface = Interface::new(&config);
+
         /* add interface to iftable */
         let ifindex = iface.ifindex;
         if let Some(_prior) = self.by_index.insert(ifindex, iface) {

--- a/routing/src/interfaces/iftablerw.rs
+++ b/routing/src/interfaces/iftablerw.rs
@@ -61,6 +61,11 @@ impl IfTableWriter {
         let (w, r) = left_right::new_from_empty::<IfTable, IfTableChange>(IfTable::new());
         (IfTableWriter(w), IfTableReader(r))
     }
+    #[cfg(test)]
+    pub fn new_with_data(iftable: IfTable) -> (IfTableWriter, IfTableReader) {
+        let (w, r) = left_right::new_from_empty::<IfTable, IfTableChange>(iftable);
+        (IfTableWriter(w), IfTableReader(r))
+    }
     #[must_use]
     pub fn as_iftable_reader(&self) -> IfTableReader {
         IfTableReader::new(self.0.clone())

--- a/routing/src/interfaces/iftablerw.rs
+++ b/routing/src/interfaces/iftablerw.rs
@@ -11,10 +11,10 @@ use crate::rib::vrftable::VrfTable;
 use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle};
 
 use crate::interfaces::iftable::IfTable;
-use crate::interfaces::interface::{IfAddress, IfIndex, IfState, Interface};
+use crate::interfaces::interface::{IfAddress, IfIndex, IfState, RouterInterfaceConfig};
 
 enum IfTableChange {
-    Add(Interface),
+    Add(RouterInterfaceConfig),
     Del(IfIndex),
     Attach((IfIndex, FibReader)),
     Detach(IfIndex),
@@ -27,8 +27,8 @@ enum IfTableChange {
 impl Absorb<IfTableChange> for IfTable {
     fn absorb_first(&mut self, change: &mut IfTableChange, _: &Self) {
         match change {
-            IfTableChange::Add(interface) => {
-                self.add_interface(interface.clone());
+            IfTableChange::Add(ifconfig) => {
+                self.add_interface(&ifconfig);
             }
             IfTableChange::Del(ifindex) => self.del_interface(*ifindex),
             IfTableChange::Attach((ifindex, fibr)) => {
@@ -73,8 +73,8 @@ impl IfTableWriter {
     pub fn enter(&self) -> Option<ReadGuard<'_, IfTable>> {
         self.0.enter()
     }
-    pub fn add_interface(&mut self, iface: Interface) {
-        self.0.append(IfTableChange::Add(iface));
+    pub fn add_interface(&mut self, ifconfig: RouterInterfaceConfig) {
+        self.0.append(IfTableChange::Add(ifconfig));
         self.0.publish();
     }
     pub fn del_interface(&mut self, ifindex: IfIndex) {

--- a/routing/src/interfaces/mod.rs
+++ b/routing/src/interfaces/mod.rs
@@ -12,6 +12,8 @@ pub mod tests {
     use crate::display::IfTableAddress;
     use crate::fib::fibtype::{FibId, FibWriter};
     use crate::interfaces::iftable::IfTable;
+    use crate::interfaces::iftablerw::IfTableReader;
+    use crate::interfaces::iftablerw::IfTableWriter;
     use crate::interfaces::interface::{
         Attachment, IfDataDot1q, IfDataEthernet, IfState, IfType, Interface,
     };
@@ -97,6 +99,12 @@ pub mod tests {
         let iftable = populate_test_iftable();
         println!("{}", &iftable);
         iftable
+    }
+
+    // Build a left-right iftable for the test iftable built above
+    pub fn build_test_iftable_left_right() -> (IfTableWriter, IfTableReader) {
+        let iftable = build_test_iftable();
+        IfTableWriter::new_with_data(iftable)
     }
 
     #[test]

--- a/routing/src/interfaces/mod.rs
+++ b/routing/src/interfaces/mod.rs
@@ -16,7 +16,7 @@ pub mod tests {
     use crate::interfaces::interface::{
         Attachment, IfDataDot1q, IfDataEthernet, IfState, IfType, RouterInterfaceConfig,
     };
-    use crate::rib::vrf::Vrf;
+    use crate::rib::vrf::{RouterVrfConfig, Vrf};
     use net::eth::mac::Mac;
     use net::vlan::Vid;
     use std::net::IpAddr;
@@ -109,8 +109,9 @@ pub mod tests {
         let (fibw, fibr) = FibWriter::new(FibId::Id(0));
 
         /* Create a VRF for that fib */
-        #[allow(clippy::arc_with_non_send_sync)]
-        let vrf = Vrf::new("default-vrf", 0, Some(fibw));
+        let vrf_cfg = RouterVrfConfig::new(0, "default");
+        let mut vrf = Vrf::new(&vrf_cfg);
+        vrf.set_fibw(fibw);
 
         /* lookup interface with non-existent index */
         let iface = iftable.get_interface(100);

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod atable;
 pub mod cli;
+pub mod config;
 pub mod cpi;
 mod cpi_process;
 pub mod ctl;

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -28,4 +28,4 @@ pub mod testfib;
 
 // re-exports
 pub use errors::RouterError;
-pub use router::{Router, RouterConfig, RouterConfigBuilder};
+pub use router::{Router, RouterParams, RouterParamsBuilder};

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -114,6 +114,7 @@ pub struct Vrf {
     pub name: String,
     pub vrfid: VrfId,
     pub tableid: Option<RouteTableId>,
+    pub description: Option<String>,
     pub(crate) status: VrfStatus,
     pub(crate) routesv4: RTrieMap<Ipv4Prefix, Route>,
     pub(crate) routesv6: RTrieMap<Ipv6Prefix, Route>,
@@ -160,6 +161,7 @@ impl Vrf {
             name: name.to_owned(),
             vrfid,
             tableid: None,
+            description: None,
             status: VrfStatus::Active,
             routesv4: RTrieMap::with_capacity(capa_v4),
             routesv6: RTrieMap::with_capacity(capa_v6),
@@ -189,6 +191,13 @@ impl Vrf {
     /////////////////////////////////////////////////////////////////////////
     pub fn set_tableid(&mut self, tableid: RouteTableId) {
         self.tableid = Some(tableid);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    /// Set a description for a [`Vrf`]
+    /////////////////////////////////////////////////////////////////////////
+    pub fn set_description(&mut self, description: &str) {
+        self.description = Some(description.to_owned());
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -159,12 +159,7 @@ impl RouterVrfConfig {
         self.tableid = Some(tableid);
         self
     }
-    #[cfg(test)]
-    pub fn set_vni(mut self, vni: Vni) -> Self {
-        self.vni = Some(vni);
-        self
-    }
-    pub fn set_vni_opt(mut self, vni: Option<Vni>) -> Self {
+    pub fn set_vni(mut self, vni: Option<Vni>) -> Self {
         self.vni = vni;
         self
     }

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -272,7 +272,8 @@ impl Vrf {
     /// Set the status of a [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     pub fn set_status(&mut self, status: VrfStatus) {
-        if self.status != status {
+        // the default vrf (vrfid = 0) can't be deleted and it's always active
+        if self.status != status && self.vrfid != 0 {
             self.status = status;
             debug!("Vrf {} status changed to {status}", self.name);
         }

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -147,6 +147,9 @@ impl RouterVrfConfig {
             vni: None,
         }
     }
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_owned();
+    }
     pub fn set_description(mut self, description: &str) -> Self {
         self.description = Some(description.to_owned());
         self
@@ -160,9 +163,8 @@ impl RouterVrfConfig {
         self.vni = Some(vni);
         self
     }
-    #[cfg(not(test))]
-    pub fn set_vni(&mut self, vni: Vni) {
-        self.vni = Some(vni);
+    pub fn reset_vni(&mut self, vni: Option<Vni>) {
+        self.vni = vni;
     }
 }
 

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -163,6 +163,10 @@ impl RouterVrfConfig {
         self.vni = Some(vni);
         self
     }
+    pub fn set_vni_opt(mut self, vni: Option<Vni>) -> Self {
+        self.vni = vni;
+        self
+    }
     pub fn reset_vni(&mut self, vni: Option<Vni>) {
         self.vni = vni;
     }
@@ -279,10 +283,17 @@ impl Vrf {
     /// the config causes the vtep ip or mac to change.
     /////////////////////////////////////////////////////////////////////////
     pub fn set_vtep(&mut self, vtep: &Vtep) {
-        debug!("Setting VTEP for VRF {}...", self.name);
         if let Some(ref mut fibw) = self.fibw {
+            debug!("Updating VTEP for VRF {}...", self.name);
             fibw.set_vtep(vtep.clone());
         }
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////
+    /// Get the VTEP for a [`Vrf`]. N.B: this gets the value currently visible by readers
+    //////////////////////////////////////////////////////////////////////////////////////
+    pub fn get_vtep(&self) -> Option<Vtep> {
+        self.fibw.as_ref().map(|fibw| fibw.get_vtep().clone())
     }
 
     #[inline]

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -100,10 +100,19 @@ impl ShimNhop {
     }
 }
 
+#[derive(Copy, Clone, PartialEq)]
+#[allow(unused)]
+pub enum VrfStatus {
+    Active,
+    Deleting,
+    Deleted,
+}
+
 #[allow(unused)]
 pub struct Vrf {
     pub name: String,
     pub vrfid: VrfId,
+    pub(crate) status: VrfStatus,
     pub(crate) routesv4: RTrieMap<Ipv4Prefix, Route>,
     pub(crate) routesv6: RTrieMap<Ipv6Prefix, Route>,
     pub(crate) nhstore: NhopStore,
@@ -148,6 +157,7 @@ impl Vrf {
         let mut vrf = Self {
             name: name.to_owned(),
             vrfid,
+            status: VrfStatus::Active,
             routesv4: RTrieMap::with_capacity(capa_v4),
             routesv6: RTrieMap::with_capacity(capa_v6),
             nhstore: NhopStore::new(),
@@ -199,6 +209,16 @@ impl Vrf {
     pub fn set_vni(&mut self, vni: Vni) {
         self.vni = Some(vni);
         debug!("Associated vni {vni} to Vrf '{}'", self.name);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    /// Set the status of a Vrf
+    /////////////////////////////////////////////////////////////////////////
+    pub fn set_status(&mut self, status: VrfStatus) {
+        if self.status != status {
+            self.status = status;
+            debug!("Vrf {} status changed to {status}", self.name);
+        }
     }
 
     /////////////////////////////////////////////////////////////////////////

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -20,6 +20,7 @@ use crate::interfaces::interface::IfIndex;
 use crate::prefix::Prefix;
 use iptrie::map::RTrieMap;
 use iptrie::{Ipv4Prefix, Ipv6Prefix};
+use net::route::RouteTableId;
 use net::vxlan::Vni;
 
 /// Every VRF is univocally identified with a numerical VRF id
@@ -112,6 +113,7 @@ pub enum VrfStatus {
 pub struct Vrf {
     pub name: String,
     pub vrfid: VrfId,
+    pub tableid: Option<RouteTableId>,
     pub(crate) status: VrfStatus,
     pub(crate) routesv4: RTrieMap<Ipv4Prefix, Route>,
     pub(crate) routesv6: RTrieMap<Ipv6Prefix, Route>,
@@ -157,6 +159,7 @@ impl Vrf {
         let mut vrf = Self {
             name: name.to_owned(),
             vrfid,
+            tableid: None,
             status: VrfStatus::Active,
             routesv4: RTrieMap::with_capacity(capa_v4),
             routesv6: RTrieMap::with_capacity(capa_v6),
@@ -182,14 +185,21 @@ impl Vrf {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    /// Set the fibw for a given VRF
+    /// Set the table id for a [`Vrf`]
+    /////////////////////////////////////////////////////////////////////////
+    pub fn set_tableid(&mut self, tableid: RouteTableId) {
+        self.tableid = Some(tableid);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    /// Set the fibw for a [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     pub fn set_fibw(&mut self, fibw: FibWriter) {
         self.fibw = Some(fibw);
     }
 
     ////////////////////////////////////////////////////////////////////////
-    /// Get a fibreader for the fib associated to this VRF
+    /// Get a fibreader for the fib associated to this [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     #[allow(clippy::redundant_closure_for_method_calls)]
     pub fn get_vrf_fibr(&self) -> Option<FibReader> {
@@ -197,14 +207,14 @@ impl Vrf {
     }
 
     ////////////////////////////////////////////////////////////////////////
-    /// Get the `FibId` of the Fib associated to this VRF
+    /// Get the `FibId` of the Fib associated to this [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     pub fn get_vrf_fibid(&self) -> Option<FibId> {
         self.get_vrf_fibr()?.get_id()
     }
 
     /////////////////////////////////////////////////////////////////////////
-    /// Set the VNI for a Vrf
+    /// Set the [`Vni`] for a [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     pub fn set_vni(&mut self, vni: Vni) {
         self.vni = Some(vni);
@@ -212,7 +222,7 @@ impl Vrf {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    /// Set the status of a Vrf
+    /// Set the status of a [`Vrf`]
     /////////////////////////////////////////////////////////////////////////
     pub fn set_status(&mut self, status: VrfStatus) {
         if self.status != status {
@@ -222,7 +232,7 @@ impl Vrf {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    /// Set the VTEP for a Vrf. This should be set on vrf creation or anytime
+    /// Set the VTEP for a [`Vrf`]. This should be set on vrf creation or anytime
     /// the config causes the vtep ip or mac to change.
     /////////////////////////////////////////////////////////////////////////
     pub fn set_vtep(&mut self, vtep: &Vtep) {

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -132,6 +132,7 @@ impl Vrf {
     /// Initial capacities are 0. We may want to have some default sizes.
     /// Else, we can always call `Self::with_capacities()`.
     /////////////////////////////////////////////////////////////////////////
+    #[must_use]
     pub fn new(name: &str, vrfid: VrfId, fibw: Option<FibWriter>) -> Self {
         Self::with_capacities(name, vrfid, 0, 0, fibw)
     }
@@ -150,6 +151,7 @@ impl Vrf {
     /////////////////////////////////////////////////////////////////////////
     /// Create VRF with some initial capacities
     /////////////////////////////////////////////////////////////////////////
+    #[must_use]
     pub fn with_capacities(
         name: &str,
         vrfid: VrfId,

--- a/routing/src/rib/vrf.rs
+++ b/routing/src/rib/vrf.rs
@@ -198,7 +198,7 @@ impl Vrf {
     /////////////////////////////////////////////////////////////////////////
     pub fn set_vni(&mut self, vni: Vni) {
         self.vni = Some(vni);
-        debug!("Vrf '{}'(Id {}) has now vni {vni}", self.name, self.vrfid,);
+        debug!("Associated vni {vni} to Vrf '{}'", self.name);
     }
 
     /////////////////////////////////////////////////////////////////////////

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -48,6 +48,8 @@ impl VrfTable {
         vrfid: VrfId,
         vni: Option<Vni>,
     ) -> Result<(), RouterError> {
+        debug!("Creating new VRF name:{name} id: {vrfid}");
+
         /* Forbid VRF addition if one exists with same id */
         if self.by_id.contains_key(&vrfid) {
             error!("Can't add VRF with id {vrfid}: a VRF with that id already exists");
@@ -404,6 +406,12 @@ mod tests {
         let vrf = vrftable.get_vrf(vrfid).expect("Should be there");
         assert_eq!(vrf.name, "VPC-1");
         assert_eq!(vrf.vni, None);
+
+        {
+            let vrf = vrftable.get_vrf_mut(vrfid).expect("Should be there");
+            vrf.set_tableid(1234.try_into().expect("Should succeed"));
+            vrf.set_description("This is the vrf for VPC-1 ACME");
+        }
 
         debug!("━━━━Test: set vni {vni} to the vrf");
         vrftable.set_vni(vrfid, vni).expect("Should succeed");

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -344,13 +344,13 @@ mod tests {
 
         /* add VRFs (default VRF is always there) */
         debug!("━━━━━━━━ Test: Add VRFs");
-        let cfg = RouterVrfConfig::new(1, "VPC-1").set_vni(mk_vni(3000));
+        let cfg = RouterVrfConfig::new(1, "VPC-1").set_vni(Some(mk_vni(3000)));
         vrftable.add_vrf(&cfg).expect("Should succeed");
 
-        let cfg = RouterVrfConfig::new(2, "VPC-2").set_vni(mk_vni(4000));
+        let cfg = RouterVrfConfig::new(2, "VPC-2").set_vni(Some(mk_vni(4000)));
         vrftable.add_vrf(&cfg).expect("Should succeed");
 
-        let cfg = RouterVrfConfig::new(3, "VPC-3").set_vni(mk_vni(5000));
+        let cfg = RouterVrfConfig::new(3, "VPC-3").set_vni(Some(mk_vni(5000)));
         vrftable.add_vrf(&cfg).expect("Should succeed");
 
         /* add VRF with already used id */
@@ -364,7 +364,7 @@ mod tests {
 
         /* add VRF with unused id but used vni */
         debug!("━━━━━━━━ Test: Add VRF with duplicated vni 3000");
-        let cfg = RouterVrfConfig::new(999, "duped-vni").set_vni(mk_vni(3000));
+        let cfg = RouterVrfConfig::new(999, "duped-vni").set_vni(Some(mk_vni(3000)));
         assert!(
             vrftable
                 .add_vrf(&cfg)

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -9,6 +9,7 @@ use crate::fib::fibtable::FibTableWriter;
 use crate::fib::fibtype::FibId;
 use crate::interfaces::iftablerw::IfTableWriter;
 use crate::{errors::RouterError, rib::vrf::RouterVrfConfig};
+use ahash::RandomState;
 use net::vxlan::Vni;
 use std::collections::HashMap;
 
@@ -16,8 +17,8 @@ use std::collections::HashMap;
 use tracing::{debug, error};
 
 pub struct VrfTable {
-    by_id: HashMap<VrfId, Vrf>,
-    by_vni: HashMap<Vni, VrfId>,
+    by_id: HashMap<VrfId, Vrf, RandomState>,
+    by_vni: HashMap<Vni, VrfId, RandomState>,
     fibtablew: FibTableWriter,
 }
 
@@ -30,8 +31,8 @@ impl VrfTable {
     #[must_use]
     pub fn new(fibtablew: FibTableWriter) -> Self {
         let mut vrftable = Self {
-            by_id: HashMap::new(),
-            by_vni: HashMap::new(),
+            by_id: HashMap::with_hasher(RandomState::with_seed(0)),
+            by_vni: HashMap::with_hasher(RandomState::with_seed(0)),
             fibtablew,
         };
         /* create default vrf: this can't fail */

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -255,6 +255,13 @@ impl VrfTable {
     pub fn len_with_vni(&self) -> usize {
         self.by_vni.len()
     }
+
+    //////////////////////////////////////////////////////////////////
+    /// Tell if the [`VrfTable`] contains a [`Vrf`] with some [`VrfId`]
+    //////////////////////////////////////////////////////////////////
+    pub fn contains(&self, vrfid: VrfId) -> bool {
+        self.by_id.contains_key(&vrfid)
+    }
 }
 
 #[cfg(test)]

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -4,7 +4,9 @@
 //! Vrf table module that stores multiple vrfs. Every vrf is uniquely identified by a vrfid
 //! and optionally identified by a Vni. A vrf table always has a default vrf.
 
-use super::vrf::{Vrf, VrfId, VrfStatus};
+#[cfg(test)]
+use super::vrf::VrfStatus;
+use super::vrf::{Vrf, VrfId};
 use crate::fib::fibtable::FibTableWriter;
 use crate::fib::fibtype::FibId;
 use crate::interfaces::iftablerw::IfTableWriter;
@@ -197,8 +199,9 @@ impl VrfTable {
     }
 
     //////////////////////////////////////////////////////////////////
-    /// Remove the vrf with the given [`VrfId`]
+    /// Remove all of the VRFs with status `Deleted``
     //////////////////////////////////////////////////////////////////
+    #[cfg(test)]
     pub fn remove_deleted_vrfs(&mut self, iftablew: &mut IfTableWriter) {
         // collect the ids of the vrfs with status deleted
         let to_delete: Vec<VrfId> = self

--- a/routing/src/rib/vrftable.rs
+++ b/routing/src/rib/vrftable.rs
@@ -290,10 +290,7 @@ mod tests {
 
         /* create iftable */
         let mut iftable = build_test_iftable();
-        let (mut iftw, _iftr) = IfTableWriter::new();
-        for interface in iftable.values() {
-            iftw.add_interface(interface.clone());
-        }
+        let (mut iftw, _iftr) = build_test_iftable_left_right();
 
         /* create vrf table */
         let mut vrftable = VrfTable::new(fibtw);

--- a/routing/src/router.rs
+++ b/routing/src/router.rs
@@ -4,6 +4,7 @@
 //! Module that implements a router instance
 
 use derive_builder::Builder;
+use std::fmt::Display;
 use std::path::PathBuf;
 use tracing::{debug, error};
 
@@ -33,6 +34,16 @@ pub struct RouterConfig {
 
     #[builder(setter(into), default = DEFAULT_FRR_AGENT_PATH.to_string().into())]
     pub frr_agent_path: PathBuf,
+}
+
+impl Display for RouterConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(f, "Router config")?;
+        writeln!(f, "  name     : {}", self.name)?;
+        writeln!(f, "  CPI path : {}", self.cpi_sock_path.display())?;
+        writeln!(f, "  CLI path : {}", self.cli_sock_path.display())?;
+        writeln!(f, "  FRR-agent: {}", self.frr_agent_path.display())
+    }
 }
 
 /// Top-most object representing a router
@@ -87,7 +98,7 @@ impl Router {
         debug!("{name}: Starting CPI...");
         let cpi = start_cpi(&cpiconf, fibtw, iftw, atabler)?;
 
-        debug!("{name}: Successfully started. Config is:\n{config:#?}");
+        debug!("{name}: Successfully started. Config is:\n{config}");
         let router = Router {
             name: name.to_owned(),
             config,

--- a/routing/src/routingdb.rs
+++ b/routing/src/routingdb.rs
@@ -23,11 +23,7 @@ pub struct RoutingDb {
 #[allow(clippy::new_without_default)]
 impl RoutingDb {
     #[must_use]
-    pub fn new(
-        fibtable: Option<FibTableWriter>,
-        iftw: IfTableWriter,
-        atabler: AtableReader,
-    ) -> Self {
+    pub fn new(fibtable: FibTableWriter, iftw: IfTableWriter, atabler: AtableReader) -> Self {
         Self {
             vrftable: VrfTable::new(fibtable),
             rmac_store: RmacStore::new(),


### PR DESCRIPTION
This PR contains a bunch of clean-ups and a conservative integration of mgmt (config) and the routing crate.
"Conservative" because I've tried to keep both as-is and not yet unify types in order to avoid circular dependencies between the crates. This is part-1 because further work needs to be done around the interfaces outside of this PR and I don't want to defer it longer.

Leaving aside the code clean-ups and refactors, the process is as follows.
* The routing entity (with its dedicated thread) exposes a config API over the control channel (that already existed).
* When mgmt has a new config to apply, it builds a request with the required "router" configuration. This includes VRFs, Interfaces and vtep. The routing thread then applies the config using the existing code and replies. So, for the mgmt processor, the router behaves as the frr-agent or the vpc-manager: an external entity to request some reconfiguration.
* To avoid races with FRR, prior to applying a config, the mgmt processor "locks it" by not allowing it to receive messages from FRR. It then sends the config, which the routing thread 1) validates 2) applies 3) verifies (verify means that we check if the internal state conforms to the config after applying it) and when the process completes, the routing entity is unlocked to process messages from FRR.
* When a config is such that a VRF should be deleted, we don't delete it immediately but mark it as status = deleting, to give FRR a chance of deleting all routes. When no route remains, the vrf is removed.
* Auto-learn of VRF is removed but not the interface ones.

Closes https://github.com/githedgehog/dataplane/issues/394