### PR TITLE
Preliminary work for static NAT source/destination split

### DIFF
--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -7,7 +7,6 @@
 use crate::NatPort;
 use crate::NatTranslationData;
 use net::buffer::PacketBufferMut;
-use std::num::NonZero;
 use net::checksum::{Checksum, ChecksumError};
 use net::headers::{
     EmbeddedTransport, TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryEmbeddedTransportMut,
@@ -18,6 +17,7 @@ use net::icmp_any::{IcmpAnyChecksumErrorPlaceholder, IcmpAnyChecksumPayload};
 use net::ipv4::Ipv4;
 use net::packet::Packet;
 use std::net::IpAddr;
+use std::num::NonZero;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IcmpErrorMsgError {
@@ -39,23 +39,19 @@ pub enum IcmpErrorMsgError {
 
 // # Return
 //
+// * `Ok(())` if checksums are valid and we can translate the inner packet
 // * An error if we fail to validate relevant checksums and packet should be dropped
-// * `true` if checksums are valid and we need to translate the inner packet
-// * `false` if we don't need to translate the inner packet
 pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
     packet: &Packet<Buf>,
-) -> Result<bool, IcmpErrorMsgError> {
+) -> Result<(), IcmpErrorMsgError> {
     let Some(net) = packet.try_ip() else {
-        // No network layer, no translation needed
-        return Ok(false);
+        return Err(IcmpErrorMsgError::BadIpHeader);
     };
     let Some(icmp) = packet.try_icmp_any() else {
-        // Not ICMPv4 or ICMPv6, no translation needed
-        return Ok(false);
+        return Err(IcmpErrorMsgError::NoTranslationPossible);
     };
     if !icmp.is_error_message() {
-        // Not an ICMP error message, no translation needed
-        return Ok(false);
+        return Err(IcmpErrorMsgError::NoTranslationPossible);
     }
 
     let icmp_payload =
@@ -71,7 +67,7 @@ pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
 
     let Some(embedded_ip) = packet.embedded_headers() else {
         // No embedded IP packet to translate
-        return Ok(false);
+        return Err(IcmpErrorMsgError::NoTranslationPossible);
     };
 
     // From REQ-3 a) from RFC 5508, "NAT Behavioral Requirements for ICMP":
@@ -85,8 +81,7 @@ pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
             .validate_checksum(&())
             .map_err(IcmpErrorMsgError::BadChecksumInnerIpv4)?;
     }
-
-    Ok(true)
+    Ok(())
 }
 
 pub(crate) fn nat_translate_icmp_inner<Buf: PacketBufferMut>(
@@ -293,7 +288,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(false));
+        assert_eq!(result, Err(IcmpErrorMsgError::BadIpHeader));
     }
 
     #[test]
@@ -312,7 +307,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(false));
+        assert_eq!(result, Err(IcmpErrorMsgError::NoTranslationPossible));
     }
 
     #[test]
@@ -339,7 +334,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(false));
+        assert_eq!(result, Err(IcmpErrorMsgError::NoTranslationPossible));
     }
 
     #[test]
@@ -363,7 +358,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(false));
+        assert_eq!(result, Err(IcmpErrorMsgError::NoTranslationPossible));
     }
 
     #[test]
@@ -402,7 +397,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(false));
+        assert_eq!(result, Err(IcmpErrorMsgError::NoTranslationPossible));
     }
 }
 
@@ -464,7 +459,7 @@ mod bolero_tests {
 
                 // Now, ICMP and inner IP headers checksums should be valid
                 let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
-                assert_eq!(res, Ok(true), "Checksum validation failed: {res:?}");
+                assert!(res.is_ok(), "Checksum validation failed: {res:?}");
 
                 // Also check outer IP header checksum, since we're at it
                 if let Some(ipv4) = icmp_error_msg_clone.headers().try_ipv4() {
@@ -608,7 +603,7 @@ mod bolero_tests {
                     // Update and validate checksums for inner IP header, ICMP header, and outer IP header
                     icmp_error_msg_clone.update_checksums();
                     let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
-                    assert_eq!(res, Ok(true), "Checksum validation failed: {res:?}");
+                    assert!(res.is_ok(), "Checksum validation failed: {res:?}");
                 },
             );
     }

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -7,6 +7,7 @@
 use crate::NatPort;
 use crate::NatTranslationData;
 use net::buffer::PacketBufferMut;
