### PR TITLE
fix(status): Flush previously collected statistics

### DIFF
--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -210,6 +210,11 @@ impl ConfigProcessor {
             guard.clone()
         };
 
+        //flush old VPC stats
+        status.vpcs.clear();
+        status.vpc_peering_counters.clear();
+        status.vpc_counters.clear();
+
         let stats_store = &self.proc_params.vpc_stats_store;
 
         let names = stats_store.snapshot_names().await;


### PR DESCRIPTION
Filter out and remove VPCs entries that are no longer in the list of alive VPCs (collect them during new cfg request)