### PR TITLE
feat(config): Reject VpcExpose with stateful NAT and port ranges

### DIFF
--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -803,6 +803,38 @@ pub mod test {
                 PrefixWithPortsSize::from(256u32 * 1000),
             ))
         );
+
+        // Incorrect: stateful NAT ips() with ports
+        let expose = VpcExpose::empty()
+            .make_stateful_nat(None)
+            .unwrap()
+            .ip(PrefixWithOptionalPorts::new(
+                "10.0.0.0/16".into(),
+                Some(PortRange::new(5001, 6000).unwrap()),
+            ))
+            .as_range(PrefixWithOptionalPorts::new("2.0.0.0/24".into(), None));
+        assert_eq!(
+            expose.validate(),
+            Err(ConfigError::Forbidden(
+                "Port ranges are not supported with stateful NAT",
+            ))
+        );
+
+        // Incorrect: stateful NAT as_range() with ports
+        let expose = VpcExpose::empty()
+            .make_stateful_nat(None)
+            .unwrap()
+            .ip(PrefixWithOptionalPorts::new("10.0.0.0/16".into(), None))
+            .as_range(PrefixWithOptionalPorts::new(
+                "2.0.0.0/24".into(),
+                Some(PortRange::new(8001, 9000).unwrap()),
+            ));
+        assert_eq!(
+            expose.validate(),
+            Err(ConfigError::Forbidden(
+                "Port ranges are not supported with stateful NAT",
+            ))
+        );
     }
 
     #[test]

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -459,7 +459,17 @@ impl VpcExpose {
             ));
         }
 
-        // 6. Forbid empty ips list if not is non-empty.
+        // 6. For stateful NAT, we don't support port ranges
+        if self.has_stateful_nat()
+            && (self.ips.iter().any(|p| p.ports().is_some())
+                || self.as_range_or_empty().iter().any(|p| p.ports().is_some()))
+        {
+            return Err(ConfigError::Forbidden(
+                "Port ranges are not supported with stateful NAT",
+            ));
+        }
+
+        // 7. Forbid empty ips list if not is non-empty.
         //    Forbid empty as_range list if not_as is non-empty.
         //    These configurations are allowed by the user API, but we don't currently support them,
         //    so we reject them during validation.

--- a/nat/src/stateful/apalloc/setup.rs
+++ b/nat/src/stateful/apalloc/setup.rs
@@ -221,6 +221,7 @@ fn create_natpool<J: NatIpWithBitmap>(
     let (bitmap_mapping, reverse_bitmap_mapping) = create_ipv6_bitmap_mappings(
         &prefixes
             .iter()
+            // FIXME: Add port range, too
             .map(PrefixWithOptionalPorts::prefix)
             .collect::<BTreeSet<Prefix>>(),
     )?;


### PR DESCRIPTION
We don't currently support port ranges with stateful NAT.

- On the "ips" side, we don't account for port ranges when building the context. If there's no overlapping IP prefixes, this should work fine, with the flow-filter taking care of denying packets using ports that are out of the specified range. But if there are some overlapping IP prefixes in use between different peerings for a given VPC, made disjoint only through their associated port ranges, then the allocator won't be able to find the right destination (or more likely, will fail to build properly because we'll try to overwrite an existing entry).

- On the "as" side, we don't take port ranges into account when allocating ports for the translated traffic, meaning we will likely translate packets using ports that are not in the provided range. This is in breach with what the user requires, and will also cause the return traffic to be dropped by the flow-filter stage.

We may support port ranges with stateful NAT in the future, but we're just not there yet. To avoid users hitting the issues mentioned above, reject configurations that use both stateful NAT and port ranges.
