### PR TITLE
feat(config): Remove NAT default to stateless NAT mode

### DIFF
--- a/config/src/converters/k8s/config/expose.rs
+++ b/config/src/converters/k8s/config/expose.rs
@@ -101,13 +101,17 @@ fn process_as_block(
             let prefix = cidr.parse::<Prefix>().map_err(|e| {
                 FromK8sConversionError::InvalidData(format!("CIDR format: {cidr}: {e}"))
             })?;
-            vpc_expose = vpc_expose.as_range(PrefixWithOptionalPorts::from(prefix));
+            vpc_expose = vpc_expose
+                .as_range(PrefixWithOptionalPorts::from(prefix))
+                .map_err(|e| FromK8sConversionError::MissingData(e.to_string()))?;
         }
         (None, Some(not)) => {
             let prefix = Prefix::try_from(PrefixString(not.as_str())).map_err(|e| {
                 FromK8sConversionError::InvalidData(format!("CIDR format: {not}: {e}"))
             })?;
-            vpc_expose = vpc_expose.not_as(PrefixWithOptionalPorts::from(prefix));
+            vpc_expose = vpc_expose
+                .not_as(PrefixWithOptionalPorts::from(prefix))
+                .map_err(|e| FromK8sConversionError::MissingData(e.to_string()))?;
         }
     }
     Ok(vpc_expose)

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -23,21 +23,29 @@ pub mod test {
     fn build_manifest_vpc1() -> VpcManifest {
         let mut m1 = VpcManifest::new("VPC-1");
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("10.0.0.0", 25)).into())
             .ip(Prefix::expect_from(("10.0.2.128", 25)).into())
             .not(Prefix::expect_from(("10.0.0.13", 32)).into())
             .not(Prefix::expect_from(("10.0.2.130", 32)).into())
             .as_range(Prefix::expect_from(("100.64.1.0", 24)).into())
+            .unwrap()
             .not_as(Prefix::expect_from(("100.64.1.13", 32)).into())
-            .not_as(Prefix::expect_from(("100.64.1.14", 32)).into());
+            .unwrap()
+            .not_as(Prefix::expect_from(("100.64.1.14", 32)).into())
+            .unwrap();
         m1.add_expose(expose);
         m1
     }
     fn build_manifest_vpc2() -> VpcManifest {
         let mut m2 = VpcManifest::new("VPC-2");
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("10.0.0.0", 24)).into())
-            .as_range(Prefix::expect_from(("100.64.2.0", 24)).into());
+            .as_range(Prefix::expect_from(("100.64.2.0", 24)).into())
+            .unwrap();
 
         m2.add_expose(expose);
         m2
