### PR TITLE
bump: Bump patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "afpacket",
  "arrayvec",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-args"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytecheck",
  "clap",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bincode2",
  "clap",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-concurrency-macros",
  "loom",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency-macros"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bolero",
  "caps",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bindgen",
  "dataplane-dpdk-sysroot-helper",
@@ -1286,18 +1286,18 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "dataplane-errno"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dataplane-flow-entry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "bolero",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-filter"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-config",
  "dataplane-lpm",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-info"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atomic-instant-full",
  "dataplane-concurrency",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-hardware"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bolero",
  "bytecheck",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-id"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bolero",
  "rkyv",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-init"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-hardware",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-interface-manager"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bolero",
  "dataplane-net",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-intf"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bolero",
  "dataplane-hardware",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-less"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-k8s-intf",
  "dataplane-tracectl",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-left-right-tlcache"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "left-right",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-lpm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bnum",
  "bolero",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-mgmt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "bolero",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-nat"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-net"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pipeline"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "dataplane-id",
@@ -1604,11 +1604,11 @@ dependencies = [
 
 [[package]]
 name = "dataplane-rekon"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "dataplane-routing"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "bitflags 2.10.0",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-stats"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrayvec",
  "bolero",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-sysfs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-id",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-test-utils"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "caps",
  "nix 0.30.1",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-tracectl"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "color-eyre",
  "linkme",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-validator"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "dataplane-config",
  "dataplane-k8s-intf",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-vpcmap"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Bump patch version number so that the fabric can pick the recent important fixes from dataplane.

We want to merge this once at least the following PRs are in:
- #1226 
- #1227