### PR TITLE
feat(nat): Move stateless NAT prefix size validation back to "config"

### DIFF
--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -17,7 +17,7 @@ pub mod test {
     use crate::external::overlay::vpcpeering::VpcManifest;
     use crate::external::overlay::vpcpeering::{VpcPeering, VpcPeeringTable};
 
-    use lpm::prefix::Prefix;
+    use lpm::prefix::{Prefix, PrefixSize};
 
     /* Build sample manifests for a peering */
     fn build_manifest_vpc1() -> VpcManifest {
@@ -203,6 +203,19 @@ pub mod test {
         assert_eq!(
             expose.validate(),
             Err(ConfigError::ExcludedAllPrefixes(Box::new(expose.clone())))
+        );
+
+        // Incorrect: mismatched prefix lists sizes
+        let expose = VpcExpose::empty()
+            .ip("10.0.0.0/16".into())
+            .not("10.0.1.0/24".into())
+            .as_range("2.0.0.0/24".into());
+        assert_eq!(
+            expose.validate(),
+            Err(ConfigError::MismatchedPrefixSizes(
+                PrefixSize::U128(65536 - 256),
+                PrefixSize::U128(256)
+            ))
         );
     }
 

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -22,7 +22,7 @@ use crate::processor::confbuild::internal::build_internal_config;
 use crate::processor::confbuild::router::generate_router_config;
 use nat::stateful::NatAllocatorWriter;
 use nat::stateless::NatTablesWriter;
-use nat::stateless::setup::{build_nat_configuration, validate_nat_configuration};
+use nat::stateless::setup::build_nat_configuration;
 use pkt_meta::dst_vpcd_lookup::VpcDiscTablesWriter;
 use pkt_meta::dst_vpcd_lookup::setup::build_dst_vni_lookup_configuration;
 use routing::frr::FrrAppliedConfig;
@@ -504,7 +504,6 @@ fn apply_stateless_nat_config(
     vpc_table: &VpcTable,
     nattablesw: &mut NatTablesWriter,
 ) -> ConfigResult {
-    validate_nat_configuration(vpc_table)?;
     let nat_table = build_nat_configuration(vpc_table)?;
     nattablesw.update_nat_tables(nat_table);
     Ok(())

--- a/nat/src/stateless/setup/mod.rs
+++ b/nat/src/stateless/setup/mod.rs
@@ -11,11 +11,11 @@ pub mod range_builder;
 pub mod tables;
 
 use crate::stateless::{NatTableValue, NatTables, PerVniTable};
+use config::ConfigError;
 use config::external::overlay::vpc::{Peering, VpcTable};
 use config::external::overlay::vpcpeering::VpcExpose;
 use config::utils::{ConfigUtilError, collapse_prefixes_peering};
-use config::{ConfigError, ConfigResult};
-use lpm::prefix::{Prefix, PrefixSize};
+use lpm::prefix::Prefix;
 use net::vxlan::Vni;
 use std::collections::BTreeSet;
 
@@ -116,42 +116,6 @@ pub fn build_nat_configuration(vpc_table: &VpcTable) -> Result<NatTables, Config
     Ok(nat_tables)
 }
 
-pub fn validate_nat_configuration(vpc_table: &VpcTable) -> ConfigResult {
-    for vpc in vpc_table.values() {
-        for peering in &vpc.peerings {
-            for manifest in [&peering.local, &peering.remote] {
-                for expose in manifest.stateless_nat_exposes() {
-                    validate_nat_expose(expose)?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn validate_nat_expose(expose: &VpcExpose) -> ConfigResult {
-    fn prefixes_size(prefixes: &BTreeSet<Prefix>) -> PrefixSize {
-        prefixes.iter().map(Prefix::size).sum()
-    }
-    let ips_sizes = prefixes_size(&expose.ips);
-    let nots_sizes = prefixes_size(&expose.nots);
-    let as_range_sizes = prefixes_size(expose.as_range_or_empty());
-    let not_as_sizes = prefixes_size(expose.not_as_or_empty());
-
-    // Ensure that, if the list of publicly-exposed addresses is not empty, then we have the same
-    // number of addresses on each side
-    //
-    // Note: We shouldn't have subtraction overflows because we check that exclusion prefixes size
-    // was smaller than allowed prefixes size when validating the config.
-    if as_range_sizes > 0 && ips_sizes - nots_sizes != as_range_sizes - not_as_sizes {
-        return Err(ConfigError::MismatchedPrefixSizes(
-            ips_sizes - nots_sizes,
-            as_range_sizes - not_as_sizes,
-        ));
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,20 +179,5 @@ mod tests {
         vni_table
             .add_peering(&peering, dst_vni)
             .expect("Failed to build NAT tables");
-    }
-
-    #[test]
-    fn test_validate_nat_expose() {
-        let expose = VpcExpose::empty()
-            .ip("10.0.0.0/16".into())
-            .not("10.0.1.0/24".into())
-            .as_range("2.0.0.0/24".into());
-        assert_eq!(
-            validate_nat_expose(&expose),
-            Err(ConfigError::MismatchedPrefixSizes(
-                PrefixSize::U128(65536 - 256),
-                PrefixSize::U128(256)
-            ))
-        );
     }
 }


### PR DESCRIPTION
In commit 28c87043f59a, we moved prefix size validation for stateless NAT out of `config`, and into the `nat` crate instead. This was because we had no way to tell whether the VpcExpose block uses stateless NAT, and whether this check was relevant, so we had to move it out of the way to allow stateful NAT to work with IP sets of different sizes.

Now that we do have a way to tell, via the presence and configuration variant of `VpcExposeNat` objects, it's trivial to apply the check only to VpcExpose that actually rely on stateless NAT. Let's move validation back to the `config` crate, along with the other validation steps. This commit is more or less a rebased revert of the aforementioned one, except that we filter exposes with `self.has_stateless_nat()` for running the check.

Fixes: #930 