### PR TITLE
Preserve flows on reconfigs with port-forwarding

### DIFF
--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -7,7 +7,7 @@
 
 use net::buffer::PacketBufferMut;
 use net::ip::UnicastIpAddr;
-use net::packet::{DoneReason, Packet};
+use net::packet::Packet;
 use std::fmt::Display;
 use std::num::NonZero;
 use std::sync::{Arc, Weak};
@@ -34,7 +34,7 @@ pub struct PortFwState {
     pub(crate) status: AtomicPortFwFlowStatus,
     use_ip: UnicastIpAddr,
     use_port: NonZero<u16>,
-    rule: Weak<PortFwEntry>,
+    pub(crate) rule: Weak<PortFwEntry>,
 }
 impl PortFwState {
     #[must_use]
@@ -197,36 +197,12 @@ pub(crate) fn get_packet_port_fw_state<Buf: PacketBufferMut>(
         debug!("Packet flow-info does not contain port-forwarding state");
         return None;
     };
-    let Some(_rule) = state.rule.upgrade() else {
-        debug!("Packet flow-info contains port-forwarding state, but rule has been deleted");
-        invalidate_flow_state(packet);
-        return None;
-    };
-
-    // Even if flow state refers to a rule, the rule may have changed and no longer include
-    // the address or the port. So, we need to check again here. We check only if the packet
-    // hit a flow with port-forwarding in the forward direction.
-    // FIXME: we don't have a way to update rules yet, other than timers
-    /*
-       if state.action() == PortFwAction::DstNat {
-           let dst_ip = packet.ip_destination().unwrap_or_else(|| unreachable!());
-           let dst_port = packet
-               .transport_dst_port()
-               .unwrap_or_else(|| unreachable!());
-
-           if !rule.ext_dst_ip.covers_addr(&dst_ip) || !rule.ext_ports.contains(dst_port) {
-               debug!("The rule this flow refers to no longer includes the ip or port");
-               invalidate_flow_state(packet);
-               return None;
-           }
-       }
-    */
     debug!("Packet hit entry with port-forwarding state: {flow}");
     Some(state.clone())
 }
 
 /// Invalidate the flow that this packet matched and the related one if any.
