### PR TITLE
test: disable n-vm tests until dpdk-sys refactor is done

### DIFF
--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -180,6 +180,7 @@ fn main() {
     std::process::exit(exit_code);
 }
 
+#[cfg(false)] // disabled until dpdk-sys refactor is complete
 #[cfg(test)]
 mod test {
     use n_vm::in_vm;

--- a/hardware/src/scan.rs
+++ b/hardware/src/scan.rs
@@ -216,6 +216,7 @@ impl<'a> IntoIterator for &'a Node {
     }
 }
 
+#[cfg(false)] // disabled until dpdk-sys refactor is complete
 #[cfg(test)]
 mod test {
     use crate::{


### PR DESCRIPTION
These tests

1. apply mostly to DPDK issues
2. which are on hold for the moment
3. and which are broken due to an oversight in our build system

The only reasonable action for the moment is to accept a brief regression until dpdk-sys / testn can make this process less fragile.