### PR TITLE
ci: fix workflow_dispatch trigger of vlab jobs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -111,7 +111,7 @@ jobs:
     needs:
       - check_changes
       - version
-    if: "${{ needs.check_changes.outputs.devfiles == 'true' || startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push' }}"
+    if: "${{ needs.check_changes.outputs.devfiles == 'true' || (startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/v')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}"
     permissions:
       checks: "write"
       pull-requests: "write"
@@ -404,7 +404,7 @@ jobs:
           limit-access-to-actor: true
 
   vlab:
-    if: "${{ needs.check_changes.outputs.devfiles == 'true' || startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push' }}"
+    if: "${{ needs.check_changes.outputs.devfiles == 'true' || (startsWith(github.event.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/v')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}"
     needs:
       - check
       - version


### PR DESCRIPTION
Addresses issue in dev.yml Workflow Dispatch where VLAB jobs were not created properly: https://github.com/githedgehog/dataplane/actions/runs/20379018360
<img width="1834" height="745" alt="image" src="https://github.com/user-attachments/assets/617a00d5-3877-4564-bd7b-f80a95ffe9a2" />

With this PR:
https://github.com/githedgehog/dataplane/actions/runs/20380250628
<img width="1827" height="734" alt="image" src="https://github.com/user-attachments/assets/96019ab6-e8ac-4ead-9edc-fd9eaa613a92" />
