### PR TITLE
chore: permit RUSTSEC-2025-0134

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,9 @@ ignore = [
     "RUSTSEC-2023-0081",
     # instant is unmaintained but is needed by afpacket with the tokio feature, remove when we stop using this crate in favor of our own
     "RUSTSEC-2024-0384",
+    # rustls_pemfile is unmaintained, but we aren't actually even using it.  We don't enable the feature of bollard
+    # which would pull this in.
+    "RUSTSEC-2025-0134"
 ]
 
 [licenses]


### PR DESCRIPTION
(fixes a minor issue which was blocking CI from passing)

RUSTSEC-2025-0134 is a very minor issue which does not impact us in any case.

All that has actually happened is that a thin wrapper around rustls-pki-types (i.e. rustls-pemfile) was archived (the main repo is still maintained).

This is irrelevant to us on multiple levels:

1. this is only indirectly pulled in via testn,
2. in dev dependencies,
3. for a feature we disable explicitly.

I created an issue in the bollard repo to address this

<https://github.com/fussybeaver/bollard/issues/612>