### PR TITLE
ci: Update filter for devfiles (exclude files not requiring a CI run)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           filters: |
             devfiles:
-              - '!(README.md|LICENSE|.gitattributes|.gitignore|.github/**)'
+              - '!(README.md|LICENSE|NOTICE|.zed/**|.vscode/**|CLAUDE.md|.rules|development/**|testing.md|workspace-deps.svg|codebook.toml|.markdownlint.json|.gitattributes|.gitignore|.github/**)'
               - '.github/workflows/dev.yml'
 
   version:


### PR DESCRIPTION
Update the "devfiles" filter that we use in the dev.yml workflow to determine whether or not we need to run the CI on a Pull Requests. There a number of files that do not require any testing from the workflow: add them as exceptions, so that they will not trigger a full CI run for Pull Requests only changing them.
