### PR TITLE
feat(net): Support ICMP-in-ICMP

### DIFF
--- a/net/src/icmp4/checksum.rs
+++ b/net/src/icmp4/checksum.rs
@@ -5,6 +5,7 @@
 
 use crate::checksum::Checksum;
 use crate::icmp4::Icmp4;
+use crate::icmp4::TruncatedIcmp4;
 use core::fmt::{Display, Formatter};
 use std::fmt::Debug;
 
@@ -88,5 +89,76 @@ impl Checksum for Icmp4 {
     fn set_checksum(&mut self, checksum: Icmp4Checksum) -> Result<&mut Self, Self::Error> {
         self.0.checksum = checksum.0;
         Ok(self)
+    }
+}
+
+/// Errors which can occur when attempting to compute a `ICMPv4` checksum for a truncated `ICMPv4` header.
+#[derive(Debug, thiserror::Error)]
+pub enum TruncatedIcmp4ChecksumError {
+    /// The header is truncated, checksum operations are not available.
+    #[error("header is truncated")]
+    Truncated,
+}
+
+impl Checksum for TruncatedIcmp4 {
+    type Error = TruncatedIcmp4ChecksumError;
+    type Payload<'a> = [u8];
+    type Checksum = Icmp4Checksum;
+
+    /// Get the [`Icmp4`] checksum of the header
+    ///
+    /// # Returns
+    ///
+    /// * `Some` if the header is a full header. The `ICMPv4` payload may be truncated, so it may be
+    ///   impossible to compute the checksum.
+    /// * `None` if the header is a truncated header. Note that the checksum may be present in the
+    ///   truncated header, but given that the header is truncated, it is irrelevant because there
+    ///   is no way to validate it, so we return `None` in that case.
+    fn checksum(&self) -> Option<Self::Checksum> {
+        match self {
+            TruncatedIcmp4::FullHeader(icmp) => icmp.checksum(),
+            TruncatedIcmp4::PartialHeader(_) => None,
+        }
+    }
+
+    /// Compute the `ICMPv4` header's checksum based on the supplied payload.
+    ///
+    /// This method _does not_ update the checksum field.
+    ///
+    /// # Errors
+    ///
+    /// * [`TruncatedIcmp4ChecksumError::Truncated`] if the header is a truncated header
+    ///
+    /// <div class="warning">
+    /// If the header is full, we perform the computation although there is no guarantee that the
+    /// `ICMPv4` _payload_ is full. It is the responsibility of the caller to ensure that the `ICMPv4`
+    /// payload is full, _and_ that the payload passed as an argument is exempt from ICMP Extension
+    /// Structures and padding.
+    /// </div>
+    fn compute_checksum(&self, payload: &Self::Payload<'_>) -> Result<Self::Checksum, Self::Error> {
+        match self {
+            TruncatedIcmp4::FullHeader(icmp) => Ok(icmp
+                .compute_checksum(payload)
+                .unwrap_or_else(|()| unreachable!())), // ICMPv4 checksum computation never fails
+            TruncatedIcmp4::PartialHeader(_) => Err(TruncatedIcmp4ChecksumError::Truncated),
+        }
+    }
+
+    /// Set the checksum field of the header.
+    ///
+    /// The validity of the checksum is not checked.
+    ///
+    /// # Errors
+    ///
+    /// * [`TruncatedIcmp4ChecksumError::Truncated`] if the header is a truncated header
+    fn set_checksum(&mut self, checksum: Self::Checksum) -> Result<&mut Self, Self::Error> {
+        match self {
+            TruncatedIcmp4::FullHeader(icmp) => {
+                icmp.set_checksum(checksum)
+                    .unwrap_or_else(|()| unreachable!()); // Setting the ICMPv4 checksum never fails
+                Ok(self)
+            }
+            TruncatedIcmp4::PartialHeader(_) => Err(TruncatedIcmp4ChecksumError::Truncated),
+        }
     }
 }

