### PR TITLE
allow non-interactive CLI commands

### DIFF
--- a/cli/bin/cmdline.rs
+++ b/cli/bin/cmdline.rs
@@ -26,4 +26,12 @@ pub struct Cmdline {
         help = "Path to bind this CLI to"
     )]
     pub bind_address: String,
+
+    #[arg(
+        long,
+        short,
+        value_name = "Command",
+        help = "Execute the provided command and exit. Multiple commands can be specified"
+    )]
+    pub command: Vec<String>,
 }

--- a/cli/bin/main.rs
+++ b/cli/bin/main.rs
@@ -9,6 +9,7 @@
 use argsparse::{ArgsError, CliArgs};
 use clap::Parser;
 use cmdline::Cmdline;
+use cmdtree::Node;
 use cmdtree_dp::gw_cmd_tree;
 use colored::Colorize;
 use dataplane_cli::cliproto::{CliAction, CliRequest, CliResponse, CliSerialize};
@@ -171,16 +172,65 @@ fn process_args(input: &TermInput) -> Result<CliArgs, ()> {
     }
 }
 
+fn process_command(
+    terminal: &mut Terminal,
+    cmds: &Rc<Node>,
+    cmdline: &Cmdline,
+    input: &mut TermInput,
+) {
+    if let Some(node) = cmds.find_best(input.get_tokens()) {
+        if let Some(action) = &node.action {
+            if let Ok(args) = process_args(input) {
+                execute_action(*action, &args, cmdline, terminal);
+            }
+        } else if node.depth > 0 {
+            print_err!("No action associated to command");
+            if node.children.is_empty() {
+                print_err!("Command is not implemented");
+            } else {
+                print_err!("Options are:");
+                node.show_children();
+            }
+        } else {
+            print_err!("syntax error");
+        }
+    }
+}
+
+fn proc_cmdline_commands(
+    terminal: &mut Terminal,
+    cmds: &Rc<Node>,
+    cmdline: &Cmdline,
+    input_cmds: &Vec<String>,
+) {
+    terminal.connect(&cmdline.bind_address, &cmdline.path);
+    if !terminal.is_connected() {
+        println!("Failed to connect to dataplane");
+        return;
+    }
+    for cmd in input_cmds {
+        if let Some(mut input) = terminal.proc_line(cmd) {
+            println!("{}{}", terminal.read_prompt(), input.get_line());
+            process_command(terminal, cmds, cmdline, &mut input);
+        }
+    }
+}
+
 fn main() {
     // parse cmd line
     let cmdline = cmdline::Cmdline::parse();
 
     // build command tree
-    let cmds = Rc::new(gw_cmd_tree());
-    let mut terminal = Terminal::new("dataplane", &cmds);
-    terminal.clear();
+    let cmdtree = Rc::new(gw_cmd_tree());
+    let mut terminal = Terminal::new("dataplane", &cmdtree);
 
-    // be polite
+    // if a command is specified, handle it and exit
+    if !cmdline.command.is_empty() {
+        proc_cmdline_commands(&mut terminal, &cmdtree, &cmdline, &cmdline.command);
+        return;
+    }
+
+    terminal.clear();
     greetings();
 
     terminal.connect(&cmdline.bind_address, &cmdline.path);
@@ -193,23 +243,7 @@ fn main() {
         }
         // don't process input if it starts with # ... but keep it in history
         if !input.get_line().starts_with('#') {
-            if let Some(node) = cmds.find_best(input.get_tokens()) {
-                if let Some(action) = &node.action {
-                    if let Ok(args) = process_args(&input) {
-                        execute_action(*action, &args, &cmdline, &mut terminal);
-                    }
-                } else if node.depth > 0 {
-                    print_err!("No action associated to command");
-                    if node.children.is_empty() {
-                        print_err!("Command is not implemented");
-                    } else {
-                        print_err!("Options are:");
-                        node.show_children();
-                    }
-                } else {
-                    print_err!("syntax error");
-                }
-            }
+            process_command(&mut terminal, &cmdtree, &cmdline, &mut input);
         }
         terminal.add_history_entry(input.get_line().to_owned());
     }

--- a/cli/bin/terminal.rs
+++ b/cli/bin/terminal.rs
@@ -125,7 +125,7 @@ impl Terminal {
         let _ = stdout().flush();
     }
     #[allow(clippy::unused_self)]
