### PR TITLE
test: Add cargo alias: "nt" -> "nextest"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,3 +13,6 @@ CARGO_LLVM_COV_BUILD_DIR = { value = "target/llvm-cov/target", relative = true, 
 
 [build]
 rustflags = ["--cfg=tokio_unstable"]
+
+[alias]
+nt = "nextest"


### PR DESCRIPTION
I've always struggled to pronounce and type "nextest". I used to rely on my shell's command-line completion, which doesn't work as well in my nix-shell as in my regular terminal for some reason. Let's add an alias for cargo, to make it easier to type.
