### PR TITLE
fix(nat): Fix validation for one-direction NAT

### DIFF
--- a/mgmt/src/models/external/overlay/vpcpeering.rs
+++ b/mgmt/src/models/external/overlay/vpcpeering.rs
@@ -185,6 +185,25 @@ impl VpcManifest {
                     &expose_right.as_range,
                     &expose_right.not_as,
                 )?;
+                // If only one of the two exposes has an empty as_range list, then there's not NAT,
+                // meaning the publicly-exposed addresses are the "ips" list.  In this case, we only
+                // need to check that there's no overlap between as_range on one side and ips on the
+                // other.
+                if expose_left.as_range.is_empty() && !expose_right.as_range.is_empty() {
+                    validate_overlapping(
+                        &expose_left.ips,
+                        &expose_left.nots,
+                        &expose_right.as_range,
+                        &expose_right.not_as,
+                    )?;
+                } else if !expose_left.as_range.is_empty() && expose_right.as_range.is_empty() {
+                    validate_overlapping(
+                        &expose_left.as_range,
+                        &expose_left.not_as,
+                        &expose_right.ips,
+                        &expose_right.nots,
+                    )?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
This is similar to commit 7344ee06abbd: when we only NAT on one direction, then one of the two VPCs uses its `ips` prefix list as public `ips` (no NAT), and these are the prefixes we should compare public addresses from `as_range` in other expose objects with.

In particular, we need to do this comparison when validating VpcManifest objects: when checking for prefix overlap, we may have to check the `as_range` blocks of an expose object with the `ips` blocks of another, if the latter expose has no `as_range`.

Note that even in that case, we still check for overlap between the `ips` lists of both expose objects, as we can't afford to have overlap for them (`ips` lists of exposes in a same manifest).
