### PR TITLE
chore: remove unneeded logs

### DIFF
--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -184,9 +184,7 @@ impl Vpc {
             })
             .collect();
 
-        if self.peerings.is_empty() {
-            warn!("Warning, VPC {} has no configured peerings", &self.name);
-        } else {
+        if !self.peerings.is_empty() {
             debug!("Vpc '{}' has {} peerings", self.name, self.peerings.len());
         }
     }


### PR DESCRIPTION
It's quite normal that we pass VPCs that doesn't have any Peerings and so seeing WARNs (or any messages) about it means nothing. We still have a DBG message about VPCs with peerings just in case.