### PR TITLE
Remove bidirectional keys from flow entry FlowKeys

### DIFF
--- a/flow-entry/src/flow_table/flow_key.rs
+++ b/flow-entry/src/flow_table/flow_key.rs
@@ -25,6 +25,7 @@ pub enum FlowKeyError {
     NoFlowKeyData,
 }
 
+#[cfg(test)]
 trait SrcLeqDst {
     fn src_leq_dst(&self) -> bool;
 }
@@ -47,6 +48,7 @@ trait SrcDstPort {
             || (self.src_port() == other.dst_port() && self.dst_port() == other.src_port())
     }
 
+    #[cfg(test)]
     fn src_leq_dst(&self) -> bool {
         self.src_port() <= self.dst_port()
     }
@@ -360,6 +362,7 @@ impl IpProtoKey {
     }
 }
 
+#[cfg(test)]
 impl SrcLeqDst for IpProtoKey {
     fn src_leq_dst(&self) -> bool {
         match self {
@@ -442,43 +445,6 @@ impl FlowKeyData {
         &self.proto_key_info
     }
 
-    #[must_use]
-    fn symmetric_eq(&self, other: &Self) -> bool {
-        // Straightforward comparison
-        let src_to_src = self.src_vpcd == other.src_vpcd
-            && self.dst_vpcd == other.dst_vpcd
-            && self.src_ip == other.src_ip
-            && self.dst_ip == other.dst_ip
-            && self.proto_key_info == other.proto_key_info;
-
-        // Src to dst
-        src_to_src
-            || self.src_vpcd == other.dst_vpcd
-                && self.dst_vpcd == other.src_vpcd
-                && self.src_ip == other.dst_ip
-                && self.dst_ip == other.src_ip
-                && self.proto_key_info == other.proto_key_info.reverse()
-    }
-
-    fn symmetric_hash<H: Hasher>(&self, state: &mut H) {
-        0xb1d1_u16.hash(state); // Magic number to make sure the hash is different for bidirectional and unidirectional flows
-        if self.src_leq_dst() {
-            self.src_vpcd.hash(state);
-            self.src_ip.hash(state);
-            self.proto_key_info.hash_src(state);
-            self.dst_vpcd.hash(state);
-            self.dst_ip.hash(state);
-            self.proto_key_info.hash_dst(state);
-        } else {
-            self.dst_vpcd.hash(state);
-            self.dst_ip.hash(state);
-            self.proto_key_info.hash_dst(state);
-            self.src_vpcd.hash(state);
-            self.src_ip.hash(state);
-            self.proto_key_info.hash_src(state);
-        }
-    }
-
     /// Creates a new flow key with src and dst swapped
     #[must_use]
     pub fn reverse(&self) -> Self {
@@ -492,6 +458,7 @@ impl FlowKeyData {
     }
 }
 
+#[cfg(test)]
 impl SrcLeqDst for FlowKeyData {
     fn src_leq_dst(&self) -> bool {
         match (self.src_vpcd, self.dst_vpcd) {
@@ -525,7 +492,6 @@ impl Hash for FlowKeyData {
 
 #[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
 pub enum FlowKey {
-    Bidirectional(FlowKeyData),
     Unidirectional(FlowKeyData),
 }
 
@@ -533,7 +499,7 @@ impl FlowKey {
     #[must_use]
     pub fn data(&self) -> &FlowKeyData {
         match self {
-            FlowKey::Bidirectional(data) | FlowKey::Unidirectional(data) => data,
+            FlowKey::Unidirectional(data) => data,
         }
     }
 
@@ -557,31 +523,10 @@ impl FlowKey {
         ))
     }
 
-    /// Create a bidirectional flow key
-    ///
-    /// packets with src -> dst and dst -> src will match and hash to the same value.
-    #[must_use]
-    pub fn bidi(
-        src_vpcd: Option<VpcDiscriminant>,
-        src_ip: IpAddr,
-        dst_vpcd: Option<VpcDiscriminant>, // If None, the dst_vpcd is ambiguous and the flow table is needed to resolve it
-        dst_ip: IpAddr,
-        proto_key_info: IpProtoKey,
-    ) -> FlowKey {
-        FlowKey::Bidirectional(FlowKeyData::new(
-            src_vpcd,
-            src_ip,
-            dst_vpcd,
-            dst_ip,
-            proto_key_info,
-        ))
-    }
-
     // Creates the flow key with src and dst swapped
     #[must_use]
     pub fn reverse(&self) -> FlowKey {
         match self {
-            FlowKey::Bidirectional(data) => FlowKey::Bidirectional(data.reverse()),
             FlowKey::Unidirectional(data) => FlowKey::Unidirectional(data.reverse()),
         }
     }
@@ -591,9 +536,7 @@ impl FlowKey {
 impl PartialEq for FlowKey {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (FlowKey::Bidirectional(a), FlowKey::Bidirectional(b)) => a.symmetric_eq(b),
             (FlowKey::Unidirectional(a), FlowKey::Unidirectional(b)) => a == b,
-            _ => false,
         }
     }
 }
@@ -601,7 +544,6 @@ impl PartialEq for FlowKey {
 impl Hash for FlowKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
-            FlowKey::Bidirectional(a) => a.symmetric_hash(state),
             FlowKey::Unidirectional(a) => a.hash(state),
         }
     }
@@ -621,21 +563,6 @@ impl Hash for FlowKey {
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct Uni<T>(pub T);
-
-/// Wrapper to specify bidirectional `FlowKey` creation
-///
-/// Example:
-/// ```
-/// # use dataplane_flow_entry::flow_table::FlowKey;
-/// # use dataplane_flow_entry::flow_table::flow_key::{Bidi};
-/// # use net::ip::NextHeader;
-/// # let packet = net::packet::test_utils::build_test_ipv4_packet_with_transport(100, Some(NextHeader::TCP)).unwrap();
-/// let flow_key = FlowKey::try_from(Bidi(&packet));
-/// # assert!(flow_key.is_ok());
-/// ```
-#[repr(transparent)]
-#[derive(Debug)]
-pub struct Bidi<T>(pub T);
 
 fn flow_key_data_from_packet<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Option<FlowKeyData> {
     let ip = packet.headers().try_ip()?;
@@ -682,28 +609,6 @@ impl<Buf: PacketBufferMut> TryFrom<Uni<&Packet<Buf>>> for FlowKey {
         } = flow_key_data_from_packet(packet).ok_or(FlowKeyError::NoFlowKeyData)?;
 
         Ok(FlowKey::uni(
-            src_vpcd,
-            src_ip,
-            dst_vpcd,
-            dst_ip,
-            proto_key_info,
-        ))
-    }
-}
-
-impl<Buf: PacketBufferMut> TryFrom<Bidi<&Packet<Buf>>> for FlowKey {
-    type Error = FlowKeyError;
-    fn try_from(packet: Bidi<&Packet<Buf>>) -> Result<Self, Self::Error> {
-        let packet = packet.0;
-        let FlowKeyData {
-            src_vpcd,
-            src_ip,
-            dst_vpcd,
-            dst_ip,
-            proto_key_info,
-        } = flow_key_data_from_packet(packet).ok_or(FlowKeyError::NoFlowKeyData)?;
-
-        Ok(FlowKey::bidi(
             src_vpcd,
             src_ip,
             dst_vpcd,
@@ -856,13 +761,8 @@ mod contract {
 
     impl TypeGenerator for FlowKey {
         fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
-            // Pick between Bidirectional and Unidirectional at random
-            let variant = driver.produce::<u8>()?;
             let data = FlowKeyData::generate(driver)?;
-            match variant % 2 {
-                0 => Some(FlowKey::Bidirectional(data)),
-                _ => Some(FlowKey::Unidirectional(data)),
-            }
+            Some(FlowKey::Unidirectional(data))
         }
     }
 }
@@ -966,35 +866,6 @@ mod tests {
     }
 
     #[test]
-    fn test_flow_key_symmetric_eq() {
-        let flow_key_1 = FlowKey::bidi(
-            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
-            "1.2.3.4".parse::<IpAddr>().unwrap(),
-            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
-            "1.2.3.5".parse::<IpAddr>().unwrap(),
-            IpProtoKey::Tcp(TcpProtoKey {
-                src_port: TcpPort::new_checked(1025).unwrap(),
-                dst_port: TcpPort::new_checked(2048).unwrap(),
-            }),
-        );
-
-        let flow_key_2 = FlowKey::bidi(
-            Some(VpcDiscriminant::VNI(Vni::new_checked(2).unwrap())),
-            "1.2.3.5".parse::<IpAddr>().unwrap(),
-            Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
-            "1.2.3.4".parse::<IpAddr>().unwrap(),
-            IpProtoKey::Tcp(TcpProtoKey {
-                src_port: TcpPort::new_checked(2048).unwrap(),
-                dst_port: TcpPort::new_checked(1025).unwrap(),
-            }),
-        );
-
-        assert_eq!(flow_key_1, flow_key_2);
-        assert_eq!(flow_key_1, flow_key_1);
-        assert_eq!(flow_key_2, flow_key_2);
-    }
-
-    #[test]
     fn test_flow_key_reverse() {
         let flow_key = FlowKey::uni(
             Some(VpcDiscriminant::VNI(Vni::new_checked(1).unwrap())),
@@ -1017,32 +888,6 @@ mod tests {
             flow_key.data().proto_key_info,
             reverse_flow_key.data().proto_key_info.reverse()
         );
-    }
-
-    #[test]
-    fn test_flow_key_bidi_hash() {
-        let flow_key = FlowKey::bidi(
-            None,
-            "1.2.3.4".parse::<IpAddr>().unwrap(),
-            None,
-            "4.5.6.7".parse::<IpAddr>().unwrap(),
-            IpProtoKey::Tcp(TcpProtoKey {
-                src_port: TcpPort::new_checked(1025).unwrap(),
-                dst_port: TcpPort::new_checked(2048).unwrap(),
-            }),
-        );
-
-        let reverse_flow_key = flow_key.reverse();
-
-        // Reverse should be equal to the original
-        assert_eq!(flow_key, reverse_flow_key);
-
-        // Hash should be the same
-        let mut hash = AHasher::default();
-        let mut reverse_hash = AHasher::default();
-        flow_key.hash(&mut hash);
-        reverse_flow_key.hash(&mut reverse_hash);
-        assert_eq!(hash.finish(), reverse_hash.finish());
     }
 
     #[test]
@@ -1147,7 +992,6 @@ mod tests {
         fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
             let packet = CommonPacket.generate(driver)?;
             let v6 = packet.headers().try_ipv6().is_some();
-            let bidi = driver.produce::<bool>()?;
             let (src_ip, dst_ip) = if v6 {
                 (
                     UnicastIpAddr::from(driver.produce::<UnicastIpv6Addr>()?).into(),
@@ -1195,17 +1039,10 @@ mod tests {
                 },
             };
             if let Some(proto) = proto {
-                let (flow_key, mut packet) = if bidi {
-                    (
-                        FlowKey::bidi(src_vpcd, src_ip, dst_vpcd, dst_ip, proto),
-                        packet,
-                    )
-                } else {
-                    (
-                        FlowKey::uni(src_vpcd, src_ip, dst_vpcd, dst_ip, proto),
-                        packet,
-                    )
-                };
+                let (flow_key, mut packet) = (
+                    FlowKey::uni(src_vpcd, src_ip, dst_vpcd, dst_ip, proto),
+                    packet,
+                );
                 set_packet_fields(&mut packet, &flow_key);
                 Some((Some(flow_key), packet))
             } else {
@@ -1219,15 +1056,6 @@ mod tests {
         bolero::check!()
             .with_generator(FlowKeyAndPacket)
             .for_each(|(flow_key, packet)| match flow_key {
-                Some(FlowKey::Bidirectional(_)) => {
-                    let gen_flow_key = FlowKey::try_from(Bidi(packet)).unwrap();
-                    assert_eq!(
-                        gen_flow_key,
-                        flow_key.unwrap(),
-                        "Flow key mismatch: {gen_flow_key:#?} != {:#?}",
-                        flow_key.unwrap()
-                    );
-                }
                 Some(FlowKey::Unidirectional(_)) => {
                     let gen_flow_key = FlowKey::try_from(Uni(packet)).unwrap();
                     assert_eq!(
@@ -1239,7 +1067,6 @@ mod tests {
                 }
                 None => {
                     assert!(FlowKey::try_from(Uni(packet)).is_err());
-                    assert!(FlowKey::try_from(Bidi(packet)).is_err());
                 }
             });
     }

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -418,13 +418,8 @@ mod tests {
                     let flow_info_str = format!("{:?}", flow_table.lookup(flow_key).unwrap());
 
                     // We purposely keep the flow alive here to make sure lookup reaps it
-                    let flow_info = flow_table.lookup(flow_key).unwrap();
-                    if let FlowKey::Bidirectional(_) = flow_key {
-                        let reverse_info = flow_table.lookup(&flow_key.reverse()).unwrap();
-                        assert!(Arc::ptr_eq(&reverse_info, &flow_info));
-                    } else {
-                        assert!(flow_table.lookup(&flow_key.reverse()).is_none());
-                    }
+                    let _flow_info = flow_table.lookup(flow_key).unwrap();
+                    assert!(flow_table.lookup(&flow_key.reverse()).is_none());
 
                     thread::sleep(Duration::from_millis(100));
                     flow_table.reap_all_expired();
@@ -446,12 +441,7 @@ mod tests {
                 .for_each(|flow_key| {
                     flow_table.insert(*flow_key, FlowInfo::new(Instant::now()));
                     let flow_info = flow_table.lookup(flow_key).unwrap();
-                    if let FlowKey::Bidirectional(_) = flow_key {
-                        let reverse_info = flow_table.lookup(&flow_key.reverse()).unwrap();
-                        assert!(Arc::ptr_eq(&reverse_info, &flow_info));
-                    } else {
-                        assert!(flow_table.lookup(&flow_key.reverse()).is_none());
-                    }
+                    assert!(flow_table.lookup(&flow_key.reverse()).is_none());
 
                     let result = flow_table.remove(flow_key);
                     assert!(result.is_some());


### PR DESCRIPTION
* Removes Bidirectional flow keys.
* Only one type of key remains (unidirectional), but this commit does not remove the variant in case other types of keys are supported in the future and so as not to break the api.

The removal of the destination vpcd from the FlowkeyData will be done in a separate PR because there's several PRs that would be affected. cc @qmonnet 