### PR TITLE
bump: dataplane version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "afpacket",
  "arrayvec",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-args"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytecheck",
  "clap",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode2",
  "clap",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dataplane-concurrency-macros",
  "loom",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency-macros"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bolero",
  "caps",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sys"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bindgen",
  "dataplane-dpdk-sysroot-helper",
@@ -1285,18 +1285,18 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "dataplane-errno"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "dataplane-flow-info"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atomic-instant-full",
  "dataplane-concurrency",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-hardware"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bolero",
  "bytecheck",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-id"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bolero",
  "rkyv",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-init"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-hardware",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-interface-manager"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bolero",
  "dataplane-net",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-intf"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bolero",
  "dataplane-hardware",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-less"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dataplane-k8s-intf",
  "dataplane-tracectl",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-left-right-tlcache"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "left-right",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-lpm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bnum",
  "bolero",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-mgmt"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "bolero",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-nat"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-net"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pipeline"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "dataplane-id",
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pkt-meta"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "bolero",
@@ -1587,11 +1587,11 @@ dependencies = [
 
 [[package]]
 name = "dataplane-rekon"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 name = "dataplane-routing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "bitflags 2.10.0",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-stats"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrayvec",
  "bolero",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-sysfs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-id",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-test-utils"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "caps",
  "nix 0.30.1",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-tracectl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "color-eyre",
  "linkme",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-vpcmap"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
The main motivation for the new version is to have fabricator pull https://github.com/githedgehog/dataplane/pull/1197 to (hopefully) fix stateful NAT and add related tests.

Do not merge before https://github.com/githedgehog/dataplane/pull/1197 is in.