### PR TITLE
chore: Mark npins/* files as generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 k8s-intf/src/generated/** linguist-generated
 k8s-intf/src/generated/mod.rs -linguist-generated
+npins/* linguist-generated


### PR DESCRIPTION
Let GitHub, for example, know that these files are generated and that we don't usually need to see the diff while reviewing Pull Requests.
