### PR TITLE
vlab scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ result*/**
 /bin
 sysroot
 devroot
+creds.json

--- a/default.nix
+++ b/default.nix
@@ -754,6 +754,117 @@ let
     config.Cmd = [ "/libexec/frr/docker-start" ];
   };
 
+  # Local dev-only container image for the vlab test environment.  Replaces
+  # the old Ubuntu-based scripts/vlab/Dockerfile: every tool the vlab runtime
+  # needs comes from nix (pinned via npins), not apt + wget + `curl | bash`,
+  # so there is no unverified download in the image build.
+  #
+  # The hhfab CLI is still fetched at runtime via i.hhdev.io/hhfab -- it is
+  # a fast-moving test tool that we intentionally track against master rather
+  # than pin into the image closure.
+  #
+  # Fixed tag "latest" so scripts/vlab/run.sh can refer to `vlab` unambiguously
+  # without threading the dataplane's `tag` argstr through.
+  containers.vlab = pkgs.dockerTools.buildLayeredImage {
+    name = "vlab";
+    tag = "latest";
+    contents = pkgs.buildEnv {
+      name = "vlab-env";
+      pathsToLink = [ "/" ];
+      paths = with pkgs.pkgsHostHost; [
+        bashInteractive
+        cacert
+        coreutils
+        curl
+        docker-client
+        dockerTools.binSh
+        dockerTools.fakeNss
+        dockerTools.usrBinEnv
+        findutils
+        gawk
+        git
+        gnugrep
+        gnused
+        gnutar
+        gzip
+        iproute2
+        jq
+        less
+        neovim
+        openssh
+        openssl
+        oras
+        qemu_kvm
+        socat
+        sudo
+        wget
+        # Python's kislyuk yq (supports the `-y` flag used by run.sh);
+        # nixpkgs.yq-go is mikefarah's Go port with a different CLI surface.
+        yq
+        zot
+
+        # nixpkgs' sudo is always built with PAM on linux, so we need to ship
+        # a /etc/pam.d/sudo config or sudo aborts with "unable to initialize
+        # PAM: Critical error - immediate abort" the moment hhfab vlab up
+        # shells out to it.  The container runs as root in a privileged
+        # sandbox, so we use pam_permit.so for every stage; absolute module
+        # paths sidestep libpam's compiled-in module search path.
+        (writeTextDir "etc/pam.d/sudo" ''
+          auth     sufficient   ${pam}/lib/security/pam_permit.so
+          account  sufficient   ${pam}/lib/security/pam_permit.so
+          password sufficient   ${pam}/lib/security/pam_permit.so
+          session  sufficient   ${pam}/lib/security/pam_permit.so
+        '')
+
+        # zot config and cert.ini are immutable across runs, so they live
+        # in the image rather than in any mount or bind-mount.
+        (writeTextDir "etc/zot/config.json" (builtins.readFile ./scripts/vlab/root/etc/zot/config.json))
+        (writeTextDir "etc/zot/cert.ini" (builtins.readFile ./scripts/vlab/root/etc/zot/cert.ini))
+
+        # Entrypoint script: generates TLS material into a tmpfs, validates
+        # or provisions ghcr.io credentials in a persistent docker volume,
+        # then execs zot.  See scripts/vlab/entrypoint.sh for modes.
+        (writeShellApplication {
+          name = "vlab-entrypoint";
+          runtimeInputs = [
+            cacert
+            coreutils
+            curl
+            jq
+            openssl
+            zot
+          ];
+          text = builtins.readFile ./scripts/vlab/entrypoint.sh;
+        })
+      ];
+    };
+
+    # /tmp, /run/vlab (for the merged CA bundle), and /vlab (the working/volume
+    # dir) don't exist in the pure nix closure; pre-create them so the
+    # entrypoint and docker exec commands can write to them.
+    # /tmp and the /vlab working dir don't exist in the pure nix closure;
+    # pre-create them so docker exec commands can write to them.  The tmpfs
+    # at /run/vlab and the vlab-secrets volume at /var/lib/vlab are created
+    # by docker at container start.
+    extraCommands = ''
+      mkdir -p tmp vlab
+      chmod 1777 tmp
+    '';
+
+    config = {
+      WorkingDir = "/vlab";
+      Volumes."/vlab" = { };
+      Env = [
+        # Go (and hhfab) read SSL_CERT_FILE; the entrypoint writes the merged
+        # bundle (nixpkgs system CAs + the freshly-minted zot CA) to this path
+        # before exec'ing zot.
+        "SSL_CERT_FILE=/run/vlab/ca-bundle.pem"
+      ];
+      Entrypoint = [ "/bin/vlab-entrypoint" ];
+      Cmd = [ "run" ];
+    };
+  };
+
   containers.frr.host = pkgs.dockerTools.buildLayeredImage {
     name = "ghcr.io/githedgehog/dataplane/frr-host";
     inherit tag;

--- a/justfile
+++ b/justfile
@@ -345,3 +345,60 @@ bump_version version:
 [script]
 shell:
    nix-shell
+
+# OCI repo used by the vlab Zot registry
+[private]
+vlab_oci_repo := "192.168.19.1:30000"
+
+# Start the vlab environment
+[script]
+vlab-up: (build "containers.vlab")
+    {{ _just_debuggable_ }}
+    docker load < ./results/containers.vlab
+    pushd ./scripts/vlab
+    ./run.sh
+    popd
+
+# Open a shell or run a command on the vlab control plane
+[script]
+vlab-control *args:
+    {{ _just_debuggable_ }}
+    pushd ./scripts/vlab
+    ./control.sh {{ args }}
+    popd
+
+# Stop the vlab container and remove the docker network
+[confirm]
+[script]
+vlab-down:
+    {{ _just_debuggable_ }}
+    docker stop vlab || true
+    docker rm vlab || true
+    docker network rm zot || true
+
+# Stop vlab and remove all associated docker volumes
+[confirm]
+[script]
+vlab-purge: vlab-down
+    {{ _just_debuggable_ }}
+    docker volume rm vlab || true
+    docker volume rm zot || true
+    docker volume rm vlab-secrets || true
+
+# Build, push the dataplane image to the vlab registry, and patch the running fabric
+[script]
+vlab-patch-dataplane:
+    {{ _just_debuggable_ }}
+    just oci_insecure=true oci_repo="{{ vlab_oci_repo }}" push-container dataplane
+    pushd ./scripts/vlab
+    ./control.sh kubectl -n fab patch fab/default --type=merge -p '{"spec":{"overrides":{"versions":{"gateway":{"dataplane":"{{version}}"}}}}}'
+    popd
+
+# Build, push the FRR image to the vlab registry, and patch the running fabric
+[script]
+vlab-patch-frr:
+    {{ _just_debuggable_ }}
+    just oci_insecure=true oci_repo="{{ vlab_oci_repo }}" push-container frr.dataplane
+    pushd ./scripts/vlab
+    ./control.sh kubectl -n fab patch fab/default --type=merge -p '{"spec":{"overrides":{"versions":{"gateway":{"frr":"{{version}}"}}}}}'
+    popd

--- a/nix/overlays/dataplane-dev.nix
+++ b/nix/overlays/dataplane-dev.nix
@@ -21,6 +21,9 @@ in
   opengrep = final.callPackage ../pkgs/opengrep {
     src = sources.opengrep;
   };
+  zot = final.callPackage ../pkgs/zot {
+    src = sources.zot;
+  };
   cargo-bolero = prev.cargo-bolero.override { inherit (override-packages) rustPlatform; };
   cargo-deny = prev.cargo-deny.override { inherit (override-packages) rustPlatform; };
   cargo-edit = prev.cargo-edit.override { inherit (override-packages) rustPlatform; };

--- a/nix/pkgs/zot/binary.sri
+++ b/nix/pkgs/zot/binary.sri
@@ -1,0 +1,1 @@
+sha256-a8CsTdz/c1F0tsc45u6cNXmYwjxVRlC+hhNdI3IN3Yw=

--- a/nix/pkgs/zot/default.nix
+++ b/nix/pkgs/zot/default.nix
@@ -1,0 +1,51 @@
+# Install a prebuilt zot binary from upstream GitHub releases.  The project
+# ships statically-linked linux/amd64 binaries per release; we fetch the asset
+# directly rather than rebuild it from source.
+#
+# Versioning: the tag name (e.g. "v2.1.15") comes from the npins `zot` pin,
+# so a plain `npins update` (i.e. `just bump pins`) bumps the version.
+# The release asset is a raw ELF binary (no archive), which npins' tarball
+# pin type rejects, so the binary's content hash is carried in ./binary.sri
+# and is refreshed by scripts/bump.sh on every `just bump pins`.
+{
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  lib,
+  src,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "zot";
+  # src.version carries the tag (e.g. "v2.1.15"); strip the leading "v" so
+  # the derivation name reads as a plain version.
+  version = lib.removePrefix "v" src.version;
+
+  src = fetchurl {
+    url = "https://github.com/project-zot/zot/releases/download/${src.version}/zot-linux-amd64";
+    hash = lib.removeSuffix "\n" (builtins.readFile ./binary.sri);
+  };
+
+  dontUnpack = true;
+  dontStrip = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  # zot ships a statically-linked Go binary, so autoPatchelfHook has nothing
+  # to patch; it's kept as a safety net in case upstream ever switches to a
+  # dynamically-linked build.
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/zot
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "OCI-native container image registry";
+    homepage = "https://zotregistry.dev";
+    license = lib.licenses.asl20;
+    mainProgram = "zot";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -97,9 +97,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "6e3abaf53ead71a48db2304b6459b5bcddbf5d09",
-      "url": "https://github.com/githedgehog/fabricator/archive/6e3abaf53ead71a48db2304b6459b5bcddbf5d09.tar.gz",
-      "hash": "sha256-xxjDIGXlSo0kv3Q058LnJtR+r4XlBd9FjgoLMhkYiD8="
+      "revision": "eb13696a3942be4eed7f57b997f897637ed9c73c",
+      "url": "https://github.com/githedgehog/fabricator/archive/eb13696a3942be4eed7f57b997f897637ed9c73c.tar.gz",
+      "hash": "sha256-NijpVAeuOq3lJyIAuGs+rDaIBIVso8kiUB4Eo235OCk="
     },
     "frr": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -88,6 +88,19 @@
       "hash": "sha256-iTCIpPD9VfgixrLGjvXgdmuqx/F+k8b/M5S7fmtYJks=",
       "frozen": true
     },
+    "fabricator": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "githedgehog",
+        "repo": "fabricator"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "6e3abaf53ead71a48db2304b6459b5bcddbf5d09",
+      "url": "https://github.com/githedgehog/fabricator/archive/6e3abaf53ead71a48db2304b6459b5bcddbf5d09.tar.gz",
+      "hash": "sha256-xxjDIGXlSo0kv3Q058LnJtR+r4XlBd9FjgoLMhkYiD8="
+    },
     "frr": {
       "type": "Git",
       "repository": {
@@ -235,6 +248,22 @@
       "revision": "e611106c527e8ab0adbb641183cda284411d575c",
       "url": "https://github.com/oxalica/rust-overlay/archive/e611106c527e8ab0adbb641183cda284411d575c.tar.gz",
       "hash": "sha256-Xq7p+Ex3YHFAd+fFFLOYw2Wv67582X7SAmrEDtIDZQ4="
+    },
+    "zot": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "project-zot",
+        "repo": "zot"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v2.1.15",
+      "revision": "ace12e2a12d0e104f6fb0aecf162b29e8c67b8a9",
+      "url": "https://api.github.com/repos/project-zot/zot/tarball/refs/tags/v2.1.15",
+      "hash": "sha256-PhPhlifLU0kOGPqH1kqKxikt+DtJO+MWEv1w6/7sZ6E="
     }
   },
   "version": 7

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -21,4 +21,13 @@ nix-hash --to-sri --type sha256 \
     "$(nix-prefetch-url --type sha256 "$opengrep_url")" \
     > nix/pkgs/opengrep/binary.sri
 
+# Refresh the zot release-asset content hash on the same contract as opengrep
+# above: the pin tracks the tag, the raw binary hash lives in
+# nix/pkgs/zot/binary.sri.
+zot_version="$(jq --exit-status --raw-output '.pins.zot.version' npins/sources.json)"
+zot_url="https://github.com/project-zot/zot/releases/download/${zot_version}/zot-linux-amd64"
+nix-hash --to-sri --type sha256 \
+    "$(nix-prefetch-url --type sha256 "$zot_url")" \
+    > nix/pkgs/zot/binary.sri
+
 ./scripts/update-doc-headers.sh

--- a/scripts/gen-pins.sh
+++ b/scripts/gen-pins.sh
@@ -67,3 +67,6 @@ npins add github githedgehog dplane-plugin --branch master # floats with branch 
 npins add github opengrep opengrep
 npins add github mermaid-js mermaid --release-prefix "mermaid@"
 npins add github KaTeX KaTeX
+
+npins add github project-zot zot
+npins add github githedgehog fabricator --branch master # floats with branch on pin bump

--- a/scripts/vlab/control.sh
+++ b/scripts/vlab/control.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Open Network Fabric Authors
+
+set -euo pipefail
+
+if [ -z "$*" ]; then
+    declare -r cmd="k9s --namespace fab --command pod"
+else
+    declare -r cmd="$(printf '%q ' "$@")"
+fi
+
+docker exec -it vlab \
+    ssh \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -t \
+        -p 22000 \
+        -i /vlab/vlab/sshkey \
+        core@localhost "export PATH=\"/usr/bin:/bin:/opt/bin\"; $cmd"

--- a/scripts/vlab/entrypoint.sh
+++ b/scripts/vlab/entrypoint.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Open Network Fabric Authors
+
+set -euo pipefail
+
+declare -r CERT_DIR=/etc/zot/certs
+declare -r SECRETS_DIR=/var/lib/vlab
+declare -r CREDS_FILE="${SECRETS_DIR}/creds.json"
+declare -r CONFIG_FILE=/etc/zot/config.json
+declare -r CERT_INI=/etc/zot/cert.ini
+# Merged CA bundle: nixpkgs cacert's system CAs plus the freshly-minted zot
+# CA. The image sets SSL_CERT_FILE to this path via config.Env so hhfab and
+# every other TLS client inside the container trusts zot.loc without the
+# Debian-style update-ca-certificates tool (which isn't in the nix closure).
+declare -r CA_BUNDLE=/run/vlab/ca-bundle.pem
+declare -r SYSTEM_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
+declare -ri RSA_BITS="${RSA_BIT_LENGTH:-4096}"
+declare -ri CERT_DAYS="${CERT_DAYS:-30}"
+
+init_ca_bundle() {
+    # The image config sets SSL_CERT_FILE to ${CA_BUNDLE}, but that file does
+    # not exist until gen_certs writes it.  The `check` and `provision`
+    # one-shots do not run gen_certs, so seed the bundle with just the system
+    # CAs here; gen_certs overwrites it with system CAs + zot CA in run mode.
+    install -d -m 0755 "$(dirname "${CA_BUNDLE}")"
+    cp -f "${SYSTEM_CA_BUNDLE}" "${CA_BUNDLE}"
+}
+
+gen_certs() {
+    install -d -m 0700 "${CERT_DIR}"
+    (
+        umask 077
+
+        openssl genrsa -out "${CERT_DIR}/ca.key" "${RSA_BITS}"
+
+        openssl req \
+            -x509 \
+            -new \
+            -nodes \
+            -sha256 \
+            -days "${CERT_DAYS}" \
+            -key "${CERT_DIR}/ca.key" \
+            -subj "/CN=loc" \
+            -out "${CERT_DIR}/ca.crt"
+
+        openssl req \
+            -new \
+            -nodes \
+            -sha256 \
+            -newkey "rsa:${RSA_BITS}" \
+            -keyout "${CERT_DIR}/zot.key" \
+            -out "${CERT_DIR}/zot.csr" \
+            -config "${CERT_INI}"
+
+        openssl x509 \
+            -req \
+            -in "${CERT_DIR}/zot.csr" \
+            -CA "${CERT_DIR}/ca.crt" \
+            -CAkey "${CERT_DIR}/ca.key" \
+            -CAcreateserial \
+            -subj "/C=US/ST=CO/L=Longmont/O=githedgehog/CN=zot.loc" \
+            -extfile <(printf 'subjectAltName=DNS:zot,DNS:zot.loc,IP:192.168.19.1') \
+            -out "${CERT_DIR}/zot.crt" \
+            -days "${CERT_DAYS}" \
+            -sha256
+    )
+
+    install -d -m 0755 "$(dirname "${CA_BUNDLE}")"
+    cat "${SYSTEM_CA_BUNDLE}" "${CERT_DIR}/ca.crt" > "${CA_BUNDLE}"
+}
+
+validate_creds() {
+    local f=$1
+    [ -f "${f}" ] || return 1
+
+    local username password
+    username=$(jq -r '."ghcr.io".username // ""' "${f}" 2>/dev/null) || return 1
+    password=$(jq -r '."ghcr.io".password // ""' "${f}" 2>/dev/null) || return 1
+    if [ -z "${username}" ] || [ -z "${password}" ]; then
+        return 1
+    fi
+
+    # --dump-header - writes the response header block to stdout;
+    # --write-out '%{http_code}' appends the status code after the body (which
+    # we discard).  The combined stdout is header-block + final status.
+    local response status
+    response=$(curl \
+        --silent \
+        --output /dev/null \
+        --dump-header - \
+        --write-out '%{http_code}' \
+        --max-time 10 \
+        --header "Authorization: Bearer ${password}" \
+        'https://api.github.com/user' 2>/dev/null) || return 1
+
+    status="${response##*$'\n'}"
+    [ "${status}" = "200" ] || return 1
+
+    # For classic PATs, X-OAuth-Scopes enumerates granted OAuth scopes, so we
+    # can catch "authenticated but not scoped for packages" early.  For
+    # fine-grained PATs the header is absent; we have no cheap way to probe
+    # Packages:read from here, so we proceed and let zot surface any
+    # permission error at sync time.
+    local scopes
+    scopes=$(printf '%s' "${response}" | awk -F': ' '
+        BEGIN { IGNORECASE = 1 }
+        /^X-OAuth-Scopes:/ {
+            sub(/\r$/, "", $2)
+            print $2
+            exit
+        }
+    ')
+
+    if [ -n "${scopes}" ]; then
+        case ",${scopes// /}," in
+            *,read:packages,*|*,write:packages,*|*,delete:packages,*)
+                ;;
+            *)
+                printf 'token authenticates but is missing a packages scope (have: %s)\n' "${scopes}" >&2
+                return 1
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+prompt_creds() {
+    cat >&2 <<'HELP'
+
+==============================================================================
+vlab: ghcr.io credentials required
+==============================================================================
+
+Zot needs a GitHub token to proxy ghcr.io/githedgehog/* images.
+
+Open this pre-filled URL to generate a classic personal access token with
+exactly the read:packages scope (nothing more):
+
+  https://github.com/settings/tokens/new?scopes=read:packages&description=vlab-zot
+
+Click Generate, copy the token, paste it below. The token is stored in a
+root-owned docker volume (vlab-secrets), not on your host filesystem in a
+user-readable location.
+
+Fine-grained PATs work too, but their scopes can't be URL-prefilled, so the
+classic flow above is the one-click path.
+
+==============================================================================
+
+HELP
+
+    local token response username
+    while :; do
+        IFS= read -rsp 'paste token: ' token < /dev/tty
+        printf '\n' >&2
+
+        if [ -z "${token}" ]; then
+            printf 'empty input, try again\n\n' >&2
+            continue
+        fi
+
+        if ! response=$(curl \
+            --silent \
+            --fail \
+            --max-time 10 \
+            --header "Authorization: Bearer ${token}" \
+            'https://api.github.com/user' 2>/dev/null); then
+            printf 'token rejected by api.github.com, try again\n\n' >&2
+            continue
+        fi
+
+        username=$(jq -r '.login // ""' <<< "${response}")
+        if [ -z "${username}" ]; then
+            printf 'could not determine GitHub username, try again\n\n' >&2
+            continue
+        fi
+
+        break
+    done
+
+    install -d -m 0700 "${SECRETS_DIR}"
+    (
+        umask 077
+        jq \
+            --null-input \
+            --arg u "${username}" \
+            --arg p "${token}" \
+            '{ "ghcr.io": { username: $u, password: $p } }' \
+            > "${CREDS_FILE}"
+    )
+    printf 'saved credentials for %s\n' "${username}" >&2
+}
+
+case "${1:-run}" in
+    check)
+        init_ca_bundle
+        validate_creds "${CREDS_FILE}"
+        ;;
+    provision)
+        init_ca_bundle
+        if validate_creds "${CREDS_FILE}"; then
+            printf 'existing credentials in %s are valid\n' "${CREDS_FILE}" >&2
+            exit 0
+        fi
+        prompt_creds
+        ;;
+    run)
+        gen_certs
+        if ! validate_creds "${CREDS_FILE}"; then
+            printf 'no valid credentials in %s\n' "${CREDS_FILE}" >&2
+            printf 'run the provisioning step first\n' >&2
+            exit 1
+        fi
+        exec zot serve "${CONFIG_FILE}"
+        ;;
+    *)
+        printf 'unknown mode: %s (expected check, provision, or run)\n' "$1" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/vlab/root/etc/zot/cert.ini
+++ b/scripts/vlab/root/etc/zot/cert.ini
@@ -1,0 +1,17 @@
+[req]
+default_bits = 4096
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = req_ext
+
+[dn]
+C = US
+ST = CO
+L = Longmont
+O = Hedgehog
+OU = Dev
+CN = zot.loc
+
+[req_ext]
+subjectAltName = IP:192.168.19.1

--- a/scripts/vlab/root/etc/zot/config.json
+++ b/scripts/vlab/root/etc/zot/config.json
@@ -1,0 +1,37 @@
+{
+    "log": {
+        "level": "debug"
+    },
+    "storage": {
+        "rootDirectory": "/zot"
+    },
+    "http": {
+        "address": "192.168.19.1",
+        "port": "30000",
+        "realm": "zot",
+        "tls": {
+            "cert": "/etc/zot/certs/zot.crt",
+            "key": "/etc/zot/certs/zot.key"
+        }
+    },
+    "extensions": {
+        "sync": {
+            "enable": true,
+            "credentialsFile": "/var/lib/vlab/creds.json",
+            "registries": [
+                {
+                    "urls": ["https://ghcr.io"],
+                    "onDemand": true,
+                    "tlsVerify": true,
+                    "content": [
+                        {
+                            "prefix": "/githedgehog/**",
+                            "destination": "/githedgehog",
+                            "stripPrefix": true
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/scripts/vlab/run.sh
+++ b/scripts/vlab/run.sh
@@ -116,7 +116,7 @@ docker exec vlab /vlab/hhfab vlab up \
     -v \
     --controls-restricted=false \
     -m=manual \
-    --recreate \
+    --recreate
 
 
 popd

--- a/scripts/vlab/run.sh
+++ b/scripts/vlab/run.sh
@@ -88,7 +88,13 @@ declare -r fabricator_rev
 
 docker exec vlab /bin/bash -c \
     "curl -fsSL 'https://i.hhdev.io/hhfab' | USE_SUDO=false INSTALL_DIR=. VERSION=v0-master-${fabricator_rev} bash"
-docker exec vlab /vlab/hhfab init --dev --registry-repo 192.168.19.1:30000 --gateway --import-host-upstream --force
+docker exec vlab /vlab/hhfab init \
+    --dev \
+    --registry-repo 192.168.19.1:30000 \
+    --gateway \
+    --import-host-upstream \
+    --force \
+    --gateways=2
 docker exec vlab mv fab.yaml fab.orig.yaml
 docker exec vlab bash -euxo pipefail -c "
   yq . fab.orig.yaml \
@@ -100,7 +106,17 @@ docker exec vlab bash -euxo pipefail -c "
     | yq -y '.[]' \
     | tee fab.yaml
 "
-docker exec vlab /vlab/hhfab vlab gen
-docker exec vlab /vlab/hhfab vlab up -v --controls-restricted=false -m=manual --recreate
+docker exec vlab /vlab/hhfab vlab gen \
+     --externals-static=1 \
+     --externals-bgp=1 \
+     --external-orphan-connections=1 \
+     --mclag-leafs-count=0 \
+     --orphan-leafs-count=2
+docker exec vlab /vlab/hhfab vlab up \
+    -v \
+    --controls-restricted=false \
+    -m=manual \
+    --recreate \
+
 
 popd

--- a/scripts/vlab/run.sh
+++ b/scripts/vlab/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Open Network Fabric Authors
+
+set -euo pipefail
+
+declare SOURCE_DIR
+SOURCE_DIR="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")"
+declare -r SOURCE_DIR
+
+pushd "${SOURCE_DIR}"
+
+docker stop vlab || true
+docker rm vlab || true
+docker network rm zot || true
+
+# /31 has exactly two addresses (192.168.19.0 and .1).  Pin .0 as the bridge
+# gateway explicitly, so docker cannot flip the assignment and claim .1 for
+# itself; the vlab container then pins --ip 192.168.19.1 at docker run time.
+# zot binds to .1 (via its config) and in-container clients resolve zot.loc
+# to .1 via --add-host, so both ends of the handshake must land on .1
+# deterministically.
+docker network create \
+    --attachable \
+    --driver bridge \
+    --ip-range 192.168.19.0/31 \
+    --subnet 192.168.19.0/31 \
+    --gateway 192.168.19.0 \
+    zot
+
+docker volume create vlab-secrets >/dev/null
+
+# Provision ghcr.io credentials if the vlab-secrets volume doesn't already
+# hold a valid token. The provision step is interactive: the user pastes a
+# classic PAT with the read:packages scope, which the entrypoint stores as
+# creds.json inside the root-owned docker volume.
+if ! docker run \
+    --rm \
+    --mount type=volume,source=vlab-secrets,target=/var/lib/vlab \
+    vlab check
+then
+    docker run \
+        --rm \
+        --interactive \
+        --tty \
+        --mount type=volume,source=vlab-secrets,target=/var/lib/vlab \
+        vlab provision
+fi
+
+docker run \
+    --network zot \
+    --ip 192.168.19.1 \
+    --privileged \
+    --mount type=volume,source=vlab-secrets,target=/var/lib/vlab \
+    --mount type=tmpfs,destination=/etc/zot/certs,tmpfs-mode=0700 \
+    --mount type=tmpfs,destination=/run/vlab,tmpfs-mode=0755 \
+    --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+    --mount type=volume,source=vlab,target=/vlab \
+    --mount type=volume,source=zot,target=/zot \
+    --env DOCKER_HOST="unix:///var/run/docker.sock" \
+    --name vlab \
+    --add-host zot:192.168.19.1 \
+    --add-host zot.loc:192.168.19.1 \
+    --rm \
+    --interactive \
+    --tty \
+    --detach \
+    vlab
+
+### part 2 (in container)
+
+# docker run --detach returns as soon as the container starts; the entrypoint
+# is still running gen_certs (RSA-4096 keygen takes a few seconds) and has not
+# yet written the CA bundle that SSL_CERT_FILE points at.  Any docker exec
+# issued before the bundle lands fails with curl error 77 (bad CA file).
+# Block on the bundle appearing, with a generous timeout for slow hosts.
+timeout 60 bash -c '
+  until docker exec vlab test -s /run/vlab/ca-bundle.pem 2>/dev/null; do
+    sleep 0.2
+  done
+'
+
+# Pin hhfab to the short revision carried by the fabricator npins pin, so
+# `just bump pins` also updates the hhfab version we install at startup.
+declare fabricator_rev
+fabricator_rev="$(jq --raw-output '.pins.fabricator.revision' "${SOURCE_DIR}/../../npins/sources.json" | cut -c 1-9)"
+declare -r fabricator_rev
+
+docker exec vlab /bin/bash -c \
+    "curl -fsSL 'https://i.hhdev.io/hhfab' | USE_SUDO=false INSTALL_DIR=. VERSION=v0-master-${fabricator_rev} bash"
+docker exec vlab /vlab/hhfab init --dev --registry-repo 192.168.19.1:30000 --gateway --import-host-upstream --force
+docker exec vlab mv fab.yaml fab.orig.yaml
+docker exec vlab bash -euxo pipefail -c "
+  yq . fab.orig.yaml \
+    | jq --slurp '
+      . as \$input |
+      \$input |
+      ([\$input[0] | setpath([\"spec\", \"config\", \"registry\", \"upstream\", \"noTLSVerify\"]; true)] +  \$input[1:])
+    ' \
+    | yq -y '.[]' \
+    | tee fab.yaml
+"
+docker exec vlab /vlab/hhfab vlab gen
+docker exec vlab /vlab/hhfab vlab up -v --controls-restricted=false -m=manual --recreate
+
+popd


### PR DESCRIPTION
Basically an "easy mode" for quickly starting a vlab.

It uses an "unlikely to be used" ip address of 192.168.19.1 to host zot and vlab in a container.

The whole show can be started up with a simple `just vlab-up`.

You can use `just vlab-control` to drop into k9s in the vlab and you can use  `just oci_insecure=true version=$X vlab-patch-dataplane` or `just oci_insecure=true version=$X vlab-patch-frr` to build (sterile) containers and push them to the local zot and patch those into the vlab instance.

The recipes aren't complex so I didn't add  much in the way of docs  for them.

Claude was mostly used to check my work and manage minor rebases.

It also wrote commit messages.