### PR TITLE
chore: Add .gitattributes file to mark generated files as such

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+k8s-intf/src/generated/** linguist-generated
+k8s-intf/src/generated/mod.rs -linguist-generated

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           filters: |
             devfiles:
-              - '!(README.md|LICENSE|.gitignore|.github/**)'
+              - '!(README.md|LICENSE|.gitattributes|.gitignore|.github/**)'
               - '.github/workflows/dev.yml'
 
   check:


### PR DESCRIPTION
Mark files under k8s-intf/src/generated/ as generated, except for mod.rs. This makes GitHub fold the diffs by default for generated files. This is what we want, as usually nobody needs to look at the content of such files.

Follow-up to https://github.com/githedgehog/dataplane/pull/1058