### PR TITLE
Stateful NAT: Implement (most of) session manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dataplane"
 version = "0.1.0"
 dependencies = [
@@ -716,6 +730,7 @@ dependencies = [
  "arrayvec",
  "clap",
  "ctrlc",
+ "dashmap",
  "dataplane-dpdk",
  "dataplane-id",
  "dataplane-mgmt",
@@ -1319,6 +1334,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
@@ -1479,7 +1500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ caps = { version = "0.5.5", default-features = false, features = [] }
 clap = { version = "4.5.40", default-features = true, features = [] }
 ctrlc = { version = "3.4.7", default-features = false, features = [] }
 chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
+dashmap = { version = "6.1.0", default-features = false, features = [] }
 derive_builder = { version = "0.20.2", default-features = false, features = ["default", "std"] }
 doxygen-bindgen = { version = "0.1.3", default-features = false, features = [] }
 dyn-iter = { version = "1.0.1", default-features = false, features = [] }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -10,6 +10,7 @@ afpacket = { workspace = true }
 arrayvec = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "usage"] }
 ctrlc = { workspace = true, features = ["termination"] }
+dashmap = { workspace = true }
 dpdk = { workspace = true }
 dyn-iter = { workspace = true }
 id = { workspace = true }

--- a/dataplane/src/nat/mod.rs
+++ b/dataplane/src/nat/mod.rs
@@ -40,7 +40,6 @@ use mgmt::models::internal::nat::tables::{NatTables, TrieValue};
 use net::buffer::PacketBufferMut;
 use net::packet::Packet;
 use pipeline::NetworkFunction;
-use std::net::Ipv4Addr;
 
 /// Indicates whether a [`Nat`] processor should perform source NAT or destination NAT.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,9 +93,8 @@ impl Nat {
             NatMode::Stateless => {
                 let _ = self.stateless_nat::<Buf>(packet, vni);
             }
-            // TODO: Add support for other IP versions
             NatMode::Stateful => {
-                let _ = self.stateful_nat::<Buf, Ipv4Addr, Ipv4Addr>(packet, vni);
+                let _ = self.stateful_nat::<Buf>(packet, vni);
             }
         }
     }

--- a/dataplane/src/nat/mod.rs
+++ b/dataplane/src/nat/mod.rs
@@ -40,6 +40,7 @@ use mgmt::models::internal::nat::tables::{NatTables, TrieValue};
 use net::buffer::PacketBufferMut;
 use net::packet::Packet;
 use pipeline::NetworkFunction;
+use stateful::sessions::{NatDefaultSessionManager, NatSessionManager};
 
 /// Indicates whether a [`Nat`] processor should perform source NAT or destination NAT.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,6 +63,7 @@ pub enum NatMode {
 #[derive(Debug)]
 pub struct Nat {
     context: NatTables,
+    sessions: NatDefaultSessionManager,
     mode: NatMode,
     direction: NatDirection,
 }
