### PR TITLE
ci: Fix bump.yml workflow with regards to 'cargo upgrade' output format

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -87,21 +87,25 @@ jobs:
           BASE="$(git rev-parse HEAD)"
 
           # Run "cargo update"
+          echo "::notice::Running cargo update"
           just cargo update
           if ! git diff --quiet; then
+              echo "Found changes after cargo update, creating commit"
               git add Cargo.lock
               git commit -sm "bump(cargo)!: bump dependencies (cargo update)"
           fi
 
           # Check updates available with "cargo upgrade",
           # then bump each package individually through separate commits
-          just cargo upgrade --incompatible=allow --dry-run > upgrade_output.txt
-          sed '/^====/d; /^name .* new req$/d; s/ .*//' upgrade_output.txt > list_packages.txt
+          echo "::notice::Looking for depencies to upgrade"
+          just cargo upgrade --incompatible=allow --dry-run | tee upgrade_output.txt
+          sed '/^====/d; /^name .*old req .*new req/d; s/ .*//' upgrade_output.txt > list_packages.txt
           nb_upgrades=$(wc -l < list_packages.txt)
 
           echo "Found the following ${nb_upgrades} upgrade(s) available:"
           cat list_packages.txt
 
+          echo "::notice::Upgrading packages that need an upgrade (if any), one by one"
           while read -r package; do
               echo "bump(cargo)!: bump $package (cargo upgrade)" | tee commit_msg.txt
               echo '' | tee -a commit_msg.txt


### PR DESCRIPTION
When doing cargo upgrades, we upgrade packages one by one, to have each bump in a separate commit (to make it easier to run bisection in case upgrades break something). And to list dependencies to upgrade one by one, we parse the output from a preliminary, dry run of `cargo upgrade`.

Parsing the output is broken at the moment. The `sed` command we use to process the output expects `new req` to be present at the end of the string for the header of the generated tables, but "cargo upgrade" may add padding spaces at the end of the string when generating the columns, see the example output below:

    name        old req       compatible    latest        new req␣␣␣␣␣␣
    ====        =======       ==========    ======        =======␣␣␣␣␣␣
    k8s-openapi 0.26.1        0.26.1        0.27.0        0.27.0␣␣␣␣␣␣␣
    kube        2.0.1         2.0.1         3.0.0         3.0.0␣␣␣␣␣␣␣␣
    libc        1.0.0-alpha.1 1.0.0-alpha.2 1.0.0-alpha.2 1.0.0-alpha.2
    ordermap    1.0.0         1.1.0         1.1.0         1.1.0␣␣␣␣␣␣␣␣
    proc-macro2 1.0.104       1.0.105       1.0.105       1.0.105␣␣␣␣␣␣
    quote       1.0.42        1.0.43        1.0.43        1.0.43␣␣␣␣␣␣␣
    rapidhash   4.2.0         4.2.1         4.2.1         4.2.1␣␣␣␣␣␣␣␣
    rustls      0.23.35       0.23.36       0.23.36       0.23.36␣␣␣␣␣␣
    serde_json  1.0.148       1.0.149       1.0.149       1.0.149␣␣␣␣␣␣
    small-map   0.1.4         0.1.5         0.1.5         0.1.5␣␣␣␣␣␣␣␣
    syn         2.0.113       2.0.114       2.0.114       2.0.114␣␣␣␣␣␣
    url         2.5.7         2.5.8         2.5.8         2.5.8␣␣␣␣␣␣␣␣

As a result, we don't delete the header row with sed, and try to upgrade a non-existent `name` dependency, making the workflow fail.

I suppose we never hit this before because `new req` is usually as long as the version numbers in the column, and doesn't usually need additional padding at the end, but looking at the sample output above it seems that libc's version number, with its `-alpha.2` suffix, is longer than usual. This is likely what trigger the issue.

Let's fix the sed command by supporting spaces at the end. As a reminder, we can't just discard the first two lines of the file, because we may have two tables in the file (and two headers to discard) if there are upgrades available for the CLI, too.
