### PR TITLE
Fix port allocation with shared ips.

### DIFF
--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -82,14 +82,12 @@ mod context {
 
     pub fn get_ip_allocator_v4(
         pool: &mut PoolTable<Ipv4Addr, Ipv4Addr>,
-        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         protocol: NextHeader,
         src_ip: Ipv4Addr,
     ) -> &IpAllocator<Ipv4Addr> {
         pool.get(&PoolTableKey::new(
             protocol,
-            src_vpcd,
             dst_vpcd,
             src_ip,
             Ipv4Addr::from_str("255.255.255.255").unwrap(),
@@ -202,8 +200,7 @@ mod std_tests {
                 .pools_src44
                 .0
                 .keys()
-                .all(|k| (k.src_id == vpcd1() && k.dst_id == vpcd2())
-                    || (k.src_id == vpcd2() && k.dst_id == vpcd1()))
+                .all(|k| k.dst_id == vpcd2() || k.dst_id == vpcd1())
         );
         // One entry for each ".ip()" from the VPCExpose objects,
         // after exclusion ranges have been applied
@@ -231,8 +228,7 @@ mod std_tests {
                 .pools_dst44
                 .0
                 .keys()
-                .all(|k| (k.src_id == vpcd1() && k.dst_id == vpcd2())
-                    || (k.src_id == vpcd2() && k.dst_id == vpcd1()))
+                .all(|k| k.dst_id == vpcd2() || k.dst_id == vpcd1())
         );
         // One entry for each ".as_range()" from the VPCExpose objects,
         // after exclusion ranges have been applied
@@ -262,7 +258,6 @@ mod std_tests {
             .pools_src44
             .get(&PoolTableKey::new(
                 NextHeader::TCP,
-                vpcd1(),
                 vpcd2(),
                 addr_v4("1.1.0.0"),
                 addr_v4("255.255.255.255"),
@@ -278,7 +273,6 @@ mod std_tests {
             .pools_dst44
             .get(&PoolTableKey::new(
                 NextHeader::TCP,
-                vpcd1(),
                 vpcd2(),
                 addr_v4("10.3.0.0"),
                 addr_v4("255.255.255.255"),
@@ -307,7 +301,6 @@ mod std_tests {
         let mut allocator = build_allocator().unwrap();
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -345,7 +338,6 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -359,7 +351,6 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -391,7 +382,6 @@ mod std_tests {
         let mut allocator = build_allocator().unwrap();
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -402,7 +392,6 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -418,7 +407,6 @@ mod std_tests {
         // Check number of allocated IPs for TCP after we have allocated for TCP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -430,7 +418,6 @@ mod std_tests {
         // Check number of allocated IPs for UDP after we have allocated for TCP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -446,7 +433,6 @@ mod std_tests {
         // Check number of allocated IPs for TCP after we have allocated for UDP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -458,7 +444,6 @@ mod std_tests {
         // Check number of allocated IPs for UDP after we have allocated for UDP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
-            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -632,7 +617,6 @@ mod tests_shuttle {
             let mut allocator_again = Arc::try_unwrap(allocator_arc).unwrap();
             let (bitmap, in_use) = get_ip_allocator_v4(
                 &mut allocator_again.pools_src44,
-                vpcd1(),
                 vpcd2(),
                 NextHeader::TCP,
                 addr_v4("1.1.0.0"),


### PR DESCRIPTION
When using stateful NAT with addresses shared by distinct VPCs, the source port (translated) must be such that the return traffic allows to unambiguously recover the original flow. The existing implementation considers the source vpc id as part of the key to locate a port allocator. This has the problem that two flows from distinct vpcs natting to the same src IP may choose the same port since distinct port allocators are used. Fix this by not considering the source vpc id as part of the key to select a port allocator. This fixes the problem in general, without breaking the behavior when nat addresses are not reused across vpcs.

When NAT addresses are re-used among VPCs, it may happen that a VPC uses many more ports than the rest, potentially starving the latter. This can and should be addressed later by tracking the number of sessions/ports-allocated on a per VPC level wrt the fair share of ports, which should be the number of ports available over the number of vpcs. This is left for future work, and classical resource-sharing policies may be applied like having a strict quota or a relaxed one with possible eviction/pre-emption.

However, before addressing the above, the number of available sessions per nat IP address could be significantly increased by changing the criteria to allocate ports: ideally, with stateful source NAT, a distinct port allocator should be used per (nat_src_ip, dst_ip, protocol, dst_port and dst_vpc_id). Currently the dst_ip and dst_port are not taken into account.

Fixes: https://github.com/githedgehog/dataplane/issues/1083