@@ -74,6 +76,7 @@ impl Nat {
         let context = NatTables::new();
         Self {
             context,
+            sessions: NatDefaultSessionManager::new(),
             mode,
             direction,
         }

--- a/dataplane/src/nat/stateful/allocator.rs
+++ b/dataplane/src/nat/stateful/allocator.rs
@@ -18,7 +18,7 @@ pub struct NatPort(u16);
 impl NatPort {
     const MIN: u16 = 1024 + 1;
 
-    fn new_checked(port: u16) -> Result<NatPort, AllocatorError> {
+    pub fn new_checked(port: u16) -> Result<NatPort, AllocatorError> {
         if port < Self::MIN {
             return Err(AllocatorError::ReservedPort(port));
         }

--- a/dataplane/src/nat/stateful/allocator.rs
+++ b/dataplane/src/nat/stateful/allocator.rs
@@ -2,6 +2,8 @@
 // Copyright Open Network Fabric Authors
 
 use super::NatIp;
+use net::tcp::port::{TcpPort, TcpPortError};
+use net::udp::port::{UdpPort, UdpPortError};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
@@ -24,13 +26,45 @@ impl NatPort {
     }
 
     #[must_use]
-    fn as_u16(self) -> u16 {
+    pub fn as_u16(self) -> u16 {
         self.0
     }
 }
 
+impl TryFrom<TcpPort> for NatPort {
+    type Error = AllocatorError;
+
+    fn try_from(port: TcpPort) -> Result<Self, Self::Error> {
+        Self::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<NatPort> for TcpPort {
+    type Error = TcpPortError;
+
+    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
+        TcpPort::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<UdpPort> for NatPort {
+    type Error = AllocatorError;
+
+    fn try_from(port: UdpPort) -> Result<Self, Self::Error> {
+        Self::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<NatPort> for UdpPort {
+    type Error = UdpPortError;
+
+    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
+        UdpPort::new_checked(port.as_u16())
+    }
+}
+
 pub trait NatPool<I: NatIp> {
-    fn allocate(&self) -> Result<(I, NatPort), AllocatorError>;
+    fn allocate(&self) -> Result<(I, Option<NatPort>), AllocatorError>;
 }
 
 #[derive(Debug, Clone)]
@@ -40,7 +74,7 @@ pub struct NatDefaultPool<I: NatIp> {
 }
 
 impl<I: NatIp> NatPool<I> for NatDefaultPool<I> {
-    fn allocate(&self) -> Result<(I, NatPort), AllocatorError> {
+    fn allocate(&self) -> Result<(I, Option<NatPort>), AllocatorError> {
         todo!()
     }
 }

--- a/dataplane/src/nat/stateful/mod.rs
+++ b/dataplane/src/nat/stateful/mod.rs
@@ -10,6 +10,7 @@ use super::Nat;
 use crate::nat::stateful::sessions::NatState;
 use net::buffer::PacketBufferMut;
 use net::headers::{Net, TryHeadersMut, TryIpMut};
+use net::ip::NextHeader;
 use net::packet::Packet;
 use net::vxlan::Vni;
 use routing::rib::vrf::VrfId;
@@ -46,12 +47,23 @@ impl NatIp for Ipv6Addr {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct NatTuple<I: NatIp> {
     src_ip: I,
     dst_ip: I,
-    next_header: u8,
+    next_header: NextHeader,
     vrf_id: VrfId,
+}
+
+impl<I: NatIp> NatTuple<I> {
+    fn new(src_ip: I, dst_ip: I, next_header: NextHeader, vrf_id: VrfId) -> Self {
+        Self {
+            src_ip,
+            dst_ip,
+            next_header,
+            vrf_id,
+        }
+    }
 }
 
 impl Nat {

--- a/dataplane/src/nat/stateful/mod.rs
+++ b/dataplane/src/nat/stateful/mod.rs
@@ -4,11 +4,11 @@
 #![allow(unused_variables)]
 
 mod allocator;
-mod sessions;
+pub mod sessions;
 
 use super::Nat;
 use crate::nat::NatDirection;
-use crate::nat::stateful::sessions::{NatDefaultSession, NatSession, NatState};
+use crate::nat::stateful::sessions::{NatDefaultSession, NatSession, NatSessionManager, NatState};
 use net::buffer::PacketBufferMut;
 use net::headers::{Net, Transport, TryHeadersMut, TryIp, TryIpMut, TryTransportMut};
 use net::ip::NextHeader;
@@ -68,7 +68,7 @@ impl NatIp for Ipv6Addr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct NatTuple<I: NatIp> {
+pub struct NatTuple<I: NatIp> {
     src_ip: I,
     dst_ip: I,
     next_header: NextHeader,
@@ -102,7 +102,7 @@ impl Nat {
         &self,
         tuple: &NatTuple<Ipv4Addr>,
     ) -> Option<NatDefaultSession> {
-        todo!()
+        self.sessions.lookup_v4_mut(tuple)
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -111,7 +111,9 @@ impl Nat {
         tuple: &NatTuple<Ipv4Addr>,
         state: NatState,
     ) -> Result<(), sessions::SessionError> {
-        todo!()
+        self.sessions.insert_session_v4(tuple.clone(), state)
+
+        // TODO: Reverse session
     }
 
     fn find_nat_pool<I: NatIp>(

--- a/dataplane/src/nat/stateful/mod.rs
+++ b/dataplane/src/nat/stateful/mod.rs
@@ -18,12 +18,13 @@ use net::tcp::port::TcpPort;
 use net::udp::port::UdpPort;
 use net::vxlan::Vni;
 use routing::rib::vrf::VrfId;
+use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 mod private {
     pub trait Sealed {}
 }
-pub trait NatIp: private::Sealed + Sized {
+pub trait NatIp: private::Sealed + Clone + Eq + Hash {
     fn to_ip_addr(&self) -> IpAddr;
     fn from_src_addr(net: &Net) -> Option<Self>;
     fn from_dst_addr(net: &Net) -> Option<Self>;
@@ -103,7 +104,7 @@ impl Nat {
     fn lookup_session_v4_mut(
         &self,
         tuple: &NatTuple<Ipv4Addr>,
-    ) -> Option<NatDefaultSession> {
+    ) -> Option<NatDefaultSession<'_, Ipv4Addr>> {
         self.sessions.lookup_v4_mut(tuple)
     }
 

--- a/dataplane/src/nat/stateful/mod.rs
+++ b/dataplane/src/nat/stateful/mod.rs
@@ -24,14 +24,8 @@ mod private {
 pub trait NatIp: private::Sealed {
     fn to_ip_addr(&self) -> IpAddr;
 }
-impl private::Sealed for IpAddr {}
 impl private::Sealed for Ipv4Addr {}
 impl private::Sealed for Ipv6Addr {}
-impl NatIp for IpAddr {
-    fn to_ip_addr(&self) -> IpAddr {
-        *self
-    }
-}
 impl NatIp for Ipv4Addr {
     fn to_ip_addr(&self) -> IpAddr {
         IpAddr::V4(*self)

--- a/dataplane/src/nat/stateful/sessions.rs
+++ b/dataplane/src/nat/stateful/sessions.rs
@@ -5,9 +5,12 @@ use super::allocator::NatPort;
 use std::net::IpAddr;
 use std::time::Instant;
 
-trait NatSessionManager {
-    fn lookup(&self, addr: &IpAddr) -> Option<&NatSession>;
-    fn create_session(&mut self, addr: IpAddr) -> Result<NatSession, ()>;
+pub trait NatSessionManager<T>
+where
+    T: NatSession,
+{
+    fn lookup(&self, addr: &IpAddr) -> Option<T>;
+    fn create_session(&mut self, addr: IpAddr) -> Result<T, ()>;
     fn remove_session(&mut self, addr: &IpAddr);
 }
 
@@ -20,11 +23,11 @@ impl NatDefaultSessionManager {
     }
 }
 
-impl NatSessionManager for NatDefaultSessionManager {
-    fn lookup(&self, addr: &IpAddr) -> Option<&NatSession> {
+impl NatSessionManager<NatDefaultSession> for NatDefaultSessionManager {
+    fn lookup(&self, addr: &IpAddr) -> Option<NatDefaultSession> {
         todo!()
     }
-    fn create_session(&mut self, addr: IpAddr) -> Result<NatSession, ()> {
+    fn create_session(&mut self, addr: IpAddr) -> Result<NatDefaultSession, ()> {
         todo!()
     }
     fn remove_session(&mut self, addr: &IpAddr) {
@@ -86,5 +89,15 @@ impl NatState {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct NatSession {}
+pub trait NatSession {
+    fn get_state_mut(&mut self) -> Option<&mut NatState>;
+}
+
+#[derive(Debug)]
+pub struct NatDefaultSession {}
+
+impl NatSession for NatDefaultSession {
+    fn get_state_mut(&mut self) -> Option<&mut NatState> {
+        todo!()
+    }
+}

--- a/dataplane/src/nat/stateful/sessions.rs
+++ b/dataplane/src/nat/stateful/sessions.rs
@@ -3,8 +3,11 @@
 
 use super::NatTuple;
 use super::allocator::NatPort;
-use std::net::{IpAddr, Ipv4Addr};
-use std::time::Instant;
+use crate::nat::stateful::NatIp;
+use dashmap::DashMap;
+use dashmap::mapref::one::RefMut;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
 pub enum SessionError {
@@ -12,13 +15,13 @@ pub enum SessionError {
     DuplicateTuple,
 }
 
-pub trait NatSessionManager<T>
+pub trait NatSessionManager<'a, T>
 where
-    T: NatSession,
+    T: 'a + NatSession,
 {
     fn new() -> Self;
 
-    fn lookup_v4_mut(&self, tuple: &NatTuple<Ipv4Addr>) -> Option<T>;
+    fn lookup_v4_mut(&'a self, tuple: &NatTuple<Ipv4Addr>) -> Option<T>;
     fn insert_session_v4(
         &mut self,
         tuple: NatTuple<Ipv4Addr>,
@@ -30,21 +33,54 @@ where
 }
 
 #[derive(Debug, Clone)]
-pub struct NatDefaultSessionManager {}
-
-impl NatDefaultSessionManager {
+pub struct NatDefaultSessionManager {
+    table_v4: DashMap<NatTuple<Ipv4Addr>, NatState>,
+    table_v6: DashMap<NatTuple<Ipv6Addr>, NatState>,
 }
 
-impl NatSessionManager<NatDefaultSession> for NatDefaultSessionManager {
+impl NatDefaultSessionManager {
+    fn clean_closed_sessions(&mut self, cooldown: Duration) {
+        self.table_v4.retain(|_, session| match session.closed_at {
+            Some(close_time) => close_time.elapsed() < cooldown,
+            None => true,
+        });
+        self.table_v6.retain(|_, session| match session.closed_at {
+            Some(close_time) => close_time.elapsed() < cooldown,
+            None => true,
+        });
+    }
+
+    fn clean_unused_sessions(&mut self, timeout: Duration) {
+        self.table_v4
+            .retain(|_, session| session.last_used.elapsed() > timeout);
+        self.table_v6
+            .retain(|_, session| session.last_used.elapsed() > timeout);
+    }
+
+    fn clean_for_originator(&mut self, originator: u64) {
+        self.table_v4
+            .retain(|_, session| session.originator != originator);
+        self.table_v6
+            .retain(|_, session| session.originator != originator);
+    }
+}
+
+impl<'a> NatSessionManager<'a, NatDefaultSession<'a, Ipv4Addr>> for NatDefaultSessionManager {
     fn new() -> Self {
-        Self {}
+        Self {
+            table_v4: DashMap::new(),
+            table_v6: DashMap::new(),
+        }
     }
 
     fn lookup_v4_mut(
-        &self,
+        &'a self,
         tuple: &NatTuple<Ipv4Addr>,
-    ) -> Option<NatDefaultSession> {
-        todo!()
+    ) -> Option<NatDefaultSession<'a, Ipv4Addr>> {
+        let map_entry = self.table_v4.get_mut(tuple)?;
+        Some(NatDefaultSession {
+            dashmap_ref: Some(map_entry),
+        })
     }
 
     fn insert_session_v4(
@@ -52,11 +88,14 @@ impl NatSessionManager<NatDefaultSession> for NatDefaultSessionManager {
         tuple: NatTuple<Ipv4Addr>,
         state: NatState,
     ) -> Result<(), SessionError> {
-        todo!()
+        // Return an error if the tuple already exists in the table
+        self.table_v4
+            .insert(tuple, state)
+            .map_or(Ok(()), |_| Err(SessionError::DuplicateTuple))
     }
 
     fn remove_session_v4(&mut self, tuple: &NatTuple<Ipv4Addr>) {
-        todo!()
+        self.table_v4.remove(tuple);
     }
 
     fn start_gc(&self) -> Result<(), SessionError> {
@@ -123,10 +162,17 @@ pub trait NatSession {
 }
 
 #[derive(Debug)]
-pub struct NatDefaultSession {}
+pub struct NatDefaultSession<'a, I: NatIp> {
+    dashmap_ref: Option<RefMut<'a, NatTuple<I>, NatState>>,
+}
 
-impl NatSession for NatDefaultSession {
+// Note that the generic parameter `I` is used to specify the type of IP address of THE TUPLES
+// associated with this session in the table, NOT the IP address of the target_ip in the state of
+// the session itself. This is because we use dashmap, and the lookup returns a reference to the
+// whole map entry, which includes the tuple and the state, and we make the dashmap_ref generic to
+// the Tuple<I>.
+impl<I: NatIp> NatSession for NatDefaultSession<'_, I> {
     fn get_state_mut(&mut self) -> Option<&mut NatState> {
-        todo!()
+        self.dashmap_ref.as_mut().map(RefMut::value_mut)
     }
 }

--- a/dataplane/src/nat/stateful/sessions.rs
+++ b/dataplane/src/nat/stateful/sessions.rs
@@ -1,36 +1,65 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use super::NatTuple;
 use super::allocator::NatPort;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::time::Instant;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum SessionError {
+    #[error("duplicate session key")]
+    DuplicateTuple,
+}
 
 pub trait NatSessionManager<T>
 where
     T: NatSession,
 {
-    fn lookup(&self, addr: &IpAddr) -> Option<T>;
-    fn create_session(&mut self, addr: IpAddr) -> Result<T, ()>;
-    fn remove_session(&mut self, addr: &IpAddr);
+    fn new() -> Self;
+
+    fn lookup_v4_mut(&self, tuple: &NatTuple<Ipv4Addr>) -> Option<T>;
+    fn insert_session_v4(
+        &mut self,
+        tuple: NatTuple<Ipv4Addr>,
+        state: NatState,
+    ) -> Result<(), SessionError>;
+    fn remove_session_v4(&mut self, tuple: &NatTuple<Ipv4Addr>);
+
+    fn start_gc(&self) -> Result<(), SessionError>;
 }
 
 #[derive(Debug, Clone)]
 pub struct NatDefaultSessionManager {}
 
 impl NatDefaultSessionManager {
-    fn new() -> Self {
-        Self {}
-    }
 }
 
 impl NatSessionManager<NatDefaultSession> for NatDefaultSessionManager {
-    fn lookup(&self, addr: &IpAddr) -> Option<NatDefaultSession> {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn lookup_v4_mut(
+        &self,
+        tuple: &NatTuple<Ipv4Addr>,
+    ) -> Option<NatDefaultSession> {
         todo!()
     }
-    fn create_session(&mut self, addr: IpAddr) -> Result<NatDefaultSession, ()> {
+
+    fn insert_session_v4(
+        &mut self,
+        tuple: NatTuple<Ipv4Addr>,
+        state: NatState,
+    ) -> Result<(), SessionError> {
         todo!()
     }
-    fn remove_session(&mut self, addr: &IpAddr) {
+
+    fn remove_session_v4(&mut self, tuple: &NatTuple<Ipv4Addr>) {
+        todo!()
+    }
+
+    fn start_gc(&self) -> Result<(), SessionError> {
         todo!()
     }
 }

--- a/dataplane/src/nat/stateful/sessions.rs
+++ b/dataplane/src/nat/stateful/sessions.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use super::allocator::NatPort;
 use std::net::IpAddr;
+use std::time::Instant;
 
 trait NatSessionManager {
     fn lookup(&self, addr: &IpAddr) -> Option<&NatSession>;
@@ -27,6 +29,60 @@ impl NatSessionManager for NatDefaultSessionManager {
     }
     fn remove_session(&mut self, addr: &IpAddr) {
         todo!()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NatState {
+    // Translation IP address and port
+    target_ip: IpAddr,
+    target_port: Option<NatPort>,
+    // Flags for session management
+    flags: u64,
+    // Timestamps for garbage-collector
+    last_used: Instant,
+    closed_at: Option<Instant>,
+    // Statistics
+    packets: u64,
+    bytes: u64,
+    // ID associated to the entity that created this session, so we can clean up the session when
+    // the entity is removed
+    originator: u64,
+}
+
+impl NatState {
+    pub fn new(target_ip: IpAddr, target_port: Option<NatPort>) -> Self {
+        Self {
+            target_ip,
+            target_port,
+            flags: 0,
+            last_used: Instant::now(),
+            closed_at: None,
+            packets: 0,
+            bytes: 0,
+            originator: 0,
+        }
+    }
+    pub fn get_nat(&self) -> (IpAddr, Option<NatPort>) {
+        (self.target_ip, self.target_port)
+    }
+    pub fn update_last_used(&mut self) {
+        self.last_used = Instant::now();
+    }
+    pub fn set_closed_at(&mut self, closed_at: Instant) {
+        self.closed_at = Some(closed_at);
+    }
+    pub fn get_num_packets(&self) -> u64 {
+        self.packets
+    }
+    pub fn get_num_bytes(&self) -> u64 {
+        self.bytes
+    }
+    pub fn increment_packets(&mut self, packets: u64) {
+        self.packets += packets;
+    }
+    pub fn increment_bytes(&mut self, bytes: u64) {
+        self.bytes += bytes;
     }
 }
 

--- a/net/src/headers.rs
+++ b/net/src/headers.rs
@@ -9,6 +9,7 @@ use crate::eth::ethtype::EthType;
 use crate::eth::{Eth, EthError};
 use crate::icmp4::Icmp4;
 use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
+use crate::ip::NextHeader;
 use crate::ip_auth::IpAuth;
 use crate::ipv4::Ipv4;
 use crate::ipv6::{Ipv6, Ipv6Ext};
@@ -63,6 +64,13 @@ impl Net {
         match self {
             Net::Ipv4(ip) => IpAddr::V4(ip.source().inner()),
             Net::Ipv6(ip) => IpAddr::V6(ip.source().inner()),
+        }
+    }
+
+    pub fn next_header(&self) -> NextHeader {
+        match self {
+            Net::Ipv4(ip) => ip.protocol().into(),
+            Net::Ipv6(ip) => ip.next_header(),
         }
     }
 }

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -12,12 +12,18 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 ///
 /// This exists to allow us to implement `TypeGenerator` without violating rust's orphan rules.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub struct NextHeader(pub(crate) IpNumber);
 
 impl From<NextHeader> for IpNumber {
     fn from(value: NextHeader) -> Self {
         value.0
+    }
+}
+
+impl From<IpNumber> for NextHeader {
+    fn from(value: IpNumber) -> Self {
+        Self(value)
     }
 }
 

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -103,6 +103,12 @@ impl<Buf: PacketBufferMut> Packet<Buf> {
         self.headers.size()
     }
 
+    /// Get total packet length.
+    #[must_use]
+    pub fn total_len(&self) -> u16 {
+        self.payload_len() + self.header_len().get()
+    }
+
     /// If the [`Packet`] is [`Vxlan`], then this method
     ///
     /// 1. strips the outer headers

--- a/net/src/tcp/mod.rs
+++ b/net/src/tcp/mod.rs
@@ -4,7 +4,7 @@
 //! TCP header type and logic.
 
 mod checksum;
-mod port;
+pub mod port;
 
 pub use checksum::*;
 pub use port::*;

--- a/net/src/tcp/port.rs
+++ b/net/src/tcp/port.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+//! TCP port type and parsing logic.
+
 use std::num::NonZero;
 
 /// A TCP port number.
@@ -12,6 +14,7 @@ use std::num::NonZero;
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 pub struct TcpPort(NonZero<u16>);
 
+/// Errors which may occur in the creation or parsing of a [`TcpPort`].
 #[repr(transparent)]
 #[derive(
     Copy,


### PR DESCRIPTION
This PR contains various changes to the code for stateful NAT, leading to the (partial) implementation of a session manager based on dashmap.

Best reviewed per-commit.

Missing components:

- Create corresponding reverse sessions when we create new sessions
- Port/IP allocator (future work)
- Garbage collector to clean up stale sessions (future work)

Fixes: #181