### PR TITLE
Add `dst_vni_lookup` pipeline stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ dependencies = [
  "dataplane-nat",
  "dataplane-net",
  "dataplane-pipeline",
+ "dataplane-pkt-meta",
  "dataplane-rekon",
  "dataplane-routing",
  "dataplane-stats",
@@ -980,6 +981,20 @@ dependencies = [
  "ordermap",
  "thiserror 2.0.12",
  "tracing",
+]
+
+[[package]]
+name = "dataplane-pkt-meta"
+version = "0.1.0"
+dependencies = [
+ "bolero",
+ "dataplane-config",
+ "dataplane-lpm",
+ "dataplane-net",
+ "left-right",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,7 @@ dependencies = [
  "dataplane-config",
  "dataplane-lpm",
  "dataplane-net",
+ "dataplane-pipeline",
  "left-right",
  "thiserror 2.0.12",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "dataplane-nat",
  "dataplane-net",
  "dataplane-pipeline",
+ "dataplane-pkt-meta",
  "dataplane-routing",
  "dataplane-stats",
  "dataplane-vpcmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 	"nat",
 	"net",
 	"pipeline",
+	"pkt-meta",
 	"rekon",
 	"routing", "stats",
 	"test-utils",
@@ -40,6 +41,7 @@ mgmt = { path = "./mgmt", package = "dataplane-mgmt" }
 nat = { path = "./nat", package = "dataplane-nat" }
 net = { path = "./net", package = "dataplane-net", features = ["test_buffer"] }
 pipeline = { path = "./pipeline", package = "dataplane-pipeline" }
+pkt-meta = { path = "./pkt-meta", package = "dataplane-pkt-meta" }
 rekon = { path = "./rekon", package = "dataplane-rekon" }
 routing = { path = "./routing", package = "dataplane-routing" }
 stats = { path = "./stats", package = "dataplane-stats" }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -26,6 +26,7 @@ pub mod errors;
 pub mod external;
 pub mod gwconfig;
 pub mod internal;
+pub mod utils;
 
 pub use errors::{ConfigError, ConfigResult, stringify}; // re-export
 pub use external::{ExternalConfig, GenId}; // re-export

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use lpm::prefix::Prefix;
+
+mod collapse;
+
+pub use collapse::collapse_prefixes_peering;
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum ConfigUtilError {
+    #[error("failed to split prefix {0}")]
+    SplitPrefixError(Prefix),
+}

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = { workspace = true }
 ordermap = { workspace = true, features = ["std"] }
 parking_lot = { workspace = true }
 pipeline = { workspace = true }
+pkt-meta = { workspace = true }
 routing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yml = { workspace = true }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -108,11 +108,12 @@ fn main() {
 
     /* mgmt: nat table */
     let nattablew = setup.nattable;
+    let vnitablesw = setup.vnitablesw;
     let vpcmapw = setup.vpcmapw;
     let statsr = setup.statsr;
 
     /* start management */
-    if let Err(e) = start_mgmt(grpc_addr, router_ctl, nattablew, vpcmapw) {
+    if let Err(e) = start_mgmt(grpc_addr, router_ctl, nattablew, vnitablesw, vpcmapw) {
         error!("Failed to start gRPC server: {e}");
         panic!("Failed to start gRPC server: {e}");
     } else {

--- a/lpm/src/trie/mod.rs
+++ b/lpm/src/trie/mod.rs
@@ -95,6 +95,14 @@ impl<V: Clone> IpPrefixTrie<V> {
             IpAddr::V6(ip) => self.ipv6.lookup(ip).map(|(k, v)| (Prefix::IPV6(*k), v)),
         }
     }
+
+    pub fn len(&self) -> usize {
+        self.ipv4.len() + self.ipv6.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ipv4.is_empty() && self.ipv6.is_empty()
+    }
 }
 
 impl<V: Clone> Default for IpPrefixTrie<V> {

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -23,6 +23,7 @@ interface-manager = { workspace = true }
 lpm = { workspace = true }
 net = { workspace = true }
 nat = { workspace = true }
+pkt-meta = { workspace = true }
 rekon = { workspace = true }
 routing = { workspace = true }
 stats = { workspace = true }

--- a/mgmt/src/processor/confbuild/internal.rs
+++ b/mgmt/src/processor/confbuild/internal.rs
@@ -151,20 +151,13 @@ impl VpcRoutingConfigIpv4 {
         /* add prefix list to vector */
         self.import_plists.push(plist);
 
-        /* natted exposes */
-        let natted = rmanifest.exposes.iter().filter(|e| e.is_natted());
-
         /* advertise */
-        let nets = natted.clone().flat_map(|e| e.as_range.iter());
+        let nets = rmanifest.exposes.iter().flat_map(|e| e.public_ips().iter());
         self.adv_nets.extend(nets);
 
         /* build adv prefix list */
         for expose in rmanifest.exposes.iter() {
-            let prefixes = if expose.is_natted() {
-                expose.as_range.iter()
-            } else {
-                expose.ips.iter()
-            };
+            let prefixes = expose.public_ips().iter();
             let plists = prefixes.map(|prefix| {
                 PrefixListEntry::new(
                     PrefixListAction::Permit,

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -17,6 +17,7 @@ use tokio::{io, spawn};
 use tokio_stream::Stream;
 
 use nat::stateless::NatTablesWriter;
+use pkt_meta::dst_vni_lookup::VniTablesWriter;
 use routing::ctl::RouterCtlSender;
 
 use crate::grpc::server::create_config_service;
@@ -170,6 +171,7 @@ pub fn start_mgmt(
     grpc_addr: GrpcAddress,
     router_ctl: RouterCtlSender,
     nattablew: NatTablesWriter,
+    vnitablesw: VniTablesWriter,
     vpcmapw: VpcMapWriter<VpcMapName>,
 ) -> Result<std::thread::JoinHandle<()>, Error> {
     /* build server address from provided grpc address */
@@ -193,7 +195,8 @@ pub fn start_mgmt(
 
             /* block thread to run gRPC and configuration processor */
             rt.block_on(async {
-                let (processor, tx) = ConfigProcessor::new(router_ctl, vpcmapw, nattablew);
+                let (processor, tx) =
+                    ConfigProcessor::new(router_ctl, vpcmapw, nattablew, vnitablesw);
                 spawn(async { processor.run().await });
 
                 // Start the appropriate server based on address type

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -21,6 +21,8 @@ use crate::processor::confbuild::internal::build_internal_config;
 use crate::processor::confbuild::router::generate_router_config;
 use nat::stateless::NatTablesWriter;
 use nat::stateless::setup::build_nat_configuration;
+use pkt_meta::dst_vni_lookup::VniTablesWriter;
+use pkt_meta::dst_vni_lookup::setup::build_dst_vni_lookup_configuration;
 
 use crate::processor::display::GwConfigDatabaseSummary;
 use crate::processor::gwconfigdb::GwConfigDatabase;
@@ -79,6 +81,7 @@ pub(crate) struct ConfigProcessor {
     vpc_mgr: VpcManager<RequiredInformationBase>,
     vpcmapw: VpcMapWriter<VpcMapName>,
     nattablew: NatTablesWriter,
+    vnitablesw: VniTablesWriter,
 }
 
 impl ConfigProcessor {
@@ -92,6 +95,7 @@ impl ConfigProcessor {
         router_ctl: RouterCtlSender,
         vpcmapw: VpcMapWriter<VpcMapName>,
         nattablew: NatTablesWriter,
+        vnitablesw: VniTablesWriter,
     ) -> (Self, Sender<ConfigChannelRequest>) {
         debug!("Creating config processor...");
         let (tx, rx) = mpsc::channel(Self::CHANNEL_SIZE);
@@ -111,6 +115,7 @@ impl ConfigProcessor {
             vpc_mgr,
             vpcmapw,
             nattablew,
+            vnitablesw,
         };
         (processor, tx)
     }
@@ -165,6 +170,7 @@ impl ConfigProcessor {
             &mut self.router_ctl,
             &mut self.vpcmapw,
             &mut self.nattablew,
+            &mut self.vnitablesw,
         )
         .await?;
 
@@ -192,6 +198,7 @@ impl ConfigProcessor {
                 &mut self.router_ctl,
                 &mut self.vpcmapw,
                 &mut self.nattablew,
+                &mut self.vnitablesw,
             )
             .await;
         }
@@ -360,6 +367,15 @@ fn apply_nat_config(overlay: &Overlay, nattablesw: &mut NatTablesWriter) -> Conf
     Ok(())
 }
 
+/// Update the VNI tables for dst_vni_lookup
+fn apply_dst_vni_lookup_config(
+    overlay: &Overlay,
+    vnitablesw: &mut VniTablesWriter,
+) -> ConfigResult {
+    let vni_tables = build_dst_vni_lookup_configuration(overlay)?;
+    vnitablesw.update_vni_tables(vni_tables);
+    Ok(())
+}
 /// Main function to apply a config
 async fn apply_gw_config(
     vpc_mgr: &VpcManager<RequiredInformationBase>,
@@ -368,6 +384,7 @@ async fn apply_gw_config(
     router_ctl: &mut RouterCtlSender,
     vpcmapw: &mut VpcMapWriter<VpcMapName>,
     nattablesw: &mut NatTablesWriter,
+    vnitablesw: &mut VniTablesWriter,
 ) -> ConfigResult {
     let genid = config.genid();
 
@@ -401,6 +418,9 @@ async fn apply_gw_config(
 
     /* apply nat config */
     apply_nat_config(&config.external.overlay, nattablesw)?;
+
+    /* apply dst_vni_lookup config */
+    apply_dst_vni_lookup_config(&config.external.overlay, vnitablesw)?;
 
     /* update stats mappings */
     update_stats_vpc_mappings(config, vpcmapw);

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -9,6 +9,7 @@ pub mod test {
     use nat::stateless::NatTablesWriter;
     use net::eth::mac::Mac;
     use net::interface::Mtu;
+    use pkt_meta::dst_vni_lookup::VniTablesWriter;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;
     use std::str::FromStr;
@@ -380,9 +381,12 @@ pub mod test {
         /* crate NatTables for stateless nat */
         let nattablesw = NatTablesWriter::new();
 
+        /* crate VniTables for dst_vni_lookup */
+        let vnitablesw = VniTablesWriter::new();
+
         /* build config processor to test the processing of a config. The processor embeds the config database
         and has the frrmi. In this test, we don't use any channel to communicate the config. */
-        let (mut processor, _sender) = ConfigProcessor::new(ctl, vpcmapw, nattablesw);
+        let (mut processor, _sender) = ConfigProcessor::new(ctl, vpcmapw, nattablesw, vnitablesw);
 
         /* let the processor process the config */
         match processor.process_incoming_config(config).await {

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -13,7 +13,6 @@ use net::headers::{Net, TryHeadersMut, TryIpMut};
 use net::ipv4::UnicastIpv4Addr;
 use net::ipv6::UnicastIpv6Addr;
 use net::packet::{DoneReason, Packet};
-use net::vxlan::Vni;
 use pipeline::NetworkFunction;
 use setup::tables::{NatTableValue, NatTables, PerVniTable};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -190,11 +189,7 @@ impl StatelessNat {
     /// # Errors
     /// This method may fail if `translate_src` or `translate_dst` fail, which can happen if
     /// addresses are invalid or an unsupported translation is required (e.g. IPv4 -> IPv6).
-    fn translate(
-        &self,
-        net: &mut Net,
-        per_vni_table: &PerVniTable,
-    ) -> Result<(bool, Option<Vni>), NatError> {
+    fn translate(&self, net: &mut Net, per_vni_table: &PerVniTable) -> Result<bool, NatError> {
         let (src_ranges, dst_ranges) =
             per_vni_table.find_nat_ranges(net.src_addr(), net.dst_addr());
 
@@ -203,15 +198,14 @@ impl StatelessNat {
         if let Some(ranges_src) = src_ranges {
             modified |= self.translate_src(net, &ranges_src)?;
         }
-        let mut dst_vni = None;
+
         if let Some(ranges_dst) = dst_ranges {
             modified |= self.translate_dst(net, &ranges_dst)?;
-            dst_vni = ranges_dst.vni;
         }
         /* Note: if dst_ranges is not Some(), we will not learn the dst_vni from this module.
         If routing is fine, it may learn it itself. However, if the packet is not to be routed,
         then dst_vni will remain unset and the drop statistics for vpc peerings not be updated. */
-        Ok((modified, dst_vni))
+        Ok(modified)
     }
 
     /// Processes one packet. This is the main entry point for processing a packet. This is also the
@@ -251,10 +245,7 @@ impl StatelessNat {
                 error!("{nfi}: {e}");
                 packet.done(DoneReason::NatFailure);
             }
-            Ok((modified, opt_vni)) => {
-                if let Some(vni) = opt_vni {
-                    packet.get_meta_mut().dst_vni = Some(vni);
-                }
+            Ok(modified) => {
                 if modified {
                     packet.get_meta_mut().refresh_chksums = true;
                     debug!("{nfi}: Packet was NAT'ed:\n{packet}");

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -190,10 +190,10 @@ mod tests {
         let mut nat_table = NatTables::new();
 
         let mut vni_table1 = PerVniTable::new(vni1);
-        add_peering(&mut vni_table1, &peering1, &vpctable).expect("Failed to build NAT tables");
+        add_peering(&mut vni_table1, &peering1).expect("Failed to build NAT tables");
 
         let mut vni_table2 = PerVniTable::new(vni2);
-        add_peering(&mut vni_table2, &peering2, &vpctable).expect("Failed to build NAT tables");
+        add_peering(&mut vni_table2, &peering2).expect("Failed to build NAT tables");
 
         nat_table.add_table(vni_table1);
         nat_table.add_table(vni_table2);

--- a/net/src/ipv4/addr.rs
+++ b/net/src/ipv4/addr.rs
@@ -4,7 +4,7 @@
 //! IPv4 address types
 
 use std::fmt::{Debug, Display, Formatter};
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
 /// Thin wrapper around [`Ipv4Addr`]
 ///
@@ -63,6 +63,16 @@ impl TryFrom<Ipv4Addr> for UnicastIpv4Addr {
 impl From<UnicastIpv4Addr> for Ipv4Addr {
     fn from(value: UnicastIpv4Addr) -> Self {
         value.inner()
+    }
+}
+
+impl TryFrom<IpAddr> for UnicastIpv4Addr {
+    type Error = IpAddr;
+    fn try_from(value: IpAddr) -> Result<Self, Self::Error> {
+        match value {
+            IpAddr::V4(addr) => Ok(UnicastIpv4Addr(addr)),
+            IpAddr::V6(_) => Err(value),
+        }
     }
 }
 

--- a/net/src/ipv6/addr.rs
+++ b/net/src/ipv6/addr.rs
@@ -7,7 +7,7 @@
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;
 use std::fmt::{Debug, Display, Formatter};
-use std::net::Ipv6Addr;
+use std::net::{IpAddr, Ipv6Addr};
 
 /// A type representing the set of unicast ipv6 addresses.
 #[non_exhaustive]
@@ -49,6 +49,22 @@ impl UnicastIpv6Addr {
     #[must_use]
     pub const fn inner(self) -> Ipv6Addr {
         self.0
+    }
+}
+
+impl From<UnicastIpv6Addr> for Ipv6Addr {
+    fn from(value: UnicastIpv6Addr) -> Self {
+        value.inner()
+    }
+}
+
+impl TryFrom<IpAddr> for UnicastIpv6Addr {
+    type Error = IpAddr;
+    fn try_from(value: IpAddr) -> Result<Self, Self::Error> {
+        match value {
+            IpAddr::V6(addr) => Ok(UnicastIpv6Addr(addr)),
+            IpAddr::V4(_) => Err(value),
+        }
     }
 }
 

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dataplane-pkt-meta"
+version = "0.1.0"
+edition = "2024"
+publish = false
+license = "Apache-2.0"
+
+[features]
+testing = []
+
+[dependencies]
+lpm = { workspace = true }
+config = { workspace = true }
+left-right = { workspace = true }
+net = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+
+[dev-dependencies]
+bolero = { workspace = true, default-features = false }
+lpm = { workspace = true, features = ["testing"] }
+tracing-test = { workspace = true, features = [] }
+

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -13,6 +13,7 @@ lpm = { workspace = true }
 config = { workspace = true }
 left-right = { workspace = true }
 net = { workspace = true }
+pipeline = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/pkt-meta/src/dst_vni_lookup/mod.rs
+++ b/pkt-meta/src/dst_vni_lookup/mod.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle, new_from_empty};
+use std::collections::HashMap;
+use tracing::{debug, error, warn};
+
+use lpm::trie::IpPrefixTrie;
+use net::buffer::PacketBufferMut;
+use net::headers::{TryHeaders, TryIp};
+use net::packet::{DoneReason, Packet};
+use net::vxlan::Vni;
+use pipeline::NetworkFunction;
+
+pub mod setup;
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum DstVniLookupError {
+    #[error("Error building dst_vni_lookup table: {0}")]
+    BuildError(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct VniTables {
+    tables_by_vni: HashMap<Vni, VniTable>,
+}
+
+impl VniTables {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            tables_by_vni: HashMap::new(),
+        }
+    }
+}
+
+impl Default for VniTables {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+enum VniTablesChange {
+    UpdateVniTables(VniTables),
+}
+
+impl Absorb<VniTablesChange> for VniTables {
+    fn absorb_first(&mut self, change: &mut VniTablesChange, _: &Self) {
+        match change {
+            VniTablesChange::UpdateVniTables(vni_tables) => {
+                *self = vni_tables.clone();
+            }
+        }
+    }
+    fn drop_first(self: Box<Self>) {}
+    fn sync_with(&mut self, first: &Self) {
+        *self = first.clone();
+    }
+}
+
+#[derive(Debug)]
+pub struct VniTablesReader(ReadHandle<VniTables>);
+impl VniTablesReader {
+    fn enter(&self) -> Option<ReadGuard<'_, VniTables>> {
+        self.0.enter()
+    }
+}
+
+#[derive(Debug)]
+pub struct VniTablesWriter(WriteHandle<VniTables, VniTablesChange>);
+impl VniTablesWriter {
+    #[must_use]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> VniTablesWriter {
+        let (w, _r) = new_from_empty::<VniTables, VniTablesChange>(VniTables::new());
+        VniTablesWriter(w)
+    }
+    #[must_use]
+    pub fn get_reader(&self) -> VniTablesReader {
+        VniTablesReader(self.0.clone())
+    }
+    pub fn update_vni_tables(&mut self, vni_tables: VniTables) {
+        self.0.append(VniTablesChange::UpdateVniTables(vni_tables));
+        self.0.publish();
+        debug!("Updated tables for Destination VNI Lookup");
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VniTable {
+    dst_vnis: IpPrefixTrie<Vni>,
+}
+
+impl VniTable {
+    fn new() -> Self {
+        Self {
+            dst_vnis: IpPrefixTrie::new(),
+        }
+    }
+}
+
+impl Default for VniTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct DstVniLookup {
+    name: String,
+    tablesr: VniTablesReader,
+}
+
+impl DstVniLookup {
+    pub fn new(name: &str, tablesr: VniTablesReader) -> Self {
+        Self {
+            name: name.to_string(),
+            tablesr,
+        }
+    }
+
+    fn process_packet<Buf: PacketBufferMut>(
+        &self,
+        tablesr: &ReadGuard<'_, VniTables>,
+        packet: &mut Packet<Buf>,
+    ) {
+        if packet.meta.dst_vni.is_some() {
+            debug!("{}: Packet already has dst_vni, skipping", self.name);
+            return;
+        }
+        let Some(net) = packet.headers().try_ip() else {
+            warn!("{}: No Ip headers, so no dst_vni to lookup", self.name);
+            return;
+        };
+        if let Some(src_vni) = packet.meta.src_vni {
+            let vni_table = tablesr.tables_by_vni.get(&src_vni);
+            if let Some(vni_table) = vni_table {
+                let dst_vni = vni_table.dst_vnis.lookup(net.dst_addr());
+                if let Some((prefix, dst_vni)) = dst_vni {
+                    debug!(
+                        "{}: Tagging packet with dst_vni {dst_vni} using {prefix} using table for src_vni {src_vni}",
+                        self.name
+                    );
+                    packet.meta.dst_vni = Some(*dst_vni);
+                } else {
+                    debug!(
+                        "{}: no dst_vni found for {} in src_vni {src_vni}, marking packet as unroutable",
+                        self.name,
+                        net.dst_addr()
+                    );
+                    packet.done(DoneReason::Unroutable);
+                }
+            } else {
+                debug!(
+                    "{}: no vni table found for src_vni {src_vni} (dst_addr={})",
+                    self.name,
+                    net.dst_addr()
+                );
+                packet.done(DoneReason::Unroutable);
+            }
+        }
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for DstVniLookup {
+    #[allow(clippy::if_not_else)]
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        input.filter_map(|mut packet| {
+            if let Some(tablesr) = &self.tablesr.enter() {
+                if !packet.is_done() {
+                    // FIXME: ideally, we'd `enter` once for the whole batch. However,
+                    // this requires boxing the closures, which may be worse than
+                    // calling `enter` per packet? ... if not uglier
+
+                    self.process_packet(tablesr, &mut packet);
+                }
+            } else {
+                error!("{}: failed to read vni tables", self.name);
+                packet.done(DoneReason::InternalFailure);
+            }
+            packet.enforce()
+        })
+    }
+}

--- a/pkt-meta/src/dst_vni_lookup/setup.rs
+++ b/pkt-meta/src/dst_vni_lookup/setup.rs
@@ -50,3 +50,203 @@ pub fn build_dst_vni_lookup_configuration(overlay: &Overlay) -> Result<VniTables
     }
     Ok(vni_tables)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use config::external::overlay::Overlay;
+    use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
+    use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest, VpcPeeringTable};
+    use lpm::prefix::Prefix;
+    use net::vxlan::Vni;
+    use std::net::IpAddr;
+
+    fn build_overlay() -> (Vni, Vni, Overlay) {
+        // Build VpcExpose objects
+        //
+        //     expose:
+        //       - ips:
+        //         - cidr: 1.1.0.0/16
+        //         - cidr: 1.2.0.0/16 # <- 1.2.3.4 will match here
+        //         - not: 1.1.5.0/24  # to account for when computing the offset
+        //         - not: 1.1.3.0/24  # to account for when computing the offset
+        //         - not: 1.1.1.0/24  # to account for when computing the offset
+        //         - not: 1.2.2.0/24  # to account for when computing the offset
+        //         as:
+        //         - cidr: 2.2.0.0/16
+        //         - cidr: 2.1.0.0/16 # <- corresp. target range, initially
+        //                            # (prefixes in BTreeSet are sorted)
+        //                            # offset for 2.1.255.4, before applying exlusions
+        //                            # final offset is for 2.2.0.4 after accounting for the one
+        //                            # relevant exclusion prefix
+        //         - not: 2.1.8.0/24  # to account for when fetching the address in range
+        //         - not: 2.2.10.0/24
+        //         - not: 2.2.1.0/24  # ignored, offset too low
+        //         - not: 2.2.2.0/24  # ignored, offset too low
+        //       - ips:
+        //         - cidr: 3.0.0.0/16
+        //         as:
+        //         - cidr: 4.0.0.0/16
+        let expose1 = VpcExpose::empty()
+            .ip("1.1.0.0/16".into())
+            .not("1.1.5.0/24".into())
+            .not("1.1.3.0/24".into())
+            .not("1.1.1.0/24".into())
+            .ip("1.2.0.0/16".into())
+            .not("1.2.2.0/24".into())
+            .as_range("2.2.0.0/16".into())
+            .not_as("2.1.8.0/24".into())
+            .not_as("2.2.10.0/24".into())
+            .not_as("2.2.1.0/24".into())
+            .not_as("2.2.2.0/24".into())
+            .as_range("2.1.0.0/16".into());
+        let expose2 = VpcExpose::empty()
+            .ip("3.0.0.0/16".into())
+            .as_range("4.0.0.0/16".into());
+
+        let manifest1 = VpcManifest {
+            name: "VPC-1".into(),
+            exposes: vec![expose1, expose2],
+        };
+
+        //     expose:
+        //       - ips: # Note the lack of "as" here
+        //         - cidr: 8.0.0.0/17
+        //         - cidr: 9.0.0.0/17
+        //         - not: 8.0.0.0/24
+        //       - ips:
+        //         - cidr: 10.0.0.0/16 # <- corresponding target range
+        //         - not: 10.0.1.0/24  # to account for when fetching the address in range
+        //         - not: 10.0.2.0/24  # to account for when fetching the address in range
+        //         as:
+        //         - cidr: 5.5.0.0/17
+        //         - cidr: 5.6.0.0/17  # <- 5.6.7.8 will match here
+        //         - not: 5.6.0.0/24   # to account for when computing the offset
+        //         - not: 5.6.8.0/24
+        let expose3 = VpcExpose::empty()
+            .ip("8.0.0.0/17".into())
+            .not("8.0.0.0/24".into())
+            .ip("9.0.0.0/17".into());
+        let expose4 = VpcExpose::empty()
+            .ip("10.0.0.0/16".into())
+            .not("10.0.1.0/24".into())
+            .not("10.0.2.0/24".into())
+            .as_range("5.5.0.0/17".into())
+            .as_range("5.6.0.0/17".into())
+            .not_as("5.6.0.0/24".into())
+            .not_as("5.6.8.0/24".into());
+
+        let manifest2 = VpcManifest {
+            name: "VPC-2".into(),
+            exposes: vec![expose3, expose4],
+        };
+
+        let peering1 = Peering {
+            name: "test_peering1".into(),
+            local: manifest1.clone(),
+            remote: manifest2.clone(),
+            remote_id: "12345".try_into().expect("Failed to create VPC ID"),
+        };
+        let peering2 = Peering {
+            name: "test_peering2".into(),
+            local: manifest2,
+            remote: manifest1,
+            remote_id: "67890".try_into().expect("Failed to create VPC ID"),
+        };
+
+        let mut vpctable = VpcTable::new();
+
+        // vpc-1
+        let vni1 = Vni::new_checked(100).unwrap();
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1.as_u32()).unwrap();
+        vpc1.peerings.push(peering1.clone());
+        vpctable.add(vpc1).unwrap();
+
+        // vpc-2
+        let vni2 = Vni::new_checked(200).unwrap();
+        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2.as_u32()).unwrap();
+        vpc2.peerings.push(peering2.clone());
+        vpctable.add(vpc2).unwrap();
+
+        // Now test building the dst_vni_lookup configuration
+        let overlay = Overlay {
+            vpc_table: vpctable,
+            peering_table: VpcPeeringTable::new(),
+        };
+
+        (vni1, vni2, overlay)
+    }
+
+    #[test]
+    fn test_setup() {
+        let (vni1, vni2, overlay) = build_overlay();
+        let result = build_dst_vni_lookup_configuration(&overlay);
+        assert!(
+            result.is_ok(),
+            "Failed to build dst_vni_lookup configuration:\n{:#?}",
+            result.err()
+        );
+
+        let vni_tables = result.unwrap();
+        assert_eq!(vni_tables.tables_by_vni.len(), 2);
+        println!(
+            "vni_tables: {:?}",
+            vni_tables.tables_by_vni.get(&vni1).unwrap().dst_vnis
+        );
+
+        //////////////////////
+        // table for vni 1 (uses second expose block, ensures we look at them all)
+        assert_eq!(
+            vni_tables
+                .tables_by_vni
+                .get(&vni1)
+                .unwrap()
+                .dst_vnis
+                .lookup("5.5.5.1".parse::<IpAddr>().unwrap()),
+            Some((Prefix::from("5.5.0.0/17"), &vni2))
+        );
+
+        assert_eq!(
+            vni_tables
+                .tables_by_vni
+                .get(&vni1)
+                .unwrap()
+                .dst_vnis
+                .lookup("5.6.0.1".parse::<IpAddr>().unwrap()),
+            None
+        );
+
+        // Make sure dst VNI lookup for non-NAT stuff works
+        assert_eq!(
+            vni_tables
+                .tables_by_vni
+                .get(&vni1)
+                .unwrap()
+                .dst_vnis
+                .lookup("8.0.1.1".parse::<IpAddr>().unwrap()),
+            Some((Prefix::from("8.0.1.0/24"), &vni2))
+        );
+
+        //////////////////////
+        // table for vni 2 (uses first expose block, ensures we look at them all)
+        assert_eq!(
+            vni_tables
+                .tables_by_vni
+                .get(&vni2)
+                .unwrap()
+                .dst_vnis
+                .lookup("2.2.0.1".parse::<IpAddr>().unwrap()),
+            Some((Prefix::from("2.2.0.0/24"), &vni1))
+        );
+
+        assert_eq!(
+            vni_tables
+                .tables_by_vni
+                .get(&vni2)
+                .unwrap()
+                .dst_vnis
+                .lookup("2.2.2.1".parse::<IpAddr>().unwrap()),
+            None
+        );
+    }
+}

--- a/pkt-meta/src/dst_vni_lookup/setup.rs
+++ b/pkt-meta/src/dst_vni_lookup/setup.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use crate::dst_vni_lookup::{DstVniLookupError, VniTable, VniTables};
+use config::ConfigError;
+use config::external::overlay::Overlay;
+use config::external::overlay::vpc::{Peering, VpcTable};
+use config::utils::{ConfigUtilError, collapse_prefixes_peering};
+
+fn process_peering(
+    table: &mut VniTable,
+    peering: &Peering,
+    vpc_table: &VpcTable,
+) -> Result<(), DstVniLookupError> {
+    let new_peering = collapse_prefixes_peering(peering).map_err(|e| match e {
+        ConfigUtilError::SplitPrefixError(prefix) => {
+            DstVniLookupError::BuildError(prefix.to_string())
+        }
+    })?;
+
+    /* get vni for remote manifest */
+    let remote_vni = vpc_table
+        .get_vpc_by_vpcid(&new_peering.remote_id)
+        .unwrap_or_else(|| unreachable!())
+        .vni;
+
+    new_peering.remote.exposes.iter().for_each(|expose| {
+        let remote_public_prefixes = expose.public_ips();
+        for prefix in remote_public_prefixes {
+            table.dst_vnis.insert(*prefix, remote_vni);
+        }
+    });
+    Ok(())
+}
+
+/// Build the `dst_vni_lookup` configuration from an overlay.
+///
+/// # Errors
+///
+/// Returns an error if the configuration cannot be built.
+pub fn build_dst_vni_lookup_configuration(overlay: &Overlay) -> Result<VniTables, ConfigError> {
+    let mut vni_tables = VniTables::new();
+    for vpc in overlay.vpc_table.values() {
+        let mut table = VniTable::new();
+        for peering in &vpc.peerings {
+            process_peering(&mut table, peering, &overlay.vpc_table)
+                .map_err(|e| ConfigError::FailureApply(e.to_string()))?;
+        }
+        vni_tables.tables_by_vni.insert(vpc.vni, table);
+    }
+    Ok(vni_tables)
+}

--- a/pkt-meta/src/lib.rs
+++ b/pkt-meta/src/lib.rs
@@ -2,3 +2,5 @@
 // Copyright Open Network Fabric Authors
 
 #![deny(clippy::all, clippy::pedantic)]
+
+pub mod dst_vni_lookup;

--- a/pkt-meta/src/lib.rs
+++ b/pkt-meta/src/lib.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
Currently the NAT stage does the dst VNI lookup and annotates the packet.

This removes that logic and adds a custom pipeline stage `DstVniLookup` that will lookup the dst VNI and drop the packet if not found, otherwise will annotate the packet with the dst VNI.