### PR TITLE
chore(net): Make debug!() a trace!() in parse_header() method

### DIFF
--- a/net/src/parse.rs
+++ b/net/src/parse.rs
@@ -6,7 +6,7 @@
 
 use std::num::NonZero;
 
-use tracing::debug;
+use tracing::trace;
 
 pub trait Parse: Sized {
     type Error: core::error::Error;
@@ -70,7 +70,7 @@ impl ParseHeader for Reader<'_> {
     fn parse_header<T: Parse, O: From<T>>(&mut self) -> Option<O> {
         self.parse::<T>()
             .map_err(|e| {
-                debug!("failed to parse {}: {e:?}", core::any::type_name::<T>());
+                trace!("failed to parse {}: {e:?}", core::any::type_name::<T>());
             })
             .map(|v| O::from(v.0))
             .ok()
@@ -78,7 +78,7 @@ impl ParseHeader for Reader<'_> {
     fn parse_header_with<T: ParseWith, O: From<T>>(&mut self, param: T::Param) -> Option<O> {
         self.parse_with::<T>(param)
             .map_err(|e| {
-                debug!("failed to parse {}: {e:?}", core::any::type_name::<T>());
+                trace!("failed to parse {}: {e:?}", core::any::type_name::<T>());
             })
             .map(|v| O::from(v.0))
             .ok()


### PR DESCRIPTION
Looks like a trace!() is enough here.

Follow-up from #876, suggested by Daniel.