### PR TITLE
ci: Fix image tag for cargo-binstall

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends ansi2txt
       - name: "install binstall"
-        uses: "cargo-bins/cargo-binstall@v1"
+        uses: "cargo-bins/cargo-binstall@main"
       - name: "install upgrade tools"
         run: |
           cargo binstall -y cargo-edit # required to make `cargo upgrade` edit the Cargo.toml file


### PR DESCRIPTION
There's no "v1" tag for that image. Let's just pull from the "main" branch, like we do in the worfklow for the dpdk-sys repository.
