### PR TITLE
Tap support phase 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa514b7c2d4cb8ac9d54925c91900d21fdda508877694661858744211c11c69c"
 dependencies = [
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -70,7 +70,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
- "libc",
+ "libc 0.2.174",
  "miniz_oxide",
  "object",
  "rustc-demangle",
@@ -437,7 +437,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "thiserror 1.0.69",
 ]
 
@@ -511,7 +511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
- "libc",
+ "libc 0.2.174",
  "libloading",
 ]
 
@@ -595,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -874,10 +874,13 @@ dependencies = [
  "dataplane-rekon",
  "derive_builder 0.20.2",
  "futures",
+ "libc 1.0.0-alpha.1",
  "multi_index_map",
+ "nix 0.30.1",
  "rtnetlink",
  "serde",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 
@@ -1168,7 +1171,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "redox_users",
  "winapi",
 ]
@@ -1179,7 +1182,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "once_cell",
  "winapi",
 ]
@@ -1240,7 +1243,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "windows-sys 0.60.2",
 ]
 
@@ -1417,7 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.174",
  "log",
  "rustversion",
  "windows",
@@ -1430,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.174",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
@@ -1441,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.174",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
@@ -1603,7 +1606,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "libc",
+ "libc 0.2.174",
  "pin-project-lite",
  "socket2 0.6.0",
  "tokio",
@@ -1659,7 +1662,7 @@ checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1734,6 +1737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libc"
+version = "1.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7222002e5385b4d9327755661e3847c970e8fbf9dea6da8c57f16e8cfbff53a8"
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,7 +1759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -1935,7 +1944,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
@@ -1972,7 +1981,7 @@ checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
 dependencies = [
  "dlopen2",
  "ipnet",
- "libc",
+ "libc 0.2.174",
  "netlink-packet-core",
  "netlink-packet-route 0.22.0",
  "netlink-sys",
@@ -2001,7 +2010,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.9.1",
  "byteorder",
- "libc",
+ "libc 0.2.174",
  "log",
  "netlink-packet-core",
  "netlink-packet-utils 0.5.2",
@@ -2015,7 +2024,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.9.1",
  "byteorder",
- "libc",
+ "libc 0.2.174",
  "log",
  "netlink-packet-core",
  "netlink-packet-utils 0.5.2",
@@ -2066,7 +2075,7 @@ checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
  "futures",
- "libc",
+ "libc 0.2.174",
  "log",
  "tokio",
 ]
@@ -2088,7 +2097,7 @@ checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -2100,7 +2109,7 @@ dependencies = [
  "autocfg",
  "bitflags 1.3.2",
  "cfg-if",
- "libc",
+ "libc 0.2.174",
  "memoffset 0.6.5",
  "pin-utils",
 ]
@@ -2114,7 +2123,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
- "libc",
+ "libc 0.2.174",
  "memoffset 0.9.1",
 ]
 
@@ -2127,7 +2136,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
- "libc",
+ "libc 0.2.174",
  "memoffset 0.9.1",
 ]
 
@@ -2230,7 +2239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.174",
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
@@ -2425,7 +2434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
- "libc",
+ "libc 0.2.174",
  "once_cell",
  "raw-cpuid",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -2626,7 +2635,7 @@ checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
- "libc",
+ "libc 0.2.174",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
 ]
@@ -2639,7 +2648,7 @@ checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
- "libc",
+ "libc 0.2.174",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.60.2",
 ]
@@ -2659,7 +2668,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "clipboard-win",
- "libc",
+ "libc 0.2.174",
  "log",
  "memchr",
  "nix 0.30.1",
@@ -2782,7 +2791,7 @@ version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -2837,7 +2846,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "windows-sys 0.52.0",
 ]
 
@@ -2930,7 +2939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.174",
 ]
 
 [[package]]
@@ -3043,7 +3052,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "io-uring",
- "libc",
+ "libc 0.2.174",
  "mio",
  "parking_lot",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "nix 0.30.1",
  "rtnetlink",
  "serde",
