### PR TITLE
Make NAT context building optional

### DIFF
--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -35,8 +35,8 @@ where
     pub router: Router,
     pub pipeline: DynPipeline<Buf>,
     pub vpcmapw: VpcMapWriter<VpcMapName>,
-    pub nattablew: NatTablesWriter,
-    pub natallocatorw: NatAllocatorWriter,
+    pub nattablew: Option<NatTablesWriter>,
+    pub natallocatorw: Option<NatAllocatorWriter>,
     pub vpcdtablesw: VpcDiscTablesWriter,
     pub stats: StatsCollector,
 }
@@ -46,7 +46,6 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     params: RouterParams,
 ) -> Result<InternalSetup<Buf>, RouterError> {
     let nattablew = NatTablesWriter::new();
-    let natallocatorw = NatAllocatorWriter::new();
     let vpcdtablesw = VpcDiscTablesWriter::new();
     let router = Router::new(params)?;
     let iftr = router.get_iftabler();
@@ -89,8 +88,8 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         router,
         pipeline,
         vpcmapw,
-        nattablew,
-        natallocatorw,
+        nattablew: Some(nattablew),
+        natallocatorw: None, // Not instanciated, current pipeline does not use stateful NAT
         vpcdtablesw,
         stats,
     })

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -171,8 +171,8 @@ pub enum GrpcAddress {
 pub fn start_mgmt(
     grpc_addr: GrpcAddress,
     router_ctl: RouterCtlSender,
-    nattablew: NatTablesWriter,
-    natallocatorw: NatAllocatorWriter,
+    nattablew: Option<NatTablesWriter>,
+    natallocatorw: Option<NatAllocatorWriter>,
     vpcdtablesw: VpcDiscTablesWriter,
     vpcmapw: VpcMapWriter<VpcMapName>,
 ) -> Result<std::thread::JoinHandle<()>, Error> {

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -393,8 +393,13 @@ pub mod test {
 
         /* build config processor to test the processing of a config. The processor embeds the config database
         and has the frrmi. In this test, we don't use any channel to communicate the config. */
-        let (mut processor, _sender) =
-            ConfigProcessor::new(ctl, vpcmapw, nattablesw, natallocatorw, vnitablesw);
+        let (mut processor, _sender) = ConfigProcessor::new(
+            ctl,
+            vpcmapw,
+            Some(nattablesw),
+            Some(natallocatorw),
+            vnitablesw,
+        );
 
         /* let the processor process the config */
         match processor.process_incoming_config(config).await {


### PR DESCRIPTION
When we build a pipeline for the dataplane, we may, or may not, want to use stateless NAT. Similarly, we may or may not want stateful NAT. We will likely have use cases for which we don't want both NAT stages.

Currently, the code in mgmt and dataplane builds the context for both pipeline stages anyway, even though the corresponding stages are not in the pipeline. Other than wasting resources, it may enforce unnecessary limitations. For example, stateless NAT requires that users specify lists of prefixes containing the same number of available addresses in the private and public sets of addresses (before and after NAT), because it relies on a 1:1 mapping of the IP addresses between the two sets. This restriction is enforced when we apply a configuration to build the context for stateless NAT: if we build this context when it is not required, we end up applying unconditionally the same restriction for stateful NAT, too!

Instead of that, let's make it so the NAT context objects can be optional. This way, we don't need to create them - and to enforce their respective additional validation steps - if they are not necessary for the pipeline in use. Before that, a first commit prepares the `start_router()` function to make it easier to handle optional objects.

We may have a pipeline with both stateless and stateful NAT stages. At the moment, both operations would apply to all packets: we do not have a way to determine from the user configuration what "expose" objects should use stateless, or stateful, NAT. In the future, we'll need to find a way to support this, but for now, we'll work with the limitation on the sizes of IP addresses sets if we use both modes - using two NAT operations on each packet doesn't really make sense at the moment anyway.

Note that objects for other pipeline stages, such as the flow table, for example, could be made optional as well. This commit only focuses on NAT-related context objects, the other may be addressed in the future.

Closes: #769