### PR TITLE
NAT: Move tests back to "nat" crate

### DIFF
--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -48,6 +48,7 @@ tracing-test = { workspace = true }
 fixin = { workspace = true }
 id = { workspace = true, features = ["bolero"] }
 interface-manager = { workspace = true, features = ["bolero"] }
+nat = { workspace = true, features = ["testing"] }
 net = { workspace = true, features = ["bolero"] }
 routing = { workspace = true, features = ["testing"] }
 test-utils = { workspace = true }

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 license = "Apache-2.0"
 
+[features]
+testing = []
+
 [dependencies]
 dashmap = { workspace = true }
 iptrie = { workspace = true }

--- a/nat/src/stateless/config/prefixtrie.rs
+++ b/nat/src/stateless/config/prefixtrie.rs
@@ -139,6 +139,28 @@ where
     }
 }
 
+impl<T> PartialEq for PrefixTrie<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.trie_ipv4.len() == other.trie_ipv4.len()
+            && self.trie_ipv6.len() == other.trie_ipv6.len()
+            && self
+                .trie_ipv4
+                .iter()
+                .zip(other.trie_ipv4.iter())
+                .all(|(a, b)| a == b)
+            && self
+                .trie_ipv6
+                .iter()
+                .zip(other.trie_ipv6.iter())
+                .all(|(a, b)| a == b)
+    }
+}
+
+impl<T> Eq for PrefixTrie<T> where T: Eq {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/nat/src/stateless/config/tables.rs
+++ b/nat/src/stateless/config/tables.rs
@@ -11,7 +11,7 @@ use std::net::IpAddr;
 /// An object containing the rules for the NAT pipeline stage, not in terms of states for the
 /// different connections established, but instead holding the base rules for stateful or static
 /// NAT.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NatTables {
     pub tables: HashMap<u32, PerVniTable>,
 }
@@ -39,7 +39,7 @@ impl Default for NatTables {
 
 /// A table containing all rules for both source and destination static NAT, for packets with a
 /// given source VNI.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PerVniTable {
     pub dst_nat: NatPrefixRuleTable,
     pub src_nat_peers: NatPeerRuleTable,
@@ -97,14 +97,14 @@ impl Default for PerVniTable {
 }
 
 /// From a current address prefix, find the target address prefix.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NatPrefixRuleTable {
     pub rules: PrefixTrie<Option<TrieValue>>,
 }
 
 /// From a current address prefix, find the relevant [`NatPrefixRuleTable`] for the target prefix
 /// lookup.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NatPeerRuleTable {
     pub rules: PrefixTrie<usize>,
 }
