### PR TITLE
ci: Add step to print images name and tags

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -159,6 +159,15 @@ jobs:
             target=x86_64-unknown-linux-gnu \
             push-container
 
+      - name: "print container image name"
+        if: ${{ matrix.profile.sterile == 'sterile' && (matrix.profile.name == 'release' || matrix.profile.name == 'debug') }}
+        run: |
+          just \
+            debug_justfile="${{matrix.debug_justfile}}" \
+            profile=${{matrix.profile.name}} \
+            target=x86_64-unknown-linux-gnu \
+            print-container-tags
+
       - id: "test"
         name: "test"
         run: |

--- a/justfile
+++ b/justfile
@@ -474,6 +474,22 @@ push-container: build-container
       sudo -E docker push "{{ _container_repo }}:$(truncate128 "{{ _slug }}")"
     fi
 
+# Print names of container images to build or push
+[script]
+print-container-tags:
+    {{ _define_truncate128 }}
+    declare build_date
+    build_date="$(date --utc --iso-8601=date --date="{{ _build_time }}")"
+    declare -r build_date
+    echo "{{ _container_repo }}:$(truncate128 "${build_date}.{{ _dirty_prefix }}{{ target }}.{{ profile }}.{{ _commit }}")"
+    echo "{{ _container_repo }}:$(truncate128 "{{ _dirty_prefix }}{{ target }}.{{ profile }}.{{ _commit }}")"
+    if [ "{{ target }}" = "x86_64-unknown-linux-gnu" ]; then
+      echo "{{ _container_repo }}:$(truncate128 "{{ _slug }}.{{ profile }}")"
+    fi
+    if [ "{{ target }}" = "x86_64-unknown-linux-gnu" ] && [ "{{ profile }}" = "release" ]; then
+      echo "{{ _container_repo }}:$(truncate128 "{{ _slug }}")"
+    fi
+
 # Run Clippy like you're in CI
 [script]
 clippy *args: (cargo "clippy" "--all-targets" "--all-features" args "--" "-D" "warnings")


### PR DESCRIPTION
Add a quick step to development CI workflow to print the names and tags of pushed container images. These names are already available from the previous step ("push container"), but it might be tedious to look for them in the logs. This additional step makes it easier to retrieve the tags.
