### PR TITLE
Add stage to count packet processing results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "bitflags 2.11.0",
  "bolero",
  "bytecheck",
+ "dataplane-common",
  "dataplane-concurrency",
  "dataplane-id",
  "derive_builder 0.20.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,8 @@ dependencies = [
  "rapidhash",
  "rkyv",
  "serde",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/cli/bin/cmdtree_dp.rs
+++ b/cli/bin/cmdtree_dp.rs
@@ -287,6 +287,14 @@ fn cmd_show_config_summary() -> Node {
     root
 }
 
+fn cmd_show_packet_stats() -> Node {
+    let mut root = Node::new("packet");
+    root += Node::new("stats")
+        .desc("Show packet stats")
+        .action(CliAction::ShowPacketStats as u16);
+    root
+}
+
 fn cmd_show_tech() -> Node {
     Node::new("tech")
         .desc("Dump dataplanes state")
@@ -307,6 +315,7 @@ fn cmd_show() -> Node {
     root += cmd_show_flow_filter();
     root += cmd_show_gateway();
     root += cmd_show_config_summary();
+    root += cmd_show_packet_stats();
     root += cmd_show_tech();
     root
 }

--- a/cli/src/cliproto.rs
+++ b/cli/src/cliproto.rs
@@ -184,6 +184,9 @@ pub enum CliAction {
     // NF: flow filter
     ShowFlowFilter,
 
+    // NF: Packet stats
+    ShowPacketStats,
+
     // internal config
     ShowConfigInternal,
 

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -19,9 +19,10 @@ use nat::portfw::{PortForwarder, PortFwTableWriter};
 use nat::stateful::NatAllocatorWriter;
 use nat::stateless::NatTablesWriter;
 use nat::{IcmpErrorHandler, StatefulNat, StatelessNat};
+use net::packet::PacketStats;
 
 use net::buffer::PacketBufferMut;
-use pipeline::sample_nfs::PacketDumper;
+use pipeline::sample_nfs::{PacketDumper, PacketStatsNF};
 use pipeline::{DynPipeline, PipelineData};
 
 use routing::{CliSources, Router, RouterError, RouterParams};
@@ -68,6 +69,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     let portfw_w = PortFwTableWriter::new();
     let portfw_factory = portfw_w.reader().factory();
     let pdata = Arc::from(PipelineData::new(0));
+    let pkt_stats = Arc::from(PacketStats::new());
 
     // collect readers and the like for cli
     let cli_sources = CliSources {
@@ -76,6 +78,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         portfw_table: Some(Box::new(portfw_w.reader().inner())),
         nat_tables: Some(Box::new(nattabler_factory.handle().inner())),
         masquerade_state: Some(Box::new(natallocator_factory.handle().inner())),
+        pkt_stats: Some(Box::new(pkt_stats.clone())),
     };
 
     // create router
@@ -109,6 +112,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
             portfw_factory.handle(),
             flow_table.clone(),
         );
+        let pkt_stats_nf = PacketStatsNF::new(pkt_stats.clone());
 
         // Build the pipeline for a router. The composition of the pipeline (in stages) is currently
         // hard-coded. In any pipeline, the Stats and ExpirationsNF stages should go last
@@ -126,6 +130,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
             .add_stage(stage_egress)
             .add_stage(flow_expirations_nf)
             .add_stage(pktdump)
+            .add_stage(pkt_stats_nf)
             .add_stage(stats_stage)
     };
 

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -84,7 +84,7 @@ impl PortForwarder {
             && (!tcp.syn() || tcp.ack())
         {
             debug!("Dropping TCP segment: it has no SYN (or ack) and we have no state for it");
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             return None;
         }
         let Some(dst_port) = transport.dst_port() else {
@@ -143,7 +143,7 @@ impl PortForwarder {
 
         // check if the packet can be port forwarded at all
         let Some((key, dst_ip, dst_port)) = Self::can_be_port_forwarded(packet) else {
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             let reason = packet.get_done().unwrap_or_else(|| unreachable!());
             debug!("{nfi}: packet cannot be port-forwarded. Dropping it (reason:{reason})");
             return;
@@ -152,7 +152,7 @@ impl PortForwarder {
         // lookup the port-forwarding rule, using the given key, that contains the destination port
         let Some(entry) = pfwtable.lookup_matching_rule(key, dst_ip.inner(), dst_port) else {
             debug!("{nfi}: no rule found for port-forwarding key {key}. Dropping packet.");
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             return;
         };
 
@@ -160,7 +160,7 @@ impl PortForwarder {
         let Some((new_dst_ip, new_dst_port)) = entry.map_address_port(dst_ip.inner(), dst_port)
         else {
             debug!("{nfi}: Unable to build usable address and port"); // FIXME:
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::InternalFailure);
             return;
         };
 
@@ -319,7 +319,7 @@ impl PortForwarder {
                 debug!("Packet hit Active flow referring to STALE port-forwarding rule.");
                 let Some(entry) = Self::get_rule_from_pkt(packet, pfwtable, &state) else {
                     debug!("Packet should no longer be forwarded. Will drop and invalidate state");
-                    packet.done(DoneReason::Filtered);
+                    packet.done(DoneReason::NatNotPortForwarded);
                     invalidate_flow_state(packet);
                     return;
                 };

--- a/nat/src/portfw/test.rs
+++ b/nat/src/portfw/test.rs
@@ -268,7 +268,7 @@ mod nf_test {
         let tcp = packet.try_tcp_mut().unwrap();
         tcp.set_syn(false);
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered));
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
 
         // process a packet in reverse direction: no flow info should have been found
         let packet = tcp_packet_reverse_reply();
@@ -528,8 +528,7 @@ mod nf_test {
 
         let packet = tcp_packet_to_port_forward();
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered));
-        //        assert!(get_pfw_flow_status(&output).is_none());
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
 
         println!("{flow_table}");
 
@@ -538,7 +537,7 @@ mod nf_test {
 
         let packet = tcp_packet_to_port_forward();
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered)); // should be filtered
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
         assert_eq!(get_flow_status(&output), None); // expiration NF should have removed the flow
         assert!(get_pfw_flow_status(&output).is_none());
         println!("{flow_table}");
@@ -817,7 +816,7 @@ mod nf_test {
         );
         let rule_referenced = get_pfw_flow_state_rule(&output);
         assert!(rule_referenced.is_none()); // flow did not get a new reference to a rule
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered)); // packet was dropped
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded)); // packet was dropped
 
         println!("{flow_table}");
     }

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -535,7 +535,7 @@ fn translate_error(error: &StatefulNatError) -> DoneReason {
 
         StatefulNatError::BadTransportHeader
         | StatefulNatError::AllocationFailure(AllocatorError::UnsupportedProtocol(_)) => {
-            DoneReason::UnsupportedTransport
+            DoneReason::NatUnsupportedProto
         }
 
         StatefulNatError::TupleParseError | StatefulNatError::InvalidPort(_) => {

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -362,7 +362,7 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         StatelessNatError::NoIpHeader
         | StatelessNatError::IcmpErrorMsg(IcmpErrorMsgError::BadIpHeader) => DoneReason::NotIp,
 
-        StatelessNatError::UnsupportedTranslation => DoneReason::UnsupportedTransport,
+        StatelessNatError::UnsupportedTranslation => DoneReason::NatUnsupportedProto,
 
         StatelessNatError::MissingTable(_) => DoneReason::Unroutable,
 
@@ -379,7 +379,7 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
 
         StatelessNatError::IcmpErrorMsg(
             IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_),
-        ) => DoneReason::Filtered,
+        ) => DoneReason::InvalidChecksum,
     }
 }
 

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -19,6 +19,7 @@ atomic-instant-full = { workspace = true }
 bitflags = { workspace = true }
 bolero = { workspace = true, features = ["alloc", "arbitrary", "std"], optional = true }
 bytecheck = { workspace = true }
