### PR TITLE
ci: Fail on rustdoc warnings

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -285,7 +285,7 @@ jobs:
       - id: "docs"
         name: "run rustdoc"
         run: |
-          just \
+          RUSTDOCFLAGS="-D warnings" just \
             debug_justfile="${{matrix.debug_justfile}}" \
             profile=${{matrix.profile.name}} \
             target=x86_64-unknown-linux-gnu \


### PR DESCRIPTION
There seems to be no option to make docs generation fail on warnings, and we've missed a few in CI in the past - latest example to date was fixed in commit 07ca7b537470.

There is a way to make the build fail on warnings, though: we need to set the `RUSTDOCFLAGS` appropriately. Let's do it to have CI raise warnings in the future.
