### PR TITLE
Small fixes to kernel driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "pyroscope_pprofrs",
  "rtnetlink",
  "serde",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -39,6 +39,7 @@ routing = { workspace = true }
 rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["derive"] }
 stats = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracectl = { workspace = true }
 tracing = { workspace = true }

--- a/dataplane/src/drivers/mod.rs
+++ b/dataplane/src/drivers/mod.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+use thiserror::Error;
+
 pub mod dpdk;
 pub mod kernel;
 mod tokio_util;
+
+#[derive(Error, Debug)]
+pub enum DriverError {
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
     .expect("Failed to start gRPC server");
 
     /* start driver with the provided pipeline builder */
-    match args.driver_name() {
+    let e = match args.driver_name() {
         "dpdk" => {
             info!("Using driver DPDK...");
             todo!();
@@ -156,12 +156,17 @@ fn main() {
                 args.kernel_interfaces(),
                 args.kernel_num_workers(),
                 &pipeline_factory,
-            );
+            )
         }
         other => {
             error!("Unknown driver '{other}'. Aborting...");
             panic!("Packet processing pipeline failed to start. Aborting...");
         }
+    };
+
+    if let Err(e) = e {
+        error!("Failed to start driver: {e}");
+        std::process::exit(-1);
     }
 
     let exit_code = stop_rx.recv().expect("failed to receive stop signal");


### PR DESCRIPTION
* FAIL if no interface is specified.
* remove the --interface ANY, since this will be useless with the new --interface syntax
* make the driver fallible; e.g. if a specified interface does not exist.
* log information about existing and selected interfaces

**Sample output (success case)**
sudo ./target/x86_64-unknown-linux-gnu/debug/dataplane --driver kernel --interface=enp73s0,dummy0,dummy1
```
2025-11-19T12:01:56.839254Z  INFO           main dataplane::drivers::kernel::kif: 112: ━━━━━━━━━━━━━━━ Available kernel interfaces ━━━━━━━━━━━━━━━
2025-11-19T12:01:56.839266Z  INFO           main dataplane::drivers::kernel::kif: 113:  ifindex name             mac                  OpState      AdmState
2025-11-19T12:01:56.839282Z  INFO           main dataplane::drivers::kernel::kif: 124:        9 dummy2           c6:28:69:85:49:d0    unknown      up    
2025-11-19T12:01:56.839289Z  INFO           main dataplane::drivers::kernel::kif: 124:        3 wlp0s20f3        66:80:52:ff:28:9c    down         up    
2025-11-19T12:01:56.839296Z  INFO           main dataplane::drivers::kernel::kif: 124:        4 enp73s0          8c:3b:4a:12:02:a5    up           up    
2025-11-19T12:01:56.839302Z  INFO           main dataplane::drivers::kernel::kif: 124:        6 docker0          12:cb:fa:71:40:79    down         up    
2025-11-19T12:01:56.839308Z  INFO           main dataplane::drivers::kernel::kif: 124:        2 enp0s31f6        a8:2b:dd:11:f7:9d    down         up    
2025-11-19T12:01:56.839314Z  INFO           main dataplane::drivers::kernel::kif: 124:        7 dummy0           86:be:93:1e:4e:a9    unknown      up    
2025-11-19T12:01:56.839320Z  INFO           main dataplane::drivers::kernel::kif: 124:        8 dummy1           6e:45:93:e7:58:3f    unknown      up    
2025-11-19T12:01:56.839326Z  INFO           main dataplane::drivers::kernel::kif: 124:        1 lo               00:00:00:00:00:00    unknown      up    
2025-11-19T12:01:56.839358Z  INFO           main dataplane::drivers::kernel::kif: 112: ━━━━━━━━━━━━━━━ Will use the following interfaces ━━━━━━━━━━━━━━━
2025-11-19T12:01:56.839364Z  INFO           main dataplane::drivers::kernel::kif: 113:  ifindex name             mac                  OpState      AdmState
2025-11-19T12:01:56.839370Z  INFO           main dataplane::drivers::kernel::kif: 124:        4 enp73s0          8c:3b:4a:12:02:a5    up           up    
2025-11-19T12:01:56.839377Z  INFO           main dataplane::drivers::kernel::kif: 124:        7 dummy0           86:be:93:1e:4e:a9    unknown      up    
2025-11-19T12:01:56.839382Z  INFO           main dataplane::drivers::kernel::kif: 124:        8 dummy1           6e:45:93:e7:58:3f    unknown      up    
2025-11-19T12:01:56.839440Z  INFO           main dataplane::drivers::kernel::kif: 36: Bringing interface enp73s0 up ...
2025-11-19T12:01:56.839941Z  INFO           main dataplane::drivers::kernel::kif: 71: Interface enp73s0 is up
2025-11-19T12:01:56.839954Z  INFO           main dataplane::drivers::kernel::kif: 36: Bringing interface dummy0 up ...
2025-11-19T12:01:56.840065Z  INFO           main dataplane::drivers::kernel::kif: 71: Interface dummy0 is up
2025-11-19T12:01:56.840074Z  INFO           main dataplane::drivers::kernel::kif: 36: Bringing interface dummy1 up ...
2025-11-19T12:01:56.840173Z  INFO           main dataplane::drivers::kernel::kif: 71: Interface dummy1 is up
2025-11-19T12:01:56.840235Z  INFO           main dataplane::drivers::kernel: 54: Spawning 1 workers
2025-11-19T12:01:56.840333Z  INFO    dp-worker-0 dataplane::drivers::kernel::worker: 155: Worker started worker=0
2025-11-19T12:01:56.840385Z  INFO kernel-driver-controller dataplane::drivers::kernel: 102: Waiting for workers to finish
2025-11-19T12:01:56.879527Z  INFO              dp-worker-0 dataplane::drivers::kernel::worker: 100: Using PACKET_FANOUT_QM for interface enp73s0 worker=0
2025-11-19T12:01:56.899328Z  INFO              dp-worker-0 dataplane::drivers::kernel::worker: 100: Using PACKET_FANOUT_QM for interface dummy0 worker=0
2025-11-19T12:01:56.931418Z  INFO              dp-worker-0 dataplane::drivers::kernel::worker: 100: Using PACKET_FANOUT_QM for interface dummy1 worker=0
``` 

**Sample output (failure)**
sudo ./target/x86_64-unknown-linux-gnu/debug/dataplane --driver kernel --interface=enp73s0,dummy0,dummy1,fooo
```
2025-11-19T12:02:08.365068Z  INFO           mgmt dataplane_mgmt::processor::proc: 387: Starting config processor...
2025-11-19T12:02:08.365362Z  INFO metrics-server run{addr=127.0.0.1:9090}: dataplane::statistics: 98: metrics server listening on 127.0.0.1:9090
2025-11-19T12:02:08.366360Z  INFO           main dataplane::drivers::kernel::kif: 112: ━━━━━━━━━━━━━━━ Available kernel interfaces ━━━━━━━━━━━━━━━
2025-11-19T12:02:08.366373Z  INFO           main dataplane::drivers::kernel::kif: 113:  ifindex name             mac                  OpState      AdmState
2025-11-19T12:02:08.366383Z  INFO           main dataplane::drivers::kernel::kif: 124:        7 dummy0           86:be:93:1e:4e:a9    unknown      up    
2025-11-19T12:02:08.366389Z  INFO           main dataplane::drivers::kernel::kif: 124:        3 wlp0s20f3        66:80:52:ff:28:9c    down         up    
2025-11-19T12:02:08.366396Z  INFO           main dataplane::drivers::kernel::kif: 124:        4 enp73s0          8c:3b:4a:12:02:a5    up           up    
2025-11-19T12:02:08.366402Z  INFO           main dataplane::drivers::kernel::kif: 124:        6 docker0          12:cb:fa:71:40:79    down         up    
2025-11-19T12:02:08.366407Z  INFO           main dataplane::drivers::kernel::kif: 124:        9 dummy2           c6:28:69:85:49:d0    unknown      up    
2025-11-19T12:02:08.366414Z  INFO           main dataplane::drivers::kernel::kif: 124:        1 lo               00:00:00:00:00:00    unknown      up    
2025-11-19T12:02:08.366421Z  INFO           main dataplane::drivers::kernel::kif: 124:        2 enp0s31f6        a8:2b:dd:11:f7:9d    down         up    
2025-11-19T12:02:08.366427Z  INFO           main dataplane::drivers::kernel::kif: 124:        8 dummy1           6e:45:93:e7:58:3f    unknown      up    
2025-11-19T12:02:08.366454Z ERROR           main dataplane: 168: Failed to start driver: IO error: Unknown interface 'fooo'

```

