### PR TITLE
fix(ci): Avoid pulling debug compile-env just for "cargo deny check"

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -131,7 +131,10 @@ jobs:
 
       - name: "cargo deny check"
         run: |
-          just debug_justfile="${{matrix.debug_justfile}}" ${{matrix.profile.sterile}} cargo deny check
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            profile=${{matrix.profile.name}} \
+            ${{matrix.profile.sterile}} cargo deny check
 
       - name: "push container"
         if: ${{ matrix.profile.sterile == 'sterile' && (matrix.profile.name == 'release' || matrix.profile.name == 'debug') }}


### PR DESCRIPTION
Pass the profile argument for the current job to the "just" invocation at the "cargo deny check" step of CI runs. Without this argument, the step would default to the "debug" profile and would _always_ pull the debug compile-env image, even for jobs where all other steps use the "release" profile, adding a useless image pull. Now that we pass the argument, the step should use the same image as the rest of the job, either "debug" or "release" depending on which job matrix case we run.

Fixes: e0dc86f54151