### PR TITLE
fix(ci): Make Summary step functional again

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -275,6 +275,17 @@ jobs:
     runs-on: "ubuntu-latest"
     needs:
       - check
+    # Run always, except when the "check" job was skipped.
+    #
+    # When the check job is skipped, summary will be marked as skipped, and
+    # it's OK for CI (it's not a failure).
+    # Why don't we do the same for check jobs? Because their names depend on
+    # matrix values, and if we skip them the names won't be generated and
+    # GitHub won't be able to find skipped jobs for required status checks.
+    if: ${{ always() && needs.check.result != 'skipped' }}
     steps:
-      - run: |
-          exit 0
+      - name: "Flag any check matrix failures"
+        if: ${{ needs.check.result != 'success' }}
+        run: |
+          echo '::error:: Some job(s) failed'
+          exit 1


### PR DESCRIPTION
In a recent commit, in an attempt to "de-clutter" the dev.yml workflow, we broke the Summary job: it doesn't run all the time, and always returns 0 anyway. Let's fix it: make it dependent on the results from the main job, so that we get meaningful results even if we skip most of the CI jobs when updating the README.md, for example.
