### PR TITLE
ci: Use GitHub App token for bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -30,6 +30,13 @@ jobs:
   cargo-upgrades:
     runs-on: "lab"
     steps:
+      # Use a GitHub App token so that the generated PR can trigger CI
+      - name: "Generate GitHub App token"
+        id: "app-token"
+        uses: "actions/create-github-app-token@v2"
+        with:
+          app-id: "${{ secrets.DP_APP_ID }}"
+          private-key: "${{ secrets.DP_PRIVATE_KEY }}"
       - name: "install rust"
         uses: "dtolnay/rust-toolchain@stable"
       - name: "install ansi2txt"
@@ -129,6 +136,7 @@ jobs:
       - name: "Create Pull Request"
         uses: "peter-evans/create-pull-request@v7"
         with:
+          token: "${{ steps.app-token.outputs.token }}"
           branch: "bump/cargo-upgrades"
           title: "bump(cargo)!: :rocket: upgrades available"
           labels: |


### PR DESCRIPTION
We have a GitHub App set up for the dataplane repository, so that updating the dpdk-sys repository can automatically create a Pull Request for the dataplane repository to update the changes to the compile-env image. We should be able to reuse this App when creating Pull Requests to bump dependencies in the dataplane repository: the expected advantage is that the generated Pull Requests should now trigger CI on creation, without the need for reviewers to close and re-open the Pull Request to manually trigger it.
