### PR TITLE
revert: chore: temp bump gateway to include related change

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -308,7 +308,7 @@ jobs:
     with:
       skip: ${{ matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+hlab') || !matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+vlab') }}
       fabricatorref: master
-      prebuild: "just bump dataplane HEAD.x86_64-unknown-linux-gnu.debug.${{ github.sha }} && just bump gateway v0-1fb670d12 1fb670d12a45c76abab345ea7bdc5550e02bb818"
+      prebuild: "just bump dataplane HEAD.x86_64-unknown-linux-gnu.debug.${{ github.sha }}"
       fabricmode: ${{ matrix.fabricmode }}
       gateway: ${{ matrix.gateway }}
       includeonie: ${{ matrix.includeonie }}


### PR DESCRIPTION
This reverts commit c233c813e74b46807eae9e708fb6c6f90c61eb95.

To be merged after:
- https://github.com/githedgehog/fabricator/pull/1046
- https://github.com/githedgehog/fabricator/pull/1045