+common = { workspace = true }
 concurrency = { workspace = true }
 derive_builder = { workspace = true, features = ["alloc"] }
 downcast-rs = { workspace = true, features = ["sync"] }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -29,6 +29,8 @@ linux-raw-sys = { workspace = true, features = ["std", "if_ether"] }
 multi_index_map = { workspace = true, default-features = false, features = ["serde"] }
 rapidhash = { workspace = true }
 rkyv = { workspace = true, features = ["alloc", "bytecheck"]}
+strum = { workspace = true }
+strum_macros = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/net/src/packet/display.rs
+++ b/net/src/packet/display.rs
@@ -16,7 +16,7 @@ use crate::vlan::Vlan;
 use crate::buffer::PacketBufferMut;
 use crate::checksum::Checksum;
 #[allow(deprecated)]
-use crate::packet::{BridgeDomain, DoneReason, InvalidPacket, Packet, PacketMeta};
+use crate::packet::{BridgeDomain, InvalidPacket, Packet, PacketMeta};
 use std::fmt::{Display, Formatter};
 
 impl Display for Eth {
@@ -226,12 +226,6 @@ impl Display for Headers {
 }
 
 /* ============= METADATA =============== */
-impl Display for DoneReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // using Debug at the moment since the enum may soon change
-        write!(f, "{self:?}")
-    }
-}
 
 fn fmt_opt<T: Display>(
     f: &mut Formatter<'_>,

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -76,6 +76,7 @@ impl Display for VpcDiscriminant {
     }
 }
 
