### PR TITLE
chore(README.md): Update IDE settings with RUSTC_BOOTSTRAP=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Add the following to your `.vscode/settings.json` file:
   "rust-analyzer.server.path": "./compile-env/bin/rust-analyzer",
   "rust-analyzer.cargo.sysroot": "./compile-env",
   "rust-analyzer.server.extraEnv": {
+    "RUSTC_BOOTSTRAP": "1",
     "RUSTC": "<absolute path to dataplane directory>/compile-env/bin/rustc",
     "CARGO": "<absolute path to dataplane directory>/compile-env/bin/cargo"
   }
@@ -194,6 +195,7 @@ Save the following to the `.zed/settings.json` file:
       "binary": {
         "path": "<absolute path to dataplane directory>/compile-env/bin/rust-analyzer",
         "env": {
+          "RUSTC_BOOTSTRAP": "1",
           "PATH": "<absolute path to dataplane directory>/compile-env/bin"
         }
       },


### PR DESCRIPTION
Commit 30e22f3e6c7a introduced the use of `RUSTC_BOOTSTRAP=1` as an environment variable, but the addition to scripts/rust.env is not automatically picked up by IDEs.

Even though the missing variable does not prevent compiling or running the linter within the IDE, an issue may arise when working with both an IDE and the terminal:

1. The IDE builds the project with `RUSTC_BOOTSTRAP` unset
2. The developer builds and runs a test, for example, in the terminal, with `RUSTC_BOOTSTRAP=1`
3. The developer trivially edit the test file in the IDE
4. The IDE rebuilds the project and runs the linter, again with `RUSTC_BOOTSTRAP` unset
5. The developer runs the test again in the terminal

Because the builds alternate values for `RUSTC_BOOTSTRAP`, some dependencies need to get rebuilt: this is the case for proc_macro2, for example, and all the other dependencies relying on it. This means that, at steps 4 and 5 of the workflow we described, we need to recompile a large chunk of dependencies.

Instead, if we pass the correct value for the variable to the IDE, we get a trivial rebuild for the crate we're working on, only.

Let's update the README.md file so that contributors can pick the variable for their editor config.

NOT TESTED WITH ZED.
