### PR TITLE
Stateful NAT: Split to submodules in prep for allocator work

### DIFF
--- a/nat/src/stateful/allocator.rs
+++ b/nat/src/stateful/allocator.rs
@@ -2,69 +2,12 @@
 // Copyright Open Network Fabric Authors
 
 use super::NatIp;
-use net::tcp::port::{TcpPort, TcpPortError};
-use net::udp::port::{UdpPort, UdpPortError};
+use super::port::{NatPort, NatPortError};
 use std::collections::HashSet;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
-pub enum AllocatorError {
-    #[error("reserved port ({0})")]
-    ReservedPort(u16),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct NatPort(u16);
-
-impl NatPort {
-    const MIN: u16 = 1024 + 1;
-
-    pub fn new_checked(port: u16) -> Result<NatPort, AllocatorError> {
-        if port < Self::MIN {
-            return Err(AllocatorError::ReservedPort(port));
-        }
-        Ok(Self(port))
-    }
-
-    #[must_use]
-    pub fn as_u16(self) -> u16 {
-        self.0
-    }
-}
-
-impl TryFrom<TcpPort> for NatPort {
-    type Error = AllocatorError;
-
-    fn try_from(port: TcpPort) -> Result<Self, Self::Error> {
-        Self::new_checked(port.as_u16())
-    }
-}
-
-impl TryFrom<NatPort> for TcpPort {
-    type Error = TcpPortError;
-
-    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
-        TcpPort::new_checked(port.as_u16())
-    }
-}
-
-impl TryFrom<UdpPort> for NatPort {
-    type Error = AllocatorError;
-
-    fn try_from(port: UdpPort) -> Result<Self, Self::Error> {
-        Self::new_checked(port.as_u16())
-    }
-}
-
-impl TryFrom<NatPort> for UdpPort {
-    type Error = UdpPortError;
-
-    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
-        UdpPort::new_checked(port.as_u16())
-    }
-}
+use std::fmt::Debug;
 
 pub trait NatPool<I: NatIp> {
-    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), AllocatorError>;
+    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), NatPortError>;
 }
 
 #[derive(Debug, Clone)]
@@ -74,7 +17,7 @@ pub struct NatDefaultPool<I: NatIp> {
 }
 
 impl<I: NatIp> NatPool<I> for NatDefaultPool<I> {
-    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), AllocatorError> {
+    fn allocate(&self) -> Result<(I, I, Option<NatPort>, Option<NatPort>), NatPortError> {
         todo!()
     }
 }

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -6,6 +6,7 @@
 #![allow(unused_imports)]
 
 mod allocator;
