### PR TITLE
Revert "fix(build): remove duplicate rustflags"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,7 @@ PKG_CONFIG_PATH = { value = "compile-env/sysroot/x86_64-unknown-linux-gnu/releas
 [build]
 target = "x86_64-unknown-linux-gnu"
 rustc = "compile-env/bin/rustc"
+rustflags = ["--cfg", "tokio_unstable"]
 
 [target.x86_64-unknown-linux-gnu]
 runner = ["scripts/test-runner.sh"]


### PR DESCRIPTION
This reverts commit 6cbf3385a8900f29b7f9fcbc6a4780e22b438ce8.

The RUSTFLAGS in the .cargo/config.toml is used by language analyzers to get the rust flags, so leave them here despite the redundancy.