--- a/net/src/icmp4/truncated.rs
+++ b/net/src/icmp4/truncated.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! `ICMPv4` header type and logic, for potentially truncated datagrams.
+
+use std::num::NonZero;
+
+use crate::icmp4::Icmp4;
+use crate::parse::{DeParse, DeParseError, LengthError, Parse, ParseError};
+
+/// A truncated `ICMPv4` header.
+///
+/// This truncated header is built from the start of a regular `ICMPv4` header, down to the last byte of
+/// the packet, but does not contain a full header. The only fields that are guaranteed to be
+/// present are the type and code values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TruncatedIcmp4Header {
+    icmp_type: u8,
+    code: u8,
+    // The rest of the header, as a byte vector, for de-parsing
+    everything_else: Vec<u8>,
+}
+
+impl TruncatedIcmp4Header {
+    const MIN_HEADER_LEN: usize = 2;
+
+    fn new(icmp_type: u8, code: u8, everything_else: Vec<u8>) -> Self {
+        Self {
+            icmp_type,
+            code,
+            everything_else,
+        }
+    }
+
+    /// Get the length of the truncated header
+    #[must_use]
+    pub fn header_len(&self) -> NonZero<usize> {
+        let len = self.everything_else.len() + Self::MIN_HEADER_LEN;
+        NonZero::new(len).unwrap_or_else(|| unreachable!())
+    }
+}
+
+impl Parse for TruncatedIcmp4Header {
+    type Error = TruncatedIcmp4Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        // We need at least two bytes to form our truncated header.
+        // RFC 792 (ICMP) says embedded packets in ICMP Error messages contain the IP header plus at
+        // least the first 64 bits from the datagram, so we should have these 2 bytes. Otherwise,
+        // it's an error.
+        if buf.len() < TruncatedIcmp4Header::MIN_HEADER_LEN {
+            return Err(ParseError::Length(LengthError {
+                expected: NonZero::new(TruncatedIcmp4Header::MIN_HEADER_LEN)
+                    .unwrap_or_else(|| unreachable!()),
+                actual: buf.len(),
+            }));
+        }
+
+        let parsed_icmp_type = u8::from_be_bytes([buf[0]]);
+        let parsed_code = u8::from_be_bytes([buf[1]]);
+
+        // buf.len() is always non-zero and lower than u16::MAX
+        #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+        let consumed = NonZero::new(buf.len() as u16).unwrap();
+
+        let parsed = Self::new(parsed_icmp_type, parsed_code, buf[2..].to_vec());
+        Ok((parsed, consumed))
+    }
+}
+
+impl DeParse for TruncatedIcmp4Header {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        let size_u16 = u16::try_from(self.header_len().get()).unwrap_or_else(|_| unreachable!());
+        NonZero::new(size_u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let buf_len = buf.len();
+        let header_len = self.header_len().get();
+        if buf_len < header_len {
+            return Err(DeParseError::Length(LengthError {
+                expected: NonZero::new(header_len).unwrap_or_else(|| unreachable!()),
+                actual: buf_len,
+            }));
+        }
+        buf[0] = self.icmp_type;
+        buf[1] = self.code;
+        buf[2..header_len].copy_from_slice(&self.everything_else);
+
+        let header_len_u16 = u16::try_from(header_len).unwrap_or_else(|_| unreachable!());
+        let written = NonZero::new(header_len_u16).unwrap_or_else(|| unreachable!());
+        Ok(written)
+    }
+}
+
+/// An `ICMPv4` header, possibly truncated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TruncatedIcmp4 {
+    /// A full `ICMPv4` header, whether payload is full or not
+    FullHeader(Icmp4),
+    /// A truncated `ICMPv4` header
+    PartialHeader(TruncatedIcmp4Header),
+}
+
+/// Errors which can occur when attempting to parse arbitrary bytes into a `TruncatedIcmp4` header.
+#[derive(Debug, thiserror::Error)]
+pub enum TruncatedIcmp4Error {
+    /// A transparent error from [`Icmp4::parse`].
+    #[error("transparent")]
+    Icmp4ParseError(LengthError),
+}
+
+impl Parse for TruncatedIcmp4 {
+    type Error = TruncatedIcmp4Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let parse_attempt = Icmp4::parse(buf);
+        match parse_attempt {
+            // If we can parse the full header, return it
+            Ok((icmp, consumed)) => Ok((TruncatedIcmp4::FullHeader(icmp), consumed)),
+            // If we encounter an unexpected issue, return the error
+            Err(ParseError::BufferTooLong(len)) => Err(ParseError::BufferTooLong(len)),
+            Err(ParseError::Invalid(e)) => {
+                Err(ParseError::Invalid(TruncatedIcmp4Error::Icmp4ParseError(e)))
+            }
+            // If we failed to parse because the header is too short, carry on and build a truncated
+            // header
+            Err(ParseError::Length(_)) => {
+                let (header, consumed) = TruncatedIcmp4Header::parse(buf)?;
+                Ok((TruncatedIcmp4::PartialHeader(header), consumed))
+            }
+        }
+    }
+}
+
+impl DeParse for TruncatedIcmp4 {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        match self {
+            TruncatedIcmp4::FullHeader(icmp) => icmp.size(),
+            TruncatedIcmp4::PartialHeader(icmp) => icmp.size(),
+        }
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        match self {
+            TruncatedIcmp4::FullHeader(icmp) => icmp.deparse(buf),
+            TruncatedIcmp4::PartialHeader(icmp) => icmp.deparse(buf),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::TruncatedIcmp4;
+    use crate::icmp4::TruncatedIcmp4Header;
+    use crate::parse::{DeParse, Parse};
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for TruncatedIcmp4 {
+        // Generate either full or partial ICMPv4 header
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let full_header = TruncatedIcmp4::FullHeader(driver.produce()?);
+            if driver.produce::<bool>()? {
+                Some(full_header)
+            } else {
+                // Max ICMP header size is 20 bytes for timestamp requests/replies; but for all
+                // other types it's 8 bytes.
+                let mut buffer = driver.produce::<[u8; 20]>()?;
+                #[allow(clippy::unwrap_used)] // We want to catch errors when deparsing, if any
+                full_header.deparse(&mut buffer).unwrap();
+                // If header size was lower than 20 (everything other than timestamp
+                // requests/replies), zero the rest of the buffer
+                buffer[full_header.size().get() as usize..20].fill(0);
+
+                // We can have up to 6 extra bytes for the header, in addition to the 2 bytes for
+                // the type and code. Beyond that, we'd have at least 8 bytes and that would make
+                // our header a full ICMPv4 header (except for timestamp requests/replies. Oh,
+                // well.).
+                let size = driver.produce::<u8>()? % 6 + 2;
+                let truncated_buffer = &buffer[..size as usize];
+                #[allow(clippy::unwrap_used)] // We want to catch errors when parsing, if any
+                let icmp = TruncatedIcmp4Header::parse(truncated_buffer)
+                    .ok()
+                    .unwrap()
+                    .0;
+
+                Some(TruncatedIcmp4::PartialHeader(icmp))
+            }
+        }
+    }
+}

