### PR TITLE
chore: Add note on permissions for Zed's Flatpak, to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ Save the following to the `.zed/settings.json` file:
 Zed wraps rust-analyzer and the debugger with `nix-shell --run`, so it does not need to be launched from the
 nix-shell.
 
+If using Zed's Flatpak integration, make sure to give it read-only access to
+`/nix`, and read/write access to `/nix/var/nix` for the LSP to work.
+
 ## Code organization
 
 The dataplane code is organized in a set of crates.


### PR DESCRIPTION
I'm pulling Zed's Flatpak from FlatHub, and the rust-analyzer recently failed to work (some time, but not immediately, after the introduction of the new Nix-based build system). Looking into the permissions, I figured that Zed misses access to some files under /nix. Let's add a note in the README to hopefully save time for other contributors.

The precise set of files I had to allow Zed to access was the following:

- `/nix:ro` (read-only)
- `/nix/var/nix/db/`
- `/nix/var/nix/gc.lock`
- `/nix/var/nix/temproots/`
