### PR TITLE
fix(net): Fix Bolero generator for UnicastIpv4Addr

### DIFF
--- a/net/src/ipv4/addr.rs
+++ b/net/src/ipv4/addr.rs
@@ -108,6 +108,11 @@ mod contract {
                     raw[2],
                     raw[3],
                 )))
+            } else if ip.is_broadcast() {
+                // Note: is_broadcast() means "is 255.255.255.255?", it doesn't account for the
+                // current network in use. So when we reach this case we can just replace by any
+                // valid unicast address.
+                Some(UnicastIpv4Addr(Ipv4Addr::new(1, 1, 1, 1)))
             } else {
                 Some(UnicastIpv4Addr(ip))
             }


### PR DESCRIPTION
Since commit efe3008734d7 ipv4 addr"), we forbid broadcast IPv4 addresses (namely, `255.255.255.255`) when building a `UnicastIpv4Addr`:

```rust
    impl UnicastIpv4Addr {
        pub fn new(ip: Ipv4Addr) -> Result<UnicastIpv4Addr, Ipv4Addr> {
            if ip.is_multicast() || ip.is_broadcast() {
                Err(ip)
            } else {
                Ok(UnicastIpv4Addr(ip))
            }
        }

        [...]
    }
```

We need to adjust the Bolero generator for `UnicastIpv4Addr` accordingly, or test `unicast_ipv4_is_unicast_ip` may end up trying to `unwrap()` on an `Err` value:

```rust
    fn unicast_ipv4_is_unicast_ip() {
        bolero::check!()
            .with_type()
            .cloned()
            .for_each(|ipv4: UnicastIpv4Addr| {
                let ip: UnicastIpAddr = ipv4.inner().try_into().unwrap();
                [...]
            });
    }
```