### PR TITLE
ci: Fix manual dispatch option name for release tests

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -351,7 +351,7 @@ jobs:
       includeonie: ${{ matrix.includeonie }}
       buildmode: ${{ matrix.buildmode }}
       vpcmode: ${{ matrix.vpcmode }}
-      releasetest: ${{ contains(github.event.pull_request.labels.*.name, 'ci:+release') || inputs.run_release_tests == true }}
+      releasetest: ${{ contains(github.event.pull_request.labels.*.name, 'ci:+release') || inputs.enable_release_tests == true }}
       hybrid: ${{ matrix.hybrid }}
 
     strategy:


### PR DESCRIPTION
We have a mismatch between the name of the option for enabling release tests in the dispatch interface ("enable_release_tests"), and the name we use when trying to evaluate the condition ("run_release_tests"), which results in the release tests never being enabled. Let's fix.

Fixes: 9f6e9d81bc5f ("ci: Add options to run VLAB/HLAB tests on manual dispatch")
