### PR TITLE
ci: Use "release" environment for fuzzing

### DIFF
--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ _container_repo := "ghcr.io/githedgehog/dataplane"
 
 # Docker images
 [private]
-_image_profile := if profile == "release" { "release" } else { "debug" }
+_image_profile := if profile == "debug" { "debug" } else { "release" }
 [private]
 _dpdk_sys_container_repo := "ghcr.io/githedgehog/dpdk-sys"
 [private]
@@ -128,10 +128,10 @@ cargo *args:
       case "$arg" in
         --debug|--profile=debug|--cargo-profile=debug)
           declare -rx RUSTFLAGS="${RUSTFLAGS_DEBUG}"
+          declare -rx LIBC_ENV_PROFILE="debug"
           ;;
         --release|--profile=release|--cargo-profile=release)
           declare -rx RUSTFLAGS="${RUSTFLAGS_RELEASE}"
-          declare -rx LIBC_ENV_PROFILE="release"
           extra_args+=("$arg")
           ;;
         --profile=fuzz|--cargo-profile=fuzz)

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -195,5 +195,5 @@ fi
   --cap-add SYS_ADMIN \
   --cap-add SYS_RAWIO \
   --read-only \
-  "ghcr.io/githedgehog/dpdk-sys/libc-env:${DPDK_SYS_COMMIT}.${LIBC_ENV_PROFILE:-debug}" \
+  "ghcr.io/githedgehog/dpdk-sys/libc-env:${DPDK_SYS_COMMIT}.${LIBC_ENV_PROFILE:-release}" \
   "${@}"


### PR DESCRIPTION
In a recent commit (fa9137378108) we adjusted the build and CI environments to use either the release or the debug images for the compile-env and libc-env containers. We made the `release` profile use the `release` environment, the `debug` profile use the `debug` environment, as one might expect. As for the `fuzz` profile? We made it use the `debug` environment, but this was the wrong pick: it should be `release`, because we're using the same LTO parameters for fuzzing as with the `release` environment. This commit makes `release` the default environment used with everything other than `debug`, so that the `fuzz` profile gets the correct environment.
