### PR TITLE
Stateful NAT: Build allocator from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ name = "dataplane-nat"
 version = "0.1.0"
 dependencies = [
  "ahash 0.8.10",
+ "arc-swap",
  "bolero",
  "dashmap",
  "dataplane-concurrency",

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -96,6 +96,7 @@ fn main() {
         grpc_addr,
         setup.router.get_ctl_tx(),
         setup.nattable,
+        setup.natallocatorw,
         setup.vpcdtablesw,
         setup.vpcmapw,
     )

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
     start_mgmt(
         grpc_addr,
         setup.router.get_ctl_tx(),
-        setup.nattable,
+        setup.nattablew,
         setup.natallocatorw,
         setup.vpcdtablesw,
         setup.vpcmapw,

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -13,6 +13,7 @@ use super::packet_processor::ipforward::IpForwarder;
 use pkt_meta::dst_vpcd_lookup::{DstVpcdLookup, VpcDiscTablesReader, VpcDiscTablesWriter};
 
 use nat::StatelessNat;
+use nat::stateful::NatAllocatorWriter;
 use nat::stateless::{NatTablesReader, NatTablesWriter};
 
 use net::buffer::PacketBufferMut;
@@ -68,6 +69,7 @@ where
     pub pipeline: DynPipeline<Buf>,
     pub vpcmapw: VpcMapWriter<VpcMapName>,
     pub nattable: NatTablesWriter,
+    pub natallocatorw: NatAllocatorWriter,
     pub vpcdtablesw: VpcDiscTablesWriter,
     pub stats: StatsCollector,
 }
@@ -77,6 +79,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     params: RouterParams,
 ) -> Result<InternalSetup<Buf>, RouterError> {
     let nattable = NatTablesWriter::new();
+    let natallocatorw = NatAllocatorWriter::new();
     let vpcdtablesw = VpcDiscTablesWriter::new();
     let router = Router::new(params)?;
     let vpcmapw = VpcMapWriter::<VpcMapName>::new();
@@ -94,6 +97,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         pipeline,
         vpcmapw,
         nattable,
+        natallocatorw,
         vpcdtablesw,
         stats,
     })

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -68,7 +68,7 @@ where
     pub router: Router,
     pub pipeline: DynPipeline<Buf>,
     pub vpcmapw: VpcMapWriter<VpcMapName>,
-    pub nattable: NatTablesWriter,
+    pub nattablew: NatTablesWriter,
     pub natallocatorw: NatAllocatorWriter,
     pub vpcdtablesw: VpcDiscTablesWriter,
     pub stats: StatsCollector,