@@ -112,36 +120,42 @@ pub mod test {
         */
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
-            .as_range("2.0.0.0/16".into());
+            .as_range("2.0.0.0/16".into())
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .not("10.0.0.0/24".into())
             .as_range("2.0.0.0/16".into())
-            .not_as("2.0.0.0/24".into());
+            .unwrap()
+            .not_as("2.0.0.0/24".into())
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("1::/64".into())
-            .as_range("2::/64".into());
+            .as_range("2::/64".into())
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
-
-        // Empty ips/as_range but non-empty nots/not_as - Currently not supported
-        /*
-        let expose = VpcExpose::empty()
-            .not("10.0.0.0/16".into())
-            .not_as("2.0.0.0/16".into());
-        assert_eq!(expose.validate(), Ok(()));
-        */
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .ip("1::/64".into())
             .as_range("2.0.0.0/16".into())
-            .as_range("2::/64".into());
+            .unwrap()
+            .as_range("2::/64".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
@@ -149,8 +163,11 @@ pub mod test {
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
-            .as_range("1::/112".into());
+            .as_range("1::/112".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
@@ -158,10 +175,14 @@ pub mod test {
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .not("1::/120".into())
             .as_range("2.0.0.0/16".into())
-            .not_as("2::/120".into());
+            .unwrap()
+            .not_as("2::/120".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
@@ -169,10 +190,14 @@ pub mod test {
 
         // Incorrect: prefix overlapping
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .ip("10.0.0.0/17".into())
             .as_range("2.0.0.0/16".into())
-            .as_range("3.0.0.0/17".into());
+            .unwrap()
+            .as_range("3.0.0.0/17".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::OverlappingPrefixes(
@@ -183,10 +208,14 @@ pub mod test {
 
         // Incorrect: out-of-range exclusion prefix
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .not("8.0.0.0/24".into())
             .as_range("2.0.0.0/16".into())
-            .not_as("2.0.1.0/24".into());
+            .unwrap()
+            .not_as("2.0.1.0/24".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::OutOfRangeExclusionPrefix("8.0.0.0/24".into()))
@@ -194,12 +223,17 @@ pub mod test {
 
         // Incorrect: all prefixes excluded
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .not("10.0.0.0/17".into())
             .not("10.0.128.0/17".into())
             .as_range("2.0.0.0/16".into())
+            .unwrap()
             .not_as("2.0.0.0/17".into())
-            .not_as("2.0.128.0/17".into());
+            .unwrap()
+            .not_as("2.0.128.0/17".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::ExcludedAllPrefixes(Box::new(expose.clone())))
@@ -207,9 +241,12 @@ pub mod test {
 
         // Incorrect: mismatched prefix lists sizes
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("10.0.0.0/16".into())
             .not("10.0.1.0/24".into())
-            .as_range("2.0.0.0/24".into());
+            .as_range("2.0.0.0/24".into())
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::MismatchedPrefixSizes(
@@ -222,20 +259,32 @@ pub mod test {
     #[test]
     fn test_manifest_expose_overlap() {
         let expose1 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("1.0.0.0/16".into()) // expose3 overlaps with this
             .ip("2.0.0.0/16".into())
             .ip("3.0.0.0/16".into())
             .as_range("11.0.0.0/16".into())
+            .unwrap()
             .as_range("12.0.0.0/16".into())
-            .as_range("13.0.0.0/16".into());
+            .unwrap()
+            .as_range("13.0.0.0/16".into())
+            .unwrap();
         let expose2 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("4.0.0.0/16".into())
-            .as_range("14.0.0.0/16".into());
+            .as_range("14.0.0.0/16".into())
+            .unwrap();
         let expose3 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("5.0.0.0/16".into())
             .ip("1.0.1.0/24".into()) // overlaps with expose1.ips
             .as_range("15.0.0.0/16".into())
-            .as_range("16.0.0.0/24".into());
+            .unwrap()
+            .as_range("16.0.0.0/24".into())
+            .unwrap();
         let expose4 = VpcExpose::empty()
             .ip("6.0.0.0/16".into())
             .ip("12.0.2.0/24".into()); // overlaps with expose1.as_range (no as_range for expose4)
@@ -304,7 +353,8 @@ pub mod test {
                         .make_stateful_nat(None)
                         .unwrap()
                         .ip("1.0.0.0/8".into())
-                        .as_range("2.0.0.0/8".into()),
+                        .as_range("2.0.0.0/8".into())
+                        .unwrap(),
                 ],
             },
             VpcManifest {
@@ -314,7 +364,8 @@ pub mod test {
                         .make_stateful_nat(None)
                         .unwrap()
                         .ip("3.0.0.0/8".into())
-                        .as_range("4.0.0.0/8".into()),
+                        .as_range("4.0.0.0/8".into())
+                        .unwrap(),
                 ],
             },
         );
@@ -350,7 +401,8 @@ pub mod test {
                         .make_stateful_nat(None)
                         .unwrap()
                         .ip("1.0.0.0/8".into())
-                        .as_range("2.0.0.0/8".into()),
+                        .as_range("2.0.0.0/8".into())
+                        .unwrap(),
                 ],
             },
             VpcManifest {
@@ -360,7 +412,8 @@ pub mod test {
                         .make_stateless_nat()
                         .unwrap()
                         .ip("3.0.0.0/8".into())
-                        .as_range("4.0.0.0/8".into()),
+                        .as_range("4.0.0.0/8".into())
+                        .unwrap(),
                 ],
             },
         );
@@ -506,11 +559,15 @@ pub mod test {
             m1.add_expose(expose);
 
             let expose = VpcExpose::empty()
+                .make_stateless_nat()
+                .unwrap()
                 .ip(Prefix::expect_from(("192.168.111.0", 24)).into())
                 .not(Prefix::expect_from(("192.168.111.2", 32)).into())
                 .not(Prefix::expect_from(("192.168.111.254", 32)).into())
                 .as_range(Prefix::expect_from(("100.64.200.0", 24)).into())
-                .not_as(Prefix::expect_from(("100.64.200.12", 31)).into());
+                .unwrap()
+                .not_as(Prefix::expect_from(("100.64.200.12", 31)).into())
+                .unwrap();
             m1.add_expose(expose);
             m1
         }
@@ -553,8 +610,11 @@ pub mod test {
             m1.add_expose(expose);
 
             let expose = VpcExpose::empty()
+                .make_stateless_nat()
+                .unwrap()
                 .ip(Prefix::expect_from(("192.168.204.4", 32)).into())
-                .as_range(Prefix::expect_from(("100.64.204.4", 32)).into());
+                .as_range(Prefix::expect_from(("100.64.204.4", 32)).into())
+                .unwrap();
             m1.add_expose(expose);
 
             let expose = VpcExpose::empty()
@@ -663,6 +723,8 @@ pub mod test {
         assert_eq!(expose.validate(), Ok(()));
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -670,10 +732,13 @@ pub mod test {
             .as_range(PrefixWithOptionalPorts::new(
                 "2.0.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -686,13 +751,17 @@ pub mod test {
                 "2.0.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
             ))
+            .unwrap()
             .not_as(PrefixWithOptionalPorts::new(
                 "2.0.0.0/25".into(),
                 Some(PortRange::new(8001, 8200).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "1::/64".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -700,7 +769,8 @@ pub mod test {
             .as_range(PrefixWithOptionalPorts::new(
                 "2::/64".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(expose.validate(), Ok(()));
 
         // Overlapping prefix, but distinct port ranges
@@ -717,6 +787,8 @@ pub mod test {
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -729,10 +801,12 @@ pub mod test {
                 "2.0.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "2::/64".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
@@ -740,6 +814,8 @@ pub mod test {
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -747,7 +823,8 @@ pub mod test {
             .as_range(PrefixWithOptionalPorts::new(
                 "1::/112".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
@@ -755,6 +832,8 @@ pub mod test {
 
         // Incorrect: prefix overlapping
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -767,10 +846,12 @@ pub mod test {
                 "2.0.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "3.0.0.0/17".into(),
                 Some(PortRange::new(8001, 8500).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::OverlappingPrefixes(
@@ -870,6 +951,8 @@ pub mod test {
 
         // Incorrect: mismatched prefix lists sizes
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(PrefixWithOptionalPorts::new(
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
@@ -881,7 +964,8 @@ pub mod test {
             .as_range(PrefixWithOptionalPorts::new(
                 "2.0.0.0/24".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::MismatchedPrefixSizes(
@@ -898,7 +982,8 @@ pub mod test {
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(5001, 6000).unwrap()),
             ))
-            .as_range(PrefixWithOptionalPorts::new("2.0.0.0/24".into(), None));
+            .as_range(PrefixWithOptionalPorts::new("2.0.0.0/24".into(), None))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::Forbidden(
@@ -914,7 +999,8 @@ pub mod test {
             .as_range(PrefixWithOptionalPorts::new(
                 "2.0.0.0/24".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         assert_eq!(
             expose.validate(),
             Err(ConfigError::Forbidden(

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -48,14 +48,7 @@ pub enum VpcExposeNatConfig {
     PortForwarding(VpcExposePortForwarding),
 }
 
-impl Default for VpcExposeNatConfig {
-    fn default() -> Self {
-        #[allow(clippy::default_constructed_unit_structs)]
-        VpcExposeNatConfig::Stateless(VpcExposeStatelessNat::default())
-    }
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VpcExposeNat {
     pub as_range: PrefixPortsSet,
     pub not_as: PrefixPortsSet,
@@ -64,6 +57,16 @@ pub struct VpcExposeNat {
 }
 
 impl VpcExposeNat {
+    #[must_use]
+    pub fn from_config(config: VpcExposeNatConfig) -> Self {
+        Self {
+            as_range: PrefixPortsSet::new(),
+            not_as: PrefixPortsSet::new(),
+            config,
+            proto: L4Protocol::default(),
+        }
+    }
+
     #[must_use]
     pub fn is_stateful(&self) -> bool {
         matches!(self.config, VpcExposeNatConfig::Stateful(_))
@@ -95,14 +98,6 @@ pub struct VpcExpose {
     pub nat: Option<VpcExposeNat>,
 }
 impl VpcExpose {
-    #[must_use]
-    pub fn make_nat(mut self) -> Self {
-        if self.nat.is_none() {
-            self.nat = Some(VpcExposeNat::default());
-        }
-        self
-    }
-
     // Make the [`VpcExpose`] use stateless NAT.
     //
     // # Errors
@@ -115,10 +110,9 @@ impl VpcExpose {
                 "refusing to overwrite previous NAT mode with stateless NAT mode for VpcExpose {self}"
             ))),
             None => {
-                self.nat = Some(VpcExposeNat {
-                    config: VpcExposeNatConfig::Stateless(VpcExposeStatelessNat {}),
-                    ..VpcExposeNat::default()
-                });
+                self.nat = Some(VpcExposeNat::from_config(VpcExposeNatConfig::Stateless(
+                    VpcExposeStatelessNat {},
+                )));
                 Ok(self)
             }
         }
@@ -147,10 +141,9 @@ impl VpcExpose {
             ))),
 
             None => {
-                self.nat = Some(VpcExposeNat {
-                    config: VpcExposeNatConfig::Stateful(options),
-                    ..VpcExposeNat::default()
-                });
+                self.nat = Some(VpcExposeNat::from_config(VpcExposeNatConfig::Stateful(
+                    options,
+                )));
                 Ok(self)
             }
         }
@@ -177,10 +170,9 @@ impl VpcExpose {
                 "refusing to overwrite previous NAT mode with port forwarding for VpcExpose {self}"
             ))),
             None => {
-                self.nat = Some(VpcExposeNat {
-                    config: VpcExposeNatConfig::PortForwarding(options),
-                    ..VpcExposeNat::default()
-                });
+                self.nat = Some(VpcExposeNat::from_config(
+                    VpcExposeNatConfig::PortForwarding(options),
+                ));
                 Ok(self)
             }
         }
@@ -240,23 +232,19 @@ impl VpcExpose {
         self.nots.insert(prefix);
         self
     }
-    #[must_use]
-    pub fn as_range(self, prefix: PrefixWithOptionalPorts) -> Self {
-        let mut ret = self.make_nat();
-        let Some(nat) = ret.nat.as_mut() else {
-            unreachable!()
-        };
+    pub fn as_range(mut self, prefix: PrefixWithOptionalPorts) -> Result<Self, ConfigError> {
+        let nat = self.nat.as_mut().ok_or(ConfigError::MissingParameter(
+            "'as' block requires NAT configuration for the expose",
+        ))?;
         nat.as_range.insert(prefix);
-        ret
+        Ok(self)
     }
-    #[must_use]
-    pub fn not_as(self, prefix: PrefixWithOptionalPorts) -> Self {
-        let mut ret = self.make_nat();
-        let Some(nat) = ret.nat.as_mut() else {
-            unreachable!()
-        };
+    pub fn not_as(mut self, prefix: PrefixWithOptionalPorts) -> Result<Self, ConfigError> {
+        let nat = self.nat.as_mut().ok_or(ConfigError::MissingParameter(
+            "'not' prefix for 'as' block requires NAT configuration for the expose",
+        ))?;
         nat.not_as.insert(prefix);
-        ret
+        Ok(self)
     }
     #[must_use]
     pub fn has_host_prefixes(&self) -> bool {

--- a/flow-filter/src/lib.rs
+++ b/flow-filter/src/lib.rs
@@ -1271,13 +1271,15 @@ mod tests {
                             .make_stateless_nat()
                             .unwrap()
                             .ip("2.0.0.0/24".into())
-                            .as_range("20.0.0.0/24".into()), // Stateless NAT
+                            .as_range("20.0.0.0/24".into()) // Stateless NAT
+                            .unwrap(),
                         VpcExpose::empty()
                             .make_stateful_nat(None)
                             .unwrap()
                             .ip("3.0.0.0/24".into())
-                            .as_range("30.0.0.0/24".into()), // Stateful NAT
-                        VpcExpose::empty().set_default(),           // Default (no NAT)
+                            .as_range("30.0.0.0/24".into()) // Stateful NAT
+                            .unwrap(),
+                        VpcExpose::empty().set_default(), // Default (no NAT)
                     ],
                 },
                 VpcManifest {
@@ -1288,13 +1290,15 @@ mod tests {
                             .make_stateless_nat()
                             .unwrap()
                             .ip("6.0.0.0/24".into())
-                            .as_range("60.0.0.0/24".into()), // Stateless NAT
+                            .as_range("60.0.0.0/24".into()) // Stateless NAT
+                            .unwrap(),
                         VpcExpose::empty()
                             .make_stateful_nat(None)
                             .unwrap()
                             .ip("7.0.0.0/24".into())
-                            .as_range("70.0.0.0/24".into()), // Stateful NAT
-                        VpcExpose::empty().set_default(),           // Default (no NAT)
+                            .as_range("70.0.0.0/24".into()) // Stateful NAT
+                            .unwrap(),
+                        VpcExpose::empty().set_default(), // Default (no NAT)
                     ],
                 },
             ))
@@ -1410,7 +1414,8 @@ mod tests {
                             .make_stateful_nat(None)
                             .unwrap()
                             .ip("1.0.0.0/24".into())
-                            .as_range("100.0.0.0/24".into()), // Stateful NAT
+                            .as_range("100.0.0.0/24".into()) // Stateful NAT
+                            .unwrap(),
                         VpcExpose::empty()
                             .make_port_forwarding(None)
                             .unwrap()
@@ -1421,7 +1426,8 @@ mod tests {
                             .as_range(PrefixWithOptionalPorts::new(
                                 "100.0.0.27/32".into(),
                                 Some(PortRange::new(3000, 3001).unwrap()),
-                            )), // Port forwarding
+                            )) // Port forwarding
+                            .unwrap(),
                     ],
                 },
                 VpcManifest {
@@ -1640,7 +1646,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.0.0.0/24".into())
-            .as_range("100.0.0.0/24".into());
+            .as_range("100.0.0.0/24".into())
+            .unwrap();
         // Create a TCP-only port forwarding expose
         let mut pf_expose = VpcExpose::empty()
             .make_port_forwarding(None)
@@ -1652,7 +1659,8 @@ mod tests {
             .as_range(PrefixWithOptionalPorts::new(
                 "100.0.0.27/32".into(),
                 Some(PortRange::new(3000, 3001).unwrap()),
-            ));
+            ))
+            .unwrap();
         pf_expose.nat.as_mut().unwrap().proto = L4Protocol::Tcp;
 
         let mut peering_table = VpcPeeringTable::new();
@@ -1787,7 +1795,8 @@ mod tests {
                             .make_stateful_nat(None)
                             .unwrap()
                             .ip("1.0.0.0/24".into())
-                            .as_range("100.0.0.0/24".into()),
+                            .as_range("100.0.0.0/24".into())
+                            .unwrap(),
                         VpcExpose::empty()
                             .make_port_forwarding(None)
                             .unwrap()
@@ -1798,7 +1807,8 @@ mod tests {
                             .as_range(PrefixWithOptionalPorts::new(
                                 "100.0.0.27/32".into(),
                                 Some(PortRange::new(3000, 3001).unwrap()),
-                            )),
+                            ))
+                            .unwrap(),
                     ],
                 },
                 VpcManifest {

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -74,13 +74,19 @@ pub mod test {
         m1.add_expose(expose);
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.50.0", 24)).into())
-            .as_range(Prefix::expect_from(("100.100.50.0", 24)).into());
+            .as_range(Prefix::expect_from(("100.100.50.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.30.0", 24)).into())
-            .as_range(Prefix::expect_from(("100.100.30.0", 24)).into());
+            .as_range(Prefix::expect_from(("100.100.30.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
         m1
     }
@@ -92,34 +98,49 @@ pub mod test {
         m1.add_expose(expose);
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.70.0", 24)).into())
-            .as_range(Prefix::expect_from(("200.200.70.0", 24)).into());
+            .as_range(Prefix::expect_from(("200.200.70.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.90.0", 24)).into())
-            .as_range(Prefix::expect_from(("200.200.90.0", 24)).into());
+            .as_range(Prefix::expect_from(("200.200.90.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
         m1
     }
     fn man_vpc1_with_vpc3() -> VpcManifest {
         let mut m1 = VpcManifest::new("VPC-1");
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.60.0", 24)).into())
-            .as_range(Prefix::expect_from(("100.100.60.0", 24)).into());
+            .as_range(Prefix::expect_from(("100.100.60.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
         m1
     }
     fn man_vpc3_with_vpc1() -> VpcManifest {
         let mut m1 = VpcManifest::new("VPC-3");
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.128.0", 27)).into())
-            .as_range(Prefix::expect_from(("100.30.128.0", 27)).into());
+            .as_range(Prefix::expect_from(("100.30.128.0", 27)).into())
+            .unwrap();
         m1.add_expose(expose);
 
         let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip(Prefix::expect_from(("192.168.100.0", 24)).into())
-            .as_range(Prefix::expect_from(("192.168.100.0", 24)).into());
+            .as_range(Prefix::expect_from(("192.168.100.0", 24)).into())
+            .unwrap();
         m1.add_expose(expose);
         m1
     }

--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -104,12 +104,15 @@ mod context {
             .ip("1.2.0.0/16".into())
             .ip("1.3.0.0/16".into())
             .as_range("10.1.0.0/30".into())
-            .not_as("10.1.0.3/32".into());
+            .unwrap()
+            .not_as("10.1.0.3/32".into())
+            .unwrap();
         let expose2 = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
             .ip("2.0.0.0/16".into())
-            .as_range("10.2.0.0/29".into());
+            .as_range("10.2.0.0/29".into())
+            .unwrap();
 
         let manifest1 = VpcManifest {
             name: "VPC-1".into(),
@@ -121,13 +124,16 @@ mod context {
             .unwrap()
             .ip("3.0.0.0/24".into())
             .ip("3.0.1.0/24".into())
-            .as_range("10.3.0.0/30".into());
+            .as_range("10.3.0.0/30".into())
+            .unwrap();
         let expose4 = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
             .ip("4.0.0.0/16".into())
             .as_range("10.4.0.0/31".into())
-            .as_range("10.4.1.0/30".into());
+            .unwrap()
+            .as_range("10.4.1.0/30".into())
+            .unwrap();
 
         let manifest2 = VpcManifest {
             name: "VPC-2".into(),

--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -78,18 +78,22 @@ mod tests {
             .make_stateful_nat(Some(ONE_MINUTE))
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("10.12.0.0/16".into());
+            .as_range("10.12.0.0/16".into())
+            .unwrap();
         let expose122 = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.2.0.0/16".into())
             .as_range("10.98.128.0/17".into())
-            .as_range("10.99.0.0/17".into());
+            .unwrap()
+            .as_range("10.99.0.0/17".into())
+            .unwrap();
         let expose123 = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.3.0.0/24".into())
-            .as_range("10.100.0.0/24".into());
+            .as_range("10.100.0.0/24".into())
+            .unwrap();
         let expose211 = VpcExpose::empty().ip("10.201.201.0/24".into());
         let expose212 = VpcExpose::empty().ip("10.201.202.0/24".into());
         let expose213 = VpcExpose::empty().ip("10.201.203.0/24".into());
@@ -100,14 +104,18 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("3.3.0.0/16".into());
+            .as_range("3.3.0.0/16".into())
+            .unwrap();
         let expose132 = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.2.0.0/16".into())
             .as_range("3.1.0.0/16".into())
+            .unwrap()
             .not_as("3.1.128.0/17".into())
-            .as_range("3.2.0.0/17".into());
+            .unwrap()
+            .as_range("3.2.0.0/17".into())
+            .unwrap();
         let expose311 = VpcExpose::empty().ip("3.3.3.0/24".into());
 
         // VPC1 <-> VPC4
@@ -115,7 +123,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("4.4.0.0/16".into());
+            .as_range("4.4.0.0/16".into())
+            .unwrap();
         let expose411 = VpcExpose::empty().ip("4.5.0.0/16".into());
 
         // VPC2 <-> VPC4
@@ -125,7 +134,9 @@ mod tests {
             .ip("2.4.0.0/16".into())
             .not("2.4.1.0/24".into())
             .as_range("44.0.0.0/16".into())
-            .not_as("44.0.200.0/24".into());
+            .unwrap()
+            .not_as("44.0.200.0/24".into())
+            .unwrap();
         let expose421 = VpcExpose::empty()
             .ip("44.4.0.0/16".into())
             .not("44.4.64.0/18".into());
@@ -135,7 +146,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("192.168.100.0/24".into())
-            .as_range("34.34.34.0/24".into());
+            .as_range("34.34.34.0/24".into())
+            .unwrap();
         let expose431 = VpcExpose::empty().ip("4.4.0.0/24".into());
 
         // VPC1 <-> VPC2
@@ -203,7 +215,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("2.2.0.0/16".into());
+            .as_range("2.2.0.0/16".into())
+            .unwrap();
         let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
 
         let mut manifest12 = VpcManifest::new("VPC-1");
@@ -788,7 +801,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("2.2.0.0/16".into());
+            .as_range("2.2.0.0/16".into())
+            .unwrap();
         let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
         let expose212 = VpcExpose::empty().set_default();
 
@@ -912,7 +926,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into());
+            .as_range("2.0.0.0/24".into())
+            .unwrap();
         let expose21 = VpcExpose::empty().ip("5.0.0.0/24".into());
 
         let mut manifest12 = VpcManifest::new("VPC-1");
@@ -927,7 +942,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into());
+            .as_range("2.0.0.0/24".into())
+            .unwrap();
         let expose23 = VpcExpose::empty().ip("5.0.0.0/24".into());
 
         let mut manifest23 = VpcManifest::new("VPC-2");
@@ -1271,7 +1287,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into());
+            .as_range("2.0.0.0/24".into())
+            .unwrap();
         let expose1_2 = VpcExpose::empty().ip("5.0.0.0/24".into());
 
         let mut manifest1_1 = VpcManifest::new("VPC-1");
@@ -1287,7 +1304,8 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("3.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into()); // Overlap
+            .as_range("2.0.0.0/24".into()) // Overlap
+            .unwrap();
         let expose2_2 = VpcExpose::empty().ip("6.0.0.0/24".into());
 
         let mut manifest2_1 = VpcManifest::new("VPC-1");

--- a/nat/src/stateless/setup/mod.rs
+++ b/nat/src/stateless/setup/mod.rs
@@ -133,6 +133,8 @@ mod tests {
     #[test]
     fn test_fabric() {
         let expose1 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("1.1.0.0/16".into())
             .not("1.1.5.0/24".into())
             .not("1.1.3.0/24".into())
@@ -140,29 +142,46 @@ mod tests {
             .ip("1.2.0.0/16".into())
             .not("1.2.2.0/24".into())
             .as_range("2.2.0.0/16".into())
+            .unwrap()
             .not_as("2.1.10.0/24".into())
+            .unwrap()
             .not_as("2.1.1.0/24".into())
+            .unwrap()
             .not_as("2.1.8.0/24".into())
+            .unwrap()
             .not_as("2.1.2.0/24".into())
-            .as_range("2.1.0.0/16".into());
+            .unwrap()
+            .as_range("2.1.0.0/16".into())
+            .unwrap();
         let expose2 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("3.0.0.0/16".into())
-            .as_range("4.0.0.0/16".into());
+            .as_range("4.0.0.0/16".into())
+            .unwrap();
 
         let mut manifest1 = VpcManifest::new("VPC-1");
         manifest1.add_expose(expose1);
         manifest1.add_expose(expose2);
 
         let expose3 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("1::/64".into())
             .not("1::/128".into())
             .as_range("1:1::/64".into())
-            .not_as("1:1::/128".into());
+            .unwrap()
+            .not_as("1:1::/128".into())
+            .unwrap();
         let expose4 = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
             .ip("2::/64".into())
             .not("2::/128".into())
             .as_range("2:4::/64".into())
-            .not_as("2:4::/128".into());
+            .unwrap()
+            .not_as("2:4::/128".into())
+            .unwrap();
 
         let mut manifest2 = VpcManifest::new("VPC-2");
         manifest2.add_expose(expose3);

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -156,16 +156,23 @@ pub(crate) mod tests {
             .ip("1.2.0.0/16".into())
             .not("1.2.2.0/24".into())
             .as_range("2.2.0.0/16".into())
+            .unwrap()
             .not_as("2.1.8.0/24".into())
+            .unwrap()
             .not_as("2.2.10.0/24".into())
+            .unwrap()
             .not_as("2.2.1.0/24".into())
+            .unwrap()
             .not_as("2.2.2.0/24".into())
-            .as_range("2.1.0.0/16".into());
+            .unwrap()
+            .as_range("2.1.0.0/16".into())
+            .unwrap();
         let expose2 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("3.0.0.0/16".into())
-            .as_range("4.0.0.0/16".into());
+            .as_range("4.0.0.0/16".into())
+            .unwrap();
 
         let manifest1 = VpcManifest {
             name: "VPC-1".into(),
@@ -196,7 +203,9 @@ pub(crate) mod tests {
             .not("8.0.0.0/24".into())
             .ip("9.0.0.0/17".into())
             .as_range("3.0.0.0/16".into())
-            .not_as("3.0.1.0/24".into());
+            .unwrap()
+            .not_as("3.0.1.0/24".into())
+            .unwrap();
         let expose4 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
@@ -204,9 +213,13 @@ pub(crate) mod tests {
             .not("10.0.1.0/24".into())
             .not("10.0.2.0/24".into())
             .as_range("5.5.0.0/17".into())
+            .unwrap()
             .as_range("5.6.0.0/17".into())
+            .unwrap()
             .not_as("5.6.0.0/24".into())
-            .not_as("5.6.8.0/24".into());
+            .unwrap()
+            .not_as("5.6.8.0/24".into())
+            .unwrap();
 
         let manifest2 = VpcManifest {
             name: "VPC-2".into(),
@@ -382,69 +395,84 @@ pub(crate) mod tests {
             .make_stateless_nat()
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("10.12.0.0/16".into());
+            .as_range("10.12.0.0/16".into())
+            .unwrap();
         let expose122 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.2.0.0/16".into())
             .as_range("10.98.128.0/17".into())
-            .as_range("10.99.0.0/17".into());
+            .unwrap()
+            .as_range("10.99.0.0/17".into())
+            .unwrap();
         let expose123 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.3.0.0/24".into())
-            .as_range("10.100.0.0/24".into());
+            .as_range("10.100.0.0/24".into())
+            .unwrap();
         let expose211 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.2.2.0/24".into())
-            .as_range("10.201.201.0/24".into());
+            .as_range("10.201.201.0/24".into())
+            .unwrap();
         let expose212 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.2.3.0/24".into())
-            .as_range("10.201.202.0/24".into());
+            .as_range("10.201.202.0/24".into())
+            .unwrap();
         let expose213 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("2.0.0.0/24".into())
-            .as_range("10.201.203.0/24".into());
+            .as_range("10.201.203.0/24".into())
+            .unwrap();
         let expose214 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("2.0.1.0/28".into())
-            .as_range("10.201.204.192/28".into());
+            .as_range("10.201.204.192/28".into())
+            .unwrap();
 
         // VPC1 <-> VPC3
         let expose131 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("3.3.0.0/16".into());
+            .as_range("3.3.0.0/16".into())
+            .unwrap();
         let expose132 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.2.0.0/16".into())
             .as_range("3.1.0.0/16".into())
+            .unwrap()
             .not_as("3.1.128.0/17".into())
-            .as_range("3.2.0.0/17".into());
+            .unwrap()
+            .as_range("3.2.0.0/17".into())
+            .unwrap();
         let expose311 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("192.168.128.0/24".into())
-            .as_range("3.3.3.0/24".into());
+            .as_range("3.3.3.0/24".into())
+            .unwrap();
 
         // VPC1 <-> VPC4
         let expose141 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("4.4.0.0/16".into());
+            .as_range("4.4.0.0/16".into())
+            .unwrap();
         let expose411 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .as_range("4.5.0.0/16".into());
+            .as_range("4.5.0.0/16".into())
+            .unwrap();
 
         // VPC2 <-> VPC4
         let expose241 = VpcExpose::empty()
@@ -453,21 +481,26 @@ pub(crate) mod tests {
             .ip("2.4.0.0/16".into())
             .not("2.4.1.0/24".into())
             .as_range("44.0.0.0/16".into())
-            .not_as("44.0.200.0/24".into());
+            .unwrap()
+            .not_as("44.0.200.0/24".into())
+            .unwrap();
         let expose421 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("4.4.0.0/16".into())
             .not("4.4.128.0/18".into())
             .as_range("44.4.0.0/16".into())
-            .not_as("44.4.64.0/18".into());
+            .unwrap()
+            .not_as("44.4.64.0/18".into())
+            .unwrap();
 
         // VPC3 <-> VPC4
         let expose341 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
             .ip("192.168.100.0/24".into())
-            .as_range("34.34.34.0/24".into());
+            .as_range("34.34.34.0/24".into())
+            .unwrap();
         let expose431 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
@@ -833,7 +866,8 @@ pub(crate) mod tests {
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         let expose2 = VpcExpose::empty().ip(PrefixWithOptionalPorts::new(
             "10.2.0.0/16".into(),
             Some(PortRange::new(1, 5).unwrap()),
@@ -915,26 +949,32 @@ pub(crate) mod tests {
                 "10.1.0.0/30".into(),
                 Some(PortRange::new(2001, 2300).unwrap()), // 4 IPs, 300 ports
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.0.128/25".into(),
                 Some(PortRange::new(2001, 3000).unwrap()), // 128 IPs, 1000 ports
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.1.0/25".into(),
                 Some(PortRange::new(2501, 3000).unwrap()), // 128 IPs, 500 ports
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.1.128/25".into(),
                 Some(PortRange::new(3001, 4000).unwrap()), // 128 IPs, 1000 ports
             ))
+            .unwrap()
             .not_as(PrefixWithOptionalPorts::new(
                 "10.1.1.128/25".into(),
                 Some(PortRange::new(3456, 3755).unwrap()), // 128 IPs, 300 ports (exclusion)
             ))
+            .unwrap()
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.2.3/32".into(),
                 Some(PortRange::new(1, 37200).unwrap()), // 1 IP, 37200 ports
-            ));
+            ))
+            .unwrap();
         // Total: (4 * 300 + 128 * 1000 + 128 * 500 + 128 * 1000 + 1 * 37200) - (128 * 300)
         //     = 320,000 ip/port combinations
 
@@ -948,7 +988,8 @@ pub(crate) mod tests {
             .as_range(PrefixWithOptionalPorts::new(
                 "10.2.0.0/30".into(),
                 Some(PortRange::new(1, 16384).unwrap()), // 4 IPs, 16384 ports
-            ));
+            ))
+            .unwrap();
 
         // First address/port (assuming ordered ranges)
 
@@ -1122,7 +1163,8 @@ pub(crate) mod tests {
             .as_range(PrefixWithOptionalPorts::new(
                 "10.1.0.0/16".into(),
                 Some(PortRange::new(8001, 9000).unwrap()),
-            ));
+            ))
+            .unwrap();
         let expose2 = VpcExpose::empty()
             .make_stateless_nat()
             .unwrap()
@@ -1133,7 +1175,8 @@ pub(crate) mod tests {
             .as_range(PrefixWithOptionalPorts::new(
                 "10.2.0.0/16".into(),
                 Some(PortRange::new(6001, 7000).unwrap()),
-            ));
+            ))
+            .unwrap();
         let expose3 = VpcExpose::empty().set_default();
 
         let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2, expose3]);


### PR DESCRIPTION
When the user didn't specify a NAT mode in the CRD, we used to default to static (stateless) NAT. We changed that recently, when we updated to the new user API with commit 018c3a980d3e. Now, when NAT is in use, the mode must be specified explicitly.

As a consequence, we want to remove the fallback to stateless NAT in the dataplane repository. This commit began with simple changes in file config/src/external/overlay/vpcpeering.rs: we remove `make_nat()` and the `Default` trait implementation for `VpcExposeNat`, and update `VpcExpose`'s `as_range()` and `not_as()` methods to use `self.nat` if present. This means that if `self.nat` is not set, we return an error: because of that, we get to update all the (numerous) calls to `as_range` and `not_as` in the tests for crates `config`, `mgmt`, `flow-filter`, and `nat`.

Having to `.unwrap()` in the tests after each call to `as_range()` or `not_as()` is not particularly pleasant, but seems like a logical consequence from the API change (and internal changes from commit cf2011702c34, where the `as_range` and `not_as` lists are now attached to a `VpcExposeNat` object): if the NAT object has not been configured, it makes no sense to set the NAT target prefixes.