### PR TITLE
Initial flow table data structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ name = "dataplane-pkt-meta"
 version = "0.1.0"
 dependencies = [
  "bolero",
+ "dashmap",
  "dataplane-config",
  "dataplane-lpm",
  "dataplane-net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-instant-full"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6541700e074cda41b1c6f98c2cae6cde819967bf142078f069cad85387cdbe"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1047,7 @@ name = "dataplane-pkt-meta"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.10",
+ "atomic-instant-full",
  "bolero",
  "dashmap",
  "dataplane-concurrency",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "left-right",
  "priority-queue",
  "thiserror 2.0.16",
+ "thread_local",
  "tracing",
  "tracing-test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,7 @@ dependencies = [
 name = "dataplane-pkt-meta"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.10",
  "bolero",
  "dashmap",
  "dataplane-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "dataplane-pipeline",
  "left-right",
  "priority-queue",
+ "shuttle",
  "thiserror 2.0.16",
  "thread_local",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,10 +485,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -1048,6 +1049,7 @@ dependencies = [
  "dataplane-net",
  "dataplane-pipeline",
  "left-right",
+ "priority-queue",
  "thiserror 2.0.16",
  "tracing",
  "tracing-test",
@@ -1143,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d7cc94194b4dd0fa12845ef8c911101b7f37633cda14997a6e82099aa0b693"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
 ]
@@ -1307,7 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc 0.2.175",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1330,6 +1332,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
 
 [[package]]
 name = "fixin"
@@ -1864,7 +1872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2464,6 +2472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,7 +2818,7 @@ dependencies = [
  "errno",
  "libc 0.2.175",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3122,7 +3141,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "ahash 0.8.10",
  "bolero",
  "dashmap",
+ "dataplane-concurrency",
  "dataplane-config",
  "dataplane-lpm",
  "dataplane-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ ordermap = { version = "0.5.9", default-features = false, features = [] }
 parking_lot = { version = "0.12.4", default-features = false, features = [] }
 prefix-trie = { version = "0.8.1", default-features = false, features = [] }
 pretty_assertions = { version = "1.4.1", default-features = false, features = ["std"] }
+priority-queue = { version = "2.5.0", default-features = false, features = [] }
 procfs = { version = "0.18.0", default-features = false, features = [] }
 rand = { version = "0.9.2", default-features = false, features = ["thread_rng"] }
 roaring = { version = "0.11.2", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ ahash = { git = "https://github.com/githedgehog/aHash", branch = "pr/daniel-nola
 arc-swap = { version = "1.7.1", default-features = false, features = [] }
 arrayvec = { version = "0.7.6", default-features = false, features = [] }
 async-trait = { version = "0.1.89", default-features = false, features = [] }
+atomic-instant-full = { version = "0.1.0", default-features = false, features = [] }
 axum = { version = "0.8.4", default-features = false, features = [] }
 axum-server = { version = "0.7.2", default-features = false, features = [] }
 bindgen = { version = "0.72.1", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ rustyline = { version = "17.0.1", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
 serde_yml = { version = "0.0.12", default-features = false, features = [] }
 shuttle = { version = "0.8.1", default-features = false, features = [] }
+thread_local = { version = "1.1.9", default-features = false, features = [] }
 small-map = { version = "0.1.3", default-features = false, features = [] }
 static_assertions = { version = "1.1.0", default-features = false, features = [] }
 strum = { version = "0.27.2", features = ["derive"] }

--- a/net/src/udp/mod.rs
+++ b/net/src/udp/mod.rs
@@ -7,13 +7,13 @@ mod checksum;
 pub mod port;
 
 pub use checksum::*;
+pub use port::*;
 
 use crate::ipv4::Ipv4;
 use crate::ipv6::Ipv6;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParsePayload, Reader,
 };
-use crate::udp::port::UdpPort;
 use crate::vxlan::{Vni, Vxlan};
 use etherparse::UdpHeader;
 use std::num::NonZero;

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -19,6 +19,7 @@ net = { workspace = true }
 pipeline = { workspace = true }
 priority-queue = { workspace = true }
 thiserror = { workspace = true }
+thread_local = { workspace = true }
 tracing = { workspace = true }
 
 

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 testing = []
 
 [dependencies]
+ahash = { workspace = true }
 lpm = { workspace = true }
 config = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"] }

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -6,11 +6,15 @@ publish = false
 license = "Apache-2.0"
 
 [features]
+shuttle = ["concurrency/shuttle"]
+std = []
 testing = []
+bolero = ["dep:bolero", "net/bolero"]
 
 [dependencies]
 ahash = { workspace = true }
 atomic-instant-full = { workspace = true }
+bolero = { workspace = true, optional = true }
 lpm = { workspace = true }
 concurrency = { workspace = true }
 config = { workspace = true }
@@ -27,5 +31,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 bolero = { workspace = true, default-features = false }
 lpm = { workspace = true, features = ["testing"] }
+net = { workspace = true, features = ["bolero"] }
 tracing-test = { workspace = true, features = [] }
-
+shuttle = { workspace = true }

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -11,6 +11,7 @@ testing = []
 [dependencies]
 ahash = { workspace = true }
 lpm = { workspace = true }
+concurrency = { workspace = true }
 config = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"] }
 left-right = { workspace = true }

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -17,6 +17,7 @@ dashmap = { workspace = true, features = ["raw-api"] }
 left-right = { workspace = true }
 net = { workspace = true }
 pipeline = { workspace = true }
+priority-queue = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -11,6 +11,7 @@ testing = []
 [dependencies]
 lpm = { workspace = true }
 config = { workspace = true }
+dashmap = { workspace = true, features = ["raw-api"] }
 left-right = { workspace = true }
 net = { workspace = true }
 pipeline = { workspace = true }

--- a/pkt-meta/Cargo.toml
+++ b/pkt-meta/Cargo.toml
@@ -10,6 +10,7 @@ testing = []
 
 [dependencies]
 ahash = { workspace = true }
+atomic-instant-full = { workspace = true }
 lpm = { workspace = true }
 concurrency = { workspace = true }
 config = { workspace = true }

--- a/pkt-meta/src/flow_table/README.md
+++ b/pkt-meta/src/flow_table/README.md
@@ -1,0 +1,28 @@
+# Flow Table
+
+The current implementation of flow table uses `dash_map` and per-thread priority queue's (for timeouts) along with `Arc` and `Weak` to get a reasonable flow table with timeouts.
+However, it leaves a lot of room for optimizations.
+
+## Flow Table Implementation
+
+The main `DashMap` holds `Weak` references to all the flow entries so that the memory gets automatically deallocated when the entry times out.  
+
+The priority queue's hold `Arc` references to the flow entries to keep them alive when they are not in any packet meta data.
+When the entry times-out and is removed from the priority queue and the last packet referencing that flow is dropped, the memory for the entry is freed.
+
+Note that in the current implementation, a flow is not removed from the flow table until the last Arc to the flow_info is dropped or the flow entry is replaced.  This can be changed if needed, or even have it be an option on the flow as to whether timeout removes the flow or not.
+
+## Optimizations
+
+In the current implementation, there has to be periodic or on-timeout reaping the Weak reference in the hash table.  
+This is better done by having a version of `DashMap` that can reap the dead `Weak` reference as it walks the table on lookups, instead of waiting for key collisions.
+The hope, for now, is that the entries in the hash table array will contain a small pointer and not take up too much extra memory.
+Those dead `Weak` pointers will prevent shrinking of the hash table though, if the implementation supports that.
+
+Second, the `priority_queue` crate uses a `HashMap` inside the queue in order to allow fast removal and re-insertion.  
+However, this wastes space and requires extra hashes.  
+The better way to do this is to have a custom priority queue integrated with the custom weak-reaping hash map so that the same hash table can be used for both operations.
+This improves cache locality, reduces memory utlization, and avoids multiple hash table lookups in many cases.
+
+However, in the interest of time to completion for the code, this module currently uses existing data structures instead of full custom implementations of everything.
+However, the interface should be able to hide a change from the current to the optimized implementation.

--- a/pkt-meta/src/flow_table/atomic_instant.rs
+++ b/pkt-meta/src/flow_table/atomic_instant.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use atomic_instant_full;
+use std::fmt::{Debug, Formatter};
+use std::ops::Deref;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+#[repr(transparent)]
+pub struct AtomicInstant(atomic_instant_full::AtomicInstant);
+
+impl Debug for AtomicInstant {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({:?})", self.0.load(Ordering::Relaxed))
+    }
+}
+
+impl Deref for AtomicInstant {
+    type Target = atomic_instant_full::AtomicInstant;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AtomicInstant {
+    #[must_use]
+    pub fn new(instant: Instant) -> Self {
+        Self(atomic_instant_full::AtomicInstant::new(instant))
+    }
+}

--- a/pkt-meta/src/flow_table/flow_info.rs
+++ b/pkt-meta/src/flow_table/flow_info.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use std::fmt::Debug;
+use std::time::{Duration, Instant};
+
+use concurrency::sync::RwLock;
+use net::packet::VpcDiscriminant;
+
+use crate::flow_table::AtomicInstant;
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+#[derive(Debug, thiserror::Error)]
+pub enum FlowInfoError {
+    #[error("flow expired")]
+    FlowExpired(Instant),
+    #[error("no such status")]
+    NoSuchStatus(u8),
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FlowStatus {
+    Active = 0,
+    Expired = 1,
+    Removed = 2,
+}
+
+impl TryFrom<u8> for FlowStatus {
+    type Error = FlowInfoError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(FlowStatus::Active),
+            1 => Ok(FlowStatus::Expired),
+            2 => Ok(FlowStatus::Removed),
+            v => Err(FlowInfoError::NoSuchStatus(v)),
+        }
+    }
+}
+
+impl From<FlowStatus> for u8 {
+    fn from(status: FlowStatus) -> Self {
+        status as u8
+    }
+}
+
+pub struct AtomicFlowStatus(AtomicU8);
+
+impl Debug for AtomicFlowStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+impl AtomicFlowStatus {
+    /// Load the flow status.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the the stored flow status is invalid, which should never happen.
+    ///
+    #[must_use]
+    pub fn load(&self, ordering: Ordering) -> FlowStatus {
+        let value = self.0.load(ordering);
+        FlowStatus::try_from(value).expect("Invalid enum state")
+    }
+
+    pub fn store(&self, state: FlowStatus, ordering: Ordering) {
+        self.0.store(u8::from(state), ordering);
+    }
+
+    /// Atomic compare and exchange of the flow status.
+    ///
+    /// # Errors
+    ///
+    /// Returns previous `FlowStatus` if the compare and exchange fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the the stored flow status is invalid, which should never happen.
+    ///
+    pub fn compare_exchange(
+        &self,
+        current: FlowStatus,
+        new: FlowStatus,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<FlowStatus, FlowStatus> {
+        match self
+            .0
+            .compare_exchange(current as u8, new as u8, success, failure)
+        {
+            Ok(prev) => Ok(FlowStatus::try_from(prev).expect("Invalid enum state")),
+            Err(prev) => Err(FlowStatus::try_from(prev).expect("Invalid enum state")),
+        }
+    }
+}
+
+impl From<FlowStatus> for AtomicFlowStatus {
+    fn from(status: FlowStatus) -> Self {
+        Self(AtomicU8::new(status as u8))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FlowInfoLocked {
+    pub dst_vpcd: Option<VpcDiscriminant>,
+}
+
+#[derive(Debug)]
+pub struct FlowInfo {
+    expires_at: AtomicInstant,
+    status: AtomicFlowStatus,
+    pub locked: RwLock<FlowInfoLocked>,
+}
+
+// TODO: We need a way to stuff an Arc<FlowInfo> into the packet
+// meta data.  That means this has to move to net or we need a generic
+// meta data extension method.
+impl FlowInfo {
+    #[must_use]
+    pub fn new(expires_at: Instant) -> Self {
+        Self {
+            expires_at: AtomicInstant::new(expires_at),
+            status: AtomicFlowStatus::from(FlowStatus::Active),
+            locked: RwLock::new(FlowInfoLocked { dst_vpcd: None }),
+        }
+    }
+
+    pub fn expires_at(&self) -> Instant {
+        self.expires_at.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Extend the expiry of the flow if it is not expired.
+    ///
+    /// # Errors
+    ///
+    /// Returns `FlowInfoError::FlowExpired` if the flow is expired with the expiry `Instant`
+    ///
+    pub fn extend_expiry(&self, duration: Duration) -> Result<(), FlowInfoError> {
+        if self.status.load(std::sync::atomic::Ordering::Relaxed) == FlowStatus::Expired {
+            return Err(FlowInfoError::FlowExpired(self.expires_at()));
+        }
+        self.extend_expiry_unchecked(duration);
+        Ok(())
+    }
+
+    /// Extend the expiry of the flow without checking if it is already expired.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe.
+    ///
+    pub fn extend_expiry_unchecked(&self, duration: Duration) {
+        self.expires_at
+            .fetch_add(duration, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn status(&self) -> FlowStatus {
+        self.status.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Update the flow status.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the status transition is invalid.
+    ///
+    pub fn update_status(&self, status: FlowStatus) -> Result<(), FlowInfoError> {
+        self.status
+            .store(status, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+}

--- a/pkt-meta/src/flow_table/flow_key.rs
+++ b/pkt-meta/src/flow_table/flow_key.rs
@@ -1,0 +1,614 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use std::hash::{Hash, Hasher};
+use std::net::IpAddr;
+
+use net::packet::VpcDiscriminant;
+use net::tcp::TcpPort;
+use net::udp::UdpPort;
+
+trait SrcLeqDst {
+    fn src_leq_dst(&self) -> bool;
+}
+
+trait HashSrc {
+    fn hash_src<H: Hasher>(&self, state: &mut H);
+}
+
+trait HashDst {
+    fn hash_dst<H: Hasher>(&self, state: &mut H);
+}
+
+trait SrcDstPort {
+    type Port: PartialEq + Eq + PartialOrd + Ord + Hash;
+    fn src_port(&self) -> &Self::Port;
+    fn dst_port(&self) -> &Self::Port;
+
+    fn symmetric_eq(&self, other: &Self) -> bool {
+        (self.src_port() == other.src_port() && self.dst_port() == other.dst_port())
+            || (self.src_port() == other.dst_port() && self.dst_port() == other.src_port())
+    }
+
+    fn src_leq_dst(&self) -> bool {
+        self.src_port() <= self.dst_port()
+    }
+
+    fn hash_src<H: Hasher>(&self, state: &mut H) {
+        self.src_port().hash(state);
+    }
+
+    fn hash_dst<H: Hasher>(&self, state: &mut H) {
+        self.dst_port().hash(state);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
+pub struct TcpProtoKey {
+    pub src_port: TcpPort,
+    pub dst_port: TcpPort,
+}
+
+impl TcpProtoKey {
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        Self {
+            src_port: self.dst_port,
+            dst_port: self.src_port,
+        }
+    }
+}
+impl SrcDstPort for TcpProtoKey {
+    type Port = TcpPort;
+    fn src_port(&self) -> &Self::Port {
+        &self.src_port
+    }
+    fn dst_port(&self) -> &Self::Port {
+        &self.dst_port
+    }
+}
+
+impl PartialEq for TcpProtoKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.symmetric_eq(other)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
+pub struct UdpProtoKey {
+    pub src_port: UdpPort,
+    pub dst_port: UdpPort,
+}
+
+impl UdpProtoKey {
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        Self {
+            src_port: self.dst_port,
+            dst_port: self.src_port,
+        }
+    }
+}
+impl SrcDstPort for UdpProtoKey {
+    type Port = UdpPort;
+    fn src_port(&self) -> &Self::Port {
+        &self.src_port
+    }
+    fn dst_port(&self) -> &Self::Port {
+        &self.dst_port
+    }
+}
+
+impl PartialEq for UdpProtoKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.symmetric_eq(other)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub enum IpProtoKey {
+    Tcp(TcpProtoKey),
+    Udp(UdpProtoKey),
+    Icmp, // TODO(mvachhar): add icmp key information, varies by message type :(
+}
+
+impl IpProtoKey {
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        match self {
+            IpProtoKey::Tcp(tcp) => IpProtoKey::Tcp(tcp.reverse()),
+            IpProtoKey::Udp(udp) => IpProtoKey::Udp(udp.reverse()),
+            IpProtoKey::Icmp => IpProtoKey::Icmp,
+        }
+    }
+}
+
+impl SrcLeqDst for IpProtoKey {
+    fn src_leq_dst(&self) -> bool {
+        match self {
+            IpProtoKey::Tcp(tcp) => tcp.src_leq_dst(),
+            IpProtoKey::Udp(udp) => udp.src_leq_dst(),
+            IpProtoKey::Icmp => true,
+        }
+    }
+}
+
+impl HashSrc for IpProtoKey {
+    fn hash_src<H: Hasher>(&self, state: &mut H) {
+        match self {
+            IpProtoKey::Tcp(tcp) => tcp.hash_src(state),
+            IpProtoKey::Udp(udp) => udp.hash_src(state),
+            IpProtoKey::Icmp => (),
+        }
+    }
+}
+
+impl HashDst for IpProtoKey {
+    fn hash_dst<H: Hasher>(&self, state: &mut H) {
+        match self {
+            IpProtoKey::Tcp(tcp) => tcp.hash_dst(state),
+            IpProtoKey::Udp(udp) => udp.hash_dst(state),
+            IpProtoKey::Icmp => (),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub struct FlowKeyData {
+    src_vpcd: Option<VpcDiscriminant>,
+    dst_vpcd: Option<VpcDiscriminant>, // If None, the dst_vpcd is ambiguous and the flow table is needed to resolve it
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    proto_key_info: IpProtoKey,
+}
+
+impl FlowKeyData {
+    #[must_use]
+    pub fn new(
+        src_vpcd: Option<VpcDiscriminant>,
+        src_ip: IpAddr,
+        dst_vpcd: Option<VpcDiscriminant>,
+        dst_ip: IpAddr,
+        ip_proto_key: IpProtoKey,
+    ) -> Self {
+        Self {
+            src_vpcd,
+            src_ip,
+            dst_vpcd,
+            dst_ip,
+            proto_key_info: ip_proto_key,
+        }
+    }
+
+    #[must_use]
+    fn symmetric_eq(&self, other: &Self) -> bool {
+        // Straightforward comparison
+        let src_to_src = self.src_vpcd == other.src_vpcd
+            && self.dst_vpcd == other.dst_vpcd
+            && self.src_ip == other.src_ip
+            && self.dst_ip == other.dst_ip
+            && self.proto_key_info == other.proto_key_info;
+
+        // Src to dst
+        src_to_src
+            || self.src_vpcd == other.dst_vpcd
+                && self.dst_vpcd == other.src_vpcd
+                && self.src_ip == other.dst_ip
+                && self.dst_ip == other.src_ip
+                && self.proto_key_info == other.proto_key_info.reverse()
+    }
+
+    fn symmetric_hash<H: Hasher>(&self, state: &mut H) {
+        0xb1d1_u16.hash(state); // Magic number to make sure the hash is different for bidirectional and unidirectional flows
+        if self.src_leq_dst() {
+            self.src_vpcd.hash(state);
+            self.src_ip.hash(state);
+            self.proto_key_info.hash_src(state);
+            self.dst_vpcd.hash(state);
+            self.dst_ip.hash(state);
+            self.proto_key_info.hash_dst(state);
+        } else {
+            self.dst_vpcd.hash(state);
+            self.dst_ip.hash(state);
+            self.proto_key_info.hash_dst(state);
+            self.src_vpcd.hash(state);
+            self.src_ip.hash(state);
+            self.proto_key_info.hash_src(state);
+        }
+    }
+
+    /// Creates a new flow key with src and dst swapped
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        Self {
+            src_vpcd: self.dst_vpcd,
+            dst_vpcd: self.src_vpcd,
+            src_ip: self.dst_ip,
+            dst_ip: self.src_ip,
+            proto_key_info: self.proto_key_info.reverse(),
+        }
+    }
+}
+
+impl SrcLeqDst for FlowKeyData {
+    fn src_leq_dst(&self) -> bool {
+        match (self.src_vpcd, self.dst_vpcd) {
+            (Some(src_vpcd), Some(dst_vpcd)) => {
+                src_vpcd < dst_vpcd
+                    || (src_vpcd == dst_vpcd && self.src_ip < self.dst_ip)
+                    || (src_vpcd == dst_vpcd
+                        && self.src_ip == self.dst_ip
+                        && self.proto_key_info.src_leq_dst())
+            }
+            (Some(_), None) => true, // No dst vpcd is bigger than anything with a src vpcd
+            (None, Some(_)) => false, // No src vpcd is bigger than anything with a dst vpcd
+            (None, None) => {
+                (self.src_ip < self.dst_ip)
+                    || (self.src_ip == self.dst_ip && self.proto_key_info.src_leq_dst())
+            }
+        }
+    }
+}
+
+impl Hash for FlowKeyData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.src_vpcd.hash(state);
+        self.src_ip.hash(state);
+        self.proto_key_info.hash_src(state);
+        self.dst_vpcd.hash(state);
+        self.dst_ip.hash(state);
+        self.proto_key_info.hash_dst(state);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
+pub enum FlowKey {
+    Bidirectional(FlowKeyData),
+    Unidirectional(FlowKeyData),
+}
+
+impl FlowKey {
+    #[must_use]
+    pub fn data(&self) -> &FlowKeyData {
+        match self {
+            FlowKey::Bidirectional(data) | FlowKey::Unidirectional(data) => data,
+        }
+    }
+
+    /// Create a unidirectional flow key
+    ///
+    /// packets with src -> dst will match, but dst -> src will not
+    #[must_use]
+    pub fn uni(
+        src_vpcd: Option<VpcDiscriminant>,
+        src_ip: IpAddr,
+        dst_vpcd: Option<VpcDiscriminant>, // If None, the dst_vpcd is ambiguous and the flow table is needed to resolve it
+        dst_ip: IpAddr,
+        proto_key_info: IpProtoKey,
+    ) -> FlowKey {
+        FlowKey::Unidirectional(FlowKeyData::new(
+            src_vpcd,
+            src_ip,
+            dst_vpcd,
+            dst_ip,
+            proto_key_info,
+        ))
+    }
+
+    /// Create a bidirectional flow key
+    ///
+    /// packets with src -> dst and dst -> src will match and hash to the same value.
+    #[must_use]
+    pub fn bidi(
+        src_vpcd: Option<VpcDiscriminant>,
+        src_ip: IpAddr,
+        dst_vpcd: Option<VpcDiscriminant>, // If None, the dst_vpcd is ambiguous and the flow table is needed to resolve it
+        dst_ip: IpAddr,
+        proto_key_info: IpProtoKey,
+    ) -> FlowKey {
+        FlowKey::Bidirectional(FlowKeyData::new(
+            src_vpcd,
+            src_ip,
+            dst_vpcd,
+            dst_ip,
+            proto_key_info,
+        ))
+    }
+
+    // Creates the flow key with src and dst swapped
+    #[must_use]
+    pub fn reverse(&self) -> FlowKey {
+        match self {
+            FlowKey::Bidirectional(data) => FlowKey::Bidirectional(data.reverse()),
+            FlowKey::Unidirectional(data) => FlowKey::Unidirectional(data.reverse()),
+        }
+    }
+}
+
+// The FlowKey Eq is symmetric, src == src or src == dst
+impl PartialEq for FlowKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (FlowKey::Bidirectional(a), FlowKey::Bidirectional(b)) => a.symmetric_eq(b),
+            (FlowKey::Unidirectional(a), FlowKey::Unidirectional(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Hash for FlowKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            FlowKey::Bidirectional(a) => a.symmetric_hash(state),
+            FlowKey::Unidirectional(a) => a.hash(state),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::{FlowKey, FlowKeyData, IpProtoKey, TcpProtoKey, UdpProtoKey};
+    use bolero::{Driver, TypeGenerator};
+    use net::ip::UnicastIpAddr;
+
+    impl TypeGenerator for TcpProtoKey {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let src_port = driver.produce()?;
+            let dst_port = driver.produce()?;
+            Some(TcpProtoKey { src_port, dst_port })
+        }
+    }
+
+    impl TypeGenerator for UdpProtoKey {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let src_port = driver.produce()?;
+            let dst_port = driver.produce()?;
+            Some(UdpProtoKey { src_port, dst_port })
+        }
+    }
+
+    impl TypeGenerator for IpProtoKey {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            // Pick a variant at random
+            let variant = driver.produce::<u8>()?;
+            match variant % 3 {
+                0 => {
+                    let tcp = TcpProtoKey::generate(driver)?;
+                    Some(IpProtoKey::Tcp(tcp))
+                }
+                1 => {
+                    let udp = UdpProtoKey::generate(driver)?;
+                    Some(IpProtoKey::Udp(udp))
+                }
+                _ => Some(IpProtoKey::Icmp),
+            }
+        }
+    }
+
+    impl TypeGenerator for FlowKeyData {
+        fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
+            let src_vpcd = driver.produce();
+            let dst_vpcd = driver.produce();
+            let src_ip = driver.produce::<UnicastIpAddr>()?.into();
+            let dst_ip = driver.produce::<UnicastIpAddr>()?.into();
+            let proto_key_info = super::IpProtoKey::generate(driver)?;
+            Some(FlowKeyData {
+                src_vpcd,
+                dst_vpcd,
+                src_ip,
+                dst_ip,
+                proto_key_info,
+            })
+        }
+    }
+
+    impl TypeGenerator for FlowKey {
+        fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
+            // Pick between Bidirectional and Unidirectional at random
+            let variant = driver.produce::<u8>()?;
+            let data = FlowKeyData::generate(driver)?;
+            match variant % 2 {
+                0 => Some(FlowKey::Bidirectional(data)),
+                _ => Some(FlowKey::Unidirectional(data)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ahash::AHasher;
+    use net::packet::VpcDiscriminant;
+    use net::vxlan::Vni;
+
+    #[test]
+    fn test_flow_key_src_leq_dst() {
+        // VNI
+        let flow_key_1 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1024).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        assert!(!flow_key_1.data().src_leq_dst());
+
+        let flow_key_2 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1025).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        assert!(flow_key_2.data().src_leq_dst());
+
+        // IP decides
+        let flow_key_3 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.5".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Udp(UdpProtoKey {
+                src_port: UdpPort::new_checked(1025).unwrap(),
+                dst_port: UdpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        assert!(flow_key_3.data().src_leq_dst());
+
+        let flow_key_4 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.5".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Udp(UdpProtoKey {
+                src_port: UdpPort::new_checked(1025).unwrap(),
+                dst_port: UdpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        assert!(!flow_key_4.data().src_leq_dst());
+
+        // Port decides
+        let flow_key_5 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Udp(UdpProtoKey {
+                src_port: UdpPort::new_checked(1025).unwrap(),
+                dst_port: UdpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        assert!(flow_key_5.data().src_leq_dst());
+
+        let flow_key_6 = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Udp(UdpProtoKey {
+                src_port: UdpPort::new_checked(2048).unwrap(),
+                dst_port: UdpPort::new_checked(1025).unwrap(),
+            }),
+        );
+
+        assert!(!flow_key_6.data().src_leq_dst());
+    }
+
+    #[test]
+    fn test_flow_key_symmetric_eq() {
+        let flow_key_1 = FlowKey::bidi(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.5".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1025).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        let flow_key_2 = FlowKey::bidi(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "1.2.3.5".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(2048).unwrap(),
+                dst_port: TcpPort::new_checked(1025).unwrap(),
+            }),
+        );
+
+        assert_eq!(flow_key_1, flow_key_2);
+        assert_eq!(flow_key_1, flow_key_1);
+        assert_eq!(flow_key_2, flow_key_2);
+    }
+
+    #[test]
+    fn test_flow_key_reverse() {
+        let flow_key = FlowKey::uni(
+            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+            "4.5.6.7".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1025).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        let reverse_flow_key = flow_key.reverse();
+
+        assert_eq!(flow_key.data().src_vpcd, reverse_flow_key.data().dst_vpcd);
+        assert_eq!(flow_key.data().dst_vpcd, reverse_flow_key.data().src_vpcd);
+        assert_eq!(flow_key.data().src_ip, reverse_flow_key.data().dst_ip);
+        assert_eq!(flow_key.data().dst_ip, reverse_flow_key.data().src_ip);
+        assert_eq!(
+            flow_key.data().proto_key_info,
+            reverse_flow_key.data().proto_key_info.reverse()
+        );
+    }
+
+    #[test]
+    fn test_flow_key_bidi_hash() {
+        let flow_key = FlowKey::bidi(
+            None,
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            None,
+            "4.5.6.7".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1025).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        let reverse_flow_key = flow_key.reverse();
+
+        // Reverse should be equal to the original
+        assert_eq!(flow_key, reverse_flow_key);
+
+        // Hash should be the same
+        let mut hash = AHasher::default();
+        let mut reverse_hash = AHasher::default();
+        flow_key.hash(&mut hash);
+        reverse_flow_key.hash(&mut reverse_hash);
+        assert_eq!(hash.finish(), reverse_hash.finish());
+    }
+
+    #[test]
+    fn test_flow_key_uni_hash() {
+        let flow_key = FlowKey::uni(
+            None,
+            "1.2.3.4".parse::<IpAddr>().unwrap(),
+            None,
+            "4.5.6.7".parse::<IpAddr>().unwrap(),
+            IpProtoKey::Tcp(TcpProtoKey {
+                src_port: TcpPort::new_checked(1025).unwrap(),
+                dst_port: TcpPort::new_checked(2048).unwrap(),
+            }),
+        );
+
+        let reverse_flow_key = flow_key.reverse();
+
+        // Reverse should not be equal to the original
+        assert_ne!(flow_key, reverse_flow_key);
+
+        // Hash should be different
+        let mut hash = AHasher::default();
+        let mut reverse_hash = AHasher::default();
+        flow_key.hash(&mut hash);
+        reverse_flow_key.hash(&mut reverse_hash);
+        assert_ne!(hash.finish(), reverse_hash.finish());
+    }
+}

--- a/pkt-meta/src/flow_table/mod.rs
+++ b/pkt-meta/src/flow_table/mod.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+pub mod atomic_instant;
+pub mod flow_info;
+pub mod flow_key;
+pub mod table;
+mod thread_local_pq;
+
+pub use flow_info::*;
+pub use flow_key::IpProtoKey;
+pub use flow_key::TcpProtoKey;
+pub use flow_key::UdpProtoKey;
+pub use flow_key::{FlowKey, FlowKeyData};
+pub use table::FlowTable;
+
+pub use atomic_instant::AtomicInstant;

--- a/pkt-meta/src/flow_table/table.rs
+++ b/pkt-meta/src/flow_table/table.rs
@@ -1,0 +1,678 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use ahash::RandomState;
+use dashmap::DashMap;
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::time::Instant;
+use tracing::{debug, error};
+
+use concurrency::sync::{Arc, RwLock, RwLockReadGuard, Weak};
+
+use crate::flow_table::thread_local_pq::{PQAction, ThreadLocalPriorityQueue};
+use crate::flow_table::{FlowInfo, FlowKey, FlowStatus};
+
+#[derive(Debug, thiserror::Error)]
+pub enum FlowTableError {
+    #[error("Invalid number of shards: {0}. Must be a power of two.")]
+    InvalidShardCount(usize),
+}
+
+type PriorityQueue = ThreadLocalPriorityQueue<FlowKey, Arc<FlowInfo>>;
+type Table = DashMap<FlowKey, Weak<FlowInfo>, RandomState>;
+
+pub struct FlowTable {
+    // TODO(mvachhar) move this to a cross beam sharded lock
+    pub(crate) table: RwLock<Table>,
+    pub(crate) priority_queue: PriorityQueue,
+}
+
+impl Default for FlowTable {
+    fn default() -> Self {
+        Self::new(1024)
+    }
+}
+
+fn hasher_state() -> &'static RandomState {
+    use std::sync::OnceLock;
+    static HASHER_STATE: OnceLock<RandomState> = OnceLock::new();
+    HASHER_STATE.get_or_init(|| RandomState::with_seeds(0, 0, 0, 0))
+}
+
+impl FlowTable {
+    #[must_use]
+    pub fn new(num_shards: usize) -> Self {
+        Self {
+            table: RwLock::new(Table::with_hasher_and_shard_amount(
+                hasher_state().clone(),
+                num_shards,
+            )),
+            priority_queue: PriorityQueue::new(),
+        }
+    }
+
+    /// Reshard the flow table into the given number of shards.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the number of shards is not a power of two.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this thread already holds the read lock on the table or
+    /// if the table lock is poisoned.
+    pub fn reshard(&self, num_shards: usize) -> Result<(), FlowTableError> {
+        if !num_shards.is_power_of_two() {
+            return Err(FlowTableError::InvalidShardCount(num_shards));
+        }
+        debug!(
+            "reshard: Resharding flow table from {} shards into {} shards",
+            self.table.read().unwrap().shards().len(),
+            num_shards
+        );
+        let mut locked_table = self.table.write().unwrap();
+        let new_table =
+            DashMap::with_hasher_and_shard_amount(locked_table.hasher().clone(), num_shards);
+        let old_table = std::mem::replace(&mut *locked_table, new_table);
+
+        // Move all entries from the old table to the new table using raw_api
+        for shard_lock in old_table.into_shards() {
+            let mut shard = shard_lock.write();
+            let drain_iter = shard.drain();
+            for (k, v) in drain_iter {
+                locked_table.insert(k, v.into_inner());
+            }
+        }
+        Ok(())
+    }
+
+    /// Add a flow to the table.
+    ///
+    /// # Returns
+    ///
+    /// Returns the old Arc<FlowInfo> associated with the flow key, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this thread already holds the read lock on the table or
+    /// if the table lock is poisoned.
+    pub fn insert(&self, flow_key: FlowKey, flow_info: FlowInfo) -> Option<Arc<FlowInfo>> {
+        debug!("insert: Inserting flow key {:?}", flow_key);
+        let val = Arc::new(flow_info);
+        self.insert_common(flow_key, &val)
+    }
+
+    /// Add a flow to the table via an Arc
+    ///
+    /// This is intended to re-add a flow to the flow table via the Arc returned from
+    /// lookup, but it can be used with a fresh Arc as well.
+    ///
+    /// # Returns
+    ///
+    /// Returns the old Arc<FlowInfo> associated with the flow key, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this thread already holds the read lock on the table or
+    /// if the table lock is poisoned.
+    pub fn reinsert(&self, flow_key: FlowKey, flow_info: &Arc<FlowInfo>) -> Option<Arc<FlowInfo>> {
+        debug!("reinsert: Re-inserting flow key {:?}", flow_key);
+        self.insert_common(flow_key, flow_info)
+    }
+
+    fn insert_common(&self, flow_key: FlowKey, val: &Arc<FlowInfo>) -> Option<Arc<FlowInfo>> {
+        let table = self.table.read().unwrap();
+        let expires_at = val.expires_at();
+        let result = table.insert(flow_key, Arc::downgrade(val));
+        self.priority_queue.push(flow_key, val.clone(), expires_at);
+        let ret = match result {
+            Some(w) => w.upgrade(),
+            None => None,
+        };
+
+        let Some(ret) = ret else {
+            return ret;
+        };
+
+        if ret.status() == FlowStatus::Expired {
+            return None;
+        }
+
+        Some(ret)
+    }
+
+    /// Lookup a flow in the table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this thread already holds the read lock on the table or
+    /// if the table lock is poisoned.
+    pub fn lookup<Q>(&self, flow_key: &Q) -> Option<Arc<FlowInfo>>
+    where
+        FlowKey: Borrow<Q>,
+        Q: Hash + Eq + ?Sized + Debug,
+    {
+        debug!("lookup: Looking up flow key {:?}", flow_key);
+        let table = self.table.read().unwrap();
+        let item = table.get(flow_key)?.upgrade();
+        let Some(item) = item else {
+            debug!(
+                "lookup: Removing flow key {:?}, found empty weak reference",
+                flow_key
+            );
+            Self::remove_with_read_lock(&table, flow_key);
+            return None;
+        };
+        if item.status() == FlowStatus::Expired {
+            debug!("lookup: Flow key {:?} is expired, removing", flow_key);
+            Self::remove_with_read_lock(&table, flow_key);
+            return None;
+        }
+        Some(item)
+    }
+
+    /// Remove a flow from the table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this thread already holds the read lock on the table or
+    /// if the table lock is poisoned.
+    pub fn remove<Q>(&self, flow_key: &Q) -> Option<(FlowKey, Arc<FlowInfo>)>
+    where
+        FlowKey: Borrow<Q>,
+        Q: Hash + Eq + ?Sized + Debug,
+    {
+        debug!("remove: Removing flow key {:?}", flow_key);
+        let table = self.table.read().unwrap();
+        Self::remove_with_read_lock(&table, flow_key)
+    }
+
+    fn remove_with_read_lock<Q>(
+        table: &RwLockReadGuard<DashMap<FlowKey, Weak<FlowInfo>, RandomState>>,
+        flow_key: &Q,
+    ) -> Option<(FlowKey, Arc<FlowInfo>)>
+    where
+        FlowKey: Borrow<Q>,
+        Q: Hash + Eq + ?Sized + Debug,
+    {
+        let result = table.remove(flow_key);
+        let (k, w) = result?;
+        let old_val = w.upgrade()?;
+        if old_val.status() == FlowStatus::Expired {
+            return None;
+        }
+        Some((k, old_val))
+    }
+
+    fn decide_expiry(now: &Instant, k: &FlowKey, v: &Arc<FlowInfo>) -> PQAction {
+        // Note(mvachhar)
+        //
+        //I'm not sure if marking the entry as expired is worthwhile here
+        // nor am I sure of the performance cost of doing this.
+        // It isn't strictly needed, though it means other holders of the Arc may
+        // be able to read stale data and wouldn't know the entry is expired.
+        //
+        // If the common case is that the entry has no other references here,
+        // then this operation should be cheap, though not free due to the
+        // dereference of the value and the lock acquisition.
+        #[allow(unused_must_use)]
+        let expires_at = v.expires_at();
+        if now >= &expires_at {
+            debug!("decide_expiry: Reap for flow key {k:?} with expires_at {expires_at:?}");
+            PQAction::Reap
+        } else {
+            debug!("decide_expiry: Update for flow key {k:?} with time {expires_at:?}");
+            PQAction::Update(expires_at)
+        }
+    }
+
+    // Pass by value here since the PQ doesn't know the value is an Arc
+    // and we get ownership of the value here
+    #[allow(clippy::needless_pass_by_value)]
+    fn do_reap(k: FlowKey, v: Arc<FlowInfo>) {
+        match v.update_status(FlowStatus::Expired) {
+            Ok(()) => {
+                debug!("do_reap: Updated flow status for {k:?} to expired");
+            }
+            Err(e) => {
+                error!("do_reap: Failed to update flow status for {k:?}: {e:?}",);
+            }
+        }
+    }
+
+    /// Reap expired entries from the priority queue for the current thread.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe but should not be called if the current thread is
+    /// holding a lock on any element in the flow table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any lock acquired by this method is poisoned.
+    pub fn reap_expired(&self) -> usize {
+        self.priority_queue
+            .reap_expired(Self::decide_expiry, Self::do_reap)
+    }
+
+    pub fn reap_all_expired(&self) -> usize {
+        self.priority_queue
+            .reap_all_expired(Self::decide_expiry, Self::do_reap)
+    }
+
+    #[cfg(all(test, feature = "shuttle"))]
+    pub fn reap_all_expired_with_time(&self, time: &Instant) -> usize {
+        self.priority_queue
+            .reap_all_expired_with_time(time, Self::decide_expiry, Self::do_reap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+    use std::time::Duration;
+
+    use concurrency::concurrency_mode;
+    use concurrency::thread;
+    use net::packet::VpcDiscriminant;
+    use net::tcp::TcpPort;
+    use net::vxlan::Vni;
+
+    use crate::flow_table::{FlowKey, FlowKeyData, IpProtoKey, TcpProtoKey};
+
+    #[concurrency_mode(std)]
+    mod std_tests {
+        use super::*;
+
+        #[test]
+        fn test_flow_table_insert_and_remove() {
+            let now = Instant::now();
+            let five_seconds = Duration::new(5, 0);
+            let five_seconds_from_now = now + five_seconds;
+
+            let flow_table = FlowTable::default();
+            let flow_key = FlowKey::Unidirectional(FlowKeyData::new(
+                Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+                "1.2.3.4".parse::<IpAddr>().unwrap(),
+                Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+                "4.5.6.7".parse::<IpAddr>().unwrap(),
+                IpProtoKey::Tcp(TcpProtoKey {
+                    src_port: TcpPort::new_checked(1025).unwrap(),
+                    dst_port: TcpPort::new_checked(2048).unwrap(),
+                }),
+            ));
+
+            let flow_info = FlowInfo::new(five_seconds_from_now);
+
+            flow_info.locked.write().unwrap().dst_vpcd =
+                Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap()));
+
+            flow_table.insert(flow_key, flow_info);
+            let result = flow_table.remove(&flow_key).unwrap();
+            assert!(result.0 == flow_key);
+            assert_eq!(
+                result.1.locked.read().unwrap().dst_vpcd,
+                Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap()))
+            );
+        }
+
+        #[test]
+        fn test_flow_table_timeout() {
+            let now = Instant::now();
+            let two_seconds = Duration::from_secs(2);
+            let one_second = Duration::from_secs(1);
+
+            let flow_table = FlowTable::default();
+            let flow_key = FlowKey::Unidirectional(FlowKeyData::new(
+                Some(VpcDiscriminant::VNI(Vni::new_checked(42).unwrap())),
+                "10.0.0.1".parse::<IpAddr>().unwrap(),
+                Some(VpcDiscriminant::VNI(Vni::new_checked(43).unwrap())),
+                "10.0.0.2".parse::<IpAddr>().unwrap(),
+                IpProtoKey::Tcp(TcpProtoKey {
+                    src_port: TcpPort::new_checked(1234).unwrap(),
+                    dst_port: TcpPort::new_checked(5678).unwrap(),
+                }),
+            ));
+
+            let flow_info = FlowInfo::new(now + two_seconds);
+            flow_table.insert(flow_key, flow_info);
+
+            // Wait 1 second, should still be present
+            thread::sleep(one_second);
+            // Reap expired entries after 1 second (should not reap our entry)
+            flow_table.reap_expired();
+            assert!(
+                flow_table.lookup(&flow_key).is_some(),
+                "Flow key should still be present after 1 second"
+            );
+
+            // Wait another 2 seconds (total 3s), should be expired
+            thread::sleep(two_seconds);
+            // Reap expired entries
+            flow_table.reap_expired();
+
+            assert!(
+                flow_table.lookup(&flow_key).is_none(),
+                "Flow key should have expired and been removed"
+            );
+        }
+
+        #[test]
+        fn test_flow_table_expire_bolero() {
+            let flow_table = FlowTable::default();
+            bolero::check!()
+                .with_type::<FlowKey>()
+                .for_each(|flow_key| {
+                    flow_table.insert(*flow_key, FlowInfo::new(Instant::now()));
+                    let flow_info_str = format!("{:?}", flow_table.lookup(flow_key).unwrap());
+
+                    // We purposely keep the flow alive here to make sure lookup reaps it
+                    let flow_info = flow_table.lookup(flow_key).unwrap();
+                    if let FlowKey::Bidirectional(_) = flow_key {
+                        let reverse_info = flow_table.lookup(&flow_key.reverse()).unwrap();
+                        assert!(Arc::ptr_eq(&reverse_info, &flow_info));
+                    } else {
+                        assert!(flow_table.lookup(&flow_key.reverse()).is_none());
+                    }
+
+                    thread::sleep(Duration::from_millis(100));
+                    flow_table.reap_all_expired();
+
+                    let result = flow_table.lookup(flow_key);
+                    assert!(
+                        result.is_none(),
+                        "flow_key lookup is not none {result:#?}, inserted {flow_info_str}, now: {:?}",
+                        Instant::now()
+                    );
+                });
+        }
+
+        #[test]
+        fn test_flow_table_remove_bolero() {
+            let flow_table = FlowTable::default();
+            bolero::check!()
+                .with_type::<FlowKey>()
+                .for_each(|flow_key| {
+                    flow_table.insert(*flow_key, FlowInfo::new(Instant::now()));
+                    let flow_info = flow_table.lookup(flow_key).unwrap();
+                    if let FlowKey::Bidirectional(_) = flow_key {
+                        let reverse_info = flow_table.lookup(&flow_key.reverse()).unwrap();
+                        assert!(Arc::ptr_eq(&reverse_info, &flow_info));
+                    } else {
+                        assert!(flow_table.lookup(&flow_key.reverse()).is_none());
+                    }
+
+                    let result = flow_table.remove(flow_key);
+                    assert!(result.is_some());
+                    let (k, v) = result.unwrap();
+                    assert_eq!(k, *flow_key);
+                    assert!(Arc::ptr_eq(&v, &flow_info));
+                    assert!(flow_table.lookup(flow_key).is_none());
+                });
+        }
+    }
+
+    #[concurrency_mode(shuttle)]
+    mod shuttle_tests {
+        use super::*;
+        use crate::flow_table::FlowInfo;
+        use concurrency::sync::Arc;
+
+        #[test]
+        fn test_flow_table_timeout() {
+            shuttle::check_random(
+                move || {
+                    let now = Instant::now();
+                    let two_seconds = Duration::from_secs(2);
+                    let one_second = Duration::from_secs(1);
+
+                    let flow_table = FlowTable::default();
+                    let flow_key = FlowKey::Unidirectional(FlowKeyData::new(
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(42).unwrap())),
+                        "10.0.0.1".parse::<IpAddr>().unwrap(),
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(43).unwrap())),
+                        "10.0.0.2".parse::<IpAddr>().unwrap(),
+                        IpProtoKey::Tcp(TcpProtoKey {
+                            src_port: TcpPort::new_checked(1234).unwrap(),
+                            dst_port: TcpPort::new_checked(5678).unwrap(),
+                        }),
+                    ));
+
+                    let flow_info = FlowInfo::new(now + two_seconds);
+                    flow_table.insert(flow_key, flow_info);
+
+                    // Reap expired entries after 1 second (should not reap our entry)
+                    // Shuttle does not model time, hence this hack
+                    flow_table.reap_all_expired_with_time(&(now + one_second));
+                    assert!(
+                        flow_table.lookup(&flow_key).is_some(),
+                        "Flow key should still be present after 1 second"
+                    );
+
+                    // Reap expired entries
+                    // Shuttle does not model time, hence this hack
+                    flow_table.reap_all_expired_with_time(&(now + two_seconds));
+
+                    assert!(
+                        flow_table.lookup(&flow_key).is_none(),
+                        "Flow key should have expired and been removed"
+                    );
+                },
+                100,
+            );
+        }
+
+        #[allow(clippy::too_many_lines)]
+        #[test]
+        #[tracing_test::traced_test]
+        fn test_flow_table_concurrent_insert_remove_lookup_timeout() {
+            const N: usize = 3;
+
+            let two_seconds = Duration::from_secs(2);
+            let flow_keys: Vec<_> = (0u16..2u16)
+                .map(|i| {
+                    FlowKey::Unidirectional(FlowKeyData::new(
+                        Some(VpcDiscriminant::VNI(
+                            Vni::new_checked(u32::from(i) + 1).unwrap(),
+                        )),
+                        format!("10.0.{i}.1").parse::<IpAddr>().unwrap(),
+                        Some(VpcDiscriminant::VNI(
+                            Vni::new_checked(u32::from(i) + 100).unwrap(),
+                        )),
+                        format!("10.0.{i}.2").parse::<IpAddr>().unwrap(),
+                        IpProtoKey::Tcp(TcpProtoKey {
+                            src_port: TcpPort::new_checked(1000 + i).unwrap(),
+                            dst_port: TcpPort::new_checked(2000 + i).unwrap(),
+                        }),
+                    ))
+                })
+                .collect();
+
+            shuttle::check_random(
+                move || {
+                    let flow_table = Arc::new(FlowTable::default());
+
+                    let now = Instant::now();
+
+                    let orig_flow_info = FlowInfo::new(now + two_seconds);
+
+                    // Insert the first flow
+                    flow_table.insert(flow_keys[0], orig_flow_info);
+                    let flow_info = flow_table.lookup(&flow_keys[0]).unwrap();
+
+                    // This holder will retain the Arc until the inserter thread starts
+                    let mut flow_info_holder = Some(flow_info);
+
+                    let mut handles = vec![];
+                    handles.push(
+                        thread::Builder::new()
+                            .name("timeout_reaper".to_string())
+                            .spawn({
+                                let flow_table = flow_table.clone();
+                                move || {
+                                    for _ in 0..N {
+                                        thread::yield_now();
+                                        flow_table.reap_expired();
+                                    }
+                                }
+                            })
+                            .unwrap(),
+                    );
+
+                    handles.push(
+                        thread::Builder::new()
+                            .name("inserter".to_string())
+                            .spawn({
+                                let flow_table = flow_table.clone();
+                                let flow_key = flow_keys[1];
+
+                                let flow_info = flow_info_holder.take();
+                                move || {
+                                    for _ in 0..N {
+                                        if let Some(flow_info) = flow_info.as_ref() {
+                                            flow_table.reinsert(flow_key, flow_info);
+                                        }
+                                        thread::yield_now();
+                                    }
+                                }
+                            })
+                            .unwrap(),
+                    );
+
+                    handles.push(
+                        thread::Builder::new()
+                            .name("remover".to_string())
+                            .spawn({
+                                let flow_table = flow_table.clone();
+                                let flow_key = flow_keys[1];
+                                move || {
+                                    for _ in 0..N {
+                                        thread::yield_now();
+                                        flow_table.remove(&flow_key);
+                                    }
+                                }
+                            })
+                            .unwrap(),
+                    );
+
+                    handles.push(
+                        thread::Builder::new()
+                            .name("lookup_and_lock".to_string())
+                            .spawn({
+                                let flow_table = flow_table.clone();
+                                let flow_key = flow_keys[1];
+                                move || {
+                                    for _ in 0..N {
+                                        thread::yield_now();
+                                        if let Some(flow_info) = flow_table.lookup(&flow_key) {
+                                            let _guard = flow_info.locked.write().unwrap();
+                                        }
+                                    }
+                                }
+                            })
+                            .unwrap(),
+                    );
+
+                    for handle in handles {
+                        handle.join().unwrap();
+                    }
+
+                    // Shuttle does not model time so we need this hack
+                    let reap_time = now + two_seconds;
+                    flow_table.reap_all_expired_with_time(&reap_time);
+
+                    // After all threads, all keys should be either gone or expired
+                    for key in &flow_keys {
+                        let result = flow_table.lookup(key);
+                        assert!(
+                            result.is_none(),
+                            "Flow key {:#?} should have expired at {:?} and been removed, now at create: {:?}, reap time: {:?}",
+                            *key,
+                            result.unwrap().expires_at(),
+                            now,
+                            reap_time
+                        );
+                    }
+                },
+                100,
+            );
+        }
+
+        #[test]
+        fn test_flow_table_reshard() {
+            shuttle::check_random(
+                move || {
+                    let flow_table = Arc::new(FlowTable::default());
+
+                    let five_seconds_from_now = Instant::now() + Duration::from_secs(5);
+                    let flow_key1 = FlowKey::Unidirectional(FlowKeyData::new(
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
+                        "1.2.3.4".parse::<IpAddr>().unwrap(),
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
+                        "4.5.6.7".parse::<IpAddr>().unwrap(),
+                        IpProtoKey::Tcp(TcpProtoKey {
+                            src_port: TcpPort::new_checked(1025).unwrap(),
+                            dst_port: TcpPort::new_checked(2048).unwrap(),
+                        }),
+                    ));
+
+                    let flow_key2 = FlowKey::Unidirectional(FlowKeyData::new(
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(10).unwrap())),
+                        "10.2.3.4".parse::<IpAddr>().unwrap(),
+                        Some(VpcDiscriminant::VNI(Vni::new_checked(20).unwrap())),
+                        "40.5.6.7".parse::<IpAddr>().unwrap(),
+                        IpProtoKey::Tcp(TcpProtoKey {
+                            src_port: TcpPort::new_checked(1025).unwrap(),
+                            dst_port: TcpPort::new_checked(2048).unwrap(),
+                        }),
+                    ));
+
+                    let flow_table_clone1 = flow_table.clone();
+                    let flow_table_clone2 = flow_table.clone();
+                    let flow_table_clone3 = flow_table.clone();
+
+                    let mut handles = vec![];
+
+                    handles.push(thread::spawn(move || {
+                        let flow_info = FlowInfo::new(five_seconds_from_now);
+                        flow_info.locked.write().unwrap().dst_vpcd =
+                            Some(VpcDiscriminant::VNI(Vni::new_checked(3).unwrap()));
+                        flow_table_clone1.insert(flow_key1, flow_info);
+                        let result = flow_table_clone1.remove(&flow_key1).unwrap();
+                        assert!(result.0 == flow_key1);
+                        assert_eq!(
+                            result.1.locked.read().unwrap().dst_vpcd,
+                            Some(VpcDiscriminant::VNI(Vni::new_checked(3).unwrap()))
+                        );
+                    }));
+
+                    handles.push(thread::spawn(move || {
+                        let flow_info = FlowInfo::new(five_seconds_from_now);
+                        flow_info.locked.write().unwrap().dst_vpcd =
+                            Some(VpcDiscriminant::VNI(Vni::new_checked(4).unwrap()));
+                        flow_table_clone2.insert(flow_key2, flow_info);
+                        let result = flow_table.remove(&flow_key2).unwrap();
+                        assert!(result.0 == flow_key2);
+                        assert_eq!(
+                            result.1.locked.read().unwrap().dst_vpcd,
+                            Some(VpcDiscriminant::VNI(Vni::new_checked(4).unwrap()))
+                        );
+                    }));
+
+                    handles.push(thread::spawn(move || {
+                        flow_table_clone3.reshard(128).unwrap();
+                    }));
+
+                    let _results: Vec<()> = handles
+                        .into_iter()
+                        .map(|handle| handle.join().unwrap())
+                        .collect();
+                },
+                100,
+            );
+        }
+    }
+}

--- a/pkt-meta/src/flow_table/thread_local_pq.rs
+++ b/pkt-meta/src/flow_table/thread_local_pq.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::time::Instant;
+
+use ahash::RandomState;
+use concurrency::sync::RwLock;
+// Should we just move this to std::collections::BinaryHeap?
+// We aren't using the hash table feature right now, though we may want it later.
+use priority_queue::PriorityQueue;
+use thread_local::ThreadLocal;
+use tracing::debug;
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Priority(Instant);
+
+impl PartialOrd for Priority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Priority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.0.cmp(&other.0) {
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Less => Ordering::Greater,
+            Ordering::Greater => Ordering::Less,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Entry<K, V>
+where
+    K: Send + Hash + PartialEq + Eq,
+    V: Send,
+{
+    key: K,
+    value: V,
+}
+
+impl<K, V> Hash for Entry<K, V>
+where
+    K: Send + Hash + PartialEq + Eq,
+    V: Send,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+    }
+}
+
+impl<K, V> PartialEq for Entry<K, V>
+where
+    K: Send + Hash + PartialEq + Eq,
+    V: Send,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl<K, V> Eq for Entry<K, V>
+where
+    K: Send + Hash + PartialEq + Eq,
+    V: Send,
+{
+}
+
+pub(crate) struct ThreadLocalPriorityQueue<K, V>
+where
+    K: Send + Hash + PartialEq + Eq,
+    V: Send,
+{
+    #[allow(clippy::type_complexity)]
+    pqs: ThreadLocal<RwLock<PriorityQueue<Entry<K, V>, Priority, RandomState>>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PQAction {
+    Reap,
+    Update(Instant),
+}
+
+impl<K, V> ThreadLocalPriorityQueue<K, V>
+where
+    K: Send + Sync + Hash + PartialEq + Eq,
+    V: Send + Sync,
+{
+    pub fn new() -> Self {
+        Self {
+            pqs: ThreadLocal::new(),
+        }
+    }
+
+    fn get_pq_lock(&self) -> &RwLock<PriorityQueue<Entry<K, V>, Priority, RandomState>> {
+        self.pqs
+            .get_or(|| RwLock::new(PriorityQueue::with_default_hasher()))
+    }
+
+    /// Insert an entry into the priority queue.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe but should not be called if the current thread is
+    /// holding a lock on any element in the priority queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any lock acquired by this method is poisoned.
+    pub fn push(&self, key: K, value: V, expires_at: Instant) -> Option<Instant> {
+        let pq = self.get_pq_lock();
+        pq.write()
+            .unwrap()
+            .push(Entry { key, value }, Priority(expires_at))
+            .map(|expires_at| expires_at.0)
+    }
+
+    /// Reap expired entries from the priority queue.
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe but should not be called if the current thread is
+    /// holding a lock on any element in the priority queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any lock acquired by this method is poisoned.
+    pub fn reap_expired(
+        &self,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        let pql = self.get_pq_lock();
+        let mut pq = pql.write().unwrap();
+        Self::reap_expired_locked(&mut pq, &on_expired, &on_reaped)
+    }
+
+    /// Reap expired entries from all priority queues (regardless of current thread)
+    ///
+    /// # Thread Safety
+    ///
+    /// This method is thread-safe but should not be called if the current thread is
+    /// holding a lock on any element in the priority queue.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any lock acquired by this method is poisoned.
+    pub fn reap_all_expired(
+        &self,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        self.reap_all_expired_with_time_internal(&Instant::now(), &on_expired, &on_reaped)
+    }
+
+    #[allow(unused)] // This is unused for now if shuttle is not enabled
+    #[cfg(test)]
+    pub fn reap_all_expired_with_time(
+        &self,
+        now: &Instant,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        self.reap_all_expired_with_time_internal(now, &on_expired, &on_reaped)
+    }
+
+    fn reap_all_expired_with_time_internal(
+        &self,
+        now: &Instant,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        let pqs = self.pqs.iter();
+        let mut count = 0;
+        for pq in pqs {
+            let mut pq = pq.write().unwrap();
+            count += Self::reap_expired_locked_with_time(&mut pq, now, &on_expired, &on_reaped);
+        }
+        count
+    }
+
+    fn reap_expired_locked(
+        pq: &mut concurrency::sync::RwLockWriteGuard<
+            PriorityQueue<Entry<K, V>, Priority, RandomState>,
+        >,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        Self::reap_expired_locked_with_time(pq, &Instant::now(), on_expired, on_reaped)
+    }
+
+    fn reap_expired_locked_with_time(
+        pq: &mut concurrency::sync::RwLockWriteGuard<
+            PriorityQueue<Entry<K, V>, Priority, RandomState>,
+        >,
+        now: &Instant,
+        on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
+        on_reaped: impl Fn(K, V),
+    ) -> usize {
+        let mut expired = Vec::new();
+        debug!(
+            "Reaping expired flows at {:?}, queue size {}",
+            now,
+            pq.len()
+        );
+        while let Some((_, expires_at)) = pq.peek() {
+            if *now >= expires_at.0 {
+                let ret = pq.pop();
+                let Some(entry) = ret else {
+                    break;
+                };
+                // This is going to copy the entry and key, even if it is to be reinserted,
+                // which sucks.  Find a better way to do this and placate the rust
+                // borrow checker.  Without this copy, the borrow checker will
+                // complain that you cannot pop the entry because of the borrow in the peek.
+                //
+                // This is probably fine for now though as we use K that is a FlowKey,
+                // copying it isn't ideal but probably cheap enough, and the value is an Arc.
+                expired.push(entry);
+            } else {
+                break;
+            }
+        }
+
+        debug!(
+            "Found {} expired flows at {:?}, queue size {}",
+            expired.len(),
+            now,
+            pq.len()
+        );
+        let mut count = 0;
+        for (entry, _) in expired {
+            match on_expired(now, &entry.key, &entry.value) {
+                PQAction::Reap => {
+                    on_reaped(entry.key, entry.value);
+                    count += 1;
+                }
+                PQAction::Update(new_expires_at) => {
+                    pq.push(entry, Priority(new_expires_at));
+                }
+            }
+        }
+
+        count
+    }
+}
+
+impl<K, V> Default for ThreadLocalPriorityQueue<K, V>
+where
+    K: Send + Sync + Hash + PartialEq + Eq,
+    V: Send + Sync,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/pkt-meta/src/lib.rs
+++ b/pkt-meta/src/lib.rs
@@ -4,3 +4,4 @@
 #![deny(clippy::all, clippy::pedantic)]
 
 pub mod dst_vpcd_lookup;
+pub mod flow_table;


### PR DESCRIPTION
This PR adds the initial flow table data structure, but not the corresponding pipeline stages.

The appropriate pipeline stages will be added as part of NAT integration and the interface for the flow table updated for anything needed that was not anticipated here.

We also need a way to run the shuttle tests in CI, but that is beyond the scope of this PR.

Fixes #783 