-fn invalidate_flow_state<Buf: PacketBufferMut>(packet: &Packet<Buf>) {
+pub(crate) fn invalidate_flow_state<Buf: PacketBufferMut>(packet: &Packet<Buf>) {
     let Some(flow_info) = packet.meta().flow_info.as_ref() else {
         return;
     };
@@ -245,25 +221,18 @@ fn invalidate_flow_state<Buf: PacketBufferMut>(packet: &Packet<Buf>) {
 /// extended by a large period. In other states, the entries are kept alive with
 /// the initial timeout just to give enough time to transition to the next status.
 ///
-/// Note: currently, in the case of TCP, we don't penalize (with the timer) entries
-/// for which packets are unexpectedly received. This will be done later.
+/// Note: currently, in the case of TCP, we don't penalize entries for which packets
+/// are unexpectedly received. This will be done later when introducing a more
+/// elaborate TCP state machine with ack & seqn numbers.
 pub(crate) fn refresh_port_fw_entry<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
+    entry: &PortFwEntry,
     state: &PortFwState, // (*)
 ) {
     //(*) Note: atm, this is a clone of the state found by the packet
     // That's fine for updating the status since it's an arc'ed atomic
 
-    // recover the rule used to port-forward this packet. If the rule has been dropped,
-    // invalidate the flows, since that indicates that the rule was removed from the config
-    // and drop the packet.
-    let Some(entry) = state.rule.upgrade() else {
-        invalidate_flow_state(packet);
-        packet.done(DoneReason::Filtered);
-        return;
-    };
-
-    // update the flow status (for port forwading) depending on the packet and the current status
+    // update the flow status (for port forwarding) depending on the packet and the current status
     let new_status = next_flow_status(packet, state);
     let current_status = state.status.load();
     if new_status != current_status {
@@ -282,7 +251,7 @@ pub(crate) fn refresh_port_fw_entry<Buf: PacketBufferMut>(
     let seconds = extend_by.as_secs();
 
     // refresh the flow. In general, we only refresh the flow in one direction ...
-    if let Some(flow) = packet.meta_mut().flow_info.as_mut() {
+    if let Some(flow) = packet.meta_mut().flow_info.as_ref() {
         match flow.reset_expiry_unchecked(extend_by) {
             Ok(()) => debug!("Extended flow lifetime by {seconds}s"),
             Err(_) => warn!("Failed to extend flow lifetime by {seconds}s"),

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -3,19 +3,23 @@
 
 //! Port forwarding stage
 
-use crate::portfw::{PortFwEntry, PortFwKey, PortFwTable, PortFwTableReader};
+use crate::portfw::{PortFwEntry, PortFwKey, PortFwState, PortFwTable, PortFwTableReader};
 use flow_entry::flow_table::FlowInfo;
 use flow_entry::flow_table::FlowTable;
+use flow_info::ExtractMut;
+use flow_info::ExtractRef;
 use net::buffer::PacketBufferMut;
 use net::headers::{TryIp, TryTcp, TryTransport};
 use net::ip::{NextHeader, UnicastIpAddr};
-use net::packet::{DoneReason, Packet};
+use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use pipeline::NetworkFunction;
 use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::portfw::flow_state::PortFwAction;
 use crate::portfw::flow_state::get_packet_port_fw_state;
+use crate::portfw::flow_state::invalidate_flow_state;
 use crate::portfw::flow_state::refresh_port_fw_entry;
 use crate::portfw::flow_state::setup_forward_flow;
 use crate::portfw::flow_state::setup_reverse_flow;
@@ -162,22 +166,177 @@ impl PortForwarder {
         self.do_port_forwarding(packet, entry, dst_ip, dst_port, new_dst_ip, new_dst_port);
     }
 
+    fn get_rule_from_pkt_fw_path<Buf: PacketBufferMut>(
+        packet: &Packet<Buf>,
+        dst_vpcd: VpcDiscriminant,
+        state: &PortFwState,
+        pfwtable: &PortFwTable,
+    ) -> Option<Arc<PortFwEntry>> {
+        // These could be retrieved from the FlowKey, but we don't have it :( ...
+        let src_vpcd = packet.meta().src_vpcd?;
+        let net = packet.try_ip()?;
+        let proto = net.next_header();
+        let dst_ip = net.dst_addr();
+        let dst_port = packet.transport_dst_port()?;
+        let key = PortFwKey::new(src_vpcd, proto);
+
+        let entry = pfwtable.lookup_matching_rule(key, dst_ip, dst_port)?;
+        debug!("Found rule ({entry}) to forward to {dst_ip}:{dst_port} ({proto}) from {src_vpcd}");
+
+        let (new_ip, new_port) = entry.map_address_port(dst_ip, dst_port)?;
+        debug!(
+            "According to rule, traffic should be port-forwarded to {new_ip}:{new_port} at {}",
+            entry.dst_vpcd
+        );
+
+        // Even if we find a rule that says that the destination ip and port should be port forwarded,
+        // we need to check if the current flow DNATs to the same target ip, port and vpc. Otherwise,
+        // we should drop the packet and the flow since we'd sending the traffic to the wrong recipient
+        // ... and the communication would be broken anyway (e.g. if TCP)
+        if state.use_ip() != new_ip || state.use_port() != new_port || entry.dst_vpcd != dst_vpcd {
+            debug!(
+                "Current state targets a distinct device; {}:{} @ vpc {dst_vpcd}. Will drop",
+                state.use_ip(),
+                state.use_port()
+            );
+            None
+        } else {
+            debug!("Packet conforms to rule {entry}");
+            Some(entry.clone())
+        }
+    }
+
+    fn get_rule_from_pkt_rev_path<Buf: PacketBufferMut>(
+        packet: &Packet<Buf>,
+        dst_vpcd: VpcDiscriminant,
+        state: &PortFwState,
+        pfwtable: &PortFwTable,
+    ) -> Option<Arc<PortFwEntry>> {
+        // get required properties from packet
+        let src_vpcd = packet.meta().src_vpcd?;
+        let net = packet.try_ip()?;
+        let proto = net.next_header();
+        let src_ip = net.src_addr();
+        let src_port = packet.transport_src_port()?;
+
+        // get the ip and port that were port-forwarded in the forward direction when this flow was created.
+        // These are the ip and port that the packets in reverse path should be SNATed with.
+        let dst_ip = state.use_ip();
+        let dst_port = state.use_port();
+        let key = PortFwKey::new(dst_vpcd, proto);
+        let entry = pfwtable.lookup_matching_rule(key, dst_ip.inner(), dst_port)?;
+        debug!("Found compatible port-forwarding rule: {entry}");
+
+        // check how forwarding rule found (presumably newer) would forward the packet
+        let (target_ip, target_port) = entry.map_address_port(dst_ip.inner(), dst_port)?;
+        let target_ip = target_ip.inner();
+        debug!(
+            "Traffic should be port-forwarded to {target_ip}:{target_port} at {}",
+            entry.dst_vpcd
+        );
+
+        // check if the forwarding rule found (presumably newer) would send the traffic to the sender of this packet
+        if target_ip != src_ip || target_port != src_port || entry.dst_vpcd != src_vpcd {
+            debug!(
+                "The latest matching rule for {dst_ip}:{dst_port} ({proto}) from {dst_vpcd} \
+                would send traffic to {target_ip}:{target_port} at {} instead of \
+                {src_ip}:{src_port} at {src_vpcd}. Will drop this flow.",
+                entry.dst_vpcd
+            );
+            None
+        } else {
+            debug!("Packet conforms to rule {entry}");
+            Some(entry.clone())
+        }
+    }
+
+    fn reassign_port_fw_rule(flow_info: &FlowInfo, entry: &Arc<PortFwEntry>) {
+        let mut flow_info_locked = flow_info.locked.write().unwrap();
+        if let Some(state) = flow_info_locked.port_fw_state.extract_mut::<PortFwState>() {
+            state.rule = Arc::downgrade(entry);
+        }
+    }
+
+    fn get_rule_from_pkt<Buf: PacketBufferMut>(
+        packet: &mut Packet<Buf>,
+        pfwtable: &PortFwTable,
+        state: &PortFwState,
+    ) -> Option<Arc<PortFwEntry>> {
+        let flow_info = packet.meta().flow_info.as_ref()?;
+        let flow_info_locked = flow_info.locked.read().unwrap();
+        let dst_vpcd = *flow_info_locked
+            .dst_vpcd
+            .as_ref()
+            .extract_ref::<VpcDiscriminant>()?;
+        drop(flow_info_locked);
+
+        // find compatible rule depending on the path this packet lives, forward or reverse
+        let entry = match state.action() {
+            PortFwAction::DstNat => {
+                Self::get_rule_from_pkt_fw_path(packet, dst_vpcd, state, pfwtable)
+            }
+            PortFwAction::SrcNat => {
+                Self::get_rule_from_pkt_rev_path(packet, dst_vpcd, state, pfwtable)
+            }
+        };
+
+        // if we found an entry, let the port-forwarding state of the flow (and the one in the reverse path)
+        // point to it so that subsequent packets are fast-forwarded.
+        if let Some(entry) = entry.as_ref() {
+            Self::reassign_port_fw_rule(flow_info, entry);
+            if let Some(related) = flow_info
+                .related
+                .as_ref()
+                .and_then(std::sync::Weak::upgrade)
+            {
+                Self::reassign_port_fw_rule(&related, entry);
+            }
+        }
+
+        // return the entry found to continue processing the packet
+        entry
+    }
+
     /// Do port forwarding for the given packet, if it is eligible and there's a rule
     fn process_packet<Buf: PacketBufferMut>(
         &self,
         packet: &mut Packet<Buf>,
         pfwtable: &PortFwTable,
     ) {
-        if let Some(pfw_state) = get_packet_port_fw_state(packet) {
-            // this is the fast-path based on the flow table
-            if !nat_packet(packet, &pfw_state) {
+        // fast-path based on the flow table
+        if let Some(state) = get_packet_port_fw_state(packet) {
+            // packet hit an Active flow with port-forwarding state. Even in that case, it may
+            // happen that the state does not refer to a valid rule because: 1) it was removed
+            // or 2) the configuration changed and the rule was replaced by another one. In both
+            // cases we need to check if the packet, that belongs to a flow that was port-forwarded
+            // in the past, should still be allowed with the new configuration, and, if so, how
+            // much should we extend the flows' lifetimes.
+            let entry = if let Some(entry) = state.rule.upgrade() {
+                debug!("Packet hit Active flow referring to VALID port-forwarding rule.");
+                entry
+            } else {
+                debug!("Packet hit Active flow referring to STALE port-forwarding rule.");
+                let Some(entry) = Self::get_rule_from_pkt(packet, pfwtable, &state) else {
+                    debug!("Packet should no longer be forwarded. Will drop and invalidate state");
+                    packet.done(DoneReason::Filtered);
+                    invalidate_flow_state(packet);
+                    return;
+                };
+                /* we found a port-forwarding rule that grants access to this packet */
+                entry
+            };
+
+            // nat the packet
+            if !nat_packet(packet, &state) {
                 error!("Failed to nat port-forwarded packet");
                 packet.done(DoneReason::InternalFailure);
                 return;
             }
-            // refresh the state. Packet may still be dropped here
-            refresh_port_fw_entry(packet, &pfw_state);
+
+            // refresh flow state and status
+            refresh_port_fw_entry(packet, entry.as_ref(), &state);
         } else {
+            // Slow path: we did not hit a flow, or, if we did, it was not Active or did not contain port-forwarding state.
             self.try_port_forwarding(packet, pfwtable);
         }
     }

--- a/nat/src/portfw/test.rs
+++ b/nat/src/portfw/test.rs
@@ -43,6 +43,20 @@ mod nf_test {
             .map(|state| state.status.load())
     }
 
+    fn get_pfw_flow_state_rule(packet: &Packet<TestBuffer>) -> Option<Arc<PortFwEntry>> {
+        packet
+            .meta()
+            .flow_info
+            .as_ref()?
+            .locked
+            .read()
+            .unwrap()
+            .port_fw_state
+            .as_ref()
+            .and_then(|s| s.extract_ref::<PortFwState>())
+            .and_then(|state| state.rule.upgrade())
+    }
+
     // build a reply for a given packet
     fn build_reply(packet: &Packet<TestBuffer>) -> Packet<TestBuffer> {
         let src_vpcd = packet.meta().src_vpcd;
@@ -682,6 +696,127 @@ mod nf_test {
         let packet = udp_packet_to_port_forward();
         let output = process_packet(&mut pipeline, packet);
         assert!(hit_port_fw_state_invalid(&output));
+
+        println!("{flow_table}");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_nf_port_forwarding_compatible_rule_updates_preserves_flows() {
+        // check that, when updating a rule, existing flows remain if the new rule would allow them
+
+        // build rule
+        let entry = PortFwEntry::new(
+            PortFwKey::new(
+                VpcDiscriminant::VNI(2000.try_into().unwrap()),
+                NextHeader::TCP,
+            ),
+            VpcDiscriminant::VNI(3000.try_into().unwrap()),
+            Prefix::from_str("70.71.72.0/24").unwrap(),
+            Prefix::from_str("192.168.1.0/24").unwrap(),
+            (3010, 3050),
+            (10, 50),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // create pipeline with port-forwarder
+        let (flow_table, mut pipeline, mut writer) = setup_pipeline(&[entry]);
+
+        // establish a TCP connection (port-forwarded). This should succeed and 2 flows be created
+        establish_tcp_connection(&mut pipeline);
+        assert_eq!(flow_table.len(), Some(2));
+
+        // update the rule to include the previous one
+        let entry = PortFwEntry::new(
+            PortFwKey::new(
+                VpcDiscriminant::VNI(2000.try_into().unwrap()),
+                NextHeader::TCP,
+            ),
+            VpcDiscriminant::VNI(3000.try_into().unwrap()),
+            Prefix::from_str("70.71.72.73/32").unwrap(),
+            Prefix::from_str("192.168.1.73/32").unwrap(),
+            (3022, 3023),
+            (22, 23),
+            None,
+            None,
+        )
+        .unwrap();
+        writer.update_table(std::slice::from_ref(&entry)).unwrap();
+
+        // send a new packet in forward path. Flow entry remains Active and flow status is still Established
+        let packet = tcp_packet_to_port_forward();
+        let output = process_packet(&mut pipeline, packet);
+        assert!(output.meta().flow_info.is_some());
+        assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
+        assert_eq!(
+            get_pfw_flow_status(&output),
+            Some(PortFwFlowStatus::Established)
+        );
+        let rule_referenced = get_pfw_flow_state_rule(&output);
+        assert_eq!(rule_referenced.as_ref().unwrap().as_ref(), &entry);
+
+        println!("{flow_table}");
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_nf_port_forwarding_incompatible_rule_updates_remove_flows() {
+        // check that, when updating a rule, existing flows remain if the new rule would allow them
+
+        // build rule
+        let entry = PortFwEntry::new(
+            PortFwKey::new(
+                VpcDiscriminant::VNI(2000.try_into().unwrap()),
+                NextHeader::TCP,
+            ),
+            VpcDiscriminant::VNI(3000.try_into().unwrap()),
+            Prefix::from_str("70.71.72.0/24").unwrap(),
+            Prefix::from_str("192.168.1.0/24").unwrap(),
+            (3010, 3050),
+            (10, 50),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // create pipeline with port-forwarder
+        let (flow_table, mut pipeline, mut writer) = setup_pipeline(&[entry]);
+
+        // establish a TCP connection (port-forwarded). This should succeed and 2 flows be created
+        establish_tcp_connection(&mut pipeline);
+        assert_eq!(flow_table.len(), Some(2));
+
+        // update the rule so that the traffic would be sent somewhere else
+        let entry = PortFwEntry::new(
+            PortFwKey::new(
+                VpcDiscriminant::VNI(2000.try_into().unwrap()),
+                NextHeader::TCP,
+            ),
+            VpcDiscriminant::VNI(3000.try_into().unwrap()),
+            Prefix::from_str("70.71.72.0/24").unwrap(),
+            Prefix::from_str("192.168.2.0/24").unwrap(),
+            (3010, 3050),
+            (10, 50),
+            None,
+            None,
+        )
+        .unwrap();
+        writer.update_table(std::slice::from_ref(&entry)).unwrap();
+
+        // send a new packet in forward path. Flow entry should be invalidated and the packet dropped
+        let packet = tcp_packet_to_port_forward();
+        let output = process_packet(&mut pipeline, packet);
+        assert!(output.meta().flow_info.is_some());
+        assert_eq!(get_flow_status(&output), Some(FlowStatus::Cancelled)); // flow should be cancelled
+        assert_eq!(
+            get_pfw_flow_status(&output),
+            Some(PortFwFlowStatus::Established) // this remains established. That's fine.
+        );
+        let rule_referenced = get_pfw_flow_state_rule(&output);
+        assert!(rule_referenced.is_none()); // flow did not get a new reference to a rule
+        assert_eq!(output.get_done(), Some(DoneReason::Filtered)); // packet was dropped
 
         println!("{flow_table}");
     }


### PR DESCRIPTION
Fixes https://github.com/orgs/githedgehog/projects/2/views/23?sliceBy%5Bvalue%5D=Fredi-raspall&pane=issue&itemId=161526276&issue=githedgehog%7Cdataplane%7C1313

In the original implementation of port-forwarding, rules referred to single ips and ports. When a flow for a port-forwarded packet was created, the corresponding state referred to the matched rule so that the data-path could refer to it (via a Weak reference) to learn things like the timeouts, needed to extend flows' lifetimes.

With rules that can contain prefixes and ports, this is more diffi- cult since, on reconfigurations, it is hard to preserve the origi- nal rule since the object (mostly immutable) may need to be replaced by a newer one in case it would need to be updated. If that happens, the Weak reference to the previous rule is dropped and it is no longer possible to recover, from a flow, the rule that lead to its creation. The option of letting the flow-filter deal with this is insufficient, because, even if after a reconfig the flow-filter would allow the flow, the port-forwarding logic requires knowing the timeouts (present only in the rule) to determine how much to extend the flows.

This patch fixes the logic so that, if a packet in either direction hits a flow with port forwarding state whose corresponding rule has been dropped or modified, the PortForwarder NF re-evaluates the packet to newly determine if it should continue to be port-forwarded according to the new config. In that case, a new Weak reference to the newer rule is created. The approach of using Weak references is hence still a valid one to expedite (omit reevaluations) most of the time in the "fast path". The slower path only applies:
  - for the first packet, when there's no state
  - for the first packet hitting a flow that refers to a stale port-forwarding rule, which can only happen after a reconfigu- ration.