### PR TITLE
Stateless NAT: Simplify TrieValue, improve error handling in IpList, fix prefix size handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ name = "dataplane-nat"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.10",
+ "bolero",
  "dashmap",
  "dataplane-net",
  "dataplane-pipeline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ name = "dataplane-routing"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.10",
+ "bolero",
  "bytes",
  "dataplane-cli",
  "dataplane-net",

--- a/mgmt/src/models/external/mod.rs
+++ b/mgmt/src/models/external/mod.rs
@@ -11,7 +11,7 @@ use crate::models::external::overlay::vpc::VpcId;
 use crate::models::external::overlay::vpcpeering::VpcExpose;
 
 use net::eth::mac::Mac;
-use routing::prefix::Prefix;
+use routing::prefix::{Prefix, PrefixSize};
 use thiserror::Error;
 
 /// The reasons why we may reject a configuration
@@ -68,8 +68,8 @@ pub enum ConfigError {
     #[error("Inconsistent IP version in VpcExpose: {0}")]
     InconsistentIpVersion(VpcExpose),
     // NAT-specific
-    #[error("Mismatched prefixes sizes for static NAT: {0} and {1}")]
-    MismatchedPrefixSizes(u128, u128),
+    #[error("Mismatched prefixes sizes for static NAT: {0:?} and {1:?}")]
+    MismatchedPrefixSizes(PrefixSize, PrefixSize),
 }
 
 /// Result-like type for configurations

