### PR TITLE
bump: Bump dataplane version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "afpacket",
  "arrayvec",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-args"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bytecheck",
  "clap",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bincode2",
  "clap",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-concurrency-macros",
  "loom",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-concurrency-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-config"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "caps",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sys"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bindgen",
  "dataplane-dpdk-sysroot-helper",
@@ -1332,18 +1332,18 @@ dependencies = [
 
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "dataplane-errno"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "dataplane-flow-entry"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bolero",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-flow-filter"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-config",
  "dataplane-lpm",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-hardware"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "bytecheck",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-id"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "rkyv",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-init"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "dataplane-hardware",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-interface-manager"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "dataplane-net",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-intf"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "dataplane-hardware",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-k8s-less"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-k8s-intf",
  "dataplane-tracectl",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-left-right-tlcache"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "left-right",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-lpm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bnum",
  "bolero",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-mgmt"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bolero",
  "bytes",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-nat"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-net"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-pipeline"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arc-swap",
  "dataplane-id",
@@ -1625,11 +1625,11 @@ dependencies = [
 
 [[package]]
 name = "dataplane-rekon"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "dataplane-routing"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-stats"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "arrayvec",
  "bolero",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-sysfs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-dpdk-sysroot-helper",
  "n-vm",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-test-utils"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "caps",
  "nix 0.31.2",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-tracectl"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "color-eyre",
  "linkme",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-validator"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dataplane-config",
  "dataplane-k8s-intf",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-vpcmap"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "bolero",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false


### PR DESCRIPTION
Bump to v0.13.0. Changes include:

- New NAT mode: port forwarding. It supports independent processing of TCP and UDP rules, it includes a TCP state machine for flow invalidation, configurable timeouts, flow preservation across reconfigurations, prefix overlap support with masquerade, and ICMP errors handling.

- The flow-filter stage supports overlapping exposed prefixes again when masquerade is in use. It received various improvements and fixes.

- Flow entries have been reworked: support for bidirectional keys was dropped, the structure of the entries have changed to accommodate for NAT use cases and for referencing other entries, for flow reaping. Some crate reorganisation also happened.

- There is no longer a default NAT mode (previously: stateless NAT).
