### PR TITLE
fix(nat): Fix timeout reset for table flows in stateful NAT

### DIFF
--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -154,7 +154,7 @@ impl StatefulNat {
         let flow_info = packet.get_meta_mut().flow_info.as_mut()?;
         let value = flow_info.locked.read().unwrap();
         let state = value.nat_state.as_ref()?.extract_ref::<NatFlowState<I>>()?;
-        flow_info.extend_expiry(state.idle_timeout).ok()?;
+        flow_info.reset_expiry(state.idle_timeout).ok()?;
         let translation_data = Self::get_translation_info(&state.src_alloc, &state.dst_alloc);
         Some(translation_data)
     }


### PR DESCRIPTION
When updating the timeout for a flow after a successful lookup in the flow table, we add the desired timeout duration to the existing timeout instant, instead of the current time, meaning that we linearly increment the duration (beyond the desired period) each time we receive a packet for that flow. Let's fix by resetting to the current time, plus the desired duration, instead.

We do this by introducing a new method `reset_expiry()`, doing

```rust
    self.expires_at.store(
        Instant::now() + duration,
        std::sync::atomic::Ordering::Relaxed,
    );
```

To compare with `extend_expiry()`, which does:

```rust
    self.expires_at
        .fetch_add(duration, std::sync::atomic::Ordering::Relaxed);
```

Fixes: #1019