### PR TITLE
style(mgmt): Fix a Clippy report

### DIFF
--- a/mgmt/src/frr/renderer/mod.rs
+++ b/mgmt/src/frr/renderer/mod.rs
@@ -19,7 +19,7 @@ use crate::models::internal::InternalConfig;
 use tracing::debug;
 
 fn render_metadata(genid: &GenId) -> String {
-    format!("! config for gen {}", genid)
+    format!("! config for gen {genid}")
 }
 
 impl Render for InternalConfig {


### PR DESCRIPTION
When trying to update to the latest dpdk-sys (I think with a Rust version upgrade?), we get a complaint from Clippy; let's address it.

(Link: https://github.com/githedgehog/dataplane/actions/runs/15975791652/job/45057799019?pr=647)