### PR TITLE
feat(kernel-driver): bring requested interfaces up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "parking_lot",
  "pyroscope",
  "pyroscope_pprofrs",
+ "rtnetlink",
  "serde",
  "tokio",
  "tracing",

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -36,6 +36,7 @@ pkt-meta = { workspace = true }
 pyroscope = { workspace = true }
 pyroscope_pprofrs = { workspace = true }
 routing = { workspace = true }
+rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["derive"] }
 stats = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Bring the kernel interfaces to be used by the kernel driver admin up to make sure that  setsockopts on AF packet sockets don't fail.