### PR TITLE
CI: Run bump.yml weekly, drop dpdk-sys update from this repo

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,43 +28,6 @@ permissions:
   pull-requests: "write"
 
 jobs:
-  dpdk-sys:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "login to ghcr.io"
-        uses: "docker/login-action@v3"
-        with:
-          registry: "ghcr.io"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
-      - name: "install envsubst"
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends gettext
-      - run: |
-          ./scripts/bump.sh
-      - name: "Create Pull Request"
-        uses: "peter-evans/create-pull-request@v7"
-        with:
-          branch: "bump/dpdk-sys"
-          title: "bump(dpdk-sys): new-version"
-          labels: |
-            automated
-            dependencies
-          signoff: "true"
-          commit-message: "bump(dpdk-sys): automated bump of dpdk-sys"
-          sign-commits: "true"
-          body: "bump dpdk-sys"
-
-      - name: "Setup tmate session for debug"
-        if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        uses: "mxschmitt/action-tmate@v3"
-        timeout-minutes: 60
-        with:
-          limit-access-to-actor: true
-
   cargo-upgrades:
     runs-on: "lab"
     steps:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -12,10 +12,9 @@ on:
         required: false
         default: false
   schedule:
-    # Check for updates at 3:18am every day.
-    # I avoid midnight because everyone uses midnight and
-    # I don't need to contribute to load spikes.
-    - cron: "18 3 * * *"
+    # Check for updates at 3:18 am every Monday
+    # (Avoid midnight so we don't contribute to load spikes)
+    - cron: "18 3 * * 1"
 
 concurrency:
   group: "${{ github.workflow }}:${{ github.ref }}"


### PR DESCRIPTION
Leave dpdk-sys updates to https://github.com/githedgehog/dpdk-sys/blob/main/.github/workflows/update-dp.yml, and run dependency updates weekly only.