--- a/mgmt/src/models/external/overlay/tests.rs
+++ b/mgmt/src/models/external/overlay/tests.rs
@@ -15,7 +15,7 @@ pub mod test {
     use crate::models::external::overlay::vpcpeering::VpcManifest;
     use crate::models::external::overlay::vpcpeering::{VpcPeering, VpcPeeringTable};
 
-    use routing::prefix::Prefix;
+    use routing::prefix::{Prefix, PrefixSize};
 
     /* Build sample manifests for a peering */
     fn build_manifest_vpc1() -> VpcManifest {
@@ -210,7 +210,10 @@ pub mod test {
             .as_range("2.0.0.0/24".into());
         assert_eq!(
             expose.validate(),
-            Err(ConfigError::MismatchedPrefixSizes(65536 - 256, 256))
+            Err(ConfigError::MismatchedPrefixSizes(
+                PrefixSize::U128(65536 - 256),
+                PrefixSize::U128(256)
+            ))
         );
     }
 

--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -4,6 +4,7 @@
 //! Dataplane configuration model: vpc peering
 
 use routing::prefix::Prefix;
+use routing::prefix::PrefixSize;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ops::Bound::{Excluded, Unbounded};
@@ -121,7 +122,7 @@ impl VpcExpose {
             }
         }
 
-        fn prefixes_size(prefixes: &BTreeSet<Prefix>) -> u128 {
+        fn prefixes_size(prefixes: &BTreeSet<Prefix>) -> PrefixSize {
             prefixes.iter().map(|p| p.size()).sum()
         }
 
@@ -427,7 +428,8 @@ fn validate_overlapping(
         let union_size = union_excludes
             .iter()
             .map(|exclude| exclude.size())
-            .sum::<u128>();
+            .sum::<PrefixSize>();
+
         if union_size < intersection_prefix.size() {
             // Some addresses at the intersection of both prefixes are not covered by the union of
             // all exclusion prefixes, in other words, they are available from both prefixes. This

--- a/mgmt/src/models/internal/natconfig/table_extend.rs
+++ b/mgmt/src/models/internal/natconfig/table_extend.rs
@@ -24,19 +24,29 @@ pub enum NatPeeringError {
 }
 
 /// Create a [`TrieValue`] from the public side of a [`VpcExpose`]
-fn get_public_trie_value(vni: Vni, expose: &VpcExpose) -> TrieValue {
-    let orig = expose.ips.clone();
+fn get_public_trie_value(vni: Vni, expose: &VpcExpose, prefix: &Prefix) -> TrieValue {
     let target = expose.as_range.clone();
-
-    TrieValue::new(vni, orig, target)
+    let mut orig_prefix_offset = 0;
+    for p in &expose.ips {
+        if p == prefix {
+            break;
+        }
+        orig_prefix_offset += p.size();
+    }
+    TrieValue::new(vni, *prefix, orig_prefix_offset, target)
 }
 
 /// Create a [`TrieValue`] from the private side of a [`VpcExpose`]
-fn get_private_trie_value(vni: Vni, expose: &VpcExpose) -> TrieValue {
-    let orig = expose.as_range.clone();
+fn get_private_trie_value(vni: Vni, expose: &VpcExpose, prefix: &Prefix) -> TrieValue {
     let target = expose.ips.clone();
-
-    TrieValue::new(vni, orig, target)
+    let mut orig_prefix_offset = 0;
+    for p in &expose.as_range {
+        if p == prefix {
+            break;
+        }
+        orig_prefix_offset += p.size();
+    }
+    TrieValue::new(vni, *prefix, orig_prefix_offset, target)
 }
 
 // Note: add_peering(table, peering) should be part of PerVniTable, but we prefer to keep it in a
@@ -67,7 +77,7 @@ pub fn add_peering(
 
         // For each private prefix, add an entry containing the set of public prefixes
         expose.ips.iter().try_for_each(|prefix| {
-            let pub_value = get_public_trie_value(table.vni, expose);
+            let pub_value = get_public_trie_value(table.vni, expose, prefix);
             peering_table
                 .insert(prefix, pub_value)
                 .map_err(|_| NatPeeringError::EntryExists)
@@ -89,7 +99,7 @@ pub fn add_peering(
     new_peering.remote.exposes.iter().try_for_each(|expose| {
         // For each public prefix, add an entry containing the set of private prefixes
         expose.as_range.iter().try_for_each(|prefix| {
-            let priv_value = get_private_trie_value(remote_vni, expose);
+            let priv_value = get_private_trie_value(remote_vni, expose, prefix);
             table
                 .dst_nat
                 .insert(prefix, priv_value)

--- a/mgmt/src/models/internal/natconfig/table_extend.rs
+++ b/mgmt/src/models/internal/natconfig/table_extend.rs
@@ -23,20 +23,18 @@ pub enum NatPeeringError {
     SplitPrefixError(Prefix),
 }
 
-/// Create a [`TrieValue`] from the public side of a [`VpcExpose`], for a given prefix in this
-/// [`VpcExpose`]
-fn get_public_trie_value(vni: Vni, expose: &VpcExpose, prefix: &Prefix) -> TrieValue {
+/// Create a [`TrieValue`] from the public side of a [`VpcExpose`]
+fn get_public_trie_value(vni: Vni, expose: &VpcExpose) -> TrieValue {
     let orig = expose.ips.clone();
     let target = expose.as_range.clone();
 
     TrieValue::new(vni, orig, target)
 }
 
-/// Create a [`TrieValue`] from the private side of a [`VpcExpose`], for a given prefix in this
-/// [`VpcExpose`]
-fn get_private_trie_value(vni: Vni, expose: &VpcExpose, prefix: &Prefix) -> TrieValue {
-    let orig = expose.ips.clone();
-    let target = expose.as_range.clone();
+/// Create a [`TrieValue`] from the private side of a [`VpcExpose`]
+fn get_private_trie_value(vni: Vni, expose: &VpcExpose) -> TrieValue {
+    let orig = expose.as_range.clone();
+    let target = expose.ips.clone();
 
     TrieValue::new(vni, orig, target)
 }
@@ -69,7 +67,7 @@ pub fn add_peering(
 
         // For each private prefix, add an entry containing the set of public prefixes
         expose.ips.iter().try_for_each(|prefix| {
-            let pub_value = get_public_trie_value(table.vni, expose, prefix);
+            let pub_value = get_public_trie_value(table.vni, expose);
             peering_table
                 .insert(prefix, pub_value)
                 .map_err(|_| NatPeeringError::EntryExists)
@@ -91,7 +89,7 @@ pub fn add_peering(
     new_peering.remote.exposes.iter().try_for_each(|expose| {
         // For each public prefix, add an entry containing the set of private prefixes
         expose.as_range.iter().try_for_each(|prefix| {
-            let priv_value = get_private_trie_value(remote_vni, expose, prefix);
+            let priv_value = get_private_trie_value(remote_vni, expose);
             table
                 .dst_nat
                 .insert(prefix, priv_value)

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -19,9 +19,11 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 # internal
+net = { workspace = true, features = ["bolero"] }
 routing = { workspace = true, features = ["testing"] }
 
 # external
+bolero = { workspace = true, default-features = false, features = ["alloc"] }
 tracing-test = { workspace = true, features = [] }
 
 [lints.rust]

--- a/nat/src/stateless/config/tables.rs
+++ b/nat/src/stateless/config/tables.rs
@@ -214,20 +214,27 @@ impl Default for NatPeerRuleTable {
 
 /// A value associated with a prefix in the trie, and that encapsulates all information required to
 /// perform the address mapping for static NAT.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrieValue {
     vni: Option<Vni>,
-    orig: BTreeSet<Prefix>,
+    orig_prefix: Prefix,
+    orig_prefix_offset: u128,
     target: BTreeSet<Prefix>,
 }
 
 impl TrieValue {
     /// Creates a new [`TrieValue`]
     #[must_use]
-    pub fn new(vni: Vni, orig: BTreeSet<Prefix>, target: BTreeSet<Prefix>) -> Self {
+    pub fn new(
+        vni: Vni,
+        orig_prefix: Prefix,
+        orig_prefix_offset: u128,
+        target: BTreeSet<Prefix>,
+    ) -> Self {
         Self {
             vni: Some(vni),
-            orig,
+            orig_prefix,
+            orig_prefix_offset,
             target,
         }
     }
@@ -237,21 +244,22 @@ impl TrieValue {
         self.vni
     }
 
-    /// Accessor for original prefixes
+    /// Accessor for original prefix offset
     #[must_use]
-    pub fn orig_prefixes(&self) -> &BTreeSet<Prefix> {
-        &self.orig
+    pub fn orig_prefix_offset(&self) -> u128 {
+        self.orig_prefix_offset
+    }
+
+    /// Accessor for original prefix
+    #[must_use]
+    pub fn orig_prefix(&self) -> &Prefix {
+        &self.orig_prefix
     }
 
     /// Accessor for target prefixes
     #[must_use]
     pub fn target_prefixes(&self) -> &BTreeSet<Prefix> {
         &self.target
-    }
-
-    /// Iterates over the original prefixes
-    pub fn orig_prefixes_iter(&self) -> impl Iterator<Item = &Prefix> {
-        self.orig.iter()
     }
 
     /// Iterates over the target prefixes

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -33,17 +33,9 @@ enum NatError {
 }
 
 #[must_use]
-fn map_ip_src_nat(ranges: &TrieValue, current_ip: &IpAddr) -> IpAddr {
+fn map_ip_nat(ranges: &TrieValue, current_ip: &IpAddr) -> IpAddr {
     let current_range = IpList::new(ranges.orig_prefixes());
     let target_range = IpList::new(ranges.target_prefixes());
-    let offset = current_range.addr_offset_in_prefix(current_ip);
-    target_range.addr_from_prefix_offset(&offset)
-}
-
-#[must_use]
-fn map_ip_dst_nat(ranges: &TrieValue, current_ip: &IpAddr) -> IpAddr {
-    let current_range = IpList::new(ranges.target_prefixes());
-    let target_range = IpList::new(ranges.orig_prefixes());
     let offset = current_range.addr_offset_in_prefix(current_ip);
     target_range.addr_from_prefix_offset(&offset)
 }
@@ -93,7 +85,7 @@ impl StatelessNat {
     fn translate_src(&self, net: &mut Net, ranges_src_nat: &TrieValue) -> Result<bool, NatError> {
         let nfi = self.name();
         let current_src = net.src_addr();
-        let target_src = map_ip_src_nat(ranges_src_nat, &current_src);
+        let target_src = map_ip_nat(ranges_src_nat, &current_src);
         if target_src == current_src {
             return Ok(false);
         }
@@ -123,7 +115,7 @@ impl StatelessNat {
     fn translate_dst(&self, net: &mut Net, ranges_dst_nat: &TrieValue) -> Result<bool, NatError> {
         let nfi = self.name();
         let current_dst = net.dst_addr();
-        let target_dst = map_ip_dst_nat(ranges_dst_nat, &current_dst);
+        let target_dst = map_ip_nat(ranges_dst_nat, &current_dst);
         if target_dst == current_dst {
             return Ok(false);
         }

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -9,7 +9,7 @@ pub mod natrw;
 
 pub use crate::stateless::natrw::{NatTablesReader, NatTablesWriter}; // re-export
 use config::tables::{NatTables, PerVniTable, TrieValue};
-use iplist::IpList;
+use iplist::{IpList, IpListSubset};
 use net::buffer::PacketBufferMut;
 use net::headers::{Net, TryHeadersMut, TryIpMut};
 use net::ipv4::UnicastIpv4Addr;
@@ -34,7 +34,7 @@ enum NatError {
 
 #[must_use]
 fn map_ip_nat(ranges: &TrieValue, current_ip: &IpAddr) -> IpAddr {
-    let current_range = IpList::new(ranges.orig_prefixes());
+    let current_range = IpListSubset::new(ranges.orig_prefix_offset(), *ranges.orig_prefix());
     let target_range = IpList::new(ranges.target_prefixes());
     let offset = current_range.addr_offset_in_prefix(current_ip);
     target_range.addr_from_prefix_offset(&offset)

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -30,6 +30,7 @@ procfs = { workspace = true }
 netdev = { workspace = true }
 
 [dev-dependencies]
+bolero = { workspace = true, default-features = false }
 serde_yml = { workspace = true }
 tracing-test = { workspace = true, features = [] }
 


### PR DESCRIPTION
- **fix(nat): Fix TrieValue building and address mapping**
- **feat(nat): Simplify struct TrieValue**
- **feat(nat): Add proper error handling for IpList (stateless NAT)**
- **fix(nat): Handle prefix size correctly**
- **test(nat): Add IPv6-based tests for IpList**
- **test(nat): Add bolero test for IpListSubset and offset checks**
- **test(routing): Add fuzzing test for PrefixSize**
- **fix(routing): Modify PrefixSize to improve mathematical soundness**
- **feat(mgmt): Simplify and optimise TrieValue generation**

The main motivation of this PR is to reduce the memory footpring and the complexity of the address mapping for stateless NAT, by reducing the amount of information stored in `struct TrieValue`.

Please refer to individual commit descriptions for details.
