### PR TITLE
Support empty `ips`/`as_range` with non-empty `nots`/`not_as`

### DIFF
--- a/mgmt/src/models/external/overlay/tests.rs
+++ b/mgmt/src/models/external/overlay/tests.rs
@@ -97,17 +97,11 @@ pub mod test {
         let expose = VpcExpose::empty().ip("10.0.0.0/16".into());
         assert_eq!(expose.validate(), Ok(()));
 
-        // Empty ips but non-empty nots - Currently not supported
-        /*
         let expose = VpcExpose::empty().not("10.0.1.0/24".into());
         assert_eq!(expose.validate(), Ok(()));
-        */
 
-        // Empty as_range but non-empty not_as - Currently not supported
-        /*
         let expose = VpcExpose::empty().not_as("2.0.1.0/24".into());
         assert_eq!(expose.validate(), Ok(()));
-        */
 
         let expose = VpcExpose::empty()
             .ip("10.0.0.0/16".into())
@@ -126,13 +120,10 @@ pub mod test {
             .as_range("2::/64".into());
         assert_eq!(expose.validate(), Ok(()));
 
-        // Empty ips/as_range but non-empty nots/not_as - Currently not supported
-        /*
         let expose = VpcExpose::empty()
             .not("10.0.0.0/16".into())
             .not_as("2.0.0.0/16".into());
         assert_eq!(expose.validate(), Ok(()));
-        */
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -129,22 +129,6 @@ impl VpcExpose {
             ));
         }
 
-        // 6. Forbid empty ips list if not is non-empty.
-        //    Forbid empty as_range list if not_as is non-empty.
-        //    These configurations are allowed by the user API, but we don't currently support them,
-        //    so we reject them during validation.
-        //    https://github.com/githedgehog/dataplane/issues/650
-        if !self.nots.is_empty() && self.ips.is_empty() {
-            return Err(ConfigError::Forbidden(
-                "Empty 'ips' with non-empty 'nots' is currently not supported",
-            ));
-        }
-        if !self.not_as.is_empty() && self.as_range.is_empty() {
-            return Err(ConfigError::Forbidden(
-                "Empty 'as_range' with non-empty 'not_as' is currently not supported",
-            ));
-        }
-
         Ok(())
     }
 }

--- a/mgmt/src/models/internal/natconfig/table_extend.rs
+++ b/mgmt/src/models/internal/natconfig/table_extend.rs
@@ -138,6 +138,14 @@ fn collapse_prefix_lists(
     excludes: &BTreeSet<Prefix>,
 ) -> Result<BTreeSet<Prefix>, NatPeeringError> {
     let mut result = prefixes.clone();
+
+    if result.is_empty() && !excludes.is_empty() {
+        match excludes.first().unwrap() {
+            Prefix::IPV4(_) => result.insert(Prefix::root_v4()),
+            Prefix::IPV6(_) => result.insert(Prefix::root_v6()),
+        };
+    }
+
     // Sort the exclusion prefixes by length in ascending order (meaning a /16 is _smaller_ than a
     // /24, and comes first). If there are some exclusion prefixes with overlap, this ensures that
     // we take out the biggest chunk from the allowed prefix first (and don't need to process the

--- a/mgmt/src/models/internal/natconfig/table_extend.rs
+++ b/mgmt/src/models/internal/natconfig/table_extend.rs
@@ -355,15 +355,6 @@ mod tests {
             expected
         );
 
-        // Empty prefixes, non-empty excludes
-        let prefixes = BTreeSet::new();
-        let excludes = btree_from(vec!["1.0.0.0/16", "2.0.0.0/24"]);
-        let expected = prefixes.clone();
-        assert_eq!(
-            collapse_prefix_lists(&prefixes, &excludes).unwrap(),
-            expected
-        );
-
         // Excludes outside prefix
         let prefixes = btree_from(vec!["10.0.0.0/16"]);
         let excludes = btree_from(vec!["1.0.0.0/16", "2.0.0.0/24"]);
@@ -542,6 +533,48 @@ mod tests {
         let prefixes = btree_from(vec!["1.0.0.0/16"]);
         let excludes = btree_from(vec!["1.0.0.0/17", "1.0.0.0/24"]);
         let expected = btree_from(vec!["1.0.128.0/17"]);
+        assert_eq!(
+            collapse_prefix_lists(&prefixes, &excludes).unwrap(),
+            expected
+        );
+
+        // Empty prefixes, non-empty excludes
+        let prefixes = BTreeSet::new();
+        let excludes = btree_from(vec!["1.0.0.0/16", "2.0.0.0/24"]);
+        let expected = btree_from(vec![
+            "0.0.0.0/8",
+            "1.1.0.0/16",
+            "1.2.0.0/15",
+            "1.4.0.0/14",
+            "1.8.0.0/13",
+            "1.16.0.0/12",
+            "1.32.0.0/11",
+            "1.64.0.0/10",
+            "1.128.0.0/9",
+            "2.0.1.0/24",
+            "2.0.2.0/23",
+            "2.0.4.0/22",
+            "2.0.8.0/21",
+            "2.0.16.0/20",
+            "2.0.32.0/19",
+            "2.0.64.0/18",
+            "2.0.128.0/17",
+            "2.1.0.0/16",
+            "2.2.0.0/15",
+            "2.4.0.0/14",
+            "2.8.0.0/13",
+            "2.16.0.0/12",
+            "2.32.0.0/11",
+            "2.64.0.0/10",
+            "2.128.0.0/9",
+            "3.0.0.0/8",
+            "4.0.0.0/6",
+            "8.0.0.0/5",
+            "16.0.0.0/4",
+            "32.0.0.0/3",
+            "64.0.0.0/2",
+            "128.0.0.0/1",
+        ]);
         assert_eq!(
             collapse_prefix_lists(&prefixes, &excludes).unwrap(),
             expected


### PR DESCRIPTION
In progress - blocked by #661
