### PR TITLE
fix(nat): Make stateful NAT code direction-independent

### DIFF
--- a/nat/src/stateful/allocator.rs
+++ b/nat/src/stateful/allocator.rs
@@ -64,7 +64,7 @@ impl TryFrom<NatPort> for UdpPort {
 }
 
 pub trait NatPool<I: NatIp> {
-    fn allocate(&self) -> Result<(I, Option<NatPort>), AllocatorError>;
+    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), AllocatorError>;
 }
 
 #[derive(Debug, Clone)]
@@ -74,7 +74,7 @@ pub struct NatDefaultPool<I: NatIp> {
 }
 
 impl<I: NatIp> NatPool<I> for NatDefaultPool<I> {
-    fn allocate(&self) -> Result<(I, Option<NatPort>), AllocatorError> {
+    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), AllocatorError> {
         todo!()
     }
 }


### PR DESCRIPTION
In commit b12d185a5e87 we changed the way we're handling directions in NAT stages. That commit mostly focused on stateful NAT, and the sensitive code portions in the module for stateful NAT were simply commented out, given that the code is not complete anyway.

Here we adjust the code for stateful NAT, on the same basis. We make it handle both source and destination NAT, in a single pipeline stage. This requires storing more information in the state tables, given that we need addresses and port for both directions.
