### PR TITLE
build: Bump Rust version in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # NOTE: you can and should manually update this on new rust releases
-channel = "1.92.0"
+channel = "1.93.0"
 
 components = [
   "rustc",


### PR DESCRIPTION
We bumped the version in dpdk-sys, but haven't updated file rust-toolchain.toml yet.