@@ -192,7 +192,7 @@ impl Default for NatPeerRuleTable {
 
 /// A value associated with a prefix in the trie, and that encapsulates all information required to
 /// perform the address mapping for static NAT.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TrieValue {
     orig: BTreeSet<Prefix>,
     orig_excludes: BTreeSet<Prefix>,

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -5,8 +5,8 @@
 
 pub mod config;
 mod iplist;
-#[cfg(test)]
-mod test;
+#[cfg(any(test, feature = "testing"))]
+pub mod test;
 
 use crate::NatDirection;
 use config::tables::{NatTables, TrieValue};

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod config;
 mod iplist;
+#[cfg(test)]
+mod test;
 
 use crate::NatDirection;
 use config::tables::{NatTables, TrieValue};

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use crate::stateless::NatTables;
+use crate::stateless::config::prefixtrie::PrefixTrie;
+use crate::stateless::config::tables::{
+    NatPeerRuleTable, NatPrefixRuleTable, PerVniTable, TrieValue,
+};
+use routing::prefix::Prefix;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+#[allow(clippy::too_many_lines)]
+#[must_use]
+pub fn build_reference_nat_tables() -> NatTables {
+    fn new_prefixtrie<T, const N: usize>(entries: [(Prefix, T); N]) -> PrefixTrie<T>
+    where
+        T: Default + Debug,
+    {
+        let mut trie = PrefixTrie::new();
+        for (prefix, value) in entries {
+            let _ = trie.insert(&prefix, value);
+        }
+        trie
+    }
+
+    NatTables {
+        tables: HashMap::from([(
+            100,
+            PerVniTable {
+                dst_nat: NatPrefixRuleTable {
+                    rules: new_prefixtrie([
+                        ("0.0.0.0/0".into(), None),
+                        (
+                            "3.0.0.0/16".into(),
+                            Some(TrieValue::new(
+                                BTreeSet::from(["8.0.0.0/17".into(), "9.0.0.0/17".into()]),
+                                BTreeSet::from(["8.0.0.0/24".into()]),
+                                BTreeSet::from(["3.0.0.0/16".into()]),
+                                BTreeSet::from(["3.0.1.0/24".into()]),
+                            )),
+                        ),
+                        ("3.0.1.0/24".into(), None),
+                        (
+                            "1.1.0.0/17".into(),
+                            Some(TrieValue::new(
+                                BTreeSet::from(["10.0.0.0/16".into()]),
+                                BTreeSet::from(["10.0.1.0/24".into(), "10.0.2.0/24".into()]),
+                                BTreeSet::from(["1.1.0.0/17".into(), "1.2.0.0/17".into()]),
+                                BTreeSet::from(["1.2.0.0/24".into(), "1.2.8.0/24".into()]),
+                            )),
+                        ),
+                        (
+                            "1.2.0.0/17".into(),
+                            Some(TrieValue::new(
+                                BTreeSet::from(["10.0.0.0/16".into()]),
+                                BTreeSet::from(["10.0.1.0/24".into(), "10.0.2.0/24".into()]),
+                                BTreeSet::from(["1.1.0.0/17".into(), "1.2.0.0/17".into()]),
+                                BTreeSet::from(["1.2.0.0/24".into(), "1.2.8.0/24".into()]),
+                            )),
+                        ),
+                        ("1.2.0.0/24".into(), None),
+                        ("1.2.8.0/24".into(), None),
+                        ("::/0".into(), None),
+                    ]),
+                },
+                src_nat_peers: NatPeerRuleTable {
+                    rules: new_prefixtrie([
+                        ("0.0.0.0/0".into(), 0),
+                        ("1.1.0.0/16".into(), 0),
+                        ("1.2.0.0/16".into(), 0),
+                        ("3.0.0.0/16".into(), 1),
+                        ("::/0".into(), 0),
+                    ]),
+                },
+                src_nat_prefixes: vec![
+                    NatPrefixRuleTable {
+                        rules: new_prefixtrie([
+                            ("0.0.0.0/0".into(), None),
+                            (
+                                "1.1.0.0/16".into(),
+                                Some(TrieValue::new(
+                                    BTreeSet::from(["1.1.0.0/16".into(), "1.2.0.0/16".into()]),
+                                    BTreeSet::from([
+                                        "1.1.1.0/24".into(),
+                                        "1.1.3.0/24".into(),
+                                        "1.1.5.0/24".into(),
+                                        "1.2.2.0/24".into(),
+                                    ]),
+                                    BTreeSet::from(["2.1.0.0/16".into(), "2.2.0.0/16".into()]),
+                                    BTreeSet::from([
+                                        "2.1.8.0/24".into(),
+                                        "2.2.1.0/24".into(),
+                                        "2.2.2.0/24".into(),
+                                        "2.2.10.0/24".into(),
+                                    ]),
+                                )),
+                            ),
+                            (
+                                "1.2.0.0/16".into(),
+                                Some(TrieValue::new(
+                                    BTreeSet::from(["1.1.0.0/16".into(), "1.2.0.0/16".into()]),
+                                    BTreeSet::from([
+                                        "1.1.1.0/24".into(),
+                                        "1.1.3.0/24".into(),
+                                        "1.1.5.0/24".into(),
+                                        "1.2.2.0/24".into(),
+                                    ]),
+                                    BTreeSet::from(["2.1.0.0/16".into(), "2.2.0.0/16".into()]),
+                                    BTreeSet::from([
+                                        "2.1.8.0/24".into(),
+                                        "2.2.1.0/24".into(),
+                                        "2.2.2.0/24".into(),
+                                        "2.2.10.0/24".into(),
+                                    ]),
+                                )),
+                            ),
+                            ("1.1.1.0/24".into(), None),
+                            ("1.1.3.0/24".into(), None),
+                            ("1.1.5.0/24".into(), None),
+                            ("1.2.2.0/24".into(), None),
+                            ("::/0".into(), None),
+                        ]),
+                    },
+                    NatPrefixRuleTable {
+                        rules: new_prefixtrie([
+                            ("0.0.0.0/0".into(), None),
+                            (
+                                "3.0.0.0/16".into(),
+                                Some(TrieValue::new(
+                                    BTreeSet::from(["3.0.0.0/16".into()]),
+                                    BTreeSet::new(),
+                                    BTreeSet::from(["4.0.0.0/16".into()]),
+                                    BTreeSet::new(),
+                                )),
+                            ),
+                            ("::/0".into(), None),
+                        ]),
+                    },
+                ],
+            },
+        )]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NatDirection;
+    use crate::StatelessNat;
+    use net::headers::TryIpv4;
+    use net::packet::test_utils::build_test_ipv4_packet;
+    use net::vxlan::Vni;
+    use pipeline::NetworkFunction;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+
+    fn addr_v4(s: &str) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::from_str(s).expect("Invalid IPv4 address"))
+    }
+
+    fn vni_100() -> Vni {
+        Vni::new_checked(100).expect("Failed to create VNI")
+    }
+
+    #[test]
+    fn test_dst_nat_stateless_44() {
+        let nat_tables = build_reference_nat_tables();
+        let mut nat = StatelessNat::new(NatDirection::DstNat);
+        nat.update_tables(nat_tables);
+
+        let packets = vec![build_test_ipv4_packet(u8::MAX).unwrap()]
+            .into_iter()
+            .map(|mut packet| {
+                packet.get_meta_mut().src_vni = Some(vni_100());
+                packet
+            });
+
+        let packets_out: Vec<_> = nat.process(packets).collect();
+
+        assert_eq!(packets_out.len(), 1);
+
+        let hdr0_out = &packets_out[0]
+            .try_ipv4()
+            .expect("Failed to get IPv4 header");
+        println!("L3 header: {hdr0_out:?}");
+        assert_eq!(hdr0_out.destination(), addr_v4("10.0.132.4"));
+    }
+
+    #[test]
+    fn test_src_nat_stateless_44() {
+        let nat_tables = build_reference_nat_tables();
+        let mut nat = StatelessNat::new(NatDirection::SrcNat);
+        nat.update_tables(nat_tables);
+
+        let packets = vec![build_test_ipv4_packet(u8::MAX).unwrap()]
+            .into_iter()
+            .map(|mut packet| {
+                packet.get_meta_mut().src_vni = Some(vni_100());
+                packet
+            });
+
+        let packets_out: Vec<_> = nat.process(packets).collect();
+
+        assert_eq!(packets_out.len(), 1);
+
+        let hdr0_out = &packets_out[0]
+            .try_ipv4()
+            .expect("Failed to get IPv4 header");
+        println!("L3 header: {hdr0_out:?}");
+        assert_eq!(hdr0_out.source().inner(), addr_v4("2.2.0.4"));
+    }
+}


### PR DESCRIPTION
- **feat(nat): Implement PartialEq, Eq for NatTables (and related types)**
- **test(nat): Add stateless NAT test in "stateless" module**
- **test(mgmt): Remove redundant tests for stateless NAT**

Please take a look at individual commit descriptions for details.