--- a/net/src/icmp6/checksum.rs
+++ b/net/src/icmp6/checksum.rs
@@ -4,7 +4,7 @@
 //! `ICMPv6` checksum type and methods
 
 use crate::checksum::Checksum;
-use crate::icmp6::Icmp6;
+use crate::icmp6::{Icmp6, TruncatedIcmp6};
 use core::fmt::{Display, Formatter};
 use etherparse::Icmpv6Header;
 use std::fmt::Debug;
@@ -133,5 +133,76 @@ impl Checksum for Icmp6 {
     fn set_checksum(&mut self, checksum: Icmp6Checksum) -> Result<&mut Self, Self::Error> {
         self.0.checksum = checksum.0;
         Ok(self)
+    }
+}
+
+/// Errors which can occur when attempting to compute a `ICMPv6` checksum for a truncated `ICMPv6` header.
+#[derive(Debug, thiserror::Error)]
+pub enum TruncatedIcmp6ChecksumError {
+    /// The header is truncated, checksum operations are not available.
+    #[error("header is truncated")]
+    Truncated,
+}
+
+impl Checksum for TruncatedIcmp6 {
+    type Error = TruncatedIcmp6ChecksumError;
+    type Payload<'a> = Icmp6ChecksumPayload<'a>;
+    type Checksum = Icmp6Checksum;
+
+    /// Get the [`Icmp6`] checksum of the header
+    ///
+    /// # Returns
+    ///
+    /// * `Some` if the header is a full header. The `ICMPv6` payload may be truncated, so it may be
+    ///   impossible to compute the checksum.
+    /// * `None` if the header is a truncated header. Note that the checksum may be present in the
+    ///   truncated header, but given that the header is truncated, it is irrelevant because there
+    ///   is no way to validate it, so we return `None` in that case.
+    fn checksum(&self) -> Option<Self::Checksum> {
+        match self {
+            TruncatedIcmp6::FullHeader(icmp) => icmp.checksum(),
+            TruncatedIcmp6::PartialHeader(_) => None,
+        }
+    }
+
+    /// Compute the `ICMPv6` header's checksum based on the supplied payload.
+    ///
+    /// This method _does not_ update the checksum field.
+    ///
+    /// # Errors
+    ///
+    /// * [`TruncatedIcmp6ChecksumError::Truncated`] if the header is a truncated header
+    ///
+    /// <div class="warning">
+    /// If the header is full, we perform the computation although there is no guarantee that the
+    /// `ICMPv6` _payload_ is full. It is the responsibility of the caller to ensure that the `ICMPv6`
+    /// payload is full, _and_ that the payload passed as an argument is exempt from ICMP Extension
+    /// Structures and padding.
+    /// </div>
+    fn compute_checksum(&self, payload: &Self::Payload<'_>) -> Result<Self::Checksum, Self::Error> {
+        match self {
+            TruncatedIcmp6::FullHeader(icmp) => Ok(icmp
+                .compute_checksum(payload)
+                .unwrap_or_else(|()| unreachable!())), // ICMPv6 checksum computation never fails
+            TruncatedIcmp6::PartialHeader(_) => Err(TruncatedIcmp6ChecksumError::Truncated),
+        }
+    }
+
+    /// Set the checksum field of the header.
+    ///
+    /// The validity of the checksum is not checked.
+    ///
+    /// # Errors
+    ///
+    /// * [`TruncatedIcmp6ChecksumError::Truncated`] if the header is a truncated header
+    fn set_checksum(&mut self, checksum: Self::Checksum) -> Result<&mut Self, Self::Error> {
+        match self {
+            TruncatedIcmp6::FullHeader(icmp) => {
+                icmp.set_checksum(checksum)
+                    .unwrap_or_else(|()| unreachable!()); // Setting the ICMPv6 checksum never fails
+                Ok(self)
+            }
+            TruncatedIcmp6::PartialHeader(_) => Err(TruncatedIcmp6ChecksumError::Truncated),
+        }
     }
 }

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -4,8 +4,10 @@
 //! `Icmp6` header type and logic.
 
 mod checksum;
