### PR TITLE
ci: Disable VLAB tests for Pull Request by default

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -414,7 +414,7 @@ jobs:
     uses: githedgehog/fabricator/.github/workflows/run-vlab.yaml@master
     with:
       # ci:+hlab is required to enable hybrid lab tests on PR
-      # ci:-vlab disables virtual lab tests on PR
+      # ci:+vlab is required to enable virtual lab tests on PR
       # ci:-upgrade disables upgrade tests on PR
       # hlab is disabled for main and merge_queue till we have gateway tests for it
       skip: >-
@@ -422,7 +422,7 @@ jobs:
           github.event_name == 'pull_request'
           && (
             matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+hlab')
-            || !matrix.hybrid && contains(github.event.pull_request.labels.*.name, 'ci:-vlab')
+            || !matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+vlab')
             || matrix.upgradefrom != '' && contains(github.event.pull_request.labels.*.name, 'ci:-upgrade')
           )
 


### PR DESCRIPTION
The VLAB tests take a long time to run, and we run them both for the PR and in the merge queue. This commit disables them, by default, for Pull Requests, but they remain enabled for the merge queue.

The idea is to save time for most Pull Requests. If the VLAB tests break, we'll still catch it from the merge queue - it's not ideal as we prefer early feedback, but we don't expect this to happen very often. We can revisit if the assumption doesn't hold.

For changes that are more likely to change the way the dataplane interacts with the fabric, contributors can, and should, enable VLAB tests explicitly by adding the "ci:+vlab" label to their Pull Request before running the checks.

This is one part of various changes that we've recently discussed to shorten CI duration for dataplane.