### PR TITLE
fix(routing): Fix doc warning (missing source code marking)

### DIFF
--- a/routing/src/fib/fibgroupstore.rs
+++ b/routing/src/fib/fibgroupstore.rs
@@ -13,7 +13,7 @@
 //! This data structure is, therefore, NOT thread-safe. Thread-safety is achieved by wrapping
 //! this structure in left-right.
 //!
-//! Any modification of the FibGroupStore or the Rc<RefCell<FibGroup>>s it contains
+//! Any modification of the FibGroupStore or the `Rc<RefCell<FibGroup>>`s it contains
 //! must be done while holding a `left_right::WriteGuard` to the `Fib` that owns it.
 //!
 //! Any use of the `FibGroupStore` or the `Rc<RefCell<FibGroup>>`s it contains


### PR DESCRIPTION
Building the Rust docs currently produces a warning:

    $ just cargo doc
    [...]
    warning: unclosed HTML tag `FibGroup`
      --> routing/src/fib/fibgroupstore.rs:16:60
       |
    16 | //! Any modification of the FibGroupStore or the Rc<RefCell<FibGroup>>s it contains
       |                                                            ^^^^^^^^^^
       |
       = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
    help: try marking as source code
       |
    16 | //! Any modification of the FibGroupStore or the `Rc<RefCell<FibGroup>>`s it contains
       |

Fix it.
