### PR TITLE
Rename tap device

### DIFF
--- a/interface-manager/src/interface/tap.rs
+++ b/interface-manager/src/interface/tap.rs
@@ -134,7 +134,7 @@ mod helper {
                 .truncate(false)
                 .open("/dev/net/tun")
                 .await?;
-            trace!("attempting to create tap device");
+            trace!("attempting to create tap device {name}");
             #[allow(unsafe_code, clippy::borrow_as_ptr)] // well-checked constraints
             let ret = unsafe { make_tap_device(tap_file.as_raw_fd(), &*self.request)? };
             if ret < 0 {
@@ -142,7 +142,7 @@ mod helper {
                 warn!("failed to create tap device {name}: {err}");
                 return Err(err);
             }
-            info!("created tap device");
+            info!("created tap device {name}");
             trace!("attempting to persist tap device");
             #[allow(unsafe_code, clippy::borrow_as_ptr)] // well-checked constraints
             let ret = unsafe { persist_tap_device(tap_file.as_raw_fd(), &*self.request)? };

--- a/mgmt/src/vpc_manager/mod.rs
+++ b/mgmt/src/vpc_manager/mod.rs
@@ -317,7 +317,7 @@ impl TryFrom<&InternalConfig> for RequiredInformationBase {
                 match &iface.iftype {
                     InterfaceType::Ethernet(eth) => {
                         let mut tap = InterfaceSpecBuilder::default();
-                        match InterfaceName::try_from(iface.name.as_str()) {
+                        match InterfaceName::try_from(format!("{}-tap", iface.name.as_str())) {
                             Ok(name) => {
                                 tap.name(name);
                             }


### PR DESCRIPTION
* This is a quick fix
* Name tap device for interface `foo`  as ` foo-tap`. Otherwise creation fails as `foo` already exists.