### PR TITLE
Batch read packets in kernel worker threads

### DIFF
--- a/dataplane/src/drivers/kernel.rs
+++ b/dataplane/src/drivers/kernel.rs
@@ -334,7 +334,7 @@ impl DriverKernel {
                         Some(_keep) => {
                             // Packet is not marked for drop by the pipeline (Delivered/None/keep=true),
                             // but we still can't TX without an oif; drop here.
-                            debug!(
+                            error!(
                                 "No oif in packet meta; enforce() => keep/Delivered; dropping here"
                             );
                         }


### PR DESCRIPTION
This PR does some cleanup of the multi-threaded kernel driver and allows batched reads in the worker process to more closely match DPDK.  This work is a prerequisite so that I can write a single tokio event wrapper around the pipeline that will work with both the kernel driver and DPDK driver.