### PR TITLE
bump: Replace unmaintained dependency serde_yml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -810,7 +810,6 @@ dependencies = [
  "ordermap",
  "parking_lot",
  "serde",
- "serde_yml",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -948,7 +947,7 @@ dependencies = [
  "num-traits",
  "prefix-trie",
  "serde",
- "serde_yml",
+ "serde_yaml_ng",
  "thiserror 2.0.16",
  "tracing",
 ]
@@ -1099,7 +1098,6 @@ dependencies = [
  "netdev",
  "procfs",
  "serde",
- "serde_yml",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -1339,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc 0.2.175",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1902,7 +1900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1913,16 +1911,6 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.4",
  "libc 0.2.175",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -2842,7 +2830,7 @@ dependencies = [
  "errno",
  "libc 0.2.175",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2932,18 +2920,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3165,7 +3151,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3559,6 +3545,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ roaring = { version = "0.11.2", default-features = false, features = [] }
 rtnetlink = { git = "https://github.com/githedgehog/rtnetlink.git", branch = "hh/tc-actions", default-features = false, features = [] }
 rustyline = { version = "17.0.1", default-features = false, features = [] }
 serde = { version = "1.0.219", default-features = false, features = [] }
-serde_yml = { version = "0.0.12", default-features = false, features = [] }
+serde_yaml_ng = { version = "0.10.0", default-features = false, features = [] }
 shuttle = { version = "0.8.1", default-features = false, features = [] }
 thread_local = { version = "1.1.9", default-features = false, features = [] }
 small-map = { version = "0.1.3", default-features = false, features = [] }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -32,7 +32,6 @@ pipeline = { workspace = true }
 pkt-meta = { workspace = true }
 routing = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_yml = { workspace = true }
 stats = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/lpm/Cargo.toml
+++ b/lpm/Cargo.toml
@@ -19,5 +19,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 bolero = { workspace = true, default-features = false }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -767,7 +767,7 @@ impl TryFrom<&PrefixSize> for u128 {
 #[cfg(test)]
 mod tests {
     use crate::prefix::*;
-    use serde_yml;
+    use serde_yaml_ng;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[test]
@@ -876,9 +876,9 @@ mod tests {
         let prefix = Prefix::from(ipv4_pfx);
 
         // serialize prefix as YAML
-        let yaml = serde_yml::to_string(&prefix).unwrap();
-        assert_eq!(yaml, "!IPV4\naddress: '1.2.3.0'\nlength: 24\n");
-        let deserialized_yaml: Prefix = serde_yml::from_str(&yaml).unwrap();
+        let yaml = serde_yaml_ng::to_string(&prefix).unwrap();
+        assert_eq!(yaml, "!IPV4\naddress: 1.2.3.0\nlength: 24\n");
+        let deserialized_yaml: Prefix = serde_yaml_ng::from_str(&yaml).unwrap();
         assert_eq!(prefix, deserialized_yaml);
 
         let ipv6_addr: Ipv6Addr = "f00:baa::".parse().expect("Bad address");
@@ -886,9 +886,9 @@ mod tests {
         let prefix = Prefix::from(ipv6_pfx);
 
         // serialize prefix as YAML
-        let yaml = serde_yml::to_string(&prefix).unwrap();
+        let yaml = serde_yaml_ng::to_string(&prefix).unwrap();
         assert_eq!(yaml, "!IPV6\naddress: 'f00:baa::'\nlength: 64\n");
-        let deserialized_yaml: Prefix = serde_yml::from_str(&yaml).unwrap();
+        let deserialized_yaml: Prefix = serde_yaml_ng::from_str(&yaml).unwrap();
         assert_eq!(prefix, deserialized_yaml);
     }
 

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -35,6 +35,5 @@ netdev = { workspace = true }
 [dev-dependencies]
 bolero = { workspace = true, default-features = false }
 lpm = { workspace = true, features = ["testing"] }
-serde_yml = { workspace = true }
 tracing-test = { workspace = true, features = [] }
 


### PR DESCRIPTION
We've been using `serde_yml` as a replacement for the abandoned crate `serde_yaml`, but now it's been abandoned as well. The corresponding RustSec advisory suggests two alternatives, `serde_yaml_ng` is one of them. It's a fork of `serde_yaml`, too, and seems to work well as a drop-in successor.

There are a couple of crates where we don't actually use the `serde_yml` dependency included from their Cargo.toml: just remove the Cargo.toml entries for those. I'm not sure we still need the Serialize/Deserialize implementations for Prefix in the lpm crate, for which we have the one test that actually requires `serde_yaml_ng` in the code base, but I left it for now.

Link: https://rustsec.org/advisories/RUSTSEC-2025-0067
Link: https://rustsec.org/advisories/RUSTSEC-2025-0068
