### PR TITLE
Use validated types for configuration

### DIFF
--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -203,7 +203,7 @@ impl VpcTable {
         self.vnis.clear();
     }
     /// Validate the [`VpcTable`]
-    pub fn validate(&self) -> ConfigResult {
+    pub fn validate(self) -> Result<ValidatedVpcTable, ConfigError> {
         for vpc in self.values() {
             let mut peers = BTreeSet::new();
             // For each VPC, loop over all peerings
@@ -217,6 +217,9 @@ impl VpcTable {
             }
             peers.clear();
         }
-        Ok(())
+        Ok(ValidatedVpcTable(self))
     }
 }
+
+#[derive(Clone, Debug, Default)]
+pub struct ValidatedVpcTable(pub VpcTable);

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -230,4 +230,15 @@ impl ValidatedVpcTable {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    /// Number of [`Vpc`]s in [`ValidatedVpcTable`]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Iterate over [`Vpc`]s in a [`ValidatedVpcTable`]
+    pub fn values(&self) -> impl Iterator<Item = &Vpc> {
+        self.0.values()
+    }
 }

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -223,3 +223,11 @@ impl VpcTable {
 
 #[derive(Clone, Debug, Default)]
 pub struct ValidatedVpcTable(pub VpcTable);
+
+impl ValidatedVpcTable {
+    /// Tells if [`ValidatedVpcTable`] is empty
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -116,3 +116,13 @@ pub struct ValidatedGwConfig {
     pub external: ValidatedExternalConfig, /* external config: received */
     pub internal: Option<InternalConfig>,  /* internal config: built by gw from internal */
 }
+
+impl ValidatedGwConfig {
+    //////////////////////////////////////////////////////////////////
+    /// Return the [`GenId`] of a [`GwConfig`] object.
+    //////////////////////////////////////////////////////////////////
+    #[must_use]
+    pub fn genid(&self) -> GenId {
+        self.external.genid
+    }
+}

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -3,8 +3,8 @@
 
 //! Top-level configuration object for the dataplane
 
-use crate::errors::ConfigResult;
-use crate::external::{ExternalConfig, GenId};
+use crate::ConfigError;
+use crate::external::{ExternalConfig, GenId, ValidatedExternalConfig};
 use crate::internal::InternalConfig;
 use std::time::SystemTime;
 use tracing::debug;
@@ -99,8 +99,20 @@ impl GwConfig {
     //////////////////////////////////////////////////////////////////
     /// Validate a [`GwConfig`]. We only validate the external.
     //////////////////////////////////////////////////////////////////
-    pub fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&mut self) -> Result<ValidatedGwConfig, ConfigError> {
         debug!("Validating external config with genid {} ..", self.genid());
-        self.external.validate()
+        let validated_external = self.external.validate()?;
+        Ok(ValidatedGwConfig {
+            meta: self.meta.clone(),
+            external: validated_external,
+            internal: self.internal.clone(),
+        })
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedGwConfig {
+    pub meta: GwConfigMeta,                /* config metadata */
+    pub external: ValidatedExternalConfig, /* external config: received */
+    pub internal: Option<InternalConfig>,  /* internal config: built by gw from internal */
 }

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -41,7 +41,7 @@ pub mod test {
 
     use routing::frr::renderer::builder::Render;
 
-    use crate::processor::confbuild::internal::build_internal_config;
+    use crate::processor::confbuild::internal::build_internal_config_from_validated;
     use crate::processor::proc::ConfigProcessor;
     use routing::{Router, RouterParamsBuilder};
     use tracing::debug;
@@ -339,13 +339,13 @@ pub mod test {
         /* Not really a test but a tool to check generated FRR configs given a gateway config */
         let external = sample_external_config();
         let mut config = GwConfig::new(external);
-        config.validate().expect("Config validation failed");
+        let validated_config = config.validate().expect("Config validation failed");
         if false {
             let vpc_table = &config.external.overlay.vpc_table;
             let peering_table = &config.external.overlay.peering_table;
             println!("\n{vpc_table}\n{peering_table}");
         }
-        let internal = build_internal_config(&config).expect("Should succeed");
+        let internal = build_internal_config_from_validated(&validated_config).expect("Should succeed");
         let rendered = internal.render(&config.genid());
         println!("{rendered}");
     }


### PR DESCRIPTION
I'm not sure this is the right approach; this looks like a lot of data cloning for not too much gain.

Fixes: #554

TO DO:

- Use validated types for `.device` and `.underlay` in `ValidatedExternalConfig`
- Commit titles + descriptions
