### PR TITLE
Introspection: pretty-print context for flow-filter

### DIFF
--- a/flow-filter/src/lib.rs
+++ b/flow-filter/src/lib.rs
@@ -22,6 +22,7 @@ use net::headers::{Transport, TryIp, TryTransport};
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use pipeline::NetworkFunction;
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::net::IpAddr;
 use std::num::NonZero;
 use tracing::{debug, error};
@@ -323,13 +324,24 @@ impl FlowTuple {
     }
 }
 
-impl std::fmt::Display for FlowTuple {
+impl Display for FlowTuple {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "srcVpc={} src={}{} dst={}{}",
             self.src_vpcd, self.src_addr, self.src_port, self.dst_addr, self.dst_port
         )
+    }
+}
+
+impl Display for FlowFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}:", self.name)?;
+        if let Some(table) = self.tablesr.enter() {
+            write!(f, "{}", *table)
+        } else {
+            writeln!(f, "[no table]")
+        }
     }
 }
 

--- a/flow-filter/src/tables.rs
+++ b/flow-filter/src/tables.rs
@@ -9,9 +9,8 @@ use lpm::prefix::range_map::DisjointRangesBTreeMap;
 use lpm::prefix::{L4Protocol, PortRange, Prefix};
 use lpm::trie::{IpPortPrefixTrie, ValueWithAssociatedRanges};
 use net::packet::VpcDiscriminant;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::fmt::Debug;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::{Debug, Display};
 use std::net::IpAddr;
 use std::ops::RangeBounds;
 
@@ -578,6 +577,123 @@ impl DstConnectionData {
             ));
         }
         self.default_remote_data = Some(PortRangeMap::AllPorts(result));
+        Ok(())
+    }
+}
+
+impl Display for FlowFilterTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Collect into a BTreeMap to get a deterministic order when dumping the entries
+        for (src_vpcd, table) in self.0.clone().into_iter().collect::<BTreeMap<_, _>>() {
+            writeln!(f, "source VPC {src_vpcd}:")?;
+            writeln!(f, "{table}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for VpcConnectionsTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (prefix, port_range_map) in self.trie.iter() {
+            match port_range_map {
+                PortRangeMap::AllPorts(data) => {
+                    writeln!(f, "  source: {prefix}")?;
+                    write!(f, "{data}")?;
+                }
+                PortRangeMap::Ranges(port_ranges) => {
+                    for (port_range, data) in port_ranges.iter() {
+                        writeln!(f, "  source: {prefix}:{port_range}")?;
+                        write!(f, "{data}")?;
+                    }
+                }
+            }
+        }
+        if let Some(default_source) = &self.default_source {
+            writeln!(f, "  local default:")?;
+            match default_source {
+                PortRangeMap::AllPorts(data) => {
+                    write!(f, "{data}")?;
+                }
+                PortRangeMap::Ranges(port_ranges) => {
+                    for (port_range, data) in port_ranges.iter() {
+                        writeln!(f, "  ports: {port_range}")?;
+                        write!(f, "{data}")?;
+                    }
+                }
+            }
+        } else {
+            writeln!(f, "  no local default")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for DstConnectionData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (prefix, port_range_map) in self.trie.iter() {
+            match port_range_map {
+                PortRangeMap::AllPorts(result) => {
+                    writeln!(f, "    destination: {prefix}, data:")?;
+                    write!(f, "{result}")?;
+                }
+                PortRangeMap::Ranges(port_ranges) => {
+                    for (port_range, result) in port_ranges.iter() {
+                        writeln!(f, "    destination: {prefix}:{port_range}, data:")?;
+                        write!(f, "{result}")?;
+                    }
+                }
+            }
+        }
+        if let Some(port_range_map) = &self.default_remote_data {
+            match port_range_map {
+                PortRangeMap::AllPorts(result) => {
+                    writeln!(f, "    remote default data:")?;
+                    write!(f, "{result}")?;
+                }
+                PortRangeMap::Ranges(port_ranges) => {
+                    writeln!(f, "    remote default:")?;
+                    for (port_range, result) in port_ranges.iter() {
+                        writeln!(f, "    ports: {port_range}, data:")?;
+                        write!(f, "{result}")?;
+                    }
+                }
+            }
+        } else {
+            writeln!(f, "    no remote default")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for VpcdLookupResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VpcdLookupResult::Single(remote_data) => {
+                writeln!(f, "      {remote_data}")
+            }
+            VpcdLookupResult::MultipleMatches(remote_data_set) => {
+                for remote_data in remote_data_set {
+                    writeln!(f, "      {remote_data}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Display for RemoteData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "destination VPC: {}, ", self.vpcd)?;
+        if let Some(src_nat_req) = &self.src_nat_req {
+            write!(f, "source NAT: {src_nat_req:?}, ")?;
+        } else {
+            write!(f, "source NAT: -, ")?;
+        }
+        if let Some(dst_nat_req) = &self.dst_nat_req {
+            write!(f, "destination NAT: {dst_nat_req:?}")?;
+        } else {
+            write!(f, "destination NAT: -")?;
+        }
         Ok(())
     }
 }

--- a/lpm/src/trie/ip_port_prefix_trie.rs
+++ b/lpm/src/trie/ip_port_prefix_trie.rs
@@ -98,6 +98,10 @@ where
         }
         None
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (Prefix, &V)> {
+        self.0.iter()
+    }
 }
 
 impl<V> Default for IpPortPrefixTrie<V>


### PR DESCRIPTION
To facilitate troubleshooting the flow-filter stage lookup, implement the `Display` trait to dump the content of the context table in a more human-friendly fashion.

<details><summary>Sample output (click to unfold)</summary>

```
test-filter:
source VPC VNI(100):
  source: 1.0.0.0/24:0-1999
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.0/24:2002-65535
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.0/28:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.16/29:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.24/31:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.26/32:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.27/32:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: PortForwarding(Any), destination NAT: -
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.28/30:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.32/27:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.64/26:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  source: 1.0.0.128/25:2000-2001
    destination: 5.0.0.0/24, data:
      destination VPC: VNI(200), source NAT: Stateful, destination NAT: -
    no remote default
  no local default

source VPC VNI(200):
  source: 5.0.0.0/24
    destination: 100.0.0.0/24:0-2999, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.0/24:3002-65535, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.0/28:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.16/29:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.24/31:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.26/32:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.27/32:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: PortForwarding(Any)
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.28/30:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.32/27:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.64/26:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    destination: 100.0.0.128/25:3000-3001, data:
      destination VPC: VNI(100), source NAT: -, destination NAT: Stateful
    no remote default
  no local default

```
</details>