+mod truncated;
 
 pub use checksum::*;
+pub use truncated::*;
 
 use crate::headers::{AbstractEmbeddedHeaders, EmbeddedHeaders, EmbeddedIpVersion};
 use crate::icmp_any::get_payload_for_checksum;
@@ -173,7 +175,7 @@ impl DeParse for Icmp6 {
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use crate::headers::{EmbeddedHeaders, EmbeddedTransport, Net};
-    use crate::icmp6::Icmp6;
+    use crate::icmp6::{Icmp6, TruncatedIcmp6};
     use crate::ip::NextHeader;
     use crate::ipv6::GenWithNextHeader;
     use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse};
@@ -285,10 +287,18 @@ mod contract {
     impl ValueGenerator for Icmp6EmbeddedHeadersGenerator {
         type Output = EmbeddedHeaders;
 
+        #[allow(clippy::unwrap_used)]
         fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
-            let transport = match driver.produce::<u32>()? % 9 {
-                0..=3 => Some(EmbeddedTransport::Tcp(driver.produce::<TruncatedTcp>()?)),
-                4..=7 => Some(EmbeddedTransport::Udp(driver.produce::<TruncatedUdp>()?)),
+            let transport = match driver.produce::<u32>()? % 11 {
+                0..=3 => Some(EmbeddedTransport::Tcp(
+                    driver.produce::<TruncatedTcp>().unwrap(),
+                )),
+                4..=7 => Some(EmbeddedTransport::Udp(
+                    driver.produce::<TruncatedUdp>().unwrap(),
+                )),
+                8..=9 => Some(EmbeddedTransport::Icmp6(
+                    driver.produce::<TruncatedIcmp6>().unwrap(),
+                )),
                 _ => None,
             };
             let net = match transport {
@@ -298,6 +308,14 @@ mod contract {
                 }
                 Some(EmbeddedTransport::Udp(_)) => {
                     let net_gen = GenWithNextHeader(NextHeader::UDP);
+                    Some(Net::Ipv6(net_gen.generate(driver)?))
+                }
+                Some(EmbeddedTransport::Icmp4(_)) => {
+                    // We never produce ICMPv4 headers to embed inside ICMPv6 Error messages
+                    unreachable!()
+                }
+                Some(EmbeddedTransport::Icmp6(_)) => {
+                    let net_gen = GenWithNextHeader(NextHeader::ICMP);
                     Some(Net::Ipv6(net_gen.generate(driver)?))
                 }
                 None => {

--- a/net/src/icmp6/truncated.rs
+++ b/net/src/icmp6/truncated.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! `ICMPv6` header type and logic, for potentially truncated datagrams.
+
+use std::num::NonZero;
+
+use crate::icmp6::Icmp6;
+use crate::parse::{DeParse, DeParseError, LengthError, Parse, ParseError};
+
+/// A truncated `ICMPv6` header.
+///
+/// This truncated header is built from the start of a regular `ICMPv6` header, down to the last byte of
+/// the packet, but does not contain a full header. The only fields that are guaranteed to be
+/// present are the type and code values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TruncatedIcmp6Header {
+    icmp_type: u8,
+    code: u8,
+    // The rest of the header, as a byte vector, for de-parsing
+    everything_else: Vec<u8>,
+}
+
+impl TruncatedIcmp6Header {
+    const MIN_HEADER_LEN: usize = 2;
+
+    fn new(icmp_type: u8, code: u8, everything_else: Vec<u8>) -> Self {
+        Self {
+            icmp_type,
+            code,
+            everything_else,
+        }
+    }
+
+    /// Get the length of the truncated header
+    #[must_use]
+    pub fn header_len(&self) -> NonZero<usize> {
+        let len = self.everything_else.len() + Self::MIN_HEADER_LEN;
+        NonZero::new(len).unwrap_or_else(|| unreachable!())
+    }
+}
+
+impl Parse for TruncatedIcmp6Header {
+    type Error = TruncatedIcmp6Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        // We need at least two bytes to form our truncated header.
+        // RFC 792 (ICMP) says embedded packets in ICMP Error messages contain the IP header plus at
+        // least the first 64 bits from the datagram, so we should have these 2 bytes. Otherwise,
+        // it's an error.
+        if buf.len() < TruncatedIcmp6Header::MIN_HEADER_LEN {
+            return Err(ParseError::Length(LengthError {
+                expected: NonZero::new(TruncatedIcmp6Header::MIN_HEADER_LEN)
+                    .unwrap_or_else(|| unreachable!()),
+                actual: buf.len(),
+            }));
+        }
+
+        let parsed_icmp_type = u8::from_be_bytes([buf[0]]);
+        let parsed_code = u8::from_be_bytes([buf[1]]);
+
+        // buf.len() is always non-zero and lower than u16::MAX
+        #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+        let consumed = NonZero::new(buf.len() as u16).unwrap();
+
+        let parsed = Self::new(parsed_icmp_type, parsed_code, buf[2..].to_vec());
+        Ok((parsed, consumed))
+    }
+}
+
+impl DeParse for TruncatedIcmp6Header {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        let size_u16 = u16::try_from(self.header_len().get()).unwrap_or_else(|_| unreachable!());
+        NonZero::new(size_u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let buf_len = buf.len();
+        let header_len = self.header_len().get();
+        if buf_len < header_len {
+            return Err(DeParseError::Length(LengthError {
+                expected: NonZero::new(header_len).unwrap_or_else(|| unreachable!()),
+                actual: buf_len,
+            }));
+        }
+        buf[0] = self.icmp_type;
+        buf[1] = self.code;
+        buf[2..header_len].copy_from_slice(&self.everything_else);
+
+        let header_len_u16 = u16::try_from(header_len).unwrap_or_else(|_| unreachable!());
+        let written = NonZero::new(header_len_u16).unwrap_or_else(|| unreachable!());
+        Ok(written)
+    }
+}
+
+/// An `ICMPv6` header, possibly truncated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TruncatedIcmp6 {
+    /// A full `ICMPv6` header, whether payload is full or not
+    FullHeader(Icmp6),
+    /// A truncated `ICMPv6` header
+    PartialHeader(TruncatedIcmp6Header),
+}
+
+/// Errors which can occur when attempting to parse arbitrary bytes into a `TruncatedIcmp6` header.
+#[derive(Debug, thiserror::Error)]
+pub enum TruncatedIcmp6Error {
+    /// A transparent error from [`Icmp6::parse`].
+    #[error("transparent")]
+    Icmp6ParseError(LengthError),
+}
+
+impl Parse for TruncatedIcmp6 {
+    type Error = TruncatedIcmp6Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let parse_attempt = Icmp6::parse(buf);
+        match parse_attempt {
+            // If we can parse the full header, return it
+            Ok((icmp, consumed)) => Ok((TruncatedIcmp6::FullHeader(icmp), consumed)),
+            // If we encounter an unexpected issue, return the error
+            Err(ParseError::BufferTooLong(len)) => Err(ParseError::BufferTooLong(len)),
+            Err(ParseError::Invalid(e)) => {
+                Err(ParseError::Invalid(TruncatedIcmp6Error::Icmp6ParseError(e)))
+            }
+            // If we failed to parse because the header is too short, carry on and build a truncated
+            // header
+            Err(ParseError::Length(_)) => {
+                let (header, consumed) = TruncatedIcmp6Header::parse(buf)?;
+                Ok((TruncatedIcmp6::PartialHeader(header), consumed))
+            }
+        }
+    }
+}
+
+impl DeParse for TruncatedIcmp6 {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        match self {
+            TruncatedIcmp6::FullHeader(icmp) => icmp.size(),
+            TruncatedIcmp6::PartialHeader(icmp) => icmp.size(),
+        }
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        match self {
+            TruncatedIcmp6::FullHeader(icmp) => icmp.deparse(buf),
+            TruncatedIcmp6::PartialHeader(icmp) => icmp.deparse(buf),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::TruncatedIcmp6;
+    use crate::icmp6::TruncatedIcmp6Header;
+    use crate::parse::{DeParse, Parse};
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for TruncatedIcmp6 {
+        // Generate either full or partial ICMPv6 header
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let full_header = TruncatedIcmp6::FullHeader(driver.produce()?);
+            if driver.produce::<bool>()? {
+                Some(full_header)
+            } else {
+                // The size for ICMPv6 headers (at least as considered in etherparse) is always 8 bytes
+                let mut buffer = driver.produce::<[u8; 8]>()?;
+                #[allow(clippy::unwrap_used)] // We want to catch errors when deparsing, if any
+                full_header.deparse(&mut buffer).unwrap();
+
+                // We can have up to 6 extra bytes for the header, in addition to the 2 bytes for
+                // the type and code. Beyond that, we'd have at least 8 bytes and that would make
+                // our header a full ICMPv6 header.
+                let size = driver.produce::<u8>()? % 6 + 2;
+                let truncated_buffer = &buffer[..size as usize];
+                #[allow(clippy::unwrap_used)] // We want to catch errors when parsing, if any
+                let icmp = TruncatedIcmp6Header::parse(truncated_buffer)
+                    .ok()
+                    .unwrap()
+                    .0;
+
+                Some(TruncatedIcmp6::PartialHeader(icmp))
+            }
+        }
+    }
+}

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -235,8 +235,8 @@ pub fn build_test_icmpv4_destination_unreachable_packet(
 
     // Inner transport
     let mut inner_transport = EmbeddedTransport::Tcp(TruncatedTcp::FullHeader(Tcp::default()));
-    inner_transport.set_source(inner_src_port);
-    inner_transport.set_destination(inner_dst_port);
+    inner_transport.set_source(inner_src_port).unwrap();
+    inner_transport.set_destination(inner_dst_port).unwrap();
 
     // Inner IPv4
     let mut inner_ipv4 = Ipv4::default();

--- a/net/src/tcp/truncated.rs
+++ b/net/src/tcp/truncated.rs
@@ -233,7 +233,7 @@ impl DeParse for TruncatedTcp {
 
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
-    use super::{Tcp, TruncatedTcp};
+    use super::{Tcp, TruncatedTcp, TruncatedTcpHeader};
     use crate::parse::{DeParse, Parse};
     use bolero::{Driver, TypeGenerator};
 
@@ -254,10 +254,7 @@ mod contract {
                 let size = driver.produce::<u8>()? % 16 + 4;
                 let truncated_buffer = &buffer[..size as usize];
                 #[allow(clippy::unwrap_used)] // We want to catch errors when parsing, if any
-                let tcp = crate::tcp::TruncatedTcpHeader::parse(truncated_buffer)
-                    .ok()
-                    .unwrap()
-                    .0;
+                let tcp = TruncatedTcpHeader::parse(truncated_buffer).ok().unwrap().0;
 
                 Some(TruncatedTcp::PartialHeader(tcp))
             }

--- a/net/src/udp/truncated.rs
+++ b/net/src/udp/truncated.rs
@@ -233,7 +233,7 @@ impl DeParse for TruncatedUdp {
 
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
-    use super::{TruncatedUdp, Udp};
+    use super::{TruncatedUdp, TruncatedUdpHeader, Udp};
     use crate::parse::{DeParse, Parse};
     use bolero::{Driver, TypeGenerator};
 
@@ -254,10 +254,7 @@ mod contract {
                 let size = driver.produce::<u8>()? % 4 + 4;
                 let truncated_buffer = &buffer[..size as usize];
                 #[allow(clippy::unwrap_used)] // We want to catch errors when parsing, if any
-                let udp = crate::udp::TruncatedUdpHeader::parse(truncated_buffer)
-                    .ok()
-                    .unwrap()
-                    .0;
+                let udp = TruncatedUdpHeader::parse(truncated_buffer).ok().unwrap().0;
 
                 Some(TruncatedUdp::PartialHeader(udp))
             }


### PR DESCRIPTION
So we recently added support for parsing ICMP Error messages' inner messages. We processed the network layer of the inner packet, and the transport layer of the inner packet, which can be only TCP or UDP.

... Says who? As it turns out, we can just as well have an error message for an ICMP Echo Request, for example, in which case we need to NAT the message just like for TCP or UDP.

Add the required infrastructure. It's more code that I'd like, but I don't really see a simple alternative: we get new traits for `EmbeddedTransport`, and support for potentially truncated ICMP headers messages, even though it's unlikely we get truncated ones - RFC 792 says there should be at least 8 bytes of the transport header, which is enough to hold most ICMPv4 or ICMPv6 headers (as defined in `etherparse`, at least), with the exception of Timestamp Requests and Replies. The code for the truncated headers (`TruncatedIcmp4`, `TruncatedIcmp6`) is largely derived from `TruncatedTcp` and `TruncatedUdp`. Similarly, we implement Checksum for these new types. The annoying bit, as always when adding ICMP support for a transport layer, is that we suddenly get a header that may not have source and destination ports. Happily, the only location where this matters is in NAT code, where we don't support fully ICMP yet - we'll add the relevant processing soon.

We _DO NOT_ parse ICMP's embedded headers (if any) recursively. The use case here is to correctly process a “Destination Unreachable” message emitted from an ICMP Echo Request.

Test-wise, we're already covered by the Bolero tests using the `IcmpErrMsg` generator.

Relates to #805.