-    fn proc_line(&self, line: &str) -> Option<TermInput> {
+    pub fn proc_line(&self, line: &str) -> Option<TermInput> {
         let mut split = line.split_whitespace();
         let mut tokens: VecDeque<String> = VecDeque::new();
         let mut args = HashMap::new();
@@ -175,6 +175,9 @@ impl Terminal {
     }
     pub fn is_connected(&self) -> bool {
         self.connected
+    }
+    pub fn read_prompt(&self) -> &String {
+        &self.prompt
     }
 
     fn open_unix_sock<P: AsRef<Path>>(bind_addr: &P) -> Result<UnixDatagram, &'static str> {


### PR DESCRIPTION
* Allow invoking the cli in non-interactive mode, indicating the command to be executed
* This was requested a long ago by @pau-hedgehog 
* One or more commands can be provided

**Sample input**

```
dataplane-cli  -c "show vrf" -c "show interface" -c "show ip route vrfid=0" -c "show router events"
```

**Sample output**

```
dataplane(✔)# show vrf

 ─────────────────────────────────── VRFs (4)  ───────────────────────────────────
            name       id      vni  Ipv4-routes  Ipv6-routes   status table-id description
       AAAAA-vrf       17     3000            7            1   active     3000 VPC-1
       CCCCC-vrf       14     2000            5            1   active     2000 VPC-3
       BBBBB-vrf       20     4000            7            1   active     4000 VPC-2
         default        0        0           16            1   active       -- 

dataplane(✔)# show interface

 ──────────────────────────────── interfaces (4)  ────────────────────────────────
 name               id    mtu AdmStatus OpStatus  attachment           type
 eth2               50   1500 up        unknown   VRF: vrfid: 0        Ethernet        mac:16:ad:78:b4:5f:99
 eth1               59   1500 up        unknown   VRF: vrfid: 0        Ethernet        mac:16:eb:8a:df:64:cb
 lo                  1     -- up        unknown   VRF: vrfid: 0        Loopback        
 eth0               48   1500 up        unknown   VRF: vrfid: 0        Ethernet        mac:5e:e6:16:90:7d:cb

dataplane(✔)# show ip route vrfid=0

 ━━━━━━━━━
 Vrf: 'default' (id: 0) description: --
 ─────────────────────────────── Ipv4 routes (16)  ───────────────────────────────
   0.0.0.0/0 other [0/0] 00:38:59
        action Drop
   7.0.0.1/32 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
        via 10.0.1.13 interface eth2 (idx 50)
   7.0.0.2/32 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
   7.0.0.3/32 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
        via 10.0.1.13 interface eth2 (idx 50)
   7.0.0.4/32 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
        via 10.0.1.13 interface eth2 (idx 50)
   7.0.0.5/32 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
        via 10.0.1.13 interface eth2 (idx 50)
   7.0.0.6/32 bgp [20/0] 00:12:54
        via 10.0.1.13 interface eth2 (idx 50)
   7.0.0.100/32 local [0/0] 00:13:00
        interface lo (idx 1)
   10.0.0.12/30 connected [0/0] 00:13:00
        interface eth0 (idx 48)
   10.0.0.14/32 local [0/0] 00:13:00
        interface eth0 (idx 48)
   10.0.1.12/30 connected [0/0] 00:13:00
        interface eth2 (idx 50)
   10.0.1.14/32 local [0/0] 00:13:00
        interface eth2 (idx 50)
   13.13.13.0/29 bgp [20/0] 00:12:54
        via 10.0.0.13 interface eth0 (idx 48)
        via 10.0.1.13 interface eth2 (idx 50)
   99.99.0.0/16 bgp [20/0] 00:12:54
        via 10.0.1.13 interface eth2 (idx 50)
   172.16.0.0/24 connected [0/0] 00:13:00
        interface eth1 (idx 59)
   172.16.0.1/32 local [0/0] 00:13:00
        interface eth1 (idx 59)

dataplane(✔)# show router events
 ROUTER_EVENTS
 generated: 7 stored: 7 capacity: 1000
 ━━━━━━━━━━━━━
 0    2026-03-11T 08:58:20: Started!
 1    2026-03-11T 08:58:21: Connected to frr-agent
 2    2026-03-11T 09:23:37: CPI status changed to Connected
 3    2026-03-11T 09:24:18: Router config request received for generation 2
 4    2026-03-11T 09:24:18: Router config request for generation 2 SUCCEEDED
 5    2026-03-11T 09:24:19: Requested FRR configuration for generation 2
 6    2026-03-11T 09:24:19: FRR configuration for generation 2 SUCCEEDED

``` 