### PR TITLE
chore: Ignore local Zed configuration files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/target/**
 /.bin/**
 /.vscode/**
+/.zed/**
 /artifact/**
 /compile-env
 /compile-env/**


### PR DESCRIPTION
At some point we talked about committing some shared configuration for Zed to the repository, but this didn't happen. Until we do that, tell Git to ignore local configuration files.

We don't want to add ignore rules for all editors that are around, but several people in the team use Zed (at various frequencies) at the moment, so it seems worth adding.