+ "static_assertions",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2856,9 +2857,15 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
- "libc",
+ "libc 0.2.174",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ hyper = { version = "1.6.0", default-features = false, features = ["http1", "ser
 hyper-util = { version = "0.1.16", features = ["tokio"]}
 ipnet = { version = "2.11.0", default-features = false, features = [] }
 left-right = { version = "0.11.5" }
+libc = { version = "1.0.0-alpha.1", default-features = false, features = [] }
 linux-raw-sys = { version = "0.10.0", default-features = false, features = [] }
 mac_address = { version = "1.1.8", default-features = false, features = [] }
 metrics = { version = "0.24.2", default-features = false, features = [] }
@@ -93,6 +94,7 @@ rtnetlink = { git = "https://github.com/githedgehog/rtnetlink.git", branch = "hh
 rustyline = { version = "16.0.0", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
+static_assertions = { version = "1.1.0", default-features = false, features = [] }
 strum = { version = "0.27.2", features = ["derive"] }
 thiserror = { version = "2.0.12", default-features = false, features = [] }
 tokio = { version = "1.46.1", default-features = false, features = [] }
@@ -102,7 +104,6 @@ tracing = { version = "0.1.41", default-features = false, features = ["attribute
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [] }
 tracing-test = { version = "0.2.5", default-features = false, features = [] }
 uuid = { version = "1.17.0", default-features = false, features = [] }
-libc = { version = "1.0.0-alpha.1", default-features = false, features = [] }
 
 [profile.dev]
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tracing = { version = "0.1.41", default-features = false, features = ["attribute
 tracing-subscriber = { version = "0.3.19", default-features = false, features = [] }
 tracing-test = { version = "0.2.5", default-features = false, features = [] }
 uuid = { version = "1.17.0", default-features = false, features = [] }
+libc = { version = "1.0.0-alpha.1", default-features = false, features = [] }
 
 [profile.dev]
 panic = "unwind"

--- a/interface-manager/Cargo.toml
+++ b/interface-manager/Cargo.toml
@@ -24,6 +24,7 @@ nix = { workspace = true, default-features = false, features = ["ioctl"] }
 rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
+tokio = { workspace = true, default-features = false, features = ["fs", "io-util"] }
 tracing = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]

--- a/interface-manager/Cargo.toml
+++ b/interface-manager/Cargo.toml
@@ -18,7 +18,9 @@ rekon = { workspace = true }
 bolero = { workspace = true, optional = true, default-features = false, features = ["alloc"] }
 derive_builder = { workspace = true, default-features = false, features = ["default"] }
 futures = { workspace = true, features = ["default"] }
+libc = { workspace = true, features = [] }
 multi_index_map = { workspace = true, features = ["serde"] }
+nix = { workspace = true, default-features = false, features = ["ioctl"] }
 rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }

--- a/interface-manager/Cargo.toml
+++ b/interface-manager/Cargo.toml
@@ -23,6 +23,7 @@ multi_index_map = { workspace = true, features = ["serde"] }
 nix = { workspace = true, default-features = false, features = ["ioctl"] }
 rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["std"] }
+static_assertions = { workspace = true, features = [] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, default-features = false, features = ["fs", "io-util"] }
 tracing = { workspace = true, features = ["attributes"] }

--- a/interface-manager/src/interface/mod.rs
+++ b/interface-manager/src/interface/mod.rs
@@ -7,6 +7,7 @@ mod association;
 mod bridge;
 mod pci;
 mod properties;
+mod tap;
 mod vrf;
 mod vtep;
 
@@ -20,6 +21,8 @@ pub use bridge::*;
 pub use pci::*;
 #[allow(unused_imports)] // re-export
 pub use properties::*;
+#[allow(unused_imports)] // re-export
+pub use tap::*;
 #[allow(unused_imports)] // re-export
 pub use vrf::*;
 #[allow(unused_imports)] // re-export

--- a/interface-manager/src/interface/tap.rs
+++ b/interface-manager/src/interface/tap.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use net::buffer::{PacketBuffer, PacketBufferMut};
+use net::interface::InterfaceName;
+use std::num::NonZero;
+use std::os::fd::AsRawFd;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{debug, error, info};
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct TapDevice {
+    file: tokio::fs::File,
+}
+
+mod helper {
+    /// This is a validated type around a value which is regrettably fragile.
+    ///
+    /// 1. Passed directly to the kernel.
+    /// 2. By a privileged thread.
+    /// 3. In an ioctl.
+    /// 4. By an implicitly null terminated pointer.
+    ///
+    /// As a result, strict checks are in place to ensure memory integrity.
+    ///
+    /// <div class=warning>
+    ///
+    /// It is essential that this type remains transparent.
+    /// Only zero-sized types may be added to this structure as we don't control the ABI.
+    /// We are subject to a contract with the kernel.
+    /// </div>
+    #[repr(transparent)]
+    #[derive(Debug, Copy, Clone)]
+    pub(super) struct InterfaceRequest(libc::ifreq);
+
+    use net::interface::InterfaceName;
+    use nix::libc;
+
+    nix::ioctl_write_ptr_bad!(
+        /// Create a tap device
+        make_tap_device,
+        libc::TUNSETIFF,
+        InterfaceRequest
+    );
+
+    nix::ioctl_write_ptr_bad!(
+        /// Keep the tap device after the program ends
+        persist_tap_device,
+        libc::TUNSETPERSIST,
+        InterfaceRequest
+    );
+
+    impl InterfaceRequest {
+        /// Create a new `InterfaceRequest`.
+        #[cold]
+        #[tracing::instrument(level = "trace")]
+        pub(super) fn new(name: &InterfaceName) -> Self {
+            assert_eq!(
+                libc::IF_NAMESIZE,
+                InterfaceName::MAX_LEN + 1,
+                "unsupported platform"
+            );
+            let mut ifreq = libc::ifreq {
+                ifr_name: [0; libc::IF_NAMESIZE],
+                ifr_ifru: libc::__c_anonymous_ifr_ifru {
+                    ifru_ifindex: libc::IFF_TAP | libc::IFF_NO_PI,
+                },
+            };
+            for (i, byte) in name.as_ref().as_bytes().iter().enumerate() {
+                // already confirmed that we are ASCII in the InterfaceName contract
+                #[allow(clippy::cast_possible_wrap)]
+                {
+                    ifreq.ifr_name[i] = *byte as libc::c_char;
+                }
+            }
+            InterfaceRequest(ifreq)
+        }
+    }
+
+    #[cfg(any(test, feature = "bolero"))]
+    mod contract {
+        use crate::interface::tap::helper::InterfaceRequest;
+        use bolero::{Driver, TypeGenerator};
+
+        impl TypeGenerator for InterfaceRequest {
+            fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+                Some(Self::new(&driver.produce()?))
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use crate::interface::tap::helper::InterfaceRequest;
+        use net::interface::InterfaceName;
+        use std::ffi::CStr;
+
+        #[test]
+        fn interface_request_new_contract() {
+            bolero::check!()
+                .with_type()
+                .for_each(|name: &InterfaceName| {
+                    let name_str = name.to_string();
+                    let ifreq = InterfaceRequest::new(name);
+                    assert_eq!(ifreq.0.ifr_name[ifreq.0.ifr_name.len() - 1], 0);
+                    assert_eq!(ifreq.0.ifr_name[name_str.len()], 0);
+                    #[allow(unsafe_code)] // test code
+                    let as_cstr = unsafe { CStr::from_ptr(ifreq.0.ifr_name.as_ptr()) };
+                    assert_eq!(
+                        name_str.len(),
+                        as_cstr.to_bytes().len(),
+                        "memory integrity error"
+                    );
+                    assert_eq!(name_str.as_bytes(), as_cstr.to_bytes());
+                    assert_eq!(name_str.as_bytes(), as_cstr.to_str().unwrap().as_bytes());
+                    let name_parse_back =
+                        InterfaceName::try_from(as_cstr.to_str().unwrap()).unwrap();
+                    assert_eq!(*name, name_parse_back);
+                    assert_eq!(
+                        ifreq.0.ifr_name,
+                        InterfaceRequest::new(&name_parse_back).0.ifr_name
+                    );
+                });
+        }
+
+        #[test]
+        fn interface_request_contract() {
+            bolero::check!()
+                .with_type()
+                .for_each(|req: &InterfaceRequest| {
+                    #[allow(unsafe_code)] // test code
+                    let as_cstr = unsafe { CStr::from_ptr(req.0.ifr_name.as_ptr()) };
+                    let as_ifname = InterfaceName::try_from(as_cstr.to_str().unwrap()).unwrap();
+                    assert_eq!(req.0.ifr_name, InterfaceRequest::new(&as_ifname).0.ifr_name);
+                });
+        }
+    }
+}

--- a/interface-manager/src/interface/tap.rs
+++ b/interface-manager/src/interface/tap.rs
@@ -56,11 +56,8 @@ mod helper {
         #[cold]
         #[tracing::instrument(level = "trace")]
         pub(super) fn new(name: &InterfaceName) -> Self {
-            assert_eq!(
-                libc::IF_NAMESIZE,
-                InterfaceName::MAX_LEN + 1,
-                "unsupported platform"
-            );
+            // we cannot support any platform for which this condition does not hold
+            static_assertions::const_assert_eq!(libc::IF_NAMESIZE, InterfaceName::MAX_LEN + 1);
             let mut ifreq = libc::ifreq {
                 ifr_name: [0; libc::IF_NAMESIZE],
                 ifr_ifru: libc::__c_anonymous_ifr_ifru {

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -19,11 +19,11 @@ impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom + Debug + 'static {}
 
 /// Super trait representing the abstract operations which may be performed on mutable a packet buffer.
 pub trait PacketBufferMut:
-    PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + Headroom + Tailroom
+    PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + TrimFromEnd + Headroom + Tailroom
 {
 }
 impl<T> PacketBufferMut for T where
-    T: PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + Headroom + Tailroom
+    T: PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + TrimFromEnd + Headroom + Tailroom
 {
 }
 

--- a/net/src/interface/mod.rs
+++ b/net/src/interface/mod.rs
@@ -108,7 +108,7 @@ impl From<InterfaceIndex> for u32 {
     }
 }
 
-const MAX_INTERFACE_NAME_LEN: usize = 16;
+const MAX_INTERFACE_NAME_LEN: usize = 15;
 
 /// A string which has been checked to be a legal linux network interface name.
 ///
@@ -130,7 +130,7 @@ impl Display for InterfaceName {
 }
 
 impl InterfaceName {
-    /// The maximum legal length of a linux network interface name (including the trailing NUL)
+    /// The maximum legal length of a linux network interface name (excluding the trailing NUL)
     pub const MAX_LEN: usize = MAX_INTERFACE_NAME_LEN;
 }
 
@@ -365,7 +365,7 @@ mod contract {
             ];
             #[allow(clippy::cast_possible_truncation)] // const eval
             let target_length =
-                (1 + (driver.produce::<u8>()? % (InterfaceName::MAX_LEN as u8 - 2))) as usize;
+                (1 + (driver.produce::<u8>()? % (InterfaceName::MAX_LEN as u8 - 1))) as usize;
             let mut base_string = String::with_capacity(target_length + 1);
             for _ in 0..target_length {
                 let selected_char_index = (driver.produce::<u8>()? % NUM_LEGAL_CHARS) as usize;


### PR DESCRIPTION
This is the first of a series of PRs which add the ability to inject traffic from our pipeline back into the linux kernel.

Each of the commits messages contain reasoning for why this change is needed.

The first commit, which changes the max lenght of InterfaceName is especially important in order to maintain our contract with linux when we create tap devices via ioctl.