### PR TITLE
fix(dataplane): use dataplane cli as the shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ COPY --link --chown=0:0 "${ARTIFACT}" /dataplane
 COPY --link --chown=0:0 "${ARTIFACT_CLI}" /dataplane-cli
 WORKDIR /
 ENTRYPOINT ["/dataplane"]
+SHELL ["/dataplane-cli"]


### PR DESCRIPTION
It is annoying to launch the dataplane container shell without this.