### PR TITLE
set alloc feature in chrono dependency

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,7 +14,7 @@ tracectl = { workspace = true }
 k8s-intf = { workspace = true }
 
 # external
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["alloc"] }
 derive_builder = { workspace = true, default-features = false, features = ["default"] }
 ipnet = { workspace = true }
 linkme = { workspace = true }


### PR DESCRIPTION
Enable the alloc feature of chrono. Otherwise, tests for config fail if run separately.