### PR TITLE
revert: "fix(ci): disable upgrade jobs in merge queues"

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -417,7 +417,6 @@ jobs:
       # ci:-vlab disables virtual lab tests on PR
       # ci:-upgrade disables upgrade tests on PR
       # hlab is disabled for main and merge_queue till we have gateway tests for it
-      # upgrade jobs are temporarily skipped in merge_queue until we fix the issue with 25.05
       skip: >-
         ${{
           github.event_name == 'pull_request'
@@ -434,7 +433,7 @@ jobs:
           )
 
           || (github.event_name == 'push' || github.event_name == 'merge_group')
-          && (matrix.hybrid || matrix.upgradefrom != '')
+          && matrix.hybrid
         }}
       fabricatorref: master
       prebuild: "just bump dataplane ${{ needs.version.outputs.version }}-release"


### PR DESCRIPTION
This reverts commit dce2a6e536b292411957bcf49d493ba7f030726d.

Upgrade jobs are way more stable now

Fixes #1095 