### PR TITLE
Extend `IpPrefix` with `.size()`, `.last_address()`

### DIFF
--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -59,6 +59,8 @@ pub trait IpPrefix: Debug + Clone + From<Self::Addr> + PartialEq {
 
     fn network(&self) -> Self::Addr;
 
+    fn last_address(&self) -> Self::Addr;
+
     fn len(&self) -> u8;
 }
 
@@ -127,6 +129,9 @@ impl IpPrefix for Ipv4Prefix {
 
     fn network(&self) -> Self::Addr {
         self.0.network()
+    }
+    fn last_address(&self) -> Self::Addr {
+        self.0.broadcast()
     }
     fn len(&self) -> u8 {
         self.0.prefix_len()
@@ -243,6 +248,9 @@ impl IpPrefix for Ipv6Prefix {
     }
     fn network(&self) -> Self::Addr {
         self.0.network()
+    }
+    fn last_address(&self) -> Self::Addr {
+        self.0.broadcast()
     }
     fn len(&self) -> u8 {
         self.0.prefix_len()

--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Display};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
-use crate::prefix::PrefixError;
+use crate::prefix::{PrefixError, PrefixSize};
 use ipnet::{Ipv4Net, Ipv6Net};
 use num_traits::{CheckedShr, PrimInt, Unsigned, Zero};
 
@@ -62,6 +62,8 @@ pub trait IpPrefix: Debug + Clone + From<Self::Addr> + PartialEq {
     fn last_address(&self) -> Self::Addr;
 
     fn len(&self) -> u8;
+
+    fn size(&self) -> PrefixSize;
 }
 
 pub trait IpPrefixCovering<Other> {
@@ -135,6 +137,9 @@ impl IpPrefix for Ipv4Prefix {
     }
     fn len(&self) -> u8 {
         self.0.prefix_len()
+    }
+    fn size(&self) -> PrefixSize {
+        PrefixSize::U128(2u128.pow(32 - u32::from(self.len())))
     }
 }
 
@@ -254,6 +259,13 @@ impl IpPrefix for Ipv6Prefix {
     }
     fn len(&self) -> u8 {
         self.0.prefix_len()
+    }
+    fn size(&self) -> PrefixSize {
+        if self.len() == 0 {
+            PrefixSize::Ipv6MaxAddrs
+        } else {
+            PrefixSize::U128(2u128.pow(128 - u32::from(self.len())))
+        }
     }
 }
 

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -119,9 +119,8 @@ impl Prefix {
     #[must_use]
     pub fn size(&self) -> PrefixSize {
         match *self {
-            Prefix::IPV4(p) => PrefixSize::U128(2u128.pow(32 - u32::from(p.len()))),
-            Prefix::IPV6(p) if p.len() == 0 => PrefixSize::Ipv6MaxAddrs,
-            Prefix::IPV6(p) => PrefixSize::U128(2u128.pow(128 - u32::from(p.len()))),
+            Prefix::IPV4(p) => p.size(),
+            Prefix::IPV6(p) => p.size(),
         }
     }
 


### PR DESCRIPTION
Define and implement two methods to the `IpPrefix` trait to return the size and the last address within a prefix range, respectively.

This is in preparation for the work for the IP/port allocator for stateful NAT.
