### PR TITLE
stateful NAT: Omit session creation

### DIFF
--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -206,7 +206,8 @@ impl StatefulNat {
         let flow_info = FlowInfo::new(session_timeout_time(idle_timeout));
         flow_info.locked.write().unwrap().nat_state = Some(Box::new(state));
 
-        self.sessions.insert(*flow_key, flow_info);
+        // Woopsies! We forgot to actually insert the session
+        // self.sessions.insert(*flow_key, flow_info);
     }
 
     #[allow(clippy::unnecessary_wraps)]


### PR DESCRIPTION
This is for profiling tests. We want to profile the time spent in the allocator, let's make sure we allocate new IPs and ports by removing session creation.