### PR TITLE
Stateless NAT: use `dst_vni` packet metadata

### DIFF
--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -21,8 +21,8 @@ mod tests {
     use config::internal::routing::vrf::VrfConfig;
 
     use crate::StatelessNat;
+    use crate::stateless::setup::build_nat_configuration;
     use crate::stateless::setup::tables::{NatTables, PerVniTable};
-    use crate::stateless::setup::{add_peering, build_nat_configuration};
 
     use net::buffer::PacketBufferMut;
     use net::eth::mac::Mac;
@@ -190,10 +190,14 @@ mod tests {
         let mut nat_table = NatTables::new();
 
         let mut vni_table1 = PerVniTable::new(vni1);
-        add_peering(&mut vni_table1, &peering1, vni2).expect("Failed to build NAT tables");
+        vni_table1
+            .add_peering(&peering1, vni2)
+            .expect("Failed to build NAT tables");
 
         let mut vni_table2 = PerVniTable::new(vni2);
-        add_peering(&mut vni_table2, &peering2, vni1).expect("Failed to build NAT tables");
+        vni_table2
+            .add_peering(&peering2, vni1)
+            .expect("Failed to build NAT tables");
 
         nat_table.add_table(vni_table1);
         nat_table.add_table(vni_table2);


### PR DESCRIPTION
Now that we can rely on a dedicated pipeline stage to perform the destination discriminant lookup (at the moment, destination VNI), we do not need to keep this indirection level in the NAT tables to find the rule (virtually) associated with the destination VNI for source NAT.

Instead of keeping the two lookups - first to find the index of the `NatPrefixRuleTable` in the `NatPeerRuleTable`, then to consult the `NatPrefixRuleTable` - simplify the structure of the NAT tables for source NAT, to only contain a per-destination-VNI hashmap containing the rules. This makes the NAT code simpler, in particular for building the rules tables.
