### PR TITLE
build(justfile): Fix "just prune-old-compile-env" target

### DIFF
--- a/justfile
+++ b/justfile
@@ -305,7 +305,7 @@ refresh-compile-env: pull remove-compile-env create-compile-env
 prune-old-compile-env:
     {{ _just_debuggable_ }}
     docker image list "{{ _compile_env_image_name }}" --format "{{{{.Repository}}:{{{{.Tag}}" | \
-        grep -v "{{ _dpdk_sys_container_tag }}" || true | \
+        grep -v "{{ _dpdk_sys_container_tag }}" | \
         xargs -r docker image rm
 
 # Install "fake-nix" (required for local builds to function)


### PR DESCRIPTION
The target doesn't work because there's a `|| true` in the middle of the command that prevents the execution of `docker image rm`: the command is interpreted as:

    docker image list ... | grep -v ... || (true | xargs docker rmi ...)

so the xargs command never runs. Let's fix this. The `|| true` is not needed anyway because `grep -v` does not fail if it doesn't find the pattern to exclude.