### PR TITLE
Pass params to mgmt

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -14,8 +14,7 @@ use crate::statistics::MetricsServer;
 use args::{CmdArgs, Parser};
 
 use drivers::kernel::DriverKernel;
-
-use mgmt::processor::launch::start_mgmt;
+use mgmt::{ConfigProcessorParams, MgmtParams, start_mgmt};
 
 use pyroscope::PyroscopeAgent;
 use pyroscope_pprofrs::{PprofConfig, pprof_backend};
@@ -127,19 +126,21 @@ fn main() {
 
     MetricsServer::new(args.metrics_address(), setup.stats);
 
-    /* pipeline builder */
+    // pipeline builder
     let pipeline_factory = setup.pipeline;
 
     /* start management */
-    start_mgmt(
+    start_mgmt(MgmtParams {
         grpc_addr,
-        setup.router.get_ctl_tx(),
-        setup.nattablew,
-        setup.natallocatorw,
-        setup.vpcdtablesw,
-        setup.vpcmapw,
-        setup.vpc_stats_store,
-    )
+        processor_params: ConfigProcessorParams {
+            router_ctl: setup.router.get_ctl_tx(),
+            vpcmapw: setup.vpcmapw,
+            nattablesw: setup.nattablesw,
+            natallocatorw: setup.natallocatorw,
+            vpcdtablesw: setup.vpcdtablesw,
+            vpc_stats_store: setup.vpc_stats_store,
+        },
+    })
     .expect("Failed to start gRPC server");
 
     /* start driver with the provided pipeline builder */

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -36,7 +36,7 @@ where
     pub router: Router,
     pub pipeline: Arc<dyn Send + Sync + Fn() -> DynPipeline<Buf>>,
     pub vpcmapw: VpcMapWriter<VpcMapName>,
-    pub nattablew: NatTablesWriter,
+    pub nattablesw: NatTablesWriter,
     pub natallocatorw: NatAllocatorWriter,
     pub vpcdtablesw: VpcDiscTablesWriter,
     pub stats: StatsCollector,
@@ -47,7 +47,7 @@ where
 pub(crate) fn start_router<Buf: PacketBufferMut>(
     params: RouterParams,
 ) -> Result<InternalSetup<Buf>, RouterError> {
-    let nattablew = NatTablesWriter::new();
+    let nattablesw = NatTablesWriter::new();
     let natallocatorw = NatAllocatorWriter::new();
     let vpcdtablesw = VpcDiscTablesWriter::new();
     let router = Router::new(params)?;
@@ -67,7 +67,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     let fibtr_factory = router.get_fibtr_factory();
     let vpcdtablesr_factory = vpcdtablesw.get_reader_factory();
     let atabler_factory = router.get_atabler_factory();
-    let nattabler_factory = nattablew.get_reader_factory();
+    let nattabler_factory = nattablesw.get_reader_factory();
     let natallocator_factory = natallocatorw.get_reader_factory();
 
     let pipeline_builder = move || {
@@ -108,7 +108,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         router,
         pipeline: Arc::new(pipeline_builder),
         vpcmapw,
-        nattablew,
+        nattablesw,
         natallocatorw,
         vpcdtablesw,
         stats,

--- a/mgmt/src/lib.rs
+++ b/mgmt/src/lib.rs
@@ -3,17 +3,13 @@
 
 //! Dataplane management module
 
-/* gRPC entry point */
-pub mod grpc;
-
-/* Configuration processor */
-pub mod processor;
-
-/* VPC manager */
+mod grpc;
+mod processor;
+mod tests;
 pub mod vpc_manager;
 
-#[cfg(test)]
-mod tests;
+pub use processor::launch::{MgmtParams, start_mgmt};
+pub use processor::proc::ConfigProcessorParams;
 
 use tracectl::trace_target;
 trace_target!("mgmt", LevelFilter::DEBUG, &["management"]);

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, info};
 
 /// Configuration database, keeps a set of [`GwConfig`]s keyed by generation id [`GenId`]
 #[derive(Default)]
-pub struct GwConfigDatabase {
+pub(crate) struct GwConfigDatabase {
     configs: BTreeMap<GenId, GwConfig>, /* collection of configs */
     current: Option<GenId>,             /* [`GenId`] of currently applied config */
 }
@@ -52,7 +52,7 @@ impl GwConfigDatabase {
     pub fn get_mut(&mut self, generation: GenId) -> Option<&mut GwConfig> {
         self.configs.get_mut(&generation)
     }
-
+    #[allow(unused)]
     pub fn remove(&mut self, genid: GenId) -> ConfigResult {
         if genid == ExternalConfig::BLANK_GENID {
             debug!("Will not remove config {genid} as it is protected");

--- a/mgmt/src/processor/mod.rs
+++ b/mgmt/src/processor/mod.rs
@@ -4,8 +4,8 @@
 //! Dataplane configuration processor.
 //! This module implements the core logic to determine and build internal configurations.
 
-pub mod confbuild;
+pub(crate) mod confbuild;
 mod display;
-pub mod gwconfigdb;
-pub mod launch;
-pub mod proc;
+pub(crate) mod gwconfigdb;
+pub(crate) mod launch;
+pub(crate) mod proc;


### PR DESCRIPTION
Define struct MgmtParams to pass all of the parameters that the mgmt thread requires. This makes it much easier to pass new stuff, without the need to change several function signatures every time.