+#[repr(u8)]
 #[allow(unused)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DoneReason {
@@ -106,6 +107,15 @@ pub enum DoneReason {
     InternalDrop,         /* the packet was dropped internally due to a queue being full */
     InvalidChecksum,      /* the validation of a checksum for this packet failed */
     IcmpErrorIncomplete,  /* the packet is an ICMP error but it does not contain data it should */
+}
+
+impl From<u8> for DoneReason {
+    fn from(value: u8) -> Self {
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute(value)
+        }
+    }
 }
 
 bitflags! {

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -12,7 +12,6 @@ use crate::vxlan::Vni;
 use bitflags::bitflags;
 use concurrency::sync::Arc;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::net::IpAddr;
 use tracing::error;
@@ -254,65 +253,5 @@ impl Drop for PacketMeta {
         if self.done.is_none() && self.is_initialized() {
             error!("Attempted to drop packet with unspecified verdict!");
         }
-    }
-}
-
-#[derive(Default, Debug)]
-#[allow(unused)]
-pub struct PacketDropStats {
-    pub name: String,
-    reasons: HashMap<DoneReason, u64>,
-    //Fredi: Todo: replace by ahash or use a small vec indexed by the DropReason value
-}
-
-impl PacketDropStats {
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_owned(),
-            reasons: HashMap::default(),
-        }
-    }
-    #[allow(dead_code)]
-    pub fn incr(&mut self, reason: DoneReason, value: u64) {
-        self.reasons
-            .entry(reason)
-            .and_modify(|counter| *counter += value)
-            .or_insert(value);
-    }
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn get_stat(&self, reason: DoneReason) -> Option<u64> {
-        self.reasons.get(&reason).copied()
-    }
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn get_stats(&self) -> &HashMap<DoneReason, u64> {
-        &self.reasons
-    }
-}
-
-#[cfg(test)]
-pub mod test {
-    use super::DoneReason;
-    use super::PacketDropStats;
-
-    #[test]
-    fn test_packet_drop_stats() {
-        let mut stats = PacketDropStats::new("Stats:pipeline-FOO-stage-BAR");
-        stats.incr(DoneReason::InterfaceAdmDown, 10);
-        stats.incr(DoneReason::InterfaceAdmDown, 1);
-        stats.incr(DoneReason::RouteFailure, 9);
-        stats.incr(DoneReason::Unroutable, 13);
-
-        // look up some particular stats
-        assert_eq!(stats.get_stat(DoneReason::InterfaceAdmDown), Some(11));
-        assert_eq!(stats.get_stat(DoneReason::Unroutable), Some(13));
-        assert_eq!(stats.get_stat(DoneReason::InterfaceUnsupported), None);
-
-        // access the whole stats map
-        let read = stats.get_stats();
-        assert_eq!(read.get(&DoneReason::InterfaceAdmDown), Some(11).as_ref());
     }
 }

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -14,6 +14,7 @@ use concurrency::sync::Arc;
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;
+use strum_macros::EnumCount;
 use tracing::error;
 
 /// Every VRF is univocally identified with a numerical VRF id
