### PR TITLE
Add a tokio wrapper to worker threads in dataplane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,6 @@ dependencies = [
  "axum",
  "axum-server",
  "clap",
- "crossbeam-channel",
  "ctrlc",
  "dataplane-concurrency",
  "dataplane-dpdk",

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -12,7 +12,6 @@ axum = { workspace = true, features = ["http1", "tokio"] }
 axum-server = { workspace = true }
 clap = { workspace = true, features = ["std", "derive", "usage"] }
 concurrency = { workspace = true }
-crossbeam-channel = { workspace = true }
 ctrlc = { workspace = true, features = ["termination"] }
 dpdk = { workspace = true }
 dyn-iter = { workspace = true }

--- a/dataplane/src/drivers/mod.rs
+++ b/dataplane/src/drivers/mod.rs
@@ -5,3 +5,4 @@
 
 pub mod dpdk;
 pub mod kernel;
+mod tokio_util;

--- a/dataplane/src/drivers/tokio_util.rs
+++ b/dataplane/src/drivers/tokio_util.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use tokio::runtime::{Builder, Runtime};
+
+/// Executes a function inside a current-thread tokio runtime.
+/// The runtime will be torn down when the function returns.
+///
+/// # Panics
+/// If it fails to create a current thread runtime.
+pub fn run_in_tokio_runtime<F, Fut, R>(f: F) -> R
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    let current_runtime = tokio::runtime::Handle::try_current();
+    assert!(
+        current_runtime.is_err(),
+        "Expected no active tokio runtime, but found: {:?}",
+        current_runtime.unwrap_err()
+    );
+
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create current thread runtime");
+
+    rt.block_on(f())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{Duration, sleep};
+
+    #[test]
+    fn test_run_in_tokio_runtime_pure() {
+        let result = run_in_tokio_runtime(|| async { 42 });
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_run_in_tokio_runtime_async() {
+        let result = run_in_tokio_runtime(|| async {
+            sleep(Duration::from_millis(100)).await;
+            42
+        });
+        assert_eq!(result, 42);
+    }
+}


### PR DESCRIPTION
* Wrap worker threads in a `tokio` current-thread runtime
* Use `tokio::sync::mpsc` in place of crossbeam so that we can await message

We could use `kanal` in the current implementation, but I think that we'll eventually want to use `tokio::select!` and that will cause problems, so stick to `mpsc` for now until there is a proven performance issue with the channel.