### PR TITLE
ci: Install cargo-binstall from dedicated Action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -46,8 +46,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends ansi2txt
       - name: "install binstall"
-        run: |
-          cargo install cargo-binstall
+        uses: "cargo-bins/cargo-binstall@v1"
       - name: "install upgrade tools"
         run: |
           cargo binstall -y cargo-edit # required to make `cargo upgrade` edit the Cargo.toml file


### PR DESCRIPTION
Avoid compiling cargo-binstall from GitHub workflow - the whole point of getting this crate is to install other Rust crates without recompiling them, after all. Use the dedicated GitHub Action instead: it downloads the binary from GitHub. Compiling the crate takes close to 30 seconds, we should save most of this time (but this only affects the bump.yml workflow).

This is similar to what we do in dpdk-sys's workflows.
