### PR TITLE
bump: Bump dataplane version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "afpacket",
  "arrayvec",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-args"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytecheck",
  "clap",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bincode2",
  "clap",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-concurrency-macros",
  "loom",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "caps",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sys"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bindgen",
  "dataplane-dpdk-sysroot-helper",
@@ -1309,18 +1309,18 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "dataplane-errno"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dataplane-flow-entry"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "bolero",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-filter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-config",
  "dataplane-lpm",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-info"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "atomic-instant-full",
  "dataplane-concurrency",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-hardware"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "bytecheck",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-id"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "rkyv",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-init"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-hardware",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-interface-manager"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "dataplane-net",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-intf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "dataplane-hardware",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-less"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-k8s-intf",
  "dataplane-tracectl",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-left-right-tlcache"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "left-right",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-lpm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bnum",
  "bolero",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-mgmt"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bolero",
  "bytes",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-nat"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-net"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pipeline"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arc-swap",
  "dataplane-id",
@@ -1612,11 +1612,11 @@ dependencies = [
 
 [[package]]
 name = "dataplane-rekon"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "dataplane-routing"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-stats"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrayvec",
  "bolero",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-sysfs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "n-vm",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-test-utils"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "caps",
  "nix 0.31.1",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-tracectl"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "color-eyre",
  "linkme",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-validator"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dataplane-config",
  "dataplane-k8s-intf",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-vpcmap"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
We have several changes in this new version, but the main motivation for the version update is the adjustment for the new NAT API coming with the bump to gateway v0.42.0.

Pending on https://github.com/githedgehog/dataplane/pull/1255 - We want that PR merged before the version bump. Sergei's taking care of it.