### PR TITLE
feat(pkt-meta): Add debug message for ambiguous dst_vpcd lookup result

### DIFF
--- a/pkt-meta/src/dst_vpcd_lookup/mod.rs
+++ b/pkt-meta/src/dst_vpcd_lookup/mod.rs
@@ -269,6 +269,9 @@ impl DstVpcdLookup {
                     // pipeline stage to see if we have a session that can help us determine the
                     // right destination VPC. So, we do NOT mark the packet as "done" here, we just
                     // pass it along with no dst_vpcd attached.
+                    debug!(
+                        "{nfi}: ambiguous dst_vpcd for {dst_ip} in src_vpcd {src_vpcd}: falling back to flow table lookup to see if a session exists"
+                    );
                 }
             } else {
                 debug!(


### PR DESCRIPTION
When we fail to find one destination VPC discriminant from the lookup in the related pipeline stage because we may have several possible matches, we fall back to the flow table lookup stage, to see if there's an existing stateful NAT session with associated destination VPC information.

This fallback to the flow session table is the only case for which the `dst_vpcd_lookup` stage does not print any debug message, which may be confusing because we're unsure we went through the stage as expected when looking at debug logs; it confused us before. Add a debug log message for that case, too.

Link: https://github.com/githedgehog/fabricator/issues/1269#issuecomment-3675494287
