### PR TITLE
ci: Remove broken parameter for run-vlab.yaml workflow, disable VLAB upgrade tests

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -461,9 +461,9 @@ jobs:
           - l2vni
         hybrid:
           - false
+        # Upgrade tests are disabled at the moment
         upgradefrom:
           - ""
-          - "25.05"
         include:
           # gateway l3vni
           - fabricmode: spine-leaf


### PR DESCRIPTION
The run-vlab.yml workflow that we pull from the Fabricator repository recently removed the deprecated "gateway_agentless" argument for the workflow (Fabricator commit afd17dc75f1a ("chore: do not pass agentless flag as it's noop")). As a result, our workflow in dataplane is currently broken:

    Invalid workflow file: .github/workflows/dev.yml#L442
    The workflow is not valid. .github/workflows/dev.yml (Line: 442, Col: 26): Invalid input, gateway_agentless is not defined in the referenced workflow.

Remove the parameter to fix the workflow.

Link: https://github.com/githedgehog/fabricator/commit/afd17dc75f1a827c807c215ed14985b7f608e9c9

In a second commit, we disable VLAB upgrade tests: Sergei reports they're not currently working (or supported) for tests running with the gateway.