### PR TITLE
Move to using VPC discriminant in packet metadata

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -284,7 +284,7 @@ jobs:
     with:
       skip: ${{ matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+hlab') || !matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+vlab') }}
       fabricatorref: master
-      prebuild: "just bump dataplane HEAD.x86_64-unknown-linux-gnu.debug.${{ github.event.pull_request.merge_commit_sha }}"
+      prebuild: "just bump dataplane HEAD.x86_64-unknown-linux-gnu.debug.${{ github.sha }}"
       fabricmode: ${{ matrix.fabricmode }}
       gateway: ${{ matrix.gateway }}
       includeonie: ${{ matrix.includeonie }}

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
         grpc_addr,
         setup.router.get_ctl_tx(),
         setup.nattable,
-        setup.vnitablesw,
+        setup.vpcdtablesw,
         setup.vpcmapw,
     )
     .expect("Failed to start gRPC server");

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -17,7 +17,7 @@ use tokio::{io, spawn};
 use tokio_stream::Stream;
 
 use nat::stateless::NatTablesWriter;
-use pkt_meta::dst_vni_lookup::VniTablesWriter;
+use pkt_meta::dst_vpcd_lookup::VpcDiscTablesWriter;
 use routing::ctl::RouterCtlSender;
 
 use crate::grpc::server::create_config_service;