+mod port;
 pub mod sessions;
 
 use crate::stateful::sessions::{
@@ -149,7 +150,7 @@ impl StatefulNat {
     fn set_source_port(
         transport: &mut Transport,
         next_header: NextHeader,
-        target_port: Option<allocator::NatPort>,
+        target_port: Option<port::NatPort>,
     ) {
         let Some(port) = target_port else {
             return;
@@ -168,7 +169,7 @@ impl StatefulNat {
     fn set_destination_port(
         transport: &mut Transport,
         next_header: NextHeader,
-        target_port: Option<allocator::NatPort>,
+        target_port: Option<port::NatPort>,
     ) {
         let Some(port) = target_port else {
             return;
@@ -295,7 +296,7 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for StatefulNat {
 
 #[cfg(test)]
 mod tests {
-    use super::allocator::NatPort;
+    use super::port::NatPort;
     use super::*;
     use net::packet::test_utils::build_test_ipv4_packet;
     use net::tcp::Tcp;

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -3,12 +3,13 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
-#![allow(unused_imports)]
 
 mod allocator;
+mod natip;
 mod port;
 pub mod sessions;
 
+use crate::stateful::natip::NatIp;
 use crate::stateful::sessions::{
     NatDefaultSession, NatDefaultSessionManager, NatSession, NatSessionManager, NatState,
 };
@@ -23,56 +24,7 @@ use net::vxlan::Vni;
 use pipeline::NetworkFunction;
 use routing::rib::vrf::VrfId;
 use std::hash::Hash;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-
-mod private {
-    pub trait Sealed {}
-}
-pub trait NatIp: private::Sealed + Clone + Eq + Hash {
-    fn to_ip_addr(&self) -> IpAddr;
-    fn from_src_addr(net: &Net) -> Option<Self>;
-    fn from_dst_addr(net: &Net) -> Option<Self>;
-}
-impl private::Sealed for Ipv4Addr {}
-impl private::Sealed for Ipv6Addr {}
-impl NatIp for Ipv4Addr {
-    fn to_ip_addr(&self) -> IpAddr {
-        IpAddr::V4(*self)
-    }
-    fn from_src_addr(net: &Net) -> Option<Self> {
-        if let IpAddr::V4(addr) = net.src_addr() {
-            Some(addr)
-        } else {
-            None
-        }
-    }
-    fn from_dst_addr(net: &Net) -> Option<Self> {
-        if let IpAddr::V4(addr) = net.dst_addr() {
-            Some(addr)
-        } else {
-            None
-        }
-    }
-}
-impl NatIp for Ipv6Addr {
-    fn to_ip_addr(&self) -> IpAddr {
-        IpAddr::V6(*self)
-    }
-    fn from_src_addr(net: &Net) -> Option<Self> {
-        if let IpAddr::V6(addr) = net.src_addr() {
-            Some(addr)
-        } else {
-            None
-        }
-    }
-    fn from_dst_addr(net: &Net) -> Option<Self> {
-        if let IpAddr::V6(addr) = net.dst_addr() {
-            Some(addr)
-        } else {
-            None
-        }
-    }
-}
+use std::net::{IpAddr, Ipv4Addr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NatTuple<I: NatIp> {

--- a/nat/src/stateful/natip.rs
+++ b/nat/src/stateful/natip.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use net::headers::Net;
+use std::hash::Hash;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+mod private {
+    pub trait Sealed {}
+}
+pub trait NatIp: private::Sealed + Clone + Eq + Hash {
+    fn to_ip_addr(&self) -> IpAddr;
+    fn from_src_addr(net: &Net) -> Option<Self>;
+    fn from_dst_addr(net: &Net) -> Option<Self>;
+}
+impl private::Sealed for Ipv4Addr {}
+impl private::Sealed for Ipv6Addr {}
+impl NatIp for Ipv4Addr {
+    fn to_ip_addr(&self) -> IpAddr {
+        IpAddr::V4(*self)
+    }
+    fn from_src_addr(net: &Net) -> Option<Self> {
+        if let IpAddr::V4(addr) = net.src_addr() {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+    fn from_dst_addr(net: &Net) -> Option<Self> {
+        if let IpAddr::V4(addr) = net.dst_addr() {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+}
+impl NatIp for Ipv6Addr {
+    fn to_ip_addr(&self) -> IpAddr {
+        IpAddr::V6(*self)
+    }
+    fn from_src_addr(net: &Net) -> Option<Self> {
+        if let IpAddr::V6(addr) = net.src_addr() {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+    fn from_dst_addr(net: &Net) -> Option<Self> {
+        if let IpAddr::V6(addr) = net.dst_addr() {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+}

--- a/nat/src/stateful/port.rs
+++ b/nat/src/stateful/port.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use net::tcp::port::{TcpPort, TcpPortError};
+use net::udp::port::{UdpPort, UdpPortError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum NatPortError {
+    #[error("reserved port ({0})")]
+    ReservedPort(u16),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NatPort(u16);
+
+impl NatPort {
+    const MIN: u16 = 1024 + 1;
+
+    pub fn new_checked(port: u16) -> Result<NatPort, NatPortError> {
+        if port < Self::MIN {
+            return Err(NatPortError::ReservedPort(port));
+        }
+        Ok(Self(port))
+    }
+
+    #[must_use]
+    pub fn as_u16(self) -> u16 {
+        self.0
+    }
+}
+
+impl TryFrom<TcpPort> for NatPort {
+    type Error = NatPortError;
+
+    fn try_from(port: TcpPort) -> Result<Self, Self::Error> {
+        Self::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<NatPort> for TcpPort {
+    type Error = TcpPortError;
+
+    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
+        TcpPort::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<UdpPort> for NatPort {
+    type Error = NatPortError;
+
+    fn try_from(port: UdpPort) -> Result<Self, Self::Error> {
+        Self::new_checked(port.as_u16())
+    }
+}
+
+impl TryFrom<NatPort> for UdpPort {
+    type Error = UdpPortError;
+
+    fn try_from(port: NatPort) -> Result<Self, Self::Error> {
+        UdpPort::new_checked(port.as_u16())
+    }
+}

--- a/nat/src/stateful/sessions.rs
+++ b/nat/src/stateful/sessions.rs
@@ -2,7 +2,7 @@
 // Copyright Open Network Fabric Authors
 
 use super::NatTuple;
-use super::allocator::NatPort;
+use super::port::NatPort;
 use crate::stateful::NatIp;
 use dashmap::DashMap;
 use dashmap::mapref::one::RefMut;


### PR DESCRIPTION
Simply move some parts of the code, namely the `NatPort` struct and surrounding code, and the `NatIp` trait, to their own files, to make future updates to the stateful NAT code easier to follow.
