### PR TITLE
Make pipeline construction `Send` + `Sync` for multi threading

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -89,7 +89,7 @@ fn main() {
     let setup = start_router(config).expect("failed to start router");
     MetricsServer::new(args.metrics_address(), setup.stats);
     /* pipeline builder */
-    let builder = move || setup.pipeline;
+    let builder = setup.pipeline;
 
     /* start management */
     start_mgmt(

--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -397,6 +397,9 @@ pub struct Mbuf {
     marker: PhantomData<dpdk_sys::rte_mbuf>,
 }
 
+// dpdk_sys::rte_mbuf is Send but not Sync since it is a plain C pointer
+unsafe impl Send for Mbuf {}
+
 /// TODO: this is possibly poor optimization, we should try bulk dealloc if this slows us down
 /// TODO: we need to ensure that we don't call drop on Mbuf when they have been transmitted.
 ///       The transmit function automatically drops such mbufs and we don't want to double free.

--- a/nat/src/stateless/natrw.rs
+++ b/nat/src/stateless/natrw.rs
@@ -6,7 +6,7 @@
 #![allow(unused)]
 
 use left_right::new_from_empty;
-use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle};
+use left_right::{Absorb, ReadGuard, ReadHandle, ReadHandleFactory, WriteHandle};
 use tracing::debug;
 
 use crate::stateless::setup::tables::{NatTableValue, NatTables};
@@ -36,6 +36,19 @@ impl NatTablesReader {
     pub fn enter(&self) -> Option<ReadGuard<'_, NatTables>> {
         self.0.enter()
     }
+    #[must_use]
+    pub fn factory(&self) -> NatTablesReaderFactory {
+        NatTablesReaderFactory(self.0.factory())
+    }
+}
+
+#[derive(Debug)]
+pub struct NatTablesReaderFactory(ReadHandleFactory<NatTables>);
+impl NatTablesReaderFactory {
+    #[must_use]
+    pub fn handle(&self) -> NatTablesReader {
+        NatTablesReader(self.0.handle())
+    }
 }
 
 impl NatTablesWriter {
@@ -48,6 +61,10 @@ impl NatTablesWriter {
     #[must_use]
     pub fn get_reader(&self) -> NatTablesReader {
         NatTablesReader(self.0.clone())
+    }
+    #[must_use]
+    pub fn get_reader_factory(&self) -> NatTablesReaderFactory {
+        self.get_reader().factory()
     }
     pub fn update_nat_tables(&mut self, nat_tables: NatTables) {
         self.0.append(NatTablesChange::UpdateNatTables(nat_tables));

--- a/net/src/buffer/mod.rs
+++ b/net/src/buffer/mod.rs
@@ -19,11 +19,18 @@ impl<T> PacketBuffer for T where T: AsRef<[u8]> + Headroom + Debug + 'static {}
 
 /// Super trait representing the abstract operations which may be performed on mutable a packet buffer.
 pub trait PacketBufferMut:
-    PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + TrimFromEnd + Headroom + Tailroom
+    PacketBuffer + AsMut<[u8]> + Prepend + Send + TrimFromStart + TrimFromEnd + Headroom + Tailroom
 {
 }
 impl<T> PacketBufferMut for T where
-    T: PacketBuffer + AsMut<[u8]> + Prepend + TrimFromStart + TrimFromEnd + Headroom + Tailroom
+    T: PacketBuffer
+        + AsMut<[u8]>
+        + Prepend
+        + Send
+        + TrimFromStart
+        + TrimFromEnd
+        + Headroom
+        + Tailroom
 {
 }
 

--- a/pkt-meta/src/dst_vpcd_lookup/mod.rs
+++ b/pkt-meta/src/dst_vpcd_lookup/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle, new_from_empty};
+use left_right::{Absorb, ReadGuard, ReadHandle, ReadHandleFactory, WriteHandle, new_from_empty};
 use std::collections::HashMap;
 use tracing::{debug, error, warn};
 
@@ -64,6 +64,20 @@ impl VpcDiscTablesReader {
     fn enter(&self) -> Option<ReadGuard<'_, VpcDiscriminantTables>> {
         self.0.enter()
     }
+
+    #[must_use]
+    pub fn factory(&self) -> VpcDiscTablesReaderFactory {
+        VpcDiscTablesReaderFactory(self.0.factory())
+    }
+}
+
+#[derive(Debug)]
+pub struct VpcDiscTablesReaderFactory(ReadHandleFactory<VpcDiscriminantTables>);
+impl VpcDiscTablesReaderFactory {
+    #[must_use]
+    pub fn handle(&self) -> VpcDiscTablesReader {
+        VpcDiscTablesReader(self.0.handle())
+    }
 }
 
 #[derive(Debug)]
@@ -81,6 +95,11 @@ impl VpcDiscTablesWriter {
     pub fn get_reader(&self) -> VpcDiscTablesReader {
         VpcDiscTablesReader(self.0.clone())
     }
+
+    pub fn get_reader_factory(&self) -> VpcDiscTablesReaderFactory {
+        self.get_reader().factory()
+    }
+
     pub fn update_vpcd_tables(&mut self, vpcd_tables: VpcDiscriminantTables) {
         self.0
             .append(VpcDiscriminantTablesChange::UpdateVpcDiscTables(

--- a/routing/src/atable/atablerw.rs
+++ b/routing/src/atable/atablerw.rs
@@ -3,7 +3,7 @@
 
 //! Adjacency table left-right
 
-use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle};
+use left_right::{Absorb, ReadGuard, ReadHandle, ReadHandleFactory, WriteHandle};
 use std::net::IpAddr;
 
 use crate::atable::adjacency::{Adjacency, AdjacencyTable};
@@ -75,5 +75,17 @@ impl AtableReader {
     }
     pub fn enter(&self) -> Option<ReadGuard<'_, AdjacencyTable>> {
         self.0.enter()
+    }
+    pub fn factory(&self) -> AtableReaderFactory {
+        AtableReaderFactory(self.0.factory())
+    }
+}
+
+#[derive(Debug)]
+pub struct AtableReaderFactory(ReadHandleFactory<AdjacencyTable>);
+impl AtableReaderFactory {
+    #[must_use]
+    pub fn handle(&self) -> AtableReader {
+        AtableReader(self.0.handle())
     }
 }

--- a/routing/src/fib/fibtable.rs
+++ b/routing/src/fib/fibtable.rs
@@ -124,6 +124,15 @@ impl FibTableWriter {
     }
 }
 
+#[derive(Debug)]
+pub struct FibTableReaderFactory(ReadHandleFactory<FibTable>);
+impl FibTableReaderFactory {
+    #[must_use]
+    pub fn handle(&self) -> FibTableReader {
+        FibTableReader(self.0.handle())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct FibTableReader(ReadHandle<FibTable>);
 impl FibTableReader {
@@ -131,8 +140,8 @@ impl FibTableReader {
     pub fn enter(&self) -> Option<ReadGuard<'_, FibTable>> {
         self.0.enter()
     }
-    pub fn factory(&self) -> ReadHandleFactory<FibTable> {
-        self.0.factory()
+    pub fn factory(&self) -> FibTableReaderFactory {
+        FibTableReaderFactory(self.0.factory())
     }
 }
 

--- a/routing/src/interfaces/iftablerw.rs
+++ b/routing/src/interfaces/iftablerw.rs
@@ -8,7 +8,7 @@ use crate::fib::fibtype::FibId;
 use crate::fib::fibtype::FibReader;
 use crate::rib::vrf::VrfId;
 use crate::rib::vrftable::VrfTable;
-use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle};
+use left_right::{Absorb, ReadGuard, ReadHandle, ReadHandleFactory, WriteHandle};
 
 use crate::interfaces::iftable::IfTable;
 use crate::interfaces::interface::{IfAddress, IfIndex, IfState, RouterInterfaceConfig};
@@ -183,6 +183,19 @@ impl IfTableReader {
     #[must_use]
     pub fn enter(&self) -> Option<ReadGuard<'_, IfTable>> {
         self.0.enter()
+    }
+    #[must_use]
+    pub fn factory(&self) -> IfTableReaderFactory {
+        IfTableReaderFactory(self.0.factory())
+    }
+}
+
+#[derive(Debug)]
+pub struct IfTableReaderFactory(ReadHandleFactory<IfTable>);
+impl IfTableReaderFactory {
+    #[must_use]
+    pub fn handle(&self) -> IfTableReader {
+        IfTableReader(self.0.handle())
     }
 }
 

--- a/routing/src/router.rs
+++ b/routing/src/router.rs
@@ -9,12 +9,12 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use tracing::{debug, error};
 
-use crate::atable::atablerw::AtableReader;
+use crate::atable::atablerw::{AtableReader, AtableReaderFactory};
 use crate::atable::resolver::AtResolver;
 use crate::ctl::RouterCtlSender;
 use crate::errors::RouterError;
-use crate::fib::fibtable::{FibTableReader, FibTableWriter};
-use crate::interfaces::iftablerw::{IfTableReader, IfTableWriter};
+use crate::fib::fibtable::{FibTableReader, FibTableReaderFactory, FibTableWriter};
+use crate::interfaces::iftablerw::{IfTableReader, IfTableReaderFactory, IfTableWriter};
 use crate::rio::{RioConf, RioHandle, start_rio};
 
 use crate::rio::DEFAULT_DP_UX_PATH;
@@ -139,13 +139,28 @@ impl Router {
     }
 
     #[must_use]
+    pub fn get_atabler_factory(&self) -> AtableReaderFactory {
+        self.resolver.get_reader().factory()
+    }
+
+    #[must_use]
     pub fn get_iftabler(&self) -> IfTableReader {
         self.iftr.clone()
     }
 
     #[must_use]
+    pub fn get_iftabler_factory(&self) -> IfTableReaderFactory {
+        self.iftr.factory()
+    }
+
+    #[must_use]
     pub fn get_fibtr(&self) -> FibTableReader {
         self.fibtr.clone()
+    }
+
+    #[must_use]
+    pub fn get_fibtr_factory(&self) -> FibTableReaderFactory {
+        self.fibtr.factory()
     }
 
     #[must_use]


### PR DESCRIPTION
Multi-threading requires use to be able to construct pipelines in each worker.  This makes the code that sets up the pipeline `Send` + `Sync` so that each thread can get a the setup function and create a pipeline.

This PR does *not* actually create the worker threads in the drivers.