@@ -171,7 +171,7 @@ pub fn start_mgmt(
     grpc_addr: GrpcAddress,
     router_ctl: RouterCtlSender,
     nattablew: NatTablesWriter,
-    vnitablesw: VniTablesWriter,
+    vpcdtablesw: VpcDiscTablesWriter,
     vpcmapw: VpcMapWriter<VpcMapName>,
 ) -> Result<std::thread::JoinHandle<()>, Error> {
     /* build server address from provided grpc address */
@@ -196,7 +196,7 @@ pub fn start_mgmt(
             /* block thread to run gRPC and configuration processor */
             rt.block_on(async {
                 let (processor, tx) =
-                    ConfigProcessor::new(router_ctl, vpcmapw, nattablew, vnitablesw);
+                    ConfigProcessor::new(router_ctl, vpcmapw, nattablew, vpcdtablesw);
                 spawn(async { processor.run().await });
 
                 // Start the appropriate server based on address type

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -9,7 +9,7 @@ pub mod test {
     use nat::stateless::NatTablesWriter;
     use net::eth::mac::Mac;
     use net::interface::Mtu;
-    use pkt_meta::dst_vni_lookup::VniTablesWriter;
+    use pkt_meta::dst_vpcd_lookup::VpcDiscTablesWriter;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;
     use std::str::FromStr;
@@ -385,7 +385,7 @@ pub mod test {
         let nattablesw = NatTablesWriter::new();
 
         /* crate VniTables for dst_vni_lookup */
-        let vnitablesw = VniTablesWriter::new();
+        let vnitablesw = VpcDiscTablesWriter::new();
 
         /* build config processor to test the processing of a config. The processor embeds the config database
         and has the frrmi. In this test, we don't use any channel to communicate the config. */

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -20,7 +20,7 @@ use net::headers::{Net, Transport, TryHeadersMut, TryIp, TryIpMut, TryTransport,
 use net::ip::NextHeader;
 use net::ipv4::UnicastIpv4Addr;
 use net::ipv6::UnicastIpv6Addr;
-use net::packet::Packet;
+use net::packet::{Packet, VpcDiscriminant};
 use net::tcp::port::TcpPort;
 use net::udp::port::UdpPort;
 use net::vxlan::Vni;
@@ -429,7 +429,7 @@ impl StatefulNat {
     /// function that we pass to [`StatefulNat::process`] to iterate over packets.
     fn process_packet<Buf: PacketBufferMut>(&mut self, packet: &mut Packet<Buf>) {
         // TODO: What if no VNI
-        let Some(vni) = packet.get_meta().src_vni else {
+        let Some(VpcDiscriminant::VNI(vni)) = packet.get_meta().src_vpcd else {
             return;
         };
         let Some(net) = packet.get_headers().try_ip() else {

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -12,7 +12,7 @@ use net::buffer::PacketBufferMut;
 use net::headers::{Net, TryHeadersMut, TryIpMut};
 use net::ipv4::UnicastIpv4Addr;
 use net::ipv6::UnicastIpv6Addr;
-use net::packet::{DoneReason, Packet};
+use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use net::vxlan::Vni;
 use pipeline::NetworkFunction;
 use setup::tables::{NatTableValue, NatTables, PerVniTable};
@@ -230,14 +230,14 @@ impl StatelessNat {
         let nfi = self.name();
 
         /* get source VNI annotation */
-        let Some(src_vni) = packet.get_meta().src_vni else {
+        let Some(VpcDiscriminant::VNI(src_vni)) = packet.get_meta().src_vpcd else {
             warn!("{nfi}: Packet has no source VNI annotation!. Will drop...");
             packet.done(DoneReason::Unroutable);
             return;
         };
 
         /* get destination VNI annotation */
-        let Some(dst_vni) = packet.get_meta().dst_vni else {
+        let Some(VpcDiscriminant::VNI(dst_vni)) = packet.get_meta().dst_vpcd else {
             warn!("{nfi}: Packet has no destination VNI annotation!. Will drop...");
             packet.done(DoneReason::Unroutable);
             return;

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -27,8 +27,8 @@ mod tests {
     use net::buffer::PacketBufferMut;
     use net::eth::mac::Mac;
     use net::headers::{TryHeadersMut, TryIpv4, TryIpv4Mut};
-    use net::packet::Packet;
     use net::packet::test_utils::build_test_ipv4_packet;
+    use net::packet::{Packet, VpcDiscriminant};
     use net::vxlan::Vni;
     use pipeline::NetworkFunction;
     use std::net::Ipv4Addr;
@@ -216,10 +216,10 @@ mod tests {
 
         let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
         let mut packet_reply = packet.clone();
-        packet.get_meta_mut().src_vni = Some(vni(100));
-        packet.get_meta_mut().dst_vni = Some(vni(200));
-        packet_reply.get_meta_mut().src_vni = Some(vni(200));
-        packet_reply.get_meta_mut().dst_vni = Some(vni(100));
+        packet.get_meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
+        packet.get_meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
+        packet_reply.get_meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
+        packet_reply.get_meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
         packet.get_meta_mut().set_nat(true);
         packet_reply.get_meta_mut().set_nat(true);
 
@@ -434,8 +434,8 @@ mod tests {
     ) -> (Ipv4Addr, Ipv4Addr) {
         let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
         packet.get_meta_mut().set_nat(true);
-        packet.get_meta_mut().src_vni = Some(src_vni);
-        packet.get_meta_mut().dst_vni = Some(dst_vni);
+        packet.get_meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+        packet.get_meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
         set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
 
         let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();

--- a/net/src/packet/display.rs
+++ b/net/src/packet/display.rs
@@ -234,8 +234,8 @@ impl Display for PacketMeta {
         fmt_opt(f, " oif", self.oif, true)?;
 
         writeln!(f, "    bcast: {}", self.is_l2bcast())?;
-        fmt_opt(f, "    src-vni", self.src_vni, false)?;
-        fmt_opt(f, "    dst-vni", self.dst_vni, true)?;
+        fmt_opt(f, "    src-vpcd", self.src_vpcd, false)?;
+        fmt_opt(f, "    dst-vpcd", self.dst_vpcd, true)?;
         writeln!(f, "    do-nat: {}", self.nat())?;
         fmt_opt(f, "    vrf", self.vrf, false)?;
         fmt_opt(f, "    bd", self.bridge, true)?;

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -5,7 +5,9 @@
 
 use crate::vxlan::Vni;
 use bitflags::bitflags;
+use serde::Serialize;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::net::IpAddr;
 use tracing::error;
 
@@ -37,6 +39,39 @@ impl BridgeDomain {
     #[must_use]
     pub fn with_id(id: u32) -> Self {
         Self(id)
+    }
+}
+
+/// A dataplane-level discriminant to identify (traffic pertaining to) a Vpc
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize)]
+#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
+pub enum VpcDiscriminant {
+    VNI(Vni),
+}
+
+impl VpcDiscriminant {
+    #[must_use]
+    pub fn from_vni(vni: Vni) -> Self {
+        Self::VNI(vni)
+    }
+}
+impl AsRef<VpcDiscriminant> for VpcDiscriminant {
+    fn as_ref(&self) -> &VpcDiscriminant {
+        self
+    }
+}
+
+impl From<Vni> for VpcDiscriminant {
+    fn from(vni: Vni) -> Self {
+        Self::VNI(vni)
+    }
+}
+
+impl Display for VpcDiscriminant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VpcDiscriminant::VNI(vni) => vni.fmt(f),
+        }
     }
 }
 

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -70,7 +70,7 @@ impl From<Vni> for VpcDiscriminant {
 impl Display for VpcDiscriminant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VpcDiscriminant::VNI(vni) => vni.fmt(f),
+            VpcDiscriminant::VNI(vni) => write!(f, "VNI({vni})"),
         }
     }
 }

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -118,14 +118,14 @@ bitflags! {
 #[derive(Debug, Default, Clone)]
 pub struct PacketMeta {
     flags: MetaFlags,
-    pub iif: InterfaceId,             /* incoming interface - set early */
-    pub oif: Option<InterfaceId>,     /* outgoing interface - set late */
-    pub nh_addr: Option<IpAddr>,      /* IP address of next-hop */
-    pub vrf: Option<VrfId>,           /* for IP packet, the VRF to use to route it */
-    pub bridge: Option<BridgeDomain>, /* the bridge domain to forward the packet to */
+    pub iif: InterfaceId,                  /* incoming interface - set early */
+    pub oif: Option<InterfaceId>,          /* outgoing interface - set late */
+    pub nh_addr: Option<IpAddr>,           /* IP address of next-hop */
+    pub vrf: Option<VrfId>,                /* for IP packet, the VRF to use to route it */
+    pub bridge: Option<BridgeDomain>,      /* the bridge domain to forward the packet to */
     pub done: Option<DoneReason>, /* if Some, the reason why a packet was marked as done, including delivery to NF */
-    pub src_vni: Option<Vni>, /* the vni value of a received vxlan encap packet, if destined to gateway */
-    pub dst_vni: Option<Vni>, /* the vni value of a vxlan packet re-encapsulated by the gateway */
+    pub src_vpcd: Option<VpcDiscriminant>, /* the vpc discriminant of a received encapsulated packet */
+    pub dst_vpcd: Option<VpcDiscriminant>, /* the vpc discriminant of a packet to be (or already) re-encapsulated by the gateway */
 }
 impl PacketMeta {
     #[must_use]

--- a/pkt-meta/src/lib.rs
+++ b/pkt-meta/src/lib.rs
@@ -3,4 +3,4 @@
 
 #![deny(clippy::all, clippy::pedantic)]
 
-pub mod dst_vni_lookup;
+pub mod dst_vpcd_lookup;

--- a/stats/src/dpstats.rs
+++ b/stats/src/dpstats.rs
@@ -473,8 +473,8 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Stats {
             }
         }
         input.filter_map(|mut packet| {
-            let sdisc = packet.get_meta().src_vni.map(VpcDiscriminant::VNI);
-            let ddisc = packet.get_meta().dst_vni.map(VpcDiscriminant::VNI);
+            let sdisc = packet.get_meta().src_vpcd;
+            let ddisc = packet.get_meta().dst_vpcd;
             match (sdisc, ddisc) {
                 (Some(src), Some(dst)) => match self.update.vpc.get_mut(&src) {
                     None => {

--- a/stats/src/rate.rs
+++ b/stats/src/rate.rs
@@ -177,7 +177,7 @@ impl Derivative for SavitzkyGolayFilter<PacketAndByte<u64>> {
             .saturating_sub(data[4].packets.saturating_sub(data[0].packets));
         const NORMALIZATION: f64 = 12.;
         let packets = weighted_sum_packets as f64 / (NORMALIZATION * step);
-        let bytes = weighted_sum_packets as f64 / (NORMALIZATION * step);
+        let bytes = weighted_sum_bytes as f64 / (NORMALIZATION * step);
         Ok(PacketAndByte { packets, bytes })
     }
 }

--- a/vpcmap/src/lib.rs
+++ b/vpcmap/src/lib.rs
@@ -10,42 +10,9 @@
 
 #![deny(clippy::all, clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-use net::vxlan::Vni;
-use serde::Serialize;
-use std::fmt::Display;
 use thiserror::Error;
 
-/// A dataplane-level discriminant to identify (traffic pertaining to) a Vpc
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd, Serialize)]
-#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
-pub enum VpcDiscriminant {
-    VNI(Vni),
-}
-
-impl AsRef<VpcDiscriminant> for VpcDiscriminant {
-    fn as_ref(&self) -> &VpcDiscriminant {
-        self
-    }
-}
-
-impl VpcDiscriminant {
-    pub fn from_vni(vni: Vni) -> Self {
-        Self::VNI(vni)
-    }
-}
-
-impl From<Vni> for VpcDiscriminant {
-    fn from(vni: Vni) -> Self {
-        Self::VNI(vni)
-    }
-}
-impl Display for VpcDiscriminant {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VpcDiscriminant::VNI(vni) => vni.fmt(f),
-        }
-    }
-}
+pub use net::packet::VpcDiscriminant;
 
 /// The errors produced by the tables in this module
 #[derive(Error, Debug, PartialEq)]


### PR DESCRIPTION
This moves us to storing a VPC Discriminant in the packet meta data instead of a source and dest VNI.

It also moves `lookup_dst_vni` to `lookup_dst_vpcd` and makes it operate on discriminants instead of VNIs.

Fixes #808
Fixes #811 