### PR TITLE
chore: Add lpm crate to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "k8s-intf",
     "k8s-less",
     "left-right-tlcache",
+    "lpm",
     "mgmt",
     "nat",
     "net",


### PR DESCRIPTION
Crate "lpm" is a workspace member, but was never added as such. Fix it.