@@ -78,35 +79,36 @@ impl Display for VpcDiscriminant {
 
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumCount)]
 pub enum DoneReason {
     InternalFailure,      /* catch-all for internal issues */
-    NotEthernet,          /* could not get eth header */
-    NotIp,                /* could not get IP header - maybe it's not ip */
-    UnsupportedTransport, /* unsupported transport layer */
-    MacNotForUs,          /* frame is not broadcast nor for us */
+    InterfaceUnknown,     /* the interface cannot be found */
     InterfaceDetached,    /* interface has not been attached to any VRF */
     InterfaceAdmDown,     /* interface is admin down */
     InterfaceOperDown,    /* interface is oper down : no link */
-    InterfaceUnknown,     /* the interface cannot be found */
     InterfaceUnsupported, /* the operation is not supported on the interface */
-    NatOutOfResources,    /* can't do NAT due to lack of resources */
+    NotEthernet,          /* could not get eth header */
+    Unhandled,            /* there exists no support to handle this type of packet */
+    MacNotForUs,          /* frame is not broadcast nor for us */
+    InvalidDstMac,        /* dropped the packet since it had to have an invalid destination mac */
+    MissingEtherType,     /* couldn't determine ethertype to use */
+    Filtered,             /* The packet was administratively filtered */
+    NotIp,                /* could not get IP header or packet is not IP */
     RouteFailure,         /* missing routing information */
     RouteDrop,            /* routing explicitly requests pkts to be dropped */
     HopLimitExceeded,     /* TTL / Hop count was exceeded */
-    Filtered,             /* The packet was administratively filtered */
-    Unhandled,            /* there exists no support to handle this type of packet */
     MissL2resolution,     /* adjacency failure: we don't know mac of some ip next-hop */
-    InvalidDstMac,        /* dropped the packet since it had to have an invalid destination mac */
-    Malformed,            /* the packet does not conform / is malformed */
-    MissingEtherType,     /* can't determine ethertype to use */
-    Unroutable,           /* we don't have state to forward the packet */
+    NatOutOfResources,    /* can't do NAT due to lack of resources */
+    NatUnsupportedProto,  /* unsupported transport protocol for NATing */
     NatFailure,           /* It was not possible to NAT the packet */
-    Local,                /* the packet has to be locally consumed by kernel */
-    Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
-    InternalDrop,         /* the packet was dropped internally due to a queue being full */
+    NatNotPortForwarded,  /* Packet was sent to port forwarder and it rejected it */
+    Malformed,            /* the packet does not conform / is malformed */
+    Unroutable,           /* we don't have state to forward the packet */
     InvalidChecksum,      /* the validation of a checksum for this packet failed */
     IcmpErrorIncomplete,  /* the packet is an ICMP error but it does not contain data it should */
+    InternalDrop,         /* the packet was dropped internally due to a queue being full */
+    Local,                /* the packet has to be locally consumed by kernel */
+    Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
 }
 
 impl From<u8> for DoneReason {

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -6,6 +6,9 @@
 mod display;
 mod hash;
 mod meta;
+mod stats;
+
+pub use stats::PacketStats;
 
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -8,6 +8,7 @@ use common::cliprovider::{CliDataProvider, Heading};
 use std::fmt::Display;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use strum::EnumCount;
 
 /// A tiny table of packet counts per `DoneReason`
 pub struct PacketStats {
@@ -15,20 +16,15 @@ pub struct PacketStats {
 }
 impl PacketStats {
     #[must_use]
+    #[allow(clippy::new_without_default)]
     /// Build an instance of `PacketStats`
     pub fn new() -> Self {
         Self {
-            counts: (DoneReason::InternalFailure as u8..=DoneReason::IcmpErrorIncomplete as u8)
-                .map(|_| AtomicU64::new(0))
-                .collect(),
+            counts: (0..DoneReason::COUNT).map(|_| AtomicU64::new(0)).collect(),
         }
     }
     /// Increment the count for a given `DoneReason`
     pub fn incr(&self, done_reason: DoneReason) {
-        debug_assert_eq!(
-            self.counts.len(),
-            DoneReason::IcmpErrorIncomplete as usize + 1
-        );
         self.counts[done_reason as usize].fetch_add(1, Ordering::Relaxed);
     }
     /// Provide a snapshot of the `PacketStats`
@@ -46,39 +42,47 @@ impl Display for DoneReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InternalFailure => write!(f, "Internal failure"),
-            Self::NotEthernet => write!(f, "Non-Ethernet"),
-            Self::NotIp => write!(f, "Non-IP"),
-            Self::UnsupportedTransport => write!(f, "Unsupported transport"),
-            Self::MacNotForUs => write!(f, "Frame not for us"),
-            Self::InterfaceDetached => write!(f, "Detached interface"),
-            Self::InterfaceAdmDown => write!(f, "Interface admin down"),
-            Self::InterfaceOperDown => write!(f, "Interface oper down"),
-            Self::InterfaceUnknown => write!(f, "Unknown interface"),
-            Self::InterfaceUnsupported => write!(f, "Interface unsupported"),
-            Self::NatOutOfResources => write!(f, "NAT out of resources"),
-            Self::RouteFailure => write!(f, "Route failure"),
-            Self::RouteDrop => write!(f, "Route drop"),
-            Self::HopLimitExceeded => write!(f, "TTL exceeded"),
-            Self::Filtered => write!(f, "Filtered"),
+
+            Self::InterfaceDetached => write!(f, "Interface: detached"),
+            Self::InterfaceAdmDown => write!(f, "Interface: admin down"),
+            Self::InterfaceOperDown => write!(f, "Interface: oper down"),
+            Self::InterfaceUnknown => write!(f, "Interface: unknown"),
+            Self::InterfaceUnsupported => write!(f, "Interface: unsupported"),
+
+            Self::NotEthernet => write!(f, "Not Ethernet"),
             Self::Unhandled => write!(f, "Unhandled"),
-            Self::MissL2resolution => write!(f, "L2 resolution failure"),
-            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
-            Self::Malformed => write!(f, "Malformed packet"),
+            Self::MacNotForUs => write!(f, "Frame not for us"),
             Self::MissingEtherType => write!(f, "Missing ether type"),
+            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+
+            Self::NotIp => write!(f, "IP:  packet is not IP"),
+            Self::RouteFailure => write!(f, "IP:  missing routing info"),
+            Self::RouteDrop => write!(f, "IP:  route drop"),
+            Self::HopLimitExceeded => write!(f, "IP:  TTL exceeded"),
+            Self::MissL2resolution => write!(f, "IP:  L2 resolution failure"),
+
+            Self::Filtered => write!(f, "Filtered"),
+
+            Self::NatOutOfResources => write!(f, "NAT: out of resources"),
+            Self::NatFailure => write!(f, "NAT: failure"),
+            Self::NatUnsupportedProto => write!(f, "NAT: Unsupported protocol"),
+            Self::NatNotPortForwarded => write!(f, "NAT: not port-forwarded"),
+
+            Self::Malformed => write!(f, "Malformed packet"),
             Self::Unroutable => write!(f, "Unroutable"),
-            Self::NatFailure => write!(f, "NAT failure"),
-            Self::Local => write!(f, "Locally delivered"),
-            Self::Delivered => write!(f, "Delivered"),
-            Self::InternalDrop => write!(f, "Internal drop"),
             Self::InvalidChecksum => write!(f, "Invalid checksum"),
             Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+
+            Self::InternalDrop => write!(f, "Internal drop"),
+            Self::Local => write!(f, "Locally delivered"),
+            Self::Delivered => write!(f, "Delivered"),
         }
     }
 }
 
 macro_rules! PKT_STATS {
     () => {
-        "    {:<22} {:>10}"
+        "    {:<30} {}"
     };
 }
 

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Module to compute packet processing counters
+
+use super::meta::DoneReason;
+use common::cliprovider::{CliDataProvider, Heading};
+use std::fmt::Display;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// A tiny table of packet counts per `DoneReason`
+pub struct PacketStats {
+    counts: Vec<AtomicU64>,
+}
+impl PacketStats {
+    #[must_use]
+    /// Build an instance of `PacketStats`
+    pub fn new() -> Self {
+        Self {
+            counts: (DoneReason::InternalFailure as u8..=DoneReason::IcmpErrorIncomplete as u8)
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+        }
+    }
+    /// Increment the count for a given `DoneReason`
+    pub fn incr(&self, done_reason: DoneReason) {
+        debug_assert_eq!(
+            self.counts.len(),
+            DoneReason::IcmpErrorIncomplete as usize + 1
+        );
+        self.counts[done_reason as usize].fetch_add(1, Ordering::Relaxed);
+    }
+    /// Provide a snapshot of the `PacketStats`
+    pub fn snapshot(&self) -> impl Iterator<Item = (DoneReason, u64)> {
+        self.counts.iter().enumerate().map(|(reason, count)| {
+            (
+                DoneReason::from(u8::try_from(reason).unwrap_or_else(|_| unreachable!())),
+                count.load(Ordering::Relaxed),
+            )
+        })
+    }
+}
+
+impl Display for DoneReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InternalFailure => write!(f, "Internal failure"),
+            Self::NotEthernet => write!(f, "Non-Ethernet"),
+            Self::NotIp => write!(f, "Non-IP"),
+            Self::UnsupportedTransport => write!(f, "Unsupported transport"),
+            Self::MacNotForUs => write!(f, "Frame not for us"),
+            Self::InterfaceDetached => write!(f, "Detached interface"),
+            Self::InterfaceAdmDown => write!(f, "Interface admin down"),
+            Self::InterfaceOperDown => write!(f, "Interface oper down"),
+            Self::InterfaceUnknown => write!(f, "Unknown interface"),
+            Self::InterfaceUnsupported => write!(f, "Interface unsupported"),
+            Self::NatOutOfResources => write!(f, "NAT out of resources"),
+            Self::RouteFailure => write!(f, "Route failure"),
+            Self::RouteDrop => write!(f, "Route drop"),
+            Self::HopLimitExceeded => write!(f, "TTL exceeded"),
+            Self::Filtered => write!(f, "Filtered"),
+            Self::Unhandled => write!(f, "Unhandled"),
+            Self::MissL2resolution => write!(f, "L2 resolution failure"),
+            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+            Self::Malformed => write!(f, "Malformed packet"),
+            Self::MissingEtherType => write!(f, "Missing ether type"),
+            Self::Unroutable => write!(f, "Unroutable"),
+            Self::NatFailure => write!(f, "NAT failure"),
+            Self::Local => write!(f, "Locally delivered"),
+            Self::Delivered => write!(f, "Delivered"),
+            Self::InternalDrop => write!(f, "Internal drop"),
+            Self::InvalidChecksum => write!(f, "Invalid checksum"),
+            Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+        }
+    }
+}
+
+macro_rules! PKT_STATS {
+    () => {
+        "    {:<22} {:>10}"
+    };
+}
+
+impl Display for PacketStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading("Packet stats").fmt(f)?;
+        writeln!(f, PKT_STATS!(), "Packet result", "count")?;
+        for (reason, count) in self.snapshot() {
+            writeln!(f, PKT_STATS!(), reason.to_string(), count)?;
+        }
+        Ok(())
+    }
+}
+
+impl CliDataProvider for PacketStats {
+    fn provide(&self, _what: Option<common::cliprovider::CliData>) -> String {
+        self.to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::packet::DoneReason;
+    use crate::packet::stats::PacketStats;
+
+    #[test]
+    fn test_packet_stats_display() {
+        let stats = PacketStats::new();
+        stats.incr(DoneReason::Delivered);
+        stats.incr(DoneReason::InvalidChecksum);
+        stats.incr(DoneReason::NatFailure);
+        println!("{stats}");
+    }
+}

--- a/pipeline/src/sample_nfs.rs
+++ b/pipeline/src/sample_nfs.rs
@@ -8,7 +8,7 @@ use net::eth::mac::{DestinationMac, Mac};
 use net::headers::TryIcmp4;
 use net::headers::TryUdp;
 use net::headers::{TryEthMut, TryHeaders, TryIpv4Mut, TryIpv6Mut};
-use net::packet::Packet;
+use net::packet::{Packet, PacketStats};
 use net::vxlan::Vxlan;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -218,5 +218,30 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Passthrough {
         input: Input,
     ) -> impl Iterator<Item = Packet<Buf>> + 'a {
         input
+    }
+}
+
+/// Network function that collects packet stats
+pub struct PacketStatsNF {
+    pkt_stats: Arc<PacketStats>,
+}
+impl PacketStatsNF {
+    #[must_use]
+    /// Create a `PacketStatsNF`
+    pub fn new(pkt_stats: Arc<PacketStats>) -> Self {
+        Self { pkt_stats }
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for PacketStatsNF {
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        input.inspect(|packet| {
+            if let Some(reason) = packet.get_done() {
+                self.pkt_stats.incr(reason);
+            }
+        })
     }
 }

--- a/routing/src/cli/handler.rs
+++ b/routing/src/cli/handler.rs
@@ -527,6 +527,7 @@ fn do_handle_cli_request(
         CliAction::ShowMasquerading => {
             show_provider(request, sources.masquerade_state.as_deref(), None)
         }
+        CliAction::ShowPacketStats => show_provider(request, sources.pkt_stats.as_deref(), None),
         _ => Err(CliError::NotSupported("Not implemented yet".to_string()))?,
     };
     Ok(response)

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -87,6 +87,7 @@ pub struct CliSources {
     pub portfw_table: Option<Box<dyn CliDataProvider>>,
     pub nat_tables: Option<Box<dyn CliDataProvider>>,
     pub masquerade_state: Option<Box<dyn CliDataProvider>>,
+    pub pkt_stats: Option<Box<dyn CliDataProvider>>,
 }
 
 impl Display for RouterParams {


### PR DESCRIPTION
* Defines type PacketStats, which is a vector of atomicU64's indexed by DoneReason
* Implements PacketStatsNF and adds it to the pipeline
* Add cli command to show counts per DoneReason.
* Redefine some DoneReasons for clarity


``` 
dataplane(✔)# show packet stats
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Packet stats ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    Packet result                  count
    Internal failure               0
    Interface: unknown             10
    Interface: detached            0
    Interface: admin down          0
    Interface: oper down           0
    Interface: unsupported         0
    Not Ethernet                   0
    Unhandled                      2
    Frame not for us               289
    Invalid dst MAC                0
    Missing ether type             0
    Filtered                       0
    IP:  packet is not IP          2
    IP:  missing routing info      0
    IP:  route drop                17
    IP:  TTL exceeded              0
    IP:  L2 resolution failure     0
    NAT: out of resources          0
    NAT: Unsupported protocol      0
    NAT: failure                   0
    NAT: not port-forwarded        0
    Malformed packet               0
    Unroutable                     0
    Invalid checksum               0
    Incomplete ICMP error          0
    Internal drop                  0
    Locally delivered              200
    Delivered                      311611

``` 