@@ -78,7 +78,7 @@ where
 pub(crate) fn start_router<Buf: PacketBufferMut>(
     params: RouterParams,
 ) -> Result<InternalSetup<Buf>, RouterError> {
-    let nattable = NatTablesWriter::new();
+    let nattablew = NatTablesWriter::new();
     let natallocatorw = NatAllocatorWriter::new();
     let vpcdtablesw = VpcDiscTablesWriter::new();
     let router = Router::new(params)?;
@@ -89,14 +89,14 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         router.get_fibtr(),
         router.get_atabler(),
         writer,
-        nattable.get_reader(),
+        nattablew.get_reader(),
         vpcdtablesw.get_reader(),
     );
     Ok(InternalSetup {
         router,
         pipeline,
         vpcmapw,
-        nattable,
+        nattablew,
         natallocatorw,
         vpcdtablesw,
         stats,

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -378,6 +378,15 @@ fn apply_stateless_nat_config(
     Ok(())
 }
 
+/// Update the config for stateful NAT
+fn apply_stateful_nat_config(
+    vpc_table: &VpcTable,
+    natallocatorw: &mut NatAllocatorWriter,
+) -> ConfigResult {
+    natallocatorw.update_allocator(vpc_table);
+    Ok(())
+}
+
 /// Update the VNI tables for dst_vni_lookup
 fn apply_dst_vpcd_lookup_config(
     overlay: &Overlay,
@@ -397,7 +406,7 @@ async fn apply_gw_config(
     router_ctl: &mut RouterCtlSender,
     vpcmapw: &mut VpcMapWriter<VpcMapName>,
     nattablesw: &mut NatTablesWriter,
-    _natallocatorw: &mut NatAllocatorWriter,
+    natallocatorw: &mut NatAllocatorWriter,
     vpcdtablesw: &mut VpcDiscTablesWriter,
 ) -> ConfigResult {
     let genid = config.genid();
@@ -432,6 +441,9 @@ async fn apply_gw_config(
 
     /* apply stateless NAT config */
     apply_stateless_nat_config(&config.external.overlay.vpc_table, nattablesw)?;
+
+    /* apply stateful NAT config */
+    apply_stateful_nat_config(&config.external.overlay.vpc_table, natallocatorw)?;
 
     /* apply dst_vpcd_lookup config */
     apply_dst_vpcd_lookup_config(&config.external.overlay, vpcdtablesw)?;

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -383,7 +383,7 @@ fn apply_stateful_nat_config(
     vpc_table: &VpcTable,
     natallocatorw: &mut NatAllocatorWriter,
 ) -> ConfigResult {
-    natallocatorw.update_allocator(vpc_table);
+    natallocatorw.update_allocator(vpc_table)?;
     Ok(())
 }
 

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -6,6 +6,7 @@
 pub mod test {
     use caps::Capability::CAP_NET_ADMIN;
     use lpm::prefix::Prefix;
+    use nat::stateful::NatAllocatorWriter;
     use nat::stateless::NatTablesWriter;
     use net::eth::mac::Mac;
     use net::interface::Mtu;
@@ -384,12 +385,16 @@ pub mod test {
         /* crate NatTables for stateless nat */
         let nattablesw = NatTablesWriter::new();
 
+        /* crate NatAllocator for stateful nat */
+        let natallocatorw = NatAllocatorWriter::new();
+
         /* crate VniTables for dst_vni_lookup */
         let vnitablesw = VpcDiscTablesWriter::new();
 
         /* build config processor to test the processing of a config. The processor embeds the config database
         and has the frrmi. In this test, we don't use any channel to communicate the config. */
-        let (mut processor, _sender) = ConfigProcessor::new(ctl, vpcmapw, nattablesw, vnitablesw);
+        let (mut processor, _sender) =
+            ConfigProcessor::new(ctl, vpcmapw, nattablesw, natallocatorw, vnitablesw);
 
         /* let the processor process the config */
         match processor.process_incoming_config(config).await {

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -10,6 +10,7 @@ shuttle = ["concurrency/shuttle", "dep:shuttle"]
 
 [dependencies]
 ahash = { workspace = true }
+arc-swap = { workspace = true }
 concurrency = { workspace = true, features = [] }
 config = { workspace = true }
 dashmap = { workspace = true }

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -21,7 +21,7 @@
 //! - The total number of available (not excluded) private addresses used in an "Expose" object must
 //!   be equal to the total number of publicly exposed addresses in this object.
 
-mod stateful;
+pub mod stateful;
 pub mod stateless;
 
 pub use stateful::StatefulNat;

--- a/nat/src/stateful/allocator.rs
+++ b/nat/src/stateful/allocator.rs
@@ -49,7 +49,7 @@ pub struct AllocationResult<T: Debug> {
 /// alternative implementations of the allocator by implementing this trait and trivially replacing
 /// the allocator in use in the pipeline stage.
 #[allow(clippy::type_complexity)]
-pub trait NatAllocator<T, U>: Debug
+pub trait NatAllocator<T, U>: Debug + Sync + Send
 where
     T: Debug,
     U: Debug,

--- a/nat/src/stateful/allocator_writer.rs
+++ b/nat/src/stateful/allocator_writer.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use config::external::overlay::vpc::VpcTable;
+
 pub struct NatAllocatorWriter {}
 
 impl NatAllocatorWriter {
     #[must_use]
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn update_allocator(&mut self, _vpc_table: &VpcTable) {
+        todo!()
     }
 }
 

--- a/nat/src/stateful/allocator_writer.rs
+++ b/nat/src/stateful/allocator_writer.rs
@@ -53,6 +53,11 @@ impl NatAllocatorWriter {
         }
     }
 
+    #[must_use]
+    pub fn get_reader(&self) -> NatAllocatorReader {
+        NatAllocatorReader(self.allocator.clone())
+    }
+
     pub fn update_allocator(&mut self, vpc_table: &VpcTable) -> Result<(), ConfigError> {
         let new_config = StatefulNatConfig::new(vpc_table);
 
@@ -91,5 +96,14 @@ impl NatAllocatorWriter {
 impl Default for NatAllocatorWriter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct NatAllocatorReader(Arc<ArcSwapOption<NatDefaultAllocator>>);
+
+impl NatAllocatorReader {
+    pub fn get(&self) -> Option<Arc<NatDefaultAllocator>> {
+        self.0.load().clone()
     }
 }

--- a/nat/src/stateful/allocator_writer.rs
+++ b/nat/src/stateful/allocator_writer.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+pub struct NatAllocatorWriter {}
+
+impl NatAllocatorWriter {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for NatAllocatorWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/nat/src/stateful/allocator_writer.rs
+++ b/nat/src/stateful/allocator_writer.rs
@@ -1,18 +1,90 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use crate::stateful::{NatDefaultAllocator, NatVpcId};
+use arc_swap::ArcSwapOption;
+use config::ConfigError;
+use config::external::overlay::vpc::Peering;
 use config::external::overlay::vpc::VpcTable;
+use std::sync::Arc;
 
-pub struct NatAllocatorWriter {}
+#[derive(Debug, PartialEq)]
+pub(crate) struct StatefulNatPeering {
+    pub(crate) src_vpc_id: NatVpcId,
+    pub(crate) dst_vpc_id: NatVpcId,
+    pub(crate) peering: Peering,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct StatefulNatConfig(Vec<StatefulNatPeering>);
+
+impl StatefulNatConfig {
+    pub(crate) fn new(vpc_table: &VpcTable) -> Self {
+        let mut config = Vec::new();
+        for vpc in vpc_table.values() {
+            for peering in &vpc.peerings {
+                config.push(StatefulNatPeering {
+                    src_vpc_id: vpc.vni,
+                    dst_vpc_id: vpc_table.get_remote_vni(peering),
+                    peering: peering.clone(),
+                });
+            }
+        }
+        Self(config)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &StatefulNatPeering> {
+        self.0.iter()
+    }
+}
+
+#[derive(Debug)]
+pub struct NatAllocatorWriter {
+    config: StatefulNatConfig,
+    allocator: Arc<ArcSwapOption<NatDefaultAllocator>>,
+}
 
 impl NatAllocatorWriter {
     #[must_use]
     pub fn new() -> Self {
-        Self {}
+        Self {
+            config: StatefulNatConfig::default(),
+            allocator: Arc::new(ArcSwapOption::new(None)),
+        }
     }
 
-    pub fn update_allocator(&mut self, _vpc_table: &VpcTable) {
-        todo!()
+    pub fn update_allocator(&mut self, vpc_table: &VpcTable) -> Result<(), ConfigError> {
+        let new_config = StatefulNatConfig::new(vpc_table);
+
+        let old_allocator_guard = self.allocator.load();
+        let Some(old_allocator) = old_allocator_guard.as_deref() else {
+            // No existing allocator, build a new one
+            let new_allocator = Self::build_new_allocator(&new_config)?;
+            self.allocator.store(Some(Arc::new(new_allocator)));
+            self.config = new_config;
+            return Ok(());
+        };
+
+        if self.config == new_config {
+            // Nothing to update, simply return
+            return Ok(());
+        }
+
+        Self::update_existing_allocator(old_allocator, &self.config, &new_config)?;
+        self.config = new_config;
+        Ok(())
+    }
+
+    fn build_new_allocator(config: &StatefulNatConfig) -> Result<NatDefaultAllocator, ConfigError> {
+        NatDefaultAllocator::build_nat_allocator(config)
+    }
+
+    fn update_existing_allocator(
+        _allocator: &NatDefaultAllocator,
+        _old_config: &StatefulNatConfig,
+        _new_config: &StatefulNatConfig,
+    ) -> Result<(), ConfigError> {
+        todo!();
     }
 }
 

--- a/nat/src/stateful/apalloc/mod.rs
+++ b/nat/src/stateful/apalloc/mod.rs
@@ -54,13 +54,15 @@
 //! Returned object
 //! ```
 //!
-//! The [`AllocatedPort`](port_alloc::AllocatedPort) has a back-reference to [`AllocatedPortBlock`],
-//! to deallocate the ports when the [`AllocatedPort`](port_alloc::AllocatedPort) is dropped;
+//! The [`AllocatedPort`](port_alloc::AllocatedPort) has a back-reference to
+//! [`AllocatedPortBlock`](port_alloc::AllocatedPortBlock), to deallocate the ports when the
+//! [`AllocatedPort`](port_alloc::AllocatedPort) is dropped;
 //! [`AllocatedPortBlock`](port_alloc::AllocatedPortBlock) has a back reference to
 //! [`AllocatedIp`](alloc::AllocatedIp), and then the [`IpAllocator`](alloc::IpAllocator), to
 //! deallocate the IP address when they are dropped.
 
 #![allow(clippy::ip_constant)]
+#![allow(rustdoc::private_intra_doc_links)]
 
 use super::NatVpcId;
 use super::allocator::{AllocationResult, AllocatorError};

--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -9,9 +9,9 @@ use concurrency::concurrency_mode;
 // by tests in other modules. These helpers are not to be used outside of tests.
 mod context {
     use crate::stateful::allocator::AllocationResult;
+    use crate::stateful::allocator_writer::StatefulNatConfig;
     use crate::stateful::apalloc::alloc::IpAllocator;
     use crate::stateful::apalloc::port_alloc::AllocatedPort;
-    use crate::stateful::apalloc::setup::build_nat_allocator;
     use crate::stateful::apalloc::{NatDefaultAllocator, NatIpWithBitmap, PoolTable, PoolTableKey};
     use config::ConfigError;
     use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
@@ -132,7 +132,8 @@ mod context {
 
     pub fn build_allocator() -> Result<NatDefaultAllocator, ConfigError> {
         let vpc_table = build_context();
-        build_nat_allocator(&vpc_table)
+        let config = StatefulNatConfig::new(&vpc_table);
+        NatDefaultAllocator::build_nat_allocator(&config)
     }
 }
 

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -2,7 +2,7 @@
 // Copyright Open Network Fabric Authors
 
 mod allocator;
-mod apalloc;
+pub mod apalloc;
 mod natip;
 mod port;
 pub mod sessions;

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -2,10 +2,13 @@
 // Copyright Open Network Fabric Authors
 
 mod allocator;
+mod allocator_writer;
 pub mod apalloc;
 mod natip;
 mod port;
 pub mod sessions;
+
+pub use allocator_writer::NatAllocatorWriter;
 
 use crate::stateful::allocator::{AllocationResult, NatAllocator};
 use crate::stateful::apalloc::AllocatedIpPort;

--- a/nat/src/stateful/sessions.rs
+++ b/nat/src/stateful/sessions.rs
@@ -162,6 +162,7 @@ pub struct NatState {
 }
 
 impl NatState {
+    #[must_use]
     pub fn new(
         target_src_addr: Option<IpAddr>,
         target_dst_addr: Option<IpAddr>,
@@ -181,6 +182,7 @@ impl NatState {
             originator: 0,
         }
     }
+    #[must_use]
     pub fn get_nat(
         &self,
     ) -> (
@@ -202,9 +204,11 @@ impl NatState {
     pub fn set_closed_at(&mut self, closed_at: Instant) {
         self.closed_at = Some(closed_at);
     }
+    #[must_use]
     pub fn get_num_packets(&self) -> u64 {
         self.packets
     }
+    #[must_use]
     pub fn get_num_bytes(&self) -> u64 {
         self.bytes
     }

--- a/nat/src/stateless/setup/mod.rs
+++ b/nat/src/stateless/setup/mod.rs
@@ -94,7 +94,7 @@ impl PerVniTable {
     }
 }
 
-/// Main function to build the NAT configuration (`NatTables`) for a given `Overlay` configuration.
+/// Main function to build the NAT configuration (`NatTables`) for a given `VpcTable`.
 pub fn build_nat_configuration(vpc_table: &VpcTable) -> Result<NatTables, ConfigError> {
     let mut nat_tables = NatTables::new();
     for vpc in vpc_table.values() {

--- a/pkt-meta/src/flow_table/table.rs
+++ b/pkt-meta/src/flow_table/table.rs
@@ -92,7 +92,7 @@ impl FlowTable {
     ///
     /// # Returns
     ///
-    /// Returns the old Arc<FlowInfo> associated with the flow key, if any.
+    /// Returns the old `Arc<FlowInfo>` associated with the flow key, if any.
     ///
     /// # Panics
     ///
@@ -111,7 +111,7 @@ impl FlowTable {
     ///
     /// # Returns
     ///
-    /// Returns the old Arc<FlowInfo> associated with the flow key, if any.
+    /// Returns the old `Arc<FlowInfo>` associated with the flow key, if any.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
This PR contains a bunch of fixes for stateful NAT allocator's creation, and hooks the actual creation of the allocator to the config processing components in the `mgmt` crate.

Caveats:

- Only the initial creation of the allocator is supported at this time, not the update on subsequent configuration updates, yet
- The dataplane only supports configurations with the same numbers of original and target IPs for NAT. This is because of stateless NAT requirements, which are currently being enforced to stateful NAT, too (because the config for both modes is built unconditionally)

Relates to (but does not fully address) #790