### PR TITLE
ci: Enable VLAB tests by default on manual workflow dispatch

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,9 +28,9 @@ on:
         description: "enable to see debug statements from just recipes"
         required: false
         default: false
-      run_vlab_tests:
+      skip_vlab_tests:
         type: "boolean"
-        description: "Run VLAB tests"
+        description: "Skip VLAB tests (they run by default)"
         required: false
         default: false
       run_hlab_tests:
@@ -338,7 +338,7 @@ jobs:
           || github.event_name == 'workflow_dispatch'
           && (
             matrix.hybrid && inputs.run_hlab_tests != true
-            || !matrix.hybrid && inputs.run_vlab_tests != true
+            || !matrix.hybrid && inputs.skip_vlab_tests == true
           )
 
           || (github.event_name == 'push' || github.event_name == 'merge_group')


### PR DESCRIPTION
We turned VLAB tests on by default in CI for Pull Requests; let's also enable them by default for manual dispatch, too, for consistency.
