### PR TITLE
bump: Bump minor version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "afpacket",
  "arrayvec",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-args"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytecheck",
  "clap",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode2",
  "clap",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-concurrency-macros",
  "loom",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "caps",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sys"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bindgen",
  "dataplane-dpdk-sysroot-helper",
@@ -1290,18 +1290,18 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "dataplane-errno"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dataplane-flow-entry"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "bolero",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-filter"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-config",
  "dataplane-lpm",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-info"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "atomic-instant-full",
  "dataplane-concurrency",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-hardware"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "bytecheck",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-id"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "rkyv",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-init"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-hardware",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-interface-manager"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "dataplane-net",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-intf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "dataplane-hardware",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-less"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-k8s-intf",
  "dataplane-tracectl",
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-left-right-tlcache"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "left-right",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-lpm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bnum",
  "bolero",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-mgmt"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bolero",
  "bytes",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-nat"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-net"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pipeline"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arc-swap",
  "dataplane-id",
@@ -1593,11 +1593,11 @@ dependencies = [
 
 [[package]]
 name = "dataplane-rekon"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "dataplane-routing"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-stats"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrayvec",
  "bolero",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-sysfs"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "n-vm",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "caps",
  "nix 0.31.1",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-tracectl"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "color-eyre",
  "linkme",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-validator"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dataplane-config",
  "dataplane-k8s-intf",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-vpcmap"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
[Quentin] New minor version to pull support for BMP (https://github.com/githedgehog/dataplane/pull/1130) from fabricator