+use std::num::NonZero;
 use net::checksum::{Checksum, ChecksumError};
 use net::headers::{
     EmbeddedTransport, TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryEmbeddedTransportMut,
@@ -32,8 +33,8 @@ pub enum IcmpErrorMsgError {
     InvalidIpVersion,
     #[error("IP address {0} is not unicast")]
     NotUnicast(IpAddr),
-    #[error("no allocated identifier found for translation")]
-    NoIdentifier,
+    #[error("no translation possible")]
+    NoTranslationPossible,
 }
 
 // # Return
@@ -98,9 +99,6 @@ pub(crate) fn nat_translate_icmp_inner<Buf: PacketBufferMut>(
         state.src_port,
         state.dst_port,
     );
-    let embedded_headers = packet
-        .embedded_headers_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?;
 
     // From REQ-4 from RFC 5508, "NAT Behavioral Requirements for ICMP":
     //
@@ -110,114 +108,162 @@ pub(crate) fn nat_translate_icmp_inner<Buf: PacketBufferMut>(
     //
     //        a) Revert the IP and transport headers of the embedded IP packet to their original
     //        form, using the matching mapping;
-    let net = embedded_headers
-        .try_inner_ip_mut()
+    if let Some(src_addr) = target_src_addr {
+        nat_translate_icmp_inner_src(packet, src_addr, target_src_port)?;
+    }
+    if let Some(dst_addr) = target_dst_addr {
+        nat_translate_icmp_inner_dst(packet, dst_addr, target_dst_port)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn nat_translate_icmp_inner_src<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    target_addr: IpAddr,
+    target_port: Option<NatPort>,
+) -> Result<(), IcmpErrorMsgError> {
+    let embedded_headers = packet
+        .embedded_headers_mut()
         .ok_or(IcmpErrorMsgError::BadIpHeader)?;
-    if let Some(target_src_ip) = target_src_addr {
-        net.try_set_source(
-            target_src_ip
+
+    embedded_headers
+        .try_inner_ip_mut()
+        .ok_or(IcmpErrorMsgError::BadIpHeader)?
+        .try_set_source(
+            target_addr
                 .try_into()
-                .map_err(|_| IcmpErrorMsgError::NotUnicast(target_src_ip))?,
+                .map_err(|_| IcmpErrorMsgError::NotUnicast(target_addr))?,
         )
         .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
-    }
 
-    let net = embedded_headers
-        .try_inner_ip_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?;
-    if let Some(target_dst_ip) = target_dst_addr {
-        net.try_set_destination(target_dst_ip)
-            .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
-    }
-
+    let Some(target_port) = target_port else {
+        // No port to translate, we're done
+        return Ok(());
+    };
     let Some(transport) = embedded_headers.try_embedded_transport_mut() else {
         // No transport layer in the inner packet, that's fine, we're done here
-        // TODO: Log trace anyway?
         return Ok(());
     };
 
     match transport {
         EmbeddedTransport::Tcp(_) | EmbeddedTransport::Udp(_) => {
-            translate_inner_tcp_udp(transport, target_src_port, target_dst_port)
+            translate_inner_tcp_udp_src(transport, target_port)?;
         }
-        EmbeddedTransport::Icmp4(icmp4) => translate_inner_icmp(icmp4, target_src_port),
-        EmbeddedTransport::Icmp6(icmp6) => translate_inner_icmp(icmp6, target_src_port),
+        EmbeddedTransport::Icmp4(icmp4) => {
+            translate_inner_icmp(icmp4, target_port);
+        }
+        EmbeddedTransport::Icmp6(icmp6) => {
+            translate_inner_icmp(icmp6, target_port);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn nat_translate_icmp_inner_dst<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    target_addr: IpAddr,
+    target_port: Option<NatPort>,
+) -> Result<(), IcmpErrorMsgError> {
+    let embedded_headers = packet
+        .embedded_headers_mut()
+        .ok_or(IcmpErrorMsgError::BadIpHeader)?;
+
+    embedded_headers
+        .try_inner_ip_mut()
+        .ok_or(IcmpErrorMsgError::BadIpHeader)?
+        .try_set_destination(target_addr)
+        .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
+
+    let Some(target_port) = target_port else {
+        // No port to translate, we're done
+        return Ok(());
+    };
+    let Some(transport) = embedded_headers.try_embedded_transport_mut() else {
+        // No transport layer in the inner packet, that's fine, we're done here
+        return Ok(());
+    };
+
+    match transport {
+        EmbeddedTransport::Tcp(_) | EmbeddedTransport::Udp(_) => {
+            translate_inner_tcp_udp_dst(transport, target_port)
+        }
+        _ => Ok(()), // ICMP is dealt with when dealing with the source port
     }
 }
 
-fn translate_inner_icmp<T>(
-    icmp: &mut T,
-    target_identifier: Option<NatPort>,
-) -> Result<(), IcmpErrorMsgError>
+fn translate_inner_icmp<T>(icmp: &mut T, target_identifier: NatPort)
 where
     T: TruncatedIcmpAny + Checksum,
     u16: std::convert::From<<T as Checksum>::Checksum>,
 {
     let Some(old_identifier) = icmp.identifier() else {
         // No identifier to translate, we're done
-        return Ok(());
+        return;
     };
-    let Some(new_identifier) = target_identifier.map(NatPort::as_u16) else {
-        // We really should have received a target identifier, something went wrong
-        return Err(IcmpErrorMsgError::NoIdentifier);
-    };
+    let new_identifier = target_identifier.as_u16();
+    if new_identifier == old_identifier {
+        // No change needed
+        return;
+    }
+
     icmp.try_set_identifier(new_identifier)
         .unwrap_or_else(|_| unreachable!()); // We found an old identifier, we can set a new one
-
     let Some(current_checksum) = icmp.checksum().map(u16::from) else {
         // No checksum to update, we're done
-        return Ok(());
+        return;
     };
     let _ = icmp.increment_update_checksum(
         T::Checksum::from(current_checksum),
         old_identifier,
         new_identifier,
     );
+}
+
+fn translate_inner_tcp_udp_src(
+    transport: &mut EmbeddedTransport,
+    target_port: NatPort,
+) -> Result<(), IcmpErrorMsgError> {
+    // Assume we have TCP or UDP, with source port always present
+    let old_port = transport.source().unwrap_or_else(|| unreachable!()).into();
+    let new_port: NonZero<u16> = target_port
+        .try_into()
+        .map_err(|_| IcmpErrorMsgError::InvalidPort(target_port.as_u16()))?;
+    if old_port == new_port.get() {
+        return Ok(());
+    }
+    transport
+        .set_source(new_port)
+        .unwrap_or_else(|_| unreachable!());
+    // We don't know whether the header and payload are full: the easiest way to deal with
+    // transport checksum update is to do an unconditional, incremental update here. Note
+    // that this checksum will not be updated again when deparsing the packet.
+    if let Some(current_checksum) = transport.checksum() {
+        transport.update_checksum(current_checksum, old_port, new_port.get());
+    }
     Ok(())
 }
 
-fn translate_inner_tcp_udp(
+fn translate_inner_tcp_udp_dst(
     transport: &mut EmbeddedTransport,
-    target_src_port: Option<NatPort>,
-    target_dst_port: Option<NatPort>,
+    target_port: NatPort,
 ) -> Result<(), IcmpErrorMsgError> {
-    // Assume we have TCP or UDP, with source and destination ports always present
-    let (old_src_port, old_dst_port) = (
-        transport.source().unwrap_or_else(|| unreachable!()).into(),
-        transport
-            .destination()
-            .unwrap_or_else(|| unreachable!())
-            .into(),
-    );
-
-    if let Some(target_src_port) = target_src_port {
-        transport
-            .set_source(
-                target_src_port
-                    .try_into()
-                    .map_err(|_| IcmpErrorMsgError::InvalidPort(target_src_port.as_u16()))?,
-            )
-            .unwrap_or_else(|_| unreachable!());
-        // We don't know whether the header and payload are full: the easiest way to deal with
-        // transport checksum update is to do an unconditional, incremental update here. Note
-        // that this checksum will not be updated again when deparsing the packet.
-        if let Some(current_checksum) = transport.checksum() {
-            transport.update_checksum(current_checksum, old_src_port, target_src_port.as_u16());
-        }
+    // Assume we have TCP or UDP, with destination port always present
+    let old_port = transport
+        .destination()
+        .unwrap_or_else(|| unreachable!())
+        .into();
+    let new_port: NonZero<u16> = target_port
+        .try_into()
+        .map_err(|_| IcmpErrorMsgError::InvalidPort(target_port.as_u16()))?;
+    if old_port == new_port.get() {
+        return Ok(());
     }
-    if let Some(target_dst_port) = target_dst_port {
-        transport
-            .set_destination(
-                target_dst_port
-                    .try_into()
-                    .map_err(|_| IcmpErrorMsgError::InvalidPort(target_dst_port.as_u16()))?,
-            )
-            .unwrap_or_else(|_| unreachable!());
-        if let Some(current_checksum) = transport.checksum() {
-            transport.update_checksum(current_checksum, old_dst_port, target_dst_port.as_u16());
-        }
+    transport
+        .set_destination(new_port)
+        .unwrap_or_else(|_| unreachable!());
+    if let Some(current_checksum) = transport.checksum() {
+        transport.update_checksum(current_checksum, old_port, new_port.get());
     }
-
     Ok(())
 }
 

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -225,15 +225,14 @@ fn translate_inner_tcp_udp(
 mod tests {
     use super::*;
     use net::buffer::TestBuffer;
-    use net::eth::Eth;
     use net::eth::ethtype::EthType;
-    use net::eth::mac::{DestinationMac, Mac, SourceMac};
     use net::headers::{HeadersBuilder, Net, Transport};
     use net::icmp4::Icmp4;
     use net::icmp4::{Icmp4DestUnreachable, Icmp4EchoRequest, Icmp4Type};
     use net::ip::NextHeader;
     use net::ipv4::Ipv4;
     use net::packet::Packet;
+    use net::packet::test_utils::make_default_for_eth;
     use net::parse::DeParse;
     use std::net::Ipv4Addr;
 
@@ -241,11 +240,7 @@ mod tests {
     fn test_validate_checksums_icmp_no_network_layer() {
         // Build a packet without IP header
         let mut headers = HeadersBuilder::default();
-        headers.eth(Some(Eth::new(
-            SourceMac::new(Mac([0x2, 0, 0, 0, 0, 1])).unwrap(),
-            DestinationMac::new(Mac([0x2, 0, 0, 0, 0, 2])).unwrap(),
-            EthType::IPV4,
-        )));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
         let headers = headers.build().unwrap();
         let mut buffer = TestBuffer::new();
         headers.deparse(buffer.as_mut()).unwrap();
@@ -262,6 +257,7 @@ mod tests {
         let mut ipv4 = Ipv4::default();
         ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
         ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
         headers.net(Some(Net::Ipv4(ipv4)));
 
         let headers = headers.build().unwrap();
@@ -287,6 +283,7 @@ mod tests {
             net::tcp::TcpPort::new_checked(2).unwrap(),
         );
 
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
         headers.net(Some(Net::Ipv4(ipv4)));
         headers.transport(Some(Transport::Tcp(tcp)));
 
@@ -310,6 +307,7 @@ mod tests {
 
         let icmp = Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 1, seq: 1 }));
 
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
         headers.net(Some(Net::Ipv4(ipv4)));
         headers.transport(Some(Transport::Icmp4(icmp)));
 
@@ -331,13 +329,29 @@ mod tests {
         ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
         ipv4.set_next_header(NextHeader::ICMP);
 
-        let icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        let mut icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        icmp.update_checksum(&[]).unwrap();
 
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
         headers.net(Some(Net::Ipv4(ipv4)));
         headers.transport(Some(Transport::Icmp4(icmp)));
 
         let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
+
+        // Fill the buffer with zeroes.
+        //
+        // The test builds an ICMP Error message with no embedded packet fragment, and validates its
+        // checksum. To do so, we prepare a packet by building the headers, setting the checksum,
+        // then deparsing to a buffer. The checksum for ICMP is computed on the header and the data,
+        // and when we set it (icmp.update_checksum(&[])), we pass a pointer to the data. In this
+        // test, there is no embedded packet fragment, so the data is null (&[]). When we deparse
+        // the packet, we write the headers to a buffer: If we create the buffer with
+        // TestBuffer::new(), it's not filled with zeroes, but with some data simulating some random
+        // payload. Instead, create a buffer filled with zeroes, so that any trailing data does not
+        // mess up with checksum computation.
+        let data = vec![0u8; headers.size().get() as usize];
+        let mut buffer = TestBuffer::from_raw_data(&data);
+
         headers.deparse(buffer.as_mut()).unwrap();
         let packet = Packet::new(buffer).unwrap();
 

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -22,7 +22,11 @@ use std::num::NonZero;
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IcmpErrorMsgError {
     #[error("failure to get IP header")]
-    BadIpHeader,
+    NoIpHeader,
+    #[error("failure to get embedded headers")]
+    NoEmbeddedHeaders,
+    #[error("failure to get inner IP header")]
+    NoInnerIpHeader,
     #[error("failed to validate ICMP checksum")]
     BadChecksumIcmp(ChecksumError<IcmpAnyChecksumErrorPlaceholder>),
     #[error("failed to validate ICMP inner IP checksum")]
@@ -45,7 +49,7 @@ pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
     packet: &Packet<Buf>,
 ) -> Result<(), IcmpErrorMsgError> {
     let Some(net) = packet.try_ip() else {
-        return Err(IcmpErrorMsgError::BadIpHeader);
+        return Err(IcmpErrorMsgError::NoIpHeader);
     };
     let Some(icmp) = packet.try_icmp_any() else {
         return Err(IcmpErrorMsgError::NoTranslationPossible);
@@ -119,11 +123,11 @@ pub(crate) fn nat_translate_icmp_inner_src<Buf: PacketBufferMut>(
 ) -> Result<(), IcmpErrorMsgError> {
     let embedded_headers = packet
         .embedded_headers_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?;
+        .ok_or(IcmpErrorMsgError::NoEmbeddedHeaders)?;
 
     embedded_headers
         .try_inner_ip_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?
+        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?
         .try_set_source(
             target_addr
                 .try_into()
@@ -161,11 +165,11 @@ pub(crate) fn nat_translate_icmp_inner_dst<Buf: PacketBufferMut>(
 ) -> Result<(), IcmpErrorMsgError> {
     let embedded_headers = packet
         .embedded_headers_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?;
+        .ok_or(IcmpErrorMsgError::NoEmbeddedHeaders)?;
 
     embedded_headers
         .try_inner_ip_mut()
-        .ok_or(IcmpErrorMsgError::BadIpHeader)?
+        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?
         .try_set_destination(target_addr)
         .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
 
@@ -288,7 +292,7 @@ mod tests {
         let packet = Packet::new(buffer).unwrap();
 
         let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::BadIpHeader));
+        assert_eq!(result, Err(IcmpErrorMsgError::NoIpHeader));
     }
 
     #[test]

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -15,8 +15,8 @@ use crate::icmp_handler::icmp_error_msg::{
 pub use crate::stateless::natrw::{NatTablesReader, NatTablesWriter}; // re-export
 use net::buffer::PacketBufferMut;
 use net::headers::{
-    Net, Transport, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp, TryIp,
-    TryIpMut, TryTransportMut,
+    Net, NetError, Transport, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp,
+    TryIp, TryIpMut, TryTransportMut,
 };
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
@@ -35,15 +35,27 @@ trace_target!("stateless-nat", LevelFilter::INFO, &["nat", "pipeline"]);
 enum StatelessNatError {
     #[error("No IP header")]
     NoIpHeader,
-    #[error("Unsupported NAT translation")]
-    UnsupportedTranslation,
     #[error("Invalid address {0}")]
     // this should not happen if the nat tables contained sanitized data
     InvalidAddress(IpAddr),
+    #[error("Failed to set source IP: {0}")]
+    FailedToSetSourceIp(NetError),
+    #[error("Failed to set destination IP: {0}")]
+    FailedToSetDestIp(NetError),
+    #[error("No transport header")]
+    NoTransportHeader,
+    #[error("TCP or UDP port cannot be zero")]
+    ZeroPort,
+    #[error("Failed to set source port")]
+    FailedToSetSourcePort,
+    #[error("Failed to set destination port")]
+    FailedToSetDestPort,
     #[error("Can't find NAT tables for VNI {0}")]
     MissingTable(Vni),
     #[error("Failed to translate ICMP inner packet: {0}")]
     IcmpErrorMsg(IcmpErrorMsgError),
+    #[error("No mapping found")]
+    NoMappingFound,
 }
 
 /// A NAT processor, implementing the [`NetworkFunction`] trait. [`StatelessNat`] processes packets
@@ -89,14 +101,14 @@ impl StatelessNat {
         let nfi = self.name();
         debug!("{nfi}: Changing IP src: {} -> {new_src}", net.src_addr());
         net.try_set_source(new_src)
-            .map_err(|_| StatelessNatError::UnsupportedTranslation)
+            .map_err(StatelessNatError::FailedToSetSourceIp)
     }
 
     fn translate_dst(&self, net: &mut Net, target_dst: IpAddr) -> Result<(), StatelessNatError> {
         let nfi = self.name();
         debug!("{nfi}: Changing IP dst: {} -> {target_dst}", net.dst_addr());
         net.try_set_destination(target_dst)
-            .map_err(|_| StatelessNatError::UnsupportedTranslation)
+            .map_err(StatelessNatError::FailedToSetDestIp)
     }
 
     fn translate_src_port<Buf: PacketBufferMut>(
@@ -107,7 +119,7 @@ impl StatelessNat {
         let nfi = self.name();
         let transport = packet
             .try_transport_mut()
-            .ok_or(StatelessNatError::UnsupportedTranslation)?;
+            .ok_or(StatelessNatError::NoTransportHeader)?;
         match transport {
             Transport::Tcp(_) | Transport::Udp(_) => {
                 debug!(
@@ -116,10 +128,9 @@ impl StatelessNat {
                 );
                 packet
                     .set_source_port(
-                        NonZero::try_from(new_port)
-                            .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
+                        NonZero::try_from(new_port).map_err(|_| StatelessNatError::ZeroPort)?,
                     )
-                    .map_err(|_| StatelessNatError::UnsupportedTranslation)?;
+                    .map_err(|_| StatelessNatError::FailedToSetSourcePort)?;
             }
             Transport::Icmp4(_) | Transport::Icmp6(_) => {
                 todo!()
@@ -136,7 +147,7 @@ impl StatelessNat {
         let nfi = self.name();
         let transport = packet
             .try_transport_mut()
-            .ok_or(StatelessNatError::UnsupportedTranslation)?;
+            .ok_or(StatelessNatError::NoTransportHeader)?;
         match transport {
             Transport::Tcp(_) | Transport::Udp(_) => {
                 debug!(
@@ -145,10 +156,9 @@ impl StatelessNat {
                 );
                 packet
                     .set_destination_port(
-                        NonZero::try_from(new_port)
-                            .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
+                        NonZero::try_from(new_port).map_err(|_| StatelessNatError::ZeroPort)?,
                     )
-                    .map_err(|_| StatelessNatError::UnsupportedTranslation)?;
+                    .map_err(|_| StatelessNatError::FailedToSetDestPort)?;
             }
             Transport::Icmp4(_) | Transport::Icmp6(_) => {
                 todo!()
@@ -185,7 +195,7 @@ impl StatelessNat {
         // We're sending the inner packet back without swapping source and destination in the
         // header, so we need to swap the ranges we get from the tables lookup.
         let Some((src_addr, src_port)) = table.find_dst_mapping(&addr, port) else {
-            return Err(StatelessNatError::UnsupportedTranslation);
+            return Err(StatelessNatError::NoMappingFound);
         };
         let src_port = src_port.and_then(|p| NatPort::new_port_checked(p).ok());
         nat_translate_icmp_inner_src::<Buf>(packet, src_addr, src_port)
@@ -209,7 +219,7 @@ impl StatelessNat {
         // We're sending the inner packet back without swapping source and destination in the
         // header, so we need to swap the ranges we get from the tables lookup.
         let Some((dst_addr, dst_port)) = table.find_src_mapping(&addr, port, dst_vni) else {
-            return Err(StatelessNatError::UnsupportedTranslation);
+            return Err(StatelessNatError::NoMappingFound);
         };
         let dst_port = dst_port.and_then(|p| NatPort::new_port_checked(p).ok());
         nat_translate_icmp_inner_dst::<Buf>(packet, dst_addr, dst_port)
@@ -348,6 +358,7 @@ impl StatelessNat {
         /* do the translations needed according to the NAT tables */
         match self.translate(nat_tables, packet, src_vni, dst_vni) {
             Err(error) => {
+                debug!("{nfi}: Translation failed: {error}");
                 packet.done(translate_error(&error));
             }
             Ok(modified) => {
@@ -368,7 +379,10 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         StatelessNatError::NoIpHeader
         | StatelessNatError::IcmpErrorMsg(IcmpErrorMsgError::BadIpHeader) => DoneReason::NotIp,
 
-        StatelessNatError::UnsupportedTranslation => DoneReason::NatUnsupportedProto,
+        StatelessNatError::FailedToSetSourcePort
+        | StatelessNatError::FailedToSetDestPort
+        | StatelessNatError::ZeroPort
+        | StatelessNatError::NoTransportHeader => DoneReason::NatUnsupportedProto,
 
         StatelessNatError::MissingTable(_) => DoneReason::Unroutable,
 
@@ -379,11 +393,14 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
             DoneReason::NatFailure
         }
 
-        StatelessNatError::IcmpErrorMsg(
+        StatelessNatError::FailedToSetDestIp(_)
+        | StatelessNatError::FailedToSetSourceIp(_)
+        | StatelessNatError::IcmpErrorMsg(
             IcmpErrorMsgError::InvalidIpVersion | IcmpErrorMsgError::NoTranslationPossible,
         ) => DoneReason::InternalFailure,
 
-        StatelessNatError::IcmpErrorMsg(
+        StatelessNatError::NoMappingFound
+        | StatelessNatError::IcmpErrorMsg(
             IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_),
         ) => DoneReason::InvalidChecksum,
     }

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -18,8 +18,6 @@ use net::headers::{
 };
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
-use net::tcp::TcpPort;
-use net::udp::UdpPort;
 use net::vxlan::Vni;
 use pipeline::NetworkFunction;
 use setup::tables::{NatTableValue, NatTables, PerVniTable};
@@ -127,30 +125,19 @@ impl StatelessNat {
             .try_transport_mut()
             .ok_or(StatelessNatError::UnsupportedTranslation)?;
         match transport {
-            Transport::Tcp(tcp) => {
+            Transport::Tcp(_) | Transport::Udp(_) => {
                 debug!(
                     "{nfi}: Changing L4 source port: {:?} -> {new_port}",
-                    tcp.source()
+                    transport.src_port()
                 );
-                tcp.set_source(
-                    TcpPort::try_from(new_port)
-                        .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
-                );
+                packet
+                    .set_source_port(
+                        NonZero::try_from(new_port)
+                            .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
+                    )
+                    .map_err(|_| StatelessNatError::UnsupportedTranslation)?;
             }
-            Transport::Udp(udp) => {
-                debug!(
-                    "{nfi}: Changing L4 source port: {:?} -> {new_port}",
-                    udp.source()
-                );
-                udp.set_source(
-                    UdpPort::try_from(new_port)
-                        .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
-                );
-            }
-            Transport::Icmp4(_icmp4) => {
-                todo!()
-            }
-            Transport::Icmp6(_icmp6) => {
+            Transport::Icmp4(_) | Transport::Icmp6(_) => {
                 todo!()
             }
         }
@@ -167,30 +154,19 @@ impl StatelessNat {
             .try_transport_mut()
             .ok_or(StatelessNatError::UnsupportedTranslation)?;
         match transport {
-            Transport::Tcp(tcp) => {
+            Transport::Tcp(_) | Transport::Udp(_) => {
                 debug!(
                     "{nfi}: Changing L4 destination port: {:?} -> {new_port}",
-                    tcp.destination()
+                    transport.dst_port()
                 );
-                tcp.set_destination(
-                    TcpPort::try_from(new_port)
-                        .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
-                );
+                packet
+                    .set_destination_port(
+                        NonZero::try_from(new_port)
+                            .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
+                    )
+                    .map_err(|_| StatelessNatError::UnsupportedTranslation)?;
             }
-            Transport::Udp(udp) => {
-                debug!(
-                    "{nfi}: Changing L4 destination port: {:?} -> {new_port}",
-                    udp.destination()
-                );
-                udp.set_destination(
-                    UdpPort::try_from(new_port)
-                        .map_err(|_| StatelessNatError::UnsupportedTranslation)?,
-                );
-            }
-            Transport::Icmp4(_icmp4) => {
-                todo!()
-            }
-            Transport::Icmp6(_icmp6) => {
+            Transport::Icmp4(_) | Transport::Icmp6(_) => {
                 todo!()
             }
         }

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -16,7 +16,7 @@ pub use crate::stateless::natrw::{NatTablesReader, NatTablesWriter}; // re-expor
 use net::buffer::PacketBufferMut;
 use net::headers::{
     Net, Transport, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp, TryIp,
-    TryIpMut, TryTransport, TryTransportMut,
+    TryIpMut, TryTransportMut,
 };
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
@@ -97,24 +97,6 @@ impl StatelessNat {
         debug!("{nfi}: Changing IP dst: {} -> {target_dst}", net.dst_addr());
         net.try_set_destination(target_dst)
             .map_err(|_| StatelessNatError::UnsupportedTranslation)
-    }
-
-    fn get_ports<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> (Option<u16>, Option<u16>) {
-        let Some(transport) = packet.try_transport() else {
-            return (None, None);
-        };
-        match transport {
-            Transport::Tcp(tcp) => (
-                Some(tcp.source().as_u16()),
-                Some(tcp.destination().as_u16()),
-            ),
-            Transport::Udp(udp) => (
-                Some(udp.source().as_u16()),
-                Some(udp.destination().as_u16()),
-            ),
-            Transport::Icmp4(_icmp4) => (None, None),
-            Transport::Icmp6(_icmp6) => (None, None),
-        }
     }
 
     fn translate_src_port<Buf: PacketBufferMut>(
@@ -235,38 +217,23 @@ impl StatelessNat {
         Ok(true)
     }
 
-    /// Applies network address translation to a packet, knowing the current and target ranges.
-    /// # Errors
-    /// This method may fail if `translate_src` or `translate_dst` fail, which can happen if
-    /// addresses are invalid or an unsupported translation is required (e.g. IPv4 -> IPv6).
-    fn translate<Buf: PacketBufferMut>(
+    fn source_nat<Buf: PacketBufferMut>(
         &self,
-        nat_tables: &NatTables,
+        table: &PerVniTable,
         packet: &mut Packet<Buf>,
-        src_vni: Vni,
         dst_vni: Vni,
     ) -> Result<bool, StatelessNatError> {
         let nfi = self.name();
-
-        // Get source and destination IP addresses
-        let Some((src_addr, dst_addr)) = packet
-            .ip_source()
-            .and_then(|src| packet.ip_destination().map(|dst| (src, dst)))
-        else {
-            error!("{nfi}: Failed to get IP addresses!");
-            return Err(StatelessNatError::NoIpHeader);
-        };
-
-        // Get NAT tables
-        let Some(table) = nat_tables.get_table(src_vni) else {
-            error!("{nfi}: Can't find NAT tables for VNI {src_vni}");
-            return Err(StatelessNatError::MissingTable(src_vni));
-        };
-
-        let (src_port_opt, dst_port_opt) = Self::get_ports(packet);
         let mut modified = false;
 
-        // Run NAT
+        // Get source IP address, port
+        let Some(src_addr) = packet.ip_source() else {
+            error!("{nfi}: Failed to get source IP address");
+            return Err(StatelessNatError::NoIpHeader);
+        };
+        let src_port_opt = packet.transport_src_port().map(NonZero::get);
+
+        // Source NAT
         if let Some((new_src_addr, new_src_port_opt)) =
             table.find_src_mapping(&src_addr, src_port_opt, dst_vni)
         {
@@ -282,6 +249,32 @@ impl StatelessNat {
                 modified = true;
             }
         }
+
+        // ICMP Error messages
+        if Self::is_icmp_inner_translation_candidate(packet) {
+            validate_checksums_icmp(packet).map_err(StatelessNatError::IcmpErrorMsg)?;
+            modified |= Self::translate_icmp_inner_packet_dst_if_any(table, packet, dst_vni)?;
+        }
+
+        Ok(modified)
+    }
+
+    fn destination_nat<Buf: PacketBufferMut>(
+        &self,
+        table: &PerVniTable,
+        packet: &mut Packet<Buf>,
+    ) -> Result<bool, StatelessNatError> {
+        let nfi = self.name();
+        let mut modified = false;
+
+        // Get destination IP address, port
+        let Some(dst_addr) = packet.ip_destination() else {
+            error!("{nfi}: Failed to get destination IP address");
+            return Err(StatelessNatError::NoIpHeader);
+        };
+        let dst_port_opt = packet.transport_dst_port().map(NonZero::get);
+
+        // Destination NAT
         if let Some((new_dst_addr, new_dst_port_opt)) =
             table.find_dst_mapping(&dst_addr, dst_port_opt)
         {
@@ -298,11 +291,34 @@ impl StatelessNat {
             }
         }
 
+        // ICMP Error messages
         if Self::is_icmp_inner_translation_candidate(packet) {
-            validate_checksums_icmp(packet).map_err(StatelessNatError::IcmpErrorMsg)?;
-            modified |= Self::translate_icmp_inner_packet_dst_if_any(table, packet, dst_vni)?;
             modified |= Self::translate_icmp_inner_packet_src_if_any(table, packet)?;
         }
+        Ok(modified)
+    }
+
+    /// Applies network address translation to a packet, knowing the current and target ranges.
+    /// # Errors
+    /// This method may fail if `translate_src` or `translate_dst` fail, which can happen if
+    /// addresses are invalid or an unsupported translation is required (e.g. IPv4 -> IPv6).
+    fn translate<Buf: PacketBufferMut>(
+        &self,
+        nat_tables: &NatTables,
+        packet: &mut Packet<Buf>,
+        src_vni: Vni,
+        dst_vni: Vni,
+    ) -> Result<bool, StatelessNatError> {
+        let nfi = self.name();
+        let mut modified = false;
+
+        let Some(table) = nat_tables.get_table(src_vni) else {
+            error!("{nfi}: Can't find NAT tables for VNI {src_vni}");
+            return Err(StatelessNatError::MissingTable(src_vni));
+        };
+
+        modified |= self.source_nat(table, packet, dst_vni)?;
+        modified |= self.destination_nat(table, packet)?;
         Ok(modified)
     }
 

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -377,7 +377,7 @@ impl StatelessNat {
 fn translate_error(error: &StatelessNatError) -> DoneReason {
     match error {
         StatelessNatError::NoIpHeader
-        | StatelessNatError::IcmpErrorMsg(IcmpErrorMsgError::BadIpHeader) => DoneReason::NotIp,
+        | StatelessNatError::IcmpErrorMsg(IcmpErrorMsgError::NoIpHeader) => DoneReason::NotIp,
 
         StatelessNatError::FailedToSetSourcePort
         | StatelessNatError::FailedToSetDestPort
@@ -403,6 +403,10 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         | StatelessNatError::IcmpErrorMsg(
             IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_),
         ) => DoneReason::InvalidChecksum,
+
+        StatelessNatError::IcmpErrorMsg(
+            IcmpErrorMsgError::NoEmbeddedHeaders | IcmpErrorMsgError::NoInnerIpHeader,
+        ) => DoneReason::Filtered,
     }
 }
 

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -7,11 +7,12 @@ pub mod natrw;
 pub mod setup;
 pub(crate) mod test;
 
+use crate::NatPort;
 use crate::icmp_handler::icmp_error_msg::{
-    IcmpErrorMsgError, nat_translate_icmp_inner, validate_checksums_icmp,
+    IcmpErrorMsgError, nat_translate_icmp_inner_dst, nat_translate_icmp_inner_src,
+    validate_checksums_icmp,
 };
 pub use crate::stateless::natrw::{NatTablesReader, NatTablesWriter}; // re-export
-use crate::{NatPort, NatTranslationData};
 use net::buffer::PacketBufferMut;
 use net::headers::{
     Net, Transport, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp, TryIp,
@@ -187,52 +188,50 @@ impl StatelessNat {
         && packet.embedded_headers().is_some()
     }
 
-    fn find_translation_icmp_inner<Buf: PacketBufferMut>(
+    fn translate_icmp_inner_packet_src_if_any<Buf: PacketBufferMut>(
         table: &PerVniTable,
-        packet: &Packet<Buf>,
-        dst_vni: Vni,
-    ) -> Option<NatTranslationData> {
-        let net = packet.try_inner_ip()?;
-        let transport = packet.try_embedded_transport();
-        // Note how we swap addresses to find NAT ranges: we're sending the inner packet back
-        // without swapping source and destination in the header, so we need to swap the ranges we
-        // get from the tables lookup.
-        let src_mapping = table.find_dst_mapping(
-            &net.src_addr(),
-            transport.and_then(|t| t.destination().map(NonZero::get)),
-        );
-        let dst_mapping = table.find_src_mapping(
-            &net.dst_addr(),
-            transport.and_then(|t| t.destination().map(NonZero::get)),
-            dst_vni,
-        );
-
-        Some(NatTranslationData {
-            src_addr: src_mapping.map(|(addr, _)| addr),
-            dst_addr: dst_mapping.map(|(addr, _)| addr),
-            src_port: src_mapping.and_then(|(_, port)| {
-                port.and_then(|port| NatPort::new_port_checked(port).ok()) // TODO: FIXME ICMP
-            }),
-            dst_port: dst_mapping.and_then(|(_, port)| {
-                port.and_then(|port| NatPort::new_port_checked(port).ok()) // TODO: FIXME ICMP
-            }),
-        })
+        packet: &mut Packet<Buf>,
+    ) -> Result<bool, StatelessNatError> {
+        let addr = packet
+            .try_inner_ip()
+            .ok_or(StatelessNatError::NoIpHeader)?
+            .src_addr();
+        let port = packet
+            .try_embedded_transport()
+            .and_then(|t| t.source().map(NonZero::get));
+        // Note: we assign the _destination_ mapping to the target _source_ address.
+        // We're sending the inner packet back without swapping source and destination in the
+        // header, so we need to swap the ranges we get from the tables lookup.
+        let Some((src_addr, src_port)) = table.find_dst_mapping(&addr, port) else {
+            return Err(StatelessNatError::UnsupportedTranslation);
+        };
+        let src_port = src_port.and_then(|p| NatPort::new_port_checked(p).ok());
+        nat_translate_icmp_inner_src::<Buf>(packet, src_addr, src_port)
+            .map_err(StatelessNatError::IcmpErrorMsg)?;
+        Ok(true)
     }
 
-    fn translate_icmp_inner_packet_if_any<Buf: PacketBufferMut>(
+    fn translate_icmp_inner_packet_dst_if_any<Buf: PacketBufferMut>(
         table: &PerVniTable,
         packet: &mut Packet<Buf>,
         dst_vni: Vni,
     ) -> Result<bool, StatelessNatError> {
-        if !Self::is_icmp_inner_translation_candidate(packet) {
-            return Ok(false);
-        }
-        validate_checksums_icmp(packet).map_err(StatelessNatError::IcmpErrorMsg)?;
-
-        let Some(state) = Self::find_translation_icmp_inner(table, packet, dst_vni) else {
+        let addr = packet
+            .try_inner_ip()
+            .ok_or(StatelessNatError::NoIpHeader)?
+            .dst_addr();
+        let port = packet
+            .try_embedded_transport()
+            .and_then(|t| t.destination().map(NonZero::get));
+        // Note: we assign the _source_ mapping to the target _destination_ address.
+        // We're sending the inner packet back without swapping source and destination in the
+        // header, so we need to swap the ranges we get from the tables lookup.
+        let Some((dst_addr, dst_port)) = table.find_src_mapping(&addr, port, dst_vni) else {
             return Err(StatelessNatError::UnsupportedTranslation);
         };
-        nat_translate_icmp_inner::<Buf>(packet, &state).map_err(StatelessNatError::IcmpErrorMsg)?;
+        let dst_port = dst_port.and_then(|p| NatPort::new_port_checked(p).ok());
+        nat_translate_icmp_inner_dst::<Buf>(packet, dst_addr, dst_port)
+            .map_err(StatelessNatError::IcmpErrorMsg)?;
         Ok(true)
     }
 
@@ -299,8 +298,10 @@ impl StatelessNat {
             }
         }
 
-        if packet.is_icmp() {
-            modified |= Self::translate_icmp_inner_packet_if_any(table, packet, dst_vni)?;
+        if Self::is_icmp_inner_translation_candidate(packet) {
+            validate_checksums_icmp(packet).map_err(StatelessNatError::IcmpErrorMsg)?;
+            modified |= Self::translate_icmp_inner_packet_dst_if_any(table, packet, dst_vni)?;
+            modified |= Self::translate_icmp_inner_packet_src_if_any(table, packet)?;
         }
         Ok(modified)
     }

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -350,7 +350,7 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         }
 
         StatelessNatError::IcmpErrorMsg(
-            IcmpErrorMsgError::InvalidIpVersion | IcmpErrorMsgError::NoIdentifier,
+            IcmpErrorMsgError::InvalidIpVersion | IcmpErrorMsgError::NoTranslationPossible,
         ) => DoneReason::InternalFailure,
 
         StatelessNatError::IcmpErrorMsg(

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -14,7 +14,8 @@ pub use crate::stateless::natrw::{NatTablesReader, NatTablesWriter}; // re-expor
 use crate::{NatPort, NatTranslationData};
 use net::buffer::PacketBufferMut;
 use net::headers::{
-    Net, Transport, TryEmbeddedTransport, TryInnerIp, TryIpMut, TryTransport, TryTransportMut,
+    Net, Transport, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp, TryIp,
+    TryIpMut, TryTransport, TryTransportMut,
 };
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
@@ -173,6 +174,19 @@ impl StatelessNat {
         Ok(())
     }
 
+    // Is this an ICMP error packet that contains an embedded IP packet?
+    fn is_icmp_inner_translation_candidate<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> bool {
+        // If no network layer, no translation needed
+        packet.try_ip().is_some()
+        // If not ICMPv4 or ICMPv6, no translation needed
+        && packet.try_icmp_any().is_some_and(|icmp| {
+            // If not an ICMP error message, no translation needed
+            icmp.is_error_message()
+        })
+        // If no embedded IP packet, no translation needed
+        && packet.embedded_headers().is_some()
+    }
+
     fn find_translation_icmp_inner<Buf: PacketBufferMut>(
         table: &PerVniTable,
         packet: &Packet<Buf>,
@@ -210,11 +224,10 @@ impl StatelessNat {
         packet: &mut Packet<Buf>,
         dst_vni: Vni,
     ) -> Result<bool, StatelessNatError> {
-        match validate_checksums_icmp(packet) {
-            Err(e) => return Err(StatelessNatError::IcmpErrorMsg(e)), // Error, drop packet
-            Ok(false) => return Ok(false),                            // No translation needed
-            Ok(true) => {} // Translation needed, carry on
+        if !Self::is_icmp_inner_translation_candidate(packet) {
+            return Ok(false);
         }
+        validate_checksums_icmp(packet).map_err(StatelessNatError::IcmpErrorMsg)?;
 
         let Some(state) = Self::find_translation_icmp_inner(table, packet, dst_vni) else {
             return Err(StatelessNatError::UnsupportedTranslation);

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -50,6 +50,8 @@ enum StatelessNatError {
     FailedToSetSourcePort,
     #[error("Failed to set destination port")]
     FailedToSetDestPort,
+    #[error("Port translation not supported for ICMP")]
+    IcmpPortTranslation,
     #[error("Can't find NAT tables for VNI {0}")]
     MissingTable(Vni),
     #[error("Failed to translate ICMP inner packet: {0}")]
@@ -133,7 +135,7 @@ impl StatelessNat {
                     .map_err(|_| StatelessNatError::FailedToSetSourcePort)?;
             }
             Transport::Icmp4(_) | Transport::Icmp6(_) => {
-                todo!()
+                return Err(StatelessNatError::IcmpPortTranslation);
             }
         }
         Ok(())
@@ -161,7 +163,7 @@ impl StatelessNat {
                     .map_err(|_| StatelessNatError::FailedToSetDestPort)?;
             }
             Transport::Icmp4(_) | Transport::Icmp6(_) => {
-                todo!()
+                return Err(StatelessNatError::IcmpPortTranslation);
             }
         }
         Ok(())
@@ -382,7 +384,8 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         StatelessNatError::FailedToSetSourcePort
         | StatelessNatError::FailedToSetDestPort
         | StatelessNatError::ZeroPort
-        | StatelessNatError::NoTransportHeader => DoneReason::NatUnsupportedProto,
+        | StatelessNatError::NoTransportHeader
+        | StatelessNatError::IcmpPortTranslation => DoneReason::NatUnsupportedProto,
 
         StatelessNatError::MissingTable(_) => DoneReason::Unroutable,
 

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -58,7 +58,12 @@ fn make_default_for_transport(transport_type: Option<NextHeader>) -> Option<Tran
     }
 }
 
-fn make_default_for_eth(ethtype: EthType) -> Eth {
+/// Creates a default Ethernet frame with the given [`EthType`].
+///
+/// The source MAC address is 0x02:00:00:00:00:01 and the destination MAC address is
+/// 0x02:00:00:00:00:02.
+#[must_use]
+pub fn make_default_for_eth(ethtype: EthType) -> Eth {
     Eth::new(
         SourceMac::new(Mac([0x2, 0, 0, 0, 0, 1])).unwrap(),
         DestinationMac::new(Mac([0x2, 0, 0, 0, 0, 2])).unwrap(),


### PR DESCRIPTION
As the title says, this is some preliminary work for splitting the current static NAT stage into two steps, source and destination NAT. This will be necessary for supporting static NAT + masquerade at opposite ends of a peering. Here we do not split the stage, but we prepare for that by moving source and destination translation into individual functions. The biggest chunk of these changes is the modifications brought to the code for translating ICMP Error messages' inner packets (and the biggest part of the diff is a not-so-related clean-up in NAT tests, but it's mostly an indentation change).

~Will need to be rebased on top of #1414 and possibly #1389.~ I'll handle conflicts if necessary.