### PR TITLE
feat(flow.entry): make the aggressive reap threshold configurable

### DIFF
--- a/flow-entry/src/flow_table/nf_expirations.rs
+++ b/flow-entry/src/flow_table/nf_expirations.rs
@@ -55,7 +55,6 @@ mod test {
 
     use crate::flow_table::FlowTable;
     use crate::flow_table::nf_expirations::ExpirationsNF;
-    use crate::flow_table::thread_local_pq::AGRESSIVE_REAP_THRESHOLD;
     use net::{FlowKey, IpProtoKey, TcpProtoKey};
 
     #[test]
@@ -87,38 +86,42 @@ mod test {
 
     #[test]
     fn test_aggressive_expiration() {
-        let flow_table = Arc::new(FlowTable::default());
+        const REAP_THRESHOLD_TEST: usize = 10_000; // must be < 64K for testing
+
+        let mut flow_table = FlowTable::default();
+
+        // set the aggressive reap threshold
+        flow_table.set_reap_threshold(REAP_THRESHOLD_TEST);
+
+        let flow_table = Arc::from(flow_table);
         let mut expirations_nf = ExpirationsNF::new(flow_table.clone());
         let src_vpcd = VpcDiscriminant::VNI(Vni::new_checked(100).unwrap());
         let src_ip = "1.2.3.4".parse::<UnicastIpAddr>().unwrap();
         let dst_ip = "5.6.7.8".parse::<IpAddr>().unwrap();
 
-        // create > AGRESSIVE_REAP_THRESHOLD flows
-        for src_port in 1..u16::MAX {
-            let src_port = TcpPort::new_checked(src_port).unwrap();
-            for dst_port in
-                1..=u16::try_from(AGRESSIVE_REAP_THRESHOLD.div_ceil(u16::MAX as usize)).unwrap()
-            {
-                let dst_port = TcpPort::new_checked(dst_port).unwrap();
-                let flow_key = FlowKey::uni(
-                    Some(src_vpcd),
-                    src_ip.into(),
-                    dst_ip,
-                    IpProtoKey::Tcp(TcpProtoKey { src_port, dst_port }),
-                );
-                let flow_info =
-                    FlowInfo::new(Instant::now().checked_add(Duration::from_mins(10)).unwrap());
-                flow_table.insert(flow_key, flow_info);
-            }
+        // create REAP_THRESHOLD_TEST + 100 flows
+        for src_port in 1..=REAP_THRESHOLD_TEST + 100 {
+            #[allow(clippy::cast_possible_truncation)]
+            let src_port = TcpPort::new_checked(src_port as u16).unwrap();
+            let dst_port = TcpPort::new_checked(100).unwrap();
+            let flow_key = FlowKey::uni(
+                Some(src_vpcd),
+                src_ip.into(),
+                dst_ip,
+                IpProtoKey::Tcp(TcpProtoKey { src_port, dst_port }),
+            );
+            let flow_info =
+                FlowInfo::new(Instant::now().checked_add(Duration::from_mins(60)).unwrap());
+            flow_table.insert(flow_key, flow_info);
         }
         // check we inserted more flows than the threshold
-        assert!(flow_table.len().unwrap() > AGRESSIVE_REAP_THRESHOLD);
+        assert!(flow_table.len().unwrap() > REAP_THRESHOLD_TEST);
 
         // expire: no flow should be reaped because all are Active
         let _: Vec<_> = expirations_nf
             .process(std::iter::empty::<Packet<TestBuffer>>())
             .collect();
-        assert!(flow_table.len().unwrap() > AGRESSIVE_REAP_THRESHOLD);
+        assert!(flow_table.len().unwrap() > REAP_THRESHOLD_TEST);
 
         // pretend that all flows -but one- get Cancelled
         for (num, flow_info) in flow_table.table.read().unwrap().iter().enumerate() {

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -51,8 +51,12 @@ impl FlowTable {
                 hasher_state().clone(),
                 num_shards,
             )),
-            priority_queue: PriorityQueue::new(),
+            priority_queue: PriorityQueue::new(None),
         }
+    }
+
+    pub fn set_reap_threshold(&mut self, reap_threshold: usize) {
+        self.priority_queue.set_reap_threshold(reap_threshold);
     }
 
     /// Reshard the flow table into the given number of shards.

--- a/flow-entry/src/flow_table/thread_local_pq.rs
+++ b/flow-entry/src/flow_table/thread_local_pq.rs
@@ -20,9 +20,6 @@ trace_target!(
     &["flow-expiration", "pipeline"]
 );
 
-// this could be configurable at some point
-pub(crate) const AGRESSIVE_REAP_THRESHOLD: usize = 1_000_000;
-
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Priority(Instant);
@@ -88,6 +85,7 @@ where
 {
     #[allow(clippy::type_complexity)]
     pqs: ThreadLocal<RwLock<PriorityQueue<Entry<K, V>, Priority, RandomState>>>,
+    reap_threshold: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,10 +100,16 @@ where
     K: Send + Sync + Hash + PartialEq + Eq,
     V: Send + Sync,
 {
-    pub fn new() -> Self {
+    pub(crate) const AGRESSIVE_REAP_THRESHOLD: usize = 1_000_000;
+    pub fn new(reap_threshold: Option<usize>) -> Self {
         Self {
             pqs: ThreadLocal::new(),
+            reap_threshold: reap_threshold.unwrap_or(Self::AGRESSIVE_REAP_THRESHOLD),
         }
+    }
+
+    pub fn set_reap_threshold(&mut self, reap_threahold: usize) {
+        self.reap_threshold = reap_threahold;
     }
 
     fn get_pq_lock(&self) -> &RwLock<PriorityQueue<Entry<K, V>, Priority, RandomState>> {
@@ -162,7 +166,13 @@ where
     ) -> Vec<K> {
         let pql = self.get_pq_lock();
         let mut pq = pql.write().unwrap();
-        Self::reap_expired_locked_with_time(&mut pq, &Instant::now(), on_expired, on_reaped)
+        Self::reap_expired_locked_with_time(
+            &mut pq,
+            &Instant::now(),
+            on_expired,
+            on_reaped,
+            self.reap_threshold,
+        )
     }
 
     /// Reap expired entries from all priority queues (regardless of current thread)
@@ -204,8 +214,13 @@ where
         let mut all_reaped = vec![];
         for pq in pqs {
             let mut pq = pq.write().unwrap();
-            let mut reaped =
-                Self::reap_expired_locked_with_time(&mut pq, now, &on_expired, &on_reaped);
+            let mut reaped = Self::reap_expired_locked_with_time(
+                &mut pq,
+                now,
+                &on_expired,
+                &on_reaped,
+                self.reap_threshold,
+            );
             all_reaped.append(&mut reaped);
         }
         all_reaped
@@ -241,10 +256,11 @@ where
         now: &Instant,
         on_expired: impl Fn(&Instant, &K, &V) -> PQAction,
         on_reaped: impl Fn(&K, V),
+        reap_threshold: usize,
     ) -> Vec<K> {
         let len = pq.len();
-        if len > AGRESSIVE_REAP_THRESHOLD {
-            warn!("The number of flows ({len}) exceeds {AGRESSIVE_REAP_THRESHOLD}. Reaping...");
+        if len > reap_threshold {
+            warn!("The number of flows ({len}) exceeds {reap_threshold}. Reaping...");
             return Self::aggressive_reap(pq, now, on_expired, on_reaped);
         }
 
@@ -306,6 +322,6 @@ where
     V: Send + Sync,
 {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }


### PR DESCRIPTION
Some tests have been failing because they used the 1M default threshold and flows' lifetime was 10 minutes only, which was probably exceeded by the number of flows if the CI infra was loaded. Fix this by making the threshold configurable and setting a smaller value in the tests.