### PR TITLE
ci: Do not install Rust and cargo binstall on runner

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -101,16 +101,6 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: "install rust"
-        uses: "dtolnay/rust-toolchain@master"
-        with:
-          toolchain: "stable"
-          targets: "x86_64-unknown-linux-gnu"
-          components: "rustfmt,clippy"
-
-      - name: "install cargo binstall"
-        uses: "cargo-bins/cargo-binstall@v1.15.4"
-
       - name: "Checkout"
         uses: "actions/checkout@v5"
         with:
@@ -119,7 +109,10 @@ jobs:
 
       - name: "install just"
         run: |
-          cargo binstall --no-confirm just
+          # this keeps our GH actions logs from getting messed up with color codes
+          echo 'deb [trusted=yes] https://apt.gabe565.com /' | sudo tee /etc/apt/sources.list.d/gabe565.list
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends just
 
       - name: "set up compile-env"
         run: |


### PR DESCRIPTION
We already pull the whole cargo toolchain from the compile-env image, there's no need to install it again on the runner just to pull "just". Instead, install "just" from the package manager.
