### PR TITLE
fix(k8s-intf): Fix LegalValue<GatewayAgentSpec> duplicate VPC ids issue

### DIFF
--- a/k8s-intf/src/bolero/spec.rs
+++ b/k8s-intf/src/bolero/spec.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::ops::Bound;
 
 use bolero::{Driver, TypeGenerator, ValueGenerator};
@@ -30,6 +30,20 @@ fn extract_subnets(vpcs: &BTreeMap<String, GatewayAgentVpcs>) -> VpcSubnetMap {
     vpc_subnets
 }
 
+fn increment_string(s: &mut str) {
+    const CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let bytes = unsafe { s.as_bytes_mut() }; // Safe, we only manipulate ASCII characters
+    for byte in bytes.iter_mut().rev() {
+        let index = CHARS.iter().position(|&x| x == *byte).unwrap();
+        *byte = CHARS[(index + 1) % CHARS.len()];
+        // If we looped over available characters, also increment the previous character; otherwise,
+        // we're done.
+        if *byte != CHARS[0] {
+            break;
+        }
+    }
+}
+
 /// Generate a random legal `GatewayAgentSpec`
 ///
 /// This does not cover all legal `GatewayAgentSpecs`,
@@ -47,10 +61,17 @@ impl TypeGenerator for LegalValue<GatewayAgentSpec> {
 
         let mut vpcs = BTreeMap::new();
         let vni_base = d.gen_u32(Bound::Included(&1), Bound::Included(&1000))?;
+        let mut vpc_internal_ids = HashSet::new();
         for i in 0..num_vpcs {
             let vni_offset = u32::try_from(i).expect("too many vpcs");
             let lv_vpc = d.produce::<LegalValue<GatewayAgentVpcs>>()?;
             let mut vpc = lv_vpc.take();
+            let vpc_id = vpc.internal_id.as_mut().unwrap();
+            while !vpc_internal_ids.insert(vpc_id.clone()) {
+                // We already have a VPC with this internal_id, "increment" the string to generate a
+                // new one.
+                increment_string(vpc_id);
+            }
             vpc.vni = Some(vni_base + vni_offset);
             vpcs.insert(format!("vpc{i}"), vpc);
         }


### PR DESCRIPTION
Fuzzing test converters::k8s::config::overlay::test::test_overlay_conversion has been [caught failing due to a duplicated VPC id](https://github.com/githedgehog/dataplane/actions/runs/22962392843/job/66656429872?pr=1335):

    Error:
    panicked at config/src/converters/k8s/config/overlay.rs:104:55:
    called `Result::unwrap()` on an `Err` value: InternalError("Cannot add vpc vpc1: A VPC with id 'aaaaa' already exists")
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

This can be reproduced with:

    $ BOLERO_RANDOM_SEED=215043561514902173833823553673718402751 \
        just cargo nextest run -p dataplane-config overlay_conversion

Make sure we don't use duplicated VPC ids when building the GatewayAgentSpec, by regenerating an id if necessary.
