### PR TITLE
Extend cmd line args for interface & PCI address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ name = "dataplane-args"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dataplane-hardware",
  "dataplane-mgmt",
  "dataplane-net",
  "dataplane-routing",

--- a/args/Cargo.toml
+++ b/args/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = { workspace = true, features = ["std", "derive", "usage"] }
+hardware = { workspace = true  }
+net = { workspace = true }
 mgmt = { workspace = true  }
 rkyv = { workspace = true, features = ["alloc", "bytecheck"] }
 routing = { workspace = true }


### PR DESCRIPTION
Allowed syntax is:
  --interface ifname[=portdesc], where portdesc may be a PCI address

Examples:
  --interface eth0 -- interface eth1
  --interface eth0,eth1 is also allowed
  --interface eth0=0000:02:03.1
  --interface eth= is equivalent to --interface eth0

 * This PR should not break current behavior, but the portdesc is ignored.
 * The portdesc should deprecate --allowed of DPDK driver.