### PR TITLE
feat(net): add fuzz header builder for property-based testing

### DIFF
--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -224,14 +224,13 @@ fn translate_inner_tcp_udp(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use etherparse::icmpv4::DestUnreachableHeader;
-    use etherparse::{IcmpEchoHeader, Icmpv4Type};
     use net::buffer::TestBuffer;
     use net::eth::Eth;
     use net::eth::ethtype::EthType;
     use net::eth::mac::{DestinationMac, Mac, SourceMac};
     use net::headers::{HeadersBuilder, Net, Transport};
     use net::icmp4::Icmp4;
+    use net::icmp4::{Icmp4DestUnreachable, Icmp4EchoRequest, Icmp4Type};
     use net::ip::NextHeader;
     use net::ipv4::Ipv4;
     use net::packet::Packet;
@@ -309,8 +308,7 @@ mod tests {
         ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
         ipv4.set_next_header(NextHeader::ICMP);
 
-        let icmp_type = Icmpv4Type::EchoRequest(IcmpEchoHeader { id: 1, seq: 1 });
-        let icmp = Icmp4::with_type(icmp_type);
+        let icmp = Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 1, seq: 1 }));
 
         headers.net(Some(Net::Ipv4(ipv4)));
         headers.transport(Some(Transport::Icmp4(icmp)));
@@ -333,8 +331,7 @@ mod tests {
         ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
         ipv4.set_next_header(NextHeader::ICMP);
 
-        let icmp_type = Icmpv4Type::DestinationUnreachable(DestUnreachableHeader::Network);
-        let icmp = Icmp4::with_type(icmp_type);
+        let icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
 
         headers.net(Some(Net::Ipv4(ipv4)));
         headers.transport(Some(Transport::Icmp4(icmp)));

--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -12,7 +12,6 @@ mod tests {
     use config::external::overlay::vpcpeering::{
         VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable,
     };
-    use etherparse::Icmpv4Type;
     use flow_entry::flow_table::{FlowLookup, FlowTable};
     use flow_filter::{FlowFilter, FlowFilterTable, FlowFilterTableWriter};
     use net::buffer::{PacketBufferMut, TestBuffer};
@@ -21,6 +20,7 @@ mod tests {
     use net::headers::{
         EmbeddedTransport, TryEmbeddedTransport as _, TryIcmp4, TryInnerIpv4, TryIpv4, TryUdp,
     };
+    use net::icmp4::Icmp4Type;
     use net::icmp4::TruncatedIcmp4;
     use net::ip::NextHeader;
     use net::packet::test_utils::{
@@ -649,10 +649,10 @@ mod tests {
                 (udp.source().into(), udp.destination().into())
             }
             EmbeddedTransport::Icmp4(TruncatedIcmp4::FullHeader(icmp)) => {
-                let Icmpv4Type::EchoRequest(echo_header) = icmp.icmp_type() else {
+                let Icmp4Type::EchoRequest(echo) = icmp.icmp_type() else {
                     unreachable!();
                 };
-                (echo_header.id, echo_header.seq)
+                (echo.id, echo.seq)
             }
             _ => unreachable!(),
         };

--- a/net/src/eth/mac.rs
+++ b/net/src/eth/mac.rs
@@ -405,6 +405,14 @@ impl TryFrom<&Vec<u8>> for SourceMac {
     }
 }
 
+impl TryFrom<Mac> for DestinationMac {
+    type Error = DestinationMacAddressError;
+
+    fn try_from(value: Mac) -> Result<Self, Self::Error> {
+        DestinationMac::new(value)
+    }
+}
+
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use crate::eth::mac::{DestinationMac, Mac, SourceMac};

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -15,6 +15,7 @@ use crate::headers::{
     TryIp, TryTransport,
 };
 use crate::icmp_any::TruncatedIcmpAny;
+use crate::icmp4::Icmp4Type;
 use crate::icmp4::{Icmp4, TruncatedIcmp4};
 use crate::icmp6::{Icmp6, TruncatedIcmp6};
 use crate::ip::NextHeader;
@@ -22,7 +23,7 @@ use crate::packet::Packet;
 use crate::packet::VpcDiscriminant;
 use crate::tcp::{TcpPort, TcpPortError};
 use crate::udp::{UdpPort, UdpPortError};
-use etherparse::{Icmpv4Type, Icmpv6Type};
+use etherparse::Icmpv6Type;
 
 #[derive(Debug, thiserror::Error)]
 /// Errors that may occur when building a `FlowKey`
@@ -308,10 +309,9 @@ pub enum IcmpProtoKey {
 impl IcmpProtoKey {
     fn new_icmp_v4<Buf: PacketBufferMut>(packet: &Packet<Buf>, icmp: &Icmp4) -> Self {
         match icmp.icmp_type() {
-            Icmpv4Type::EchoRequest(echo_header) | Icmpv4Type::EchoReply(echo_header) => {
-                IcmpProtoKey::QueryMsgData(echo_header.id)
-            }
-            Icmpv4Type::TimeExceeded(_) | Icmpv4Type::DestinationUnreachable(_) => {
+            Icmp4Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
+            Icmp4Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
+            Icmp4Type::TimeExceeded(_) | Icmp4Type::DestUnreachable(_) => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -1029,10 +1029,10 @@ mod tests {
                 })),
                 // To keep in sync with IcmpProtoKey::new_icmp_v4()
                 Transport::Icmp4(icmp) => match icmp.icmp_type() {
-                    Icmpv4Type::EchoRequest(_) | Icmpv4Type::EchoReply(_) => Some(
-                        IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(driver.produce()?)),
-                    ),
-                    Icmpv4Type::DestinationUnreachable(_) | Icmpv4Type::TimeExceeded(_) => {
+                    Icmp4Type::EchoRequest(_) | Icmp4Type::EchoReply(_) => Some(IpProtoKey::Icmp(
+                        IcmpProtoKey::QueryMsgData(driver.produce()?),
+                    )),
+                    Icmp4Type::DestUnreachable(_) | Icmp4Type::TimeExceeded(_) => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -17,13 +17,13 @@ use crate::headers::{
 use crate::icmp_any::TruncatedIcmpAny;
 use crate::icmp4::Icmp4Type;
 use crate::icmp4::{Icmp4, TruncatedIcmp4};
+use crate::icmp6::Icmp6Type;
 use crate::icmp6::{Icmp6, TruncatedIcmp6};
 use crate::ip::NextHeader;
 use crate::packet::Packet;
 use crate::packet::VpcDiscriminant;
 use crate::tcp::{TcpPort, TcpPortError};
 use crate::udp::{UdpPort, UdpPortError};
-use etherparse::Icmpv6Type;
 
 #[derive(Debug, thiserror::Error)]
 /// Errors that may occur when building a `FlowKey`
@@ -319,12 +319,10 @@ impl IcmpProtoKey {
     }
 
     fn new_icmp_v6<Buf: PacketBufferMut>(packet: &Packet<Buf>, icmp: &Icmp6) -> Self {
-        #[allow(clippy::match_single_binding)]
         match icmp.icmp_type() {
-            Icmpv6Type::EchoRequest(echo_header) | Icmpv6Type::EchoReply(echo_header) => {
-                IcmpProtoKey::QueryMsgData(echo_header.id)
-            }
-            Icmpv6Type::TimeExceeded(_) | Icmpv6Type::DestinationUnreachable(_) => {
+            Icmp6Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
+            Icmp6Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
+            Icmp6Type::TimeExceeded(_) | Icmp6Type::DestUnreachable(_) => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -1039,10 +1037,10 @@ mod tests {
                 },
                 // To keep in sync with IcmpProtoKey::new_icmp_v6()
                 Transport::Icmp6(icmp) => match icmp.icmp_type() {
-                    Icmpv6Type::EchoRequest(_) | Icmpv6Type::EchoReply(_) => Some(
-                        IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(driver.produce()?)),
-                    ),
-                    Icmpv6Type::DestinationUnreachable(_) | Icmpv6Type::TimeExceeded(_) => {
+                    Icmp6Type::EchoRequest(_) | Icmp6Type::EchoReply(_) => Some(IpProtoKey::Icmp(
+                        IcmpProtoKey::QueryMsgData(driver.produce()?),
+                    )),
+                    Icmp6Type::DestUnreachable(_) | Icmp6Type::TimeExceeded(_) => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -311,7 +311,7 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp4Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp4Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp4Type::TimeExceeded(_) | Icmp4Type::DestUnreachable(_) => {
+            _ if icmp.is_error_message() => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -322,7 +322,7 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp6Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp6Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp6Type::TimeExceeded(_) | Icmp6Type::DestUnreachable(_) => {
+            _ if icmp.is_error_message() => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -1025,22 +1025,20 @@ mod tests {
                     src_port: driver.produce()?,
                     dst_port: driver.produce()?,
                 })),
-                // To keep in sync with IcmpProtoKey::new_icmp_v4()
                 Transport::Icmp4(icmp) => match icmp.icmp_type() {
                     Icmp4Type::EchoRequest(_) | Icmp4Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp4Type::DestUnreachable(_) | Icmp4Type::TimeExceeded(_) => {
+                    _ if icmp.is_error_message() => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),
                 },
-                // To keep in sync with IcmpProtoKey::new_icmp_v6()
                 Transport::Icmp6(icmp) => match icmp.icmp_type() {
                     Icmp6Type::EchoRequest(_) | Icmp6Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp6Type::DestUnreachable(_) | Icmp6Type::TimeExceeded(_) => {
+                    _ if icmp.is_error_message() => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -60,7 +60,7 @@
 
 use std::num::NonZero;
 
-use etherparse::{IcmpEchoHeader, Icmpv4Type, Icmpv6Type};
+use etherparse::{IcmpEchoHeader, Icmpv6Type};
 
 use crate::checksum::Checksum;
 use crate::eth::Eth;
@@ -636,7 +636,9 @@ impl Blank for Udp {
 
 impl Blank for Icmp4 {
     fn blank() -> Self {
-        Icmp4::with_type(Icmpv4Type::EchoRequest(IcmpEchoHeader { id: 0, seq: 0 }))
+        Icmp4::with_type(crate::icmp4::Icmp4Type::EchoRequest(
+            crate::icmp4::Icmp4EchoRequest { id: 0, seq: 0 },
+        ))
     }
 }
 

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -55,8 +55,10 @@
 //!
 //! Extension headers are supported as individual typed layers:
 //! [`HopByHop`], [`DestOpts`], [`Routing`], [`Fragment`], [`Ipv6Auth`].
-//! [`Within`] bounds enforce [RFC 8200 section 4.1] ordering at compile time
-//! (e.g. `HopByHop` may only follow `Ipv6`).
+//! [`Within`] bounds enforce key [RFC 8200 section 4.1] ordering constraints
+//! at compile time (e.g. `HopByHop` may only follow `Ipv6`).  The bounds
+//! prevent clearly invalid chains but do not enforce the full recommended
+//! ordering -- for example, two `DestOpts` layers are both permitted.
 //!
 //! IPv4 authentication headers use [`Ipv4Auth`], which can only follow `Ipv4`.
 //!
@@ -466,7 +468,7 @@ where
     // ICMPv4 subtype layers -- available after `.icmp4()`
 
     layer_method!(
-        /// Specialize as `ICMPv4` Destination Unreachable (type 3).
+        /// Specialize as `Icmp4` Destination Unreachable (type 3).
         dest_unreachable, Icmp4DestUnreachable
     );
     layer_method!(
@@ -626,7 +628,9 @@ impl Within<Ipv6> for HopByHop {
     }
 }
 
-// -- DestOpts: after Ipv6, HopByHop, or Routing (two legal positions) --
+// -- DestOpts: after Ipv6, HopByHop, Routing, Fragment, or Ipv6Auth --
+// RFC 8200 section 4.1 allows DestOpts in two positions: before Routing
+// (first occurrence) and as the final extension before the upper layer.
 impl Within<Ipv6> for DestOpts {
     fn conform(parent: &mut Ipv6) {
         parent.set_next_header(NextHeader::DEST_OPTS);
@@ -641,6 +645,18 @@ impl Within<HopByHop> for DestOpts {
 
 impl Within<Routing> for DestOpts {
     fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Fragment> for DestOpts {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Ipv6Auth> for DestOpts {
+    fn conform(parent: &mut Ipv6Auth) {
         parent.set_next_header(NextHeader::DEST_OPTS);
     }
 }
@@ -1058,42 +1074,55 @@ impl Blank for HopByHop {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
         // Minimum valid payload: 6 zero bytes (8-byte aligned with the 2-byte header prefix).
-        #[allow(clippy::unwrap_used)]
-        HopByHop::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a HopByHop by definition.
+        unsafe {
+            HopByHop::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for DestOpts {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
-        #[allow(clippy::unwrap_used)]
-        DestOpts::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a DestOpts by definition.
+        unsafe {
+            DestOpts::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for Routing {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
-        #[allow(clippy::unwrap_used)]
-        Routing::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a Routing by definition.
+        unsafe {
+            Routing::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for Fragment {
     fn blank() -> Self {
         use etherparse::{IpFragOffset, Ipv6FragmentHeader};
-        Fragment::from(Ipv6FragmentHeader::new(
-            IpNumber::TCP,
-            IpFragOffset::ZERO,
-            false,
-            0,
-        ))
+        #[allow(unsafe_code)]
+        // SAFETY: we are constructing this as a Fragment by definition.
+        unsafe {
+            Fragment::from_raw_unchecked(Ipv6FragmentHeader::new(
+                IpNumber::TCP,
+                IpFragOffset::ZERO,
+                false,
+                0,
+            ))
+        }
     }
 }
 
@@ -1367,21 +1396,26 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
 
     let payload_u16 = u16::try_from(payload.len()).map_err(|_| BuildError::PayloadTooLarge)?;
 
-    // It is safe to combine values this way because the mutually exclusive values are mapped back
-    // to zero (e.g. embedded_size is 0 when transport is UDP, encap_size is 0 when transport is
-    // ICMP, etc.).
-    // TODO: include net_ext size once IPv6 extension headers are supported.
-    let ip_payload = transport_size
+    let net_ext_size: u16 = headers.net_ext.iter().map(|e| e.size().get()).sum();
+
+    // Transport payload (used for UDP length -- excludes extension headers
+    // since they sit between IP and transport, not inside UDP).
+    let base_payload = transport_size
         .checked_add(payload_u16)
         .and_then(|v| v.checked_add(encap_size))
         .and_then(|v| v.checked_add(embedded_size))
         .ok_or(BuildError::PayloadTooLarge)?;
 
+    // IP payload includes extension headers + transport payload.
+    let ip_payload = base_payload
+        .checked_add(net_ext_size)
+        .ok_or(BuildError::PayloadTooLarge)?;
+
     match headers.transport {
         Some(Transport::Udp(ref mut udp)) => {
-            // SAFETY: `transport_size >= Udp::MIN_LENGTH` when transport is UDP, so `ip_payload`
-            // is guaranteed non-zero.
-            let udp_len = NonZero::new(ip_payload).unwrap_or_else(|| unreachable!());
+            // SAFETY: `transport_size >= Udp::MIN_LENGTH` when transport is UDP, so
+            // `base_payload` is guaranteed non-zero.
+            let udp_len = NonZero::new(base_payload).unwrap_or_else(|| unreachable!());
             #[allow(unsafe_code)]
             // SAFETY: `udp_len >= Udp::MIN_LENGTH` by construction.
             unsafe {
@@ -1651,6 +1685,38 @@ mod fuzz {
             /// Push a `Vxlan` layer.
             vxlan,
             crate::vxlan::Vxlan
+        );
+
+        // IPv6 extension header layers
+        fuzz_layer_method!(
+            /// Push a `HopByHop` extension header.
+            hop_by_hop,
+            crate::ipv6::HopByHop
+        );
+        fuzz_layer_method!(
+            /// Push a `DestOpts` extension header.
+            dest_opts,
+            crate::ipv6::DestOpts
+        );
+        fuzz_layer_method!(
+            /// Push a `Routing` extension header.
+            routing,
+            crate::ipv6::Routing
+        );
+        fuzz_layer_method!(
+            /// Push a `Fragment` extension header.
+            fragment,
+            crate::ipv6::Fragment
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv4Auth` extension header.
+            ipv4_auth,
+            crate::ip_auth::Ipv4Auth
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv6Auth` extension header.
+            ipv6_auth,
+            crate::ip_auth::Ipv6Auth
         );
 
         // ICMPv4 subtype layers
@@ -2766,6 +2832,27 @@ mod tests {
                     panic!("no embedded ipv4");
                 };
                 assert_eq!(inner_ip.destination().octets(), [169, 254, 32, 53]);
+            });
+    }
+
+    #[test]
+    fn fuzz_ipv6_ext_headers() {
+        let generator = ChainBase::new().eth(|_| {}).ipv6(|_| {}).hop_by_hop(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .cloned()
+            .for_each(|headers| {
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
+                assert!(
+                    !headers.net_ext().is_empty(),
+                    "should have extension headers"
+                );
+                let mut buf = vec![0u8; headers.size().get() as usize];
+                headers.deparse(&mut buf).unwrap();
+                let (reparsed, consumed) = Headers::parse(&buf).unwrap();
+                assert_eq!(consumed.get() as usize, buf.len());
+                assert_eq!(headers, reparsed, "deparse->parse round-trip failed");
             });
     }
 }

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -60,8 +60,6 @@
 
 use std::num::NonZero;
 
-use etherparse::{IcmpEchoHeader, Icmpv6Type};
-
 use crate::checksum::Checksum;
 use crate::eth::Eth;
 use crate::eth::ethtype::EthType;
@@ -644,7 +642,9 @@ impl Blank for Icmp4 {
 
 impl Blank for Icmp6 {
     fn blank() -> Self {
-        Icmp6::with_type(Icmpv6Type::EchoRequest(IcmpEchoHeader { id: 0, seq: 0 }))
+        Icmp6::with_type(crate::icmp6::Icmp6Type::EchoRequest(
+            crate::icmp6::Icmp6EchoRequest { id: 0, seq: 0 },
+        ))
     }
 }
 

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -51,14 +51,20 @@
 //!   fields only.  Use when checksums are irrelevant (e.g., ACL matching
 //!   tests).
 //!
-//! # Not yet supported
+//! # IPv6 Extension Headers
 //!
-//! - **IPv6 extension headers** (`Ipv6Ext`, `IpAuth`).  These chain via
-//!   `net_ext` on [`Headers`] and need their own `next_header` management
-//!   (the extension's `next_header` field, not the base `Ipv6` header's).
-//!   Requires constructors and `TypeGenerator` impls that don't exist yet.
+//! Extension headers are supported as individual typed layers:
+//! [`HopByHop`], [`DestOpts`], [`Routing`], [`Fragment`], [`Ipv6Auth`].
+//! [`Within`] bounds enforce [RFC 8200 section 4.1] ordering at compile time
+//! (e.g. `HopByHop` may only follow `Ipv6`).
+//!
+//! IPv4 authentication headers use [`Ipv4Auth`], which can only follow `Ipv4`.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
 
 use std::num::NonZero;
+
+use etherparse::IpNumber;
 
 use crate::checksum::Checksum;
 use crate::eth::Eth;
@@ -70,9 +76,10 @@ use crate::icmp4::TruncatedIcmp4;
 use crate::icmp6::Icmp6;
 use crate::icmp6::TruncatedIcmp6;
 use crate::ip::NextHeader;
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
 use crate::ipv4::Ipv4LengthError;
-use crate::ipv6::Ipv6;
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::DeParse;
 use crate::tcp::port::TcpPort;
 use crate::tcp::{Tcp, TruncatedTcp};
@@ -81,7 +88,7 @@ use crate::udp::{Udp, UdpChecksum, UdpEncap};
 use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::{Vni, Vxlan};
 
-use super::{Net, Transport};
+use super::{Net, NetExt, Transport};
 
 /// Errors that can occur when finalizing a header stack.
 ///
@@ -429,6 +436,33 @@ where
         vxlan, Vxlan
     );
 
+    // IPv6 extension header layers
+
+    layer_method!(
+        /// Push a `HopByHop` extension header (RFC 8200 section 4.3).
+        hop_by_hop, HopByHop
+    );
+    layer_method!(
+        /// Push a `DestOpts` extension header (RFC 8200 section 4.6).
+        dest_opts, DestOpts
+    );
+    layer_method!(
+        /// Push a `Routing` extension header (RFC 8200 section 4.4).
+        routing, Routing
+    );
+    layer_method!(
+        /// Push a `Fragment` extension header (RFC 8200 section 4.5).
+        fragment, Fragment
+    );
+    layer_method!(
+        /// Push an `Ipv4Auth` extension header (RFC 4302, IPv4 context).
+        ipv4_auth, Ipv4Auth
+    );
+    layer_method!(
+        /// Push an `Ipv6Auth` extension header (RFC 4302, IPv6 context).
+        ipv6_auth, Ipv6Auth
+    );
+
     // ICMPv4 subtype layers -- available after `.icmp4()`
 
     layer_method!(
@@ -573,6 +607,238 @@ impl Within<Udp> for Vxlan {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Within impls for IPv6 extension headers (RFC 8200 section 4.1 ordering)
+// ---------------------------------------------------------------------------
+//
+// Recommended order:
+//   IPv6 -> HopByHop -> DestOpts -> Routing -> Fragment -> AH -> DestOpts -> upper
+//
+// HopByHop MUST immediately follow IPv6 when present.
+// DestOpts may appear in two positions (before Routing, and after AH).
+// The `Within` bounds encode valid parent->child transitions; absence of
+// an impl = compile error = invalid ordering.
+
+// -- HopByHop: only after Ipv6 --
+impl Within<Ipv6> for HopByHop {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::HOP_BY_HOP);
+    }
+}
+
+// -- DestOpts: after Ipv6, HopByHop, or Routing (two legal positions) --
+impl Within<Ipv6> for DestOpts {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<HopByHop> for DestOpts {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Routing> for DestOpts {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+// -- Routing: after Ipv6, HopByHop, or DestOpts --
+impl Within<Ipv6> for Routing {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+impl Within<HopByHop> for Routing {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+impl Within<DestOpts> for Routing {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+// -- Fragment: after Ipv6, HopByHop, DestOpts, or Routing --
+impl Within<Ipv6> for Fragment {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<HopByHop> for Fragment {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<DestOpts> for Fragment {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<Routing> for Fragment {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+// -- Ipv4Auth: after Ipv4 only --
+impl Within<Ipv4> for Ipv4Auth {
+    fn conform(parent: &mut Ipv4) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+// -- Ipv6Auth: after Ipv6, HopByHop, DestOpts, Routing, or Fragment --
+impl Within<Ipv6> for Ipv6Auth {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<HopByHop> for Ipv6Auth {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<DestOpts> for Ipv6Auth {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<Routing> for Ipv6Auth {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<Fragment> for Ipv6Auth {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+// -- Transport after extension headers --
+// Tcp, Udp, Icmp6 can follow any IPv6 extension header.
+// Icmp4 can follow Ipv4Auth (IPv4 context).
+
+impl Within<HopByHop> for Tcp {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<DestOpts> for Tcp {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Routing> for Tcp {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Fragment> for Tcp {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Ipv4Auth> for Tcp {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Ipv6Auth> for Tcp {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<HopByHop> for Udp {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<DestOpts> for Udp {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Routing> for Udp {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Fragment> for Udp {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv4Auth> for Udp {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv6Auth> for Udp {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv4Auth> for Icmp4 {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::ICMP);
+    }
+}
+
+impl Within<HopByHop> for Icmp6 {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<DestOpts> for Icmp6 {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Routing> for Icmp6 {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Fragment> for Icmp6 {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Ipv6Auth> for Icmp6 {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
 // Install impls -- how Headers absorbs each layer
 
 impl Install<()> for Headers {
@@ -637,6 +903,78 @@ impl Install<Icmp6> for Headers {
 impl Install<Vxlan> for Headers {
     fn install(&mut self, vxlan: Vxlan) {
         self.udp_encap = Some(UdpEncap::Vxlan(vxlan));
+    }
+}
+
+impl Install<HopByHop> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, hbh: HopByHop) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::HopByHop(hbh))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<DestOpts> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, d: DestOpts) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::DestOpts(d))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Routing> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, r: Routing) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Routing(r))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Fragment> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, f: Fragment) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Fragment(f))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Ipv4Auth> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, a: Ipv4Auth) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Ipv4Auth(a))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Ipv6Auth> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, a: Ipv6Auth) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Ipv6Auth(a))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
     }
 }
 
@@ -713,6 +1051,66 @@ impl Blank for Vxlan {
     fn blank() -> Self {
         #[allow(clippy::unwrap_used)] // VNI 1 is always valid
         Vxlan::new(Vni::new_checked(1).unwrap())
+    }
+}
+
+impl Blank for HopByHop {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        // Minimum valid payload: 6 zero bytes (8-byte aligned with the 2-byte header prefix).
+        #[allow(clippy::unwrap_used)]
+        HopByHop::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for DestOpts {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        #[allow(clippy::unwrap_used)]
+        DestOpts::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for Routing {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        #[allow(clippy::unwrap_used)]
+        Routing::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for Fragment {
+    fn blank() -> Self {
+        use etherparse::{IpFragOffset, Ipv6FragmentHeader};
+        Fragment::from(Ipv6FragmentHeader::new(
+            IpNumber::TCP,
+            IpFragOffset::ZERO,
+            false,
+            0,
+        ))
+    }
+}
+
+impl Blank for Ipv4Auth {
+    fn blank() -> Self {
+        use crate::ip_auth::IpAuth;
+        use etherparse::IpAuthHeader;
+        // Default IpAuthHeader has zero-length ICV -- the minimum valid AH.
+        Ipv4Auth::new(IpAuth::from(Box::new(IpAuthHeader::default())))
+    }
+}
+
+impl Blank for Ipv6Auth {
+    fn blank() -> Self {
+        use crate::ip_auth::IpAuth;
+        use etherparse::IpAuthHeader;
+        Ipv6Auth::new(IpAuth::from(Box::new(IpAuthHeader::default())))
     }
 }
 

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -1007,6 +1007,7 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
 
     Ok(())
 }
+
 // ---------------------------------------------------------------------------
 // Fuzz header-stack generator (bolero integration)
 // ---------------------------------------------------------------------------
@@ -1068,8 +1069,8 @@ mod fuzz {
     /// next link can [`conform`](Within::conform) and install it.
     ///
     /// This trait is sealed --
-    /// only [`ChainBase`]
-    /// and [`FuzzLayer`] implement it.
+    /// only [`ChainBase`], [`FuzzLayer`],
+    /// [`FuzzEmbeddedNet`], and [`FuzzEmbeddedFull`] implement it.
     pub trait GenerateChain: sealed::Sealed {
         /// The header type sitting at the top of the stack (not yet installed).
         type Top;
@@ -1253,6 +1254,58 @@ mod fuzz {
             vxlan,
             crate::vxlan::Vxlan
         );
+
+        // ICMPv4 subtype layers
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Destination Unreachable.
+            dest_unreachable, super::Icmp4DestUnreachable
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Redirect.
+            redirect, super::Icmp4Redirect
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Time Exceeded.
+            time_exceeded, super::Icmp4TimeExceeded
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Parameter Problem.
+            param_problem, super::Icmp4ParamProblem
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Echo Request.
+            echo_request, super::Icmp4EchoRequest
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv4` Echo Reply.
+            echo_reply, super::Icmp4EchoReply
+        );
+
+        // ICMPv6 subtype layers
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Destination Unreachable.
+            dest_unreachable6, super::Icmp6DestUnreachable
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Packet Too Big.
+            packet_too_big6, super::Icmp6PacketTooBig
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Time Exceeded.
+            time_exceeded6, super::Icmp6TimeExceeded
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Parameter Problem.
+            param_problem6, super::Icmp6ParamProblem
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Echo Request.
+            echo_request6, super::Icmp6EchoRequest
+        );
+        fuzz_layer_method!(
+            /// Specialize as `ICMPv6` Echo Reply.
+            echo_reply6, super::Icmp6EchoReply
+        );
     }
 
     // -- ValueGenerator impls ------------------------------------------------
@@ -1303,6 +1356,453 @@ mod fuzz {
             Some(fixup_lengths(&mut headers, payload).map(|()| headers))
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Fuzz: ICMP subtypes and embedded header generation
+    // -----------------------------------------------------------------------
+
+    use super::{
+        EmbeddedTransport, Icmp4DestUnreachable, Icmp4EchoReply, Icmp4EchoRequest,
+        Icmp4ParamProblem, Icmp4Redirect, Icmp4RedirectCode, Icmp4TimeExceeded,
+        Icmp6DestUnreachable, Icmp6EchoReply, Icmp6EchoRequest, Icmp6PacketTooBig,
+        Icmp6ParamProblem, Icmp6ParamProblemCode, Icmp6TimeExceeded, fixup_embedded,
+    };
+    use crate::headers::Net;
+    use crate::icmp4::{Icmp4, TruncatedIcmp4};
+    use crate::icmp6::{Icmp6, TruncatedIcmp6};
+    use crate::ipv4::Ipv4;
+    use crate::ipv6::Ipv6;
+    use crate::tcp::{Tcp, TruncatedTcp};
+    use crate::udp::{TruncatedUdp, Udp};
+
+    // -- TypeGenerator impls for ICMP subtypes --------------------------------
+
+    fn pick<D: Driver, const N: usize, T: Copy>(driver: &mut D, items: [T; N]) -> Option<T> {
+        let idx = driver.gen_usize(std::ops::Bound::Included(&0), std::ops::Bound::Excluded(&N))?;
+        Some(items[idx])
+    }
+
+    impl TypeGenerator for Icmp4DestUnreachable {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let variant: u8 =
+                driver.gen_u8(std::ops::Bound::Included(&0), std::ops::Bound::Included(&5))?;
+            Some(match variant {
+                0 => Self::Network,
+                1 => Self::Host,
+                2 => Self::Protocol,
+                3 => Self::Port,
+                4 => Self::FragmentationNeeded {
+                    next_hop_mtu: std::num::NonZero::new(
+                        driver
+                            .gen_u16(std::ops::Bound::Included(&68), std::ops::Bound::Unbounded)?,
+                    ),
+                },
+                _ => Self::SourceRouteFailed,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp4Redirect {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let code = pick(
+                driver,
+                [
+                    Icmp4RedirectCode::Network,
+                    Icmp4RedirectCode::Host,
+                    Icmp4RedirectCode::TosNetwork,
+                    Icmp4RedirectCode::TosHost,
+                ],
+            )?;
+            let gateway: crate::ipv4::UnicastIpv4Addr = driver.produce()?;
+            Some(Self::new(code, gateway))
+        }
+    }
+
+    impl TypeGenerator for Icmp4TimeExceeded {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            pick(driver, [Self::TtlExceeded, Self::FragmentReassembly])
+        }
+    }
+
+    impl TypeGenerator for Icmp4ParamProblem {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let variant: u8 =
+                driver.gen_u8(std::ops::Bound::Included(&0), std::ops::Bound::Included(&2))?;
+            Some(match variant {
+                0 => Self::PointerIndicatesError(driver.produce()?),
+                1 => Self::MissingRequiredOption,
+                _ => Self::BadLength,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp4EchoRequest {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Self {
+                id: driver.produce()?,
+                seq: driver.produce()?,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp4EchoReply {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Self {
+                id: driver.produce()?,
+                seq: driver.produce()?,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp6DestUnreachable {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            pick(
+                driver,
+                [
+                    Self::NoRoute,
+                    Self::Prohibited,
+                    Self::BeyondScope,
+                    Self::Address,
+                    Self::Port,
+                    Self::SourceAddressFailedPolicy,
+                    Self::RejectRoute,
+                ],
+            )
+        }
+    }
+
+    impl TypeGenerator for Icmp6PacketTooBig {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let mtu =
+                driver.gen_u32(std::ops::Bound::Included(&1280), std::ops::Bound::Unbounded)?;
+            Some(Self::new(mtu).unwrap_or_else(|_| unreachable!()))
+        }
+    }
+
+    impl TypeGenerator for Icmp6TimeExceeded {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            pick(driver, [Self::HopLimitExceeded, Self::FragmentReassembly])
+        }
+    }
+
+    impl TypeGenerator for Icmp6ParamProblem {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let code = pick(
+                driver,
+                [
+                    Icmp6ParamProblemCode::ErroneousHeaderField,
+                    Icmp6ParamProblemCode::UnrecognizedNextHeader,
+                    Icmp6ParamProblemCode::UnrecognizedIpv6Option,
+                ],
+            )?;
+            Some(Self {
+                code,
+                pointer: driver.produce()?,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp6EchoRequest {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Self {
+                id: driver.produce()?,
+                seq: driver.produce()?,
+            })
+        }
+    }
+
+    impl TypeGenerator for Icmp6EchoReply {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Self {
+                id: driver.produce()?,
+                seq: driver.produce()?,
+            })
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Embedded ICMP header generation (flattened into the main chain)
+    // -----------------------------------------------------------------------
+
+    /// Helper to generate a net layer via [`TypeGenerator`], apply the
+    /// mutation, and wrap in [`Net`].
+    trait GenerateNet: TypeGenerator {
+        fn generate_and_wrap<D: Driver>(driver: &mut D, mutate: &impl Fn(&mut Self))
+        -> Option<Net>;
+    }
+
+    impl GenerateNet for Ipv4 {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<Net> {
+            let mut ip = Ipv4::generate(driver)?;
+            mutate(&mut ip);
+            Some(Net::Ipv4(ip))
+        }
+    }
+
+    impl GenerateNet for Ipv6 {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<Net> {
+            let mut ip = Ipv6::generate(driver)?;
+            mutate(&mut ip);
+            Some(Net::Ipv6(ip))
+        }
+    }
+
+    /// Helper to generate a transport layer via [`TypeGenerator`], apply the
+    /// mutation, and wrap in [`EmbeddedTransport`].
+    trait GenerateEmbeddedTransport: TypeGenerator {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<EmbeddedTransport>;
+    }
+
+    impl GenerateEmbeddedTransport for Tcp {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<EmbeddedTransport> {
+            let mut tcp = Tcp::generate(driver)?;
+            mutate(&mut tcp);
+            Some(EmbeddedTransport::Tcp(TruncatedTcp::FullHeader(tcp)))
+        }
+    }
+
+    impl GenerateEmbeddedTransport for Udp {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<EmbeddedTransport> {
+            let mut udp = Udp::generate(driver)?;
+            mutate(&mut udp);
+            Some(EmbeddedTransport::Udp(TruncatedUdp::FullHeader(udp)))
+        }
+    }
+
+    impl GenerateEmbeddedTransport for Icmp4 {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<EmbeddedTransport> {
+            let mut icmp = Icmp4::generate(driver)?;
+            mutate(&mut icmp);
+            Some(EmbeddedTransport::Icmp4(TruncatedIcmp4::FullHeader(icmp)))
+        }
+    }
+
+    impl GenerateEmbeddedTransport for Icmp6 {
+        fn generate_and_wrap<D: Driver>(
+            driver: &mut D,
+            mutate: &impl Fn(&mut Self),
+        ) -> Option<EmbeddedTransport> {
+            let mut icmp = Icmp6::generate(driver)?;
+            mutate(&mut icmp);
+            Some(EmbeddedTransport::Icmp6(TruncatedIcmp6::FullHeader(icmp)))
+        }
+    }
+
+    // -- FuzzEmbeddedNet: ICMP layer + embedded net, no transport ------------
+
+    /// An ICMP fuzz layer with an embedded network header but no transport.
+    ///
+    /// Obtained by calling `.embed_ipv4(...)` or `.embed_ipv6(...)` on a
+    /// an ICMP error subtype layer (e.g. `Icmp4DestUnreachable`).
+    ///
+    /// Chain `.embed_tcp(...)`, `.embed_udp(...)`, etc. to add an embedded
+    /// transport, or use directly as a [`ValueGenerator`] (net-only
+    /// embedded headers).
+    pub struct FuzzEmbeddedNet<S, N, NM> {
+        layer: S,
+        net_mutate: NM,
+        _net: PhantomData<N>,
+    }
+
+    impl<S, N, NM> sealed::Sealed for FuzzEmbeddedNet<S, N, NM> {}
+
+    impl<S, N, NM> GenerateChain for FuzzEmbeddedNet<S, N, NM>
+    where
+        S: GenerateChain,
+        N: GenerateNet,
+        NM: Fn(&mut N),
+    {
+        type Top = S::Top;
+
+        fn generate_chain<D: Driver>(&self, driver: &mut D) -> Option<(Headers, Self::Top)> {
+            let (mut headers, top) = self.layer.generate_chain(driver)?;
+            let net = N::generate_and_wrap(driver, &self.net_mutate)?;
+            headers.embedded_ip = Some(fixup_embedded(Some(net), None));
+            Some((headers, top))
+        }
+    }
+
+    impl<S, N, NM> ValueGenerator for FuzzEmbeddedNet<S, N, NM>
+    where
+        S: GenerateChain,
+        N: GenerateNet,
+        NM: Fn(&mut N),
+        Headers: Install<S::Top>,
+    {
+        type Output = Headers;
+
+        fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
+            let (mut headers, top) = self.generate_chain(driver)?;
+            headers.install(top);
+            fixup_lengths(&mut headers, &[]).ok()?;
+            Some(headers)
+        }
+    }
+
+    macro_rules! fuzz_embedded_transport_method {
+        ($(#[$meta:meta])* $method:ident, $transport:ty) => {
+            $(#[$meta])*
+            pub fn $method(
+                self,
+                f: impl Fn(&mut $transport),
+            ) -> FuzzEmbeddedFull<S, N, NM, $transport, impl Fn(&mut $transport)> {
+                FuzzEmbeddedFull {
+                    layer: self.layer,
+                    net_mutate: self.net_mutate,
+                    transport_mutate: f,
+                    _net: PhantomData,
+                    _transport: PhantomData,
+                }
+            }
+        };
+    }
+
+    impl<S, N, NM> FuzzEmbeddedNet<S, N, NM> {
+        fuzz_embedded_transport_method!(
+            /// Add a fuzzed `Tcp` embedded transport layer.
+            embed_tcp,
+            Tcp
+        );
+        fuzz_embedded_transport_method!(
+            /// Add a fuzzed `Udp` embedded transport layer.
+            embed_udp,
+            Udp
+        );
+        fuzz_embedded_transport_method!(
+            /// Add a fuzzed `Icmp4` embedded transport layer.
+            embed_icmp4,
+            Icmp4
+        );
+        fuzz_embedded_transport_method!(
+            /// Add a fuzzed `Icmp6` embedded transport layer.
+            embed_icmp6,
+            Icmp6
+        );
+    }
+
+    // -- FuzzEmbeddedFull: ICMP layer + embedded net + embedded transport ----
+
+    /// An ICMP fuzz layer with both embedded network and transport headers.
+    ///
+    /// Obtained by calling `.embed_tcp(...)`, `.embed_udp(...)`, etc. on a
+    /// [`FuzzEmbeddedNet`].  This is a terminal chain element -- it
+    /// implements [`ValueGenerator`] and can be passed directly to
+    /// `bolero::check!().with_generator(...)`.
+    pub struct FuzzEmbeddedFull<S, N, NM, T, TM> {
+        layer: S,
+        net_mutate: NM,
+        transport_mutate: TM,
+        _net: PhantomData<N>,
+        _transport: PhantomData<T>,
+    }
+
+    impl<S, N, NM, T, TM> sealed::Sealed for FuzzEmbeddedFull<S, N, NM, T, TM> {}
+
+    impl<S, N, NM, T, TM> GenerateChain for FuzzEmbeddedFull<S, N, NM, T, TM>
+    where
+        S: GenerateChain,
+        N: GenerateNet,
+        NM: Fn(&mut N),
+        T: GenerateEmbeddedTransport,
+        TM: Fn(&mut T),
+    {
+        type Top = S::Top;
+
+        fn generate_chain<D: Driver>(&self, driver: &mut D) -> Option<(Headers, Self::Top)> {
+            let (mut headers, top) = self.layer.generate_chain(driver)?;
+            let net = N::generate_and_wrap(driver, &self.net_mutate)?;
+            let transport = T::generate_and_wrap(driver, &self.transport_mutate)?;
+            headers.embedded_ip = Some(fixup_embedded(Some(net), Some(transport)));
+            Some((headers, top))
+        }
+    }
+
+    impl<S, N, NM, T, TM> ValueGenerator for FuzzEmbeddedFull<S, N, NM, T, TM>
+    where
+        S: GenerateChain,
+        N: GenerateNet,
+        NM: Fn(&mut N),
+        T: GenerateEmbeddedTransport,
+        TM: Fn(&mut T),
+        Headers: Install<S::Top>,
+    {
+        type Output = Headers;
+
+        fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
+            let (mut headers, top) = self.generate_chain(driver)?;
+            headers.install(top);
+            fixup_lengths(&mut headers, &[]).ok()?;
+            Some(headers)
+        }
+    }
+
+    // -- .embed_ipv4() / .embed_ipv6() on ICMP FuzzLayers ---------------------
+
+    macro_rules! impl_fuzz_embedded {
+        ($icmp_ty:ty) => {
+            impl<Inner, Mutation> FuzzLayer<Inner, $icmp_ty, Mutation>
+            where
+                Inner: GenerateChain,
+                $icmp_ty: TypeGenerator + Within<Inner::Top>,
+                Mutation: Fn(&mut $icmp_ty),
+                Headers: Install<Inner::Top> + Install<$icmp_ty>,
+            {
+                /// Add a fuzzed `Ipv4` embedded network layer.
+                pub fn embed_ipv4(
+                    self,
+                    f: impl Fn(&mut Ipv4),
+                ) -> FuzzEmbeddedNet<Self, Ipv4, impl Fn(&mut Ipv4)> {
+                    FuzzEmbeddedNet {
+                        layer: self,
+                        net_mutate: f,
+                        _net: PhantomData,
+                    }
+                }
+
+                /// Add a fuzzed `Ipv6` embedded network layer.
+                pub fn embed_ipv6(
+                    self,
+                    f: impl Fn(&mut Ipv6),
+                ) -> FuzzEmbeddedNet<Self, Ipv6, impl Fn(&mut Ipv6)> {
+                    FuzzEmbeddedNet {
+                        layer: self,
+                        net_mutate: f,
+                        _net: PhantomData,
+                    }
+                }
+            }
+        };
+    }
+
+    // ICMPv4 error subtypes
+    impl_fuzz_embedded!(super::Icmp4DestUnreachable);
+    impl_fuzz_embedded!(super::Icmp4Redirect);
+    impl_fuzz_embedded!(super::Icmp4TimeExceeded);
+    impl_fuzz_embedded!(super::Icmp4ParamProblem);
+
+    // ICMPv6 error subtypes
+    impl_fuzz_embedded!(super::Icmp6DestUnreachable);
+    impl_fuzz_embedded!(super::Icmp6PacketTooBig);
+    impl_fuzz_embedded!(super::Icmp6TimeExceeded);
+    impl_fuzz_embedded!(super::Icmp6ParamProblem);
 }
 
 #[cfg(any(test, feature = "bolero"))]
@@ -1703,5 +2203,171 @@ mod tests {
                 );
             },
         );
+    }
+
+    // -- Fuzz ValueGenerator tests -------------------------------------------
+
+    #[test]
+    fn fuzz_ipv4_tcp_dst_port_pinned() {
+        bolero::check!()
+            .with_generator(
+                header_chain()
+                    .eth(|_| {})
+                    .ipv4(|ip| {
+                        ip.set_source(Ipv4Addr::new(169, 254, 32, 53).try_into().unwrap());
+                    })
+                    .tcp(|tcp| {
+                        tcp.set_destination(TcpPort::new_checked(80).unwrap());
+                    }),
+            )
+            .for_each(|headers| {
+                // Layer ordering invariants (same as HeaderStack).
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV4);
+                let Some(Net::Ipv4(ipv4)) = headers.net() else {
+                    panic!("expected Ipv4");
+                };
+                // source ip is pinned
+                assert_eq!(ipv4.source().inner().octets(), [169, 254, 32, 53]);
+                // next_header is pinned
+                assert_eq!(ipv4.next_header(), NextHeader::TCP);
+
+                let Some(Transport::Tcp(tcp)) = headers.transport() else {
+                    panic!("expected Tcp");
+                };
+                // dst port is pinned
+                assert_eq!(
+                    tcp.destination(),
+                    TcpPort::new_checked(80).unwrap(),
+                    "mutation closure should pin TCP dst port to 80",
+                );
+            });
+    }
+
+    #[test]
+    fn fuzz_ipv6_udp_vxlan_conforms() {
+        let generator = ChainBase::new()
+            .eth(|_| {})
+            .ipv6(|_| {})
+            .udp(|_| {})
+            .vxlan(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .for_each(|headers| {
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
+                let Some(Net::Ipv6(ipv6)) = headers.net() else {
+                    panic!("expected Ipv6");
+                };
+                assert_eq!(ipv6.next_header(), NextHeader::UDP);
+
+                let Some(Transport::Udp(udp)) = headers.transport() else {
+                    panic!("expected Udp");
+                };
+                assert_eq!(
+                    udp.destination(),
+                    Vxlan::PORT,
+                    "Vxlan conform must set UDP dst to 4789",
+                );
+            });
+    }
+
+    #[test]
+    fn fuzz_round_trips_through_parse() {
+        let generator = ChainBase::new().eth(|_| {}).ipv4(|_| {}).tcp(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .for_each(|headers| {
+                let mut test_buffer = TestBuffer::new();
+                headers.deparse(test_buffer.as_mut()).unwrap();
+                let (headers2, consumed) = Headers::parse(test_buffer.as_ref()).unwrap();
+                assert_eq!(consumed.get() as usize, headers.size().get() as usize);
+                assert_eq!(headers, &headers2, "fuzz round-trip failed");
+            });
+    }
+
+    #[test]
+    fn fuzz_icmp4_with_embedded_ipv4_tcp() {
+        bolero::check!()
+            .with_generator(
+                header_chain()
+                    .eth(|_| {})
+                    .ipv4(|_| {})
+                    .icmp4(|_| {})
+                    .dest_unreachable(|_| {})
+                    .embed_ipv4(|ip| {
+                        ip.set_destination(std::net::Ipv4Addr::new(10, 0, 0, 1));
+                    })
+                    .embed_tcp(|tcp| {
+                        tcp.set_destination(TcpPort::new_checked(80).unwrap());
+                    }),
+            )
+            .for_each(|headers| {
+                // Outer stack invariants.
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV4);
+                assert!(matches!(headers.transport(), Some(Transport::Icmp4(_))));
+
+                // Embedded headers must be present.
+                let embedded = headers.embedded_ip().expect("embedded should exist");
+                assert!(embedded.net_headers_len() > 0, "inner IP should be present");
+                assert!(
+                    embedded.transport_headers_len() > 0,
+                    "inner transport should be present",
+                );
+            });
+    }
+
+    #[test]
+    fn fuzz_icmp6_with_embedded_ipv6_udp() {
+        let generator = ChainBase::new()
+            .eth(|_| {})
+            .ipv6(|_| {})
+            .icmp6(|_| {})
+            .dest_unreachable6(|_| {})
+            .embed_ipv6(|_| {})
+            .embed_udp(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .for_each(|headers| {
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
+                assert!(matches!(headers.transport(), Some(Transport::Icmp6(_))));
+                assert!(headers.embedded_ip().is_some());
+            });
+    }
+
+    #[test]
+    fn fuzz_icmp4_embedded_net_with_udp() {
+        bolero::check!()
+            .with_generator(
+                header_chain()
+                    .eth(|eth| {
+                        eth.set_destination(
+                            Mac([0x02, 0xCA, 0xFA, 0xBA, 0xBE, 0x01])
+                                .try_into()
+                                .unwrap(),
+                        );
+                    })
+                    .ipv4(|ip| {
+                        ip.set_destination([192, 168, 1, 2].into());
+                    })
+                    .icmp4(|_| {})
+                    .dest_unreachable(|_| {})
+                    .embed_ipv4(|ip| {
+                        ip.set_destination([169, 254, 32, 53].into());
+                    })
+                    .embed_udp(|udp| {
+                        udp.set_destination(80.try_into().unwrap());
+                    }),
+            )
+            .for_each(|headers| {
+                assert!(matches!(headers.transport(), Some(Transport::Icmp4(_))));
+                let embedded = headers.embedded_ip().expect("embedded should exist");
+                assert!(embedded.net_headers_len() > 0);
+                let Some(inner_ip) = embedded.try_inner_ipv4() else {
+                    panic!("no embedded ipv4");
+                };
+                assert_eq!(inner_ip.destination().octets(), [169, 254, 32, 53]);
+            });
     }
 }

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -88,7 +88,8 @@ use super::{Net, Transport};
 /// Errors that can occur when finalizing a header stack.
 ///
 /// Many invalid combinations (e.g. ICMP4 on IPv6, VXLAN without UDP) are
-/// compile-time impossible via [`Within`] bounds.  The errors here cover
+/// compile-time impossible via [`Within`] bounds (which also prevent
+/// headers from "dangling" without a valid parent).  The errors here cover
 /// length-computation failures that can only be detected at finalization.
 #[derive(Debug, thiserror::Error)]
 pub enum BuildError {
@@ -186,43 +187,12 @@ impl EmbeddedAssembler {
     /// and sets IP payload length to the transport header size.
     /// This is done here rather than in the transport methods so that
     /// the call order (net vs transport) does not matter.
-    pub(crate) fn finish(mut self) -> super::EmbeddedHeaders {
+    pub(crate) fn finish(self) -> super::EmbeddedHeaders {
         assert!(
             self.transport.is_none() || self.net.is_some(),
             "embedded transport requires a network layer"
         );
-
-        // Set NextHeader based on transport type.  Done in finish() so
-        // it works regardless of whether net or transport was set first.
-        let nh = match &self.transport {
-            Some(EmbeddedTransport::Tcp(_)) => Some(NextHeader::TCP),
-            Some(EmbeddedTransport::Udp(_)) => Some(NextHeader::UDP),
-            Some(EmbeddedTransport::Icmp4(_)) => Some(NextHeader::ICMP),
-            Some(EmbeddedTransport::Icmp6(_)) => Some(NextHeader::ICMP6),
-            None => None,
-        };
-        if let Some(nh) = nh {
-            set_net_next_header(&mut self.net, nh);
-        }
-
-        let transport_size = self.transport.as_ref().map_or(0u16, |t| t.size().get());
-
-        match &mut self.net {
-            Some(Net::Ipv4(ip)) => {
-                // transport_size is always small enough; ignore the error.
-                let _ = ip.set_payload_len(transport_size);
-                ip.update_checksum(&()).unwrap_or_else(|()| unreachable!());
-            }
-            Some(Net::Ipv6(ip)) => {
-                ip.set_payload_length(transport_size);
-            }
-            None => {}
-        }
-
-        let mut b = EmbeddedHeadersBuilder::default();
-        b.net(self.net).transport(self.transport);
-        #[allow(clippy::unwrap_used)] // all fields have #[builder(default)]
-        b.build().unwrap()
+        fixup_embedded(self.net, self.transport)
     }
 }
 
@@ -237,6 +207,49 @@ fn set_net_next_header(net: &mut Option<Net>, nh: NextHeader) {
         }
         None => {}
     }
+}
+
+/// Build [`EmbeddedHeaders`](super::EmbeddedHeaders) from raw net/transport
+/// layers, applying protocol fixups.
+///
+/// Sets:
+/// 1. `NextHeader` on the IP layer to match the transport variant
+/// 2. IP payload length to the transport header size
+/// 3. IPv4 header checksum (if applicable)
+///
+/// Used by [`EmbeddedAssembler::finish`].
+fn fixup_embedded(
+    mut net: Option<Net>,
+    transport: Option<EmbeddedTransport>,
+) -> super::EmbeddedHeaders {
+    let nh = match &transport {
+        Some(EmbeddedTransport::Tcp(_)) => Some(NextHeader::TCP),
+        Some(EmbeddedTransport::Udp(_)) => Some(NextHeader::UDP),
+        Some(EmbeddedTransport::Icmp4(_)) => Some(NextHeader::ICMP),
+        Some(EmbeddedTransport::Icmp6(_)) => Some(NextHeader::ICMP6),
+        None => None,
+    };
+    if let Some(nh) = nh {
+        set_net_next_header(&mut net, nh);
+    }
+
+    let transport_size = transport.as_ref().map_or(0u16, |t| t.size().get());
+
+    match &mut net {
+        Some(Net::Ipv4(ip)) => {
+            let _ = ip.set_payload_len(transport_size);
+            ip.update_checksum(&()).unwrap_or_else(|()| unreachable!());
+        }
+        Some(Net::Ipv6(ip)) => {
+            ip.set_payload_length(transport_size);
+        }
+        None => {}
+    }
+
+    let mut b = EmbeddedHeadersBuilder::default();
+    b.net(net).transport(transport);
+
+    b.build().unwrap_or_else(|_| unreachable!())
 }
 
 /// Declares that `Self` is a valid child of layer `T`.
@@ -722,6 +735,317 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Fuzz header-stack generator (bolero integration)
+// ---------------------------------------------------------------------------
+
+/// Fuzz-driven header stacking for property-based tests.
+///
+/// [`FuzzLayer`] chains implement [`ValueGenerator`](bolero::ValueGenerator),
+/// producing [`Headers`] by using [`TypeGenerator`](bolero::TypeGenerator) to
+/// create each layer, then applying caller-supplied mutation closures to pin
+/// specific field values.
+///
+/// # Design
+///
+/// Where [`HeaderStack`] eagerly builds headers using [`Blank`] values,
+/// a fuzz chain stores a *recipe* -- a chain of
+/// `(TypeGenerator, Fn(&mut T))` pairs.  At generation time the chain
+/// walks itself recursively:
+///
+/// 1. Generate the inner (preceding) layers -> `(Headers, PrevLayer)`.
+/// 2. Conform `PrevLayer` and install it into `Headers`.
+/// 3. Generate the current layer via `TypeGenerator`.
+/// 4. Apply the mutation closure.
+/// 5. Return `(Headers, CurrentLayer)`.
+///
+/// The chain is encoded in nested generics ([`ChainBase`] -> [`FuzzLayer`] -> ...),
+/// so each variant of the chain is a unique type -- Rust monomorphizes the
+/// entire build at compile time.
+///
+/// # Examples
+///
+/// ```ignore
+/// use net::headers::builder::*;
+///
+/// bolero::check!()
+///     .with_generator(
+///         ChainBase::new()
+///             .eth(|_| {})
+///             .ipv4(|_| {})
+///             .tcp(|tcp| {
+///                 tcp.set_destination(TcpPort::new_checked(80).unwrap());
+///             }),
+///     )
+///     .for_each(|headers: &Headers| {
+///         // `headers` has fuzzed values everywhere except dst port.
+///     });
+/// ```
+#[cfg(any(test, feature = "bolero"))]
+mod fuzz {
+    use std::marker::PhantomData;
+
+    use bolero::{Driver, TypeGenerator, ValueGenerator};
+
+    use super::{BuildError, Headers, Install, Within, fixup_lengths};
+
+    mod sealed {
+        pub trait Sealed {}
+        impl Sealed for super::ChainBase {}
+        impl<Inner, Layer, Mutation> Sealed for super::FuzzLayer<Inner, Layer, Mutation> {}
+    }
+
+    /// Recursive generation of the fuzz header chain.
+    ///
+    /// Each implementor can produce a `(Headers, Top)` pair from a
+    /// [`Driver`], where `Top` is the layer that has been generated
+    /// but **not yet installed** (so the next layer can [`Within::conform`]
+    /// it first).
+    ///
+    /// This trait is used internally by the
+    /// only [`ChainBase`]
+    /// and [`FuzzLayer`] implement it.
+    pub trait GenerateChain: sealed::Sealed {
+        /// The type of the layer currently held at the top of the chain.
+        ///
+        /// For [`ChainBase`] this is `()` (no layer yet).
+        type Top;
+
+        /// Walk the chain, producing a [`Headers`] and the not-yet-installed
+        /// top layer.
+        fn generate_chain<D: Driver>(&self, driver: &mut D) -> Option<(Headers, Self::Top)>;
+    }
+
+    /// Convenience entry point for fuzz header generation.
+    ///
+    /// Equivalent to [`ChainBase::new()`] -- returns a fresh chain ready
+    /// for `.eth(...)`, `.ipv4(...)`, etc.
+    #[must_use]
+    pub fn header_chain() -> ChainBase {
+        ChainBase::new()
+    }
+
+    /// The starting point for a fuzz chain -- analogous to [`super::HeaderStack<()>`].
+    #[derive(Default)]
+    #[non_exhaustive]
+    pub struct ChainBase;
+
+    impl ChainBase {
+        /// Create a new fuzz chain.
+        ///
+        /// Always starts empty, just like [`super::HeaderStack::new`].
+        #[must_use]
+        pub const fn new() -> Self {
+            ChainBase
+        }
+
+        /// Push a new layer onto the chain.
+        ///
+        /// This is the generic version; most callers use the named
+        /// convenience methods (`.eth(...)`, `.ipv4(...)`, ...).
+        pub fn stack<U, N>(self, mutate: N) -> FuzzLayer<Self, U, N>
+        where
+            U: TypeGenerator + Within<()>,
+            N: Fn(&mut U),
+        {
+            FuzzLayer {
+                inner: self,
+                mutate,
+                _layer: PhantomData,
+            }
+        }
+
+        /// Push an `Eth` layer.
+        pub fn eth(
+            self,
+            mutate: impl Fn(&mut crate::eth::Eth),
+        ) -> FuzzLayer<Self, crate::eth::Eth, impl Fn(&mut crate::eth::Eth)> {
+            self.stack(mutate)
+        }
+    }
+
+    impl GenerateChain for ChainBase {
+        type Top = ();
+
+        fn generate_chain<D: Driver>(&self, _driver: &mut D) -> Option<(Headers, ())> {
+            Some((Headers::default(), ()))
+        }
+    }
+
+    /// One link in a fuzz header chain.
+    ///
+    /// - `Inner` -- the preceding chain ([`ChainBase`] or another `FuzzLayer`).
+    /// - `Layer` -- the header type held at this position.
+    /// - `Mutation`     -- the mutation closure `Fn(&mut Layer)`.
+    pub struct FuzzLayer<Inner, Layer, Mutation> {
+        inner: Inner,
+        mutate: Mutation,
+        _layer: PhantomData<Layer>,
+    }
+
+    impl<Inner, Layer, Mutation> GenerateChain for FuzzLayer<Inner, Layer, Mutation>
+    where
+        Inner: GenerateChain,
+        Layer: TypeGenerator + Within<Inner::Top>,
+        Mutation: Fn(&mut Layer),
+        Headers: Install<Inner::Top> + Install<Layer>,
+    {
+        type Top = Layer;
+
+        fn generate_chain<D: Driver>(&self, driver: &mut D) -> Option<(Headers, Layer)> {
+            let (mut headers, mut prev) = self.inner.generate_chain(driver)?;
+            Layer::conform(&mut prev);
+            headers.install(prev);
+
+            let mut layer: Layer = driver.produce()?;
+            (self.mutate)(&mut layer);
+            Some((headers, layer))
+        }
+    }
+
+    /// Helper macro to generate named layer methods on [`FuzzLayer`].
+    ///
+    /// Each method delegates to [`FuzzLayer::stack`] with the concrete
+    /// header type, enforcing the `TypeGenerator + Within<Layer>` bound.
+    macro_rules! fuzz_layer_method {
+        ($(#[$meta:meta])* $method:ident, $header:ty) => {
+            $(#[$meta])*
+            pub fn $method(
+                self,
+                f: impl Fn(&mut $header),
+            ) -> FuzzLayer<Self, $header, impl Fn(&mut $header)>
+            where
+                $header: TypeGenerator + Within<Layer>,
+            {
+                self.stack(f)
+            }
+        };
+    }
+
+    impl<Inner, Layer, Mutation> FuzzLayer<Inner, Layer, Mutation>
+    where
+        Inner: GenerateChain,
+        Layer: TypeGenerator + Within<Inner::Top>,
+        Mutation: Fn(&mut Layer),
+        Headers: Install<Inner::Top> + Install<Layer>,
+    {
+        /// Push a new layer onto the stack.
+        ///
+        /// At generation time, the layer is created via
+        /// [`TypeGenerator::generate`], then `mutate` is applied.
+        pub fn stack<U, N>(self, mutate: N) -> FuzzLayer<Self, U, N>
+        where
+            U: TypeGenerator + Within<Layer>,
+            N: Fn(&mut U),
+        {
+            FuzzLayer {
+                inner: self,
+                mutate,
+                _layer: PhantomData,
+            }
+        }
+
+        fuzz_layer_method!(
+            /// Push an `Eth` layer.
+            eth,
+            crate::eth::Eth
+        );
+        fuzz_layer_method!(
+            /// Push a `Vlan` layer.
+            vlan,
+            crate::vlan::Vlan
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv4` layer.
+            ipv4,
+            crate::ipv4::Ipv4
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv6` layer.
+            ipv6,
+            crate::ipv6::Ipv6
+        );
+        fuzz_layer_method!(
+            /// Push a `Tcp` layer.
+            tcp,
+            crate::tcp::Tcp
+        );
+        fuzz_layer_method!(
+            /// Push a `Udp` layer.
+            udp,
+            crate::udp::Udp
+        );
+        fuzz_layer_method!(
+            /// Push an `Icmp4` layer.
+            icmp4,
+            crate::icmp4::Icmp4
+        );
+        fuzz_layer_method!(
+            /// Push an `Icmp6` layer.
+            icmp6,
+            crate::icmp6::Icmp6
+        );
+        fuzz_layer_method!(
+            /// Push a `Vxlan` layer.
+            vxlan,
+            crate::vxlan::Vxlan
+        );
+    }
+
+    // -- ValueGenerator impls ------------------------------------------------
+    //
+    // Any fuzz chain can be passed directly to `bolero::check!().with_generator(...)`
+    // without an intermediate wrapper -- no `.finish()` needed.
+
+    impl<Inner, Layer, Mutation> ValueGenerator for FuzzLayer<Inner, Layer, Mutation>
+    where
+        Inner: GenerateChain,
+        Layer: TypeGenerator + Within<Inner::Top>,
+        Mutation: Fn(&mut Layer),
+        Headers: Install<Inner::Top> + Install<Layer>,
+    {
+        type Output = Headers;
+
+        fn generate<D: Driver>(&self, driver: &mut D) -> Option<Headers> {
+            let (mut headers, top) = self.generate_chain(driver)?;
+            headers.install(top);
+            fixup_lengths(&mut headers, &[]).ok()?;
+            Some(headers)
+        }
+    }
+
+    impl<Inner, Layer, Mutation> FuzzLayer<Inner, Layer, Mutation>
+    where
+        Inner: GenerateChain,
+        Layer: TypeGenerator + Within<Inner::Top>,
+        Mutation: Fn(&mut Layer),
+        Headers: Install<Inner::Top> + Install<Layer>,
+    {
+        /// Generate headers with an explicit payload.
+        ///
+        /// Unlike the `ValueGenerator` impl (which uses an empty payload),
+        /// this method takes a `payload` slice and passes it to
+        /// [`fixup_lengths`](super::fixup_lengths) so that IP/UDP length
+        /// fields account for the trailing data.
+        ///
+        /// Returns `None` if generation fails, or `Some(Err(...))` if
+        /// length fixup overflows.
+        #[must_use]
+        pub fn generate_with_payload<D: Driver>(
+            &self,
+            driver: &mut D,
+            payload: &[u8],
+        ) -> Option<Result<Headers, BuildError>> {
+            let (mut headers, top) = self.generate_chain(driver)?;
+            headers.install(top);
+            Some(fixup_lengths(&mut headers, payload).map(|()| headers))
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+pub use fuzz::*;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1113,5 +1437,64 @@ mod tests {
                 );
             },
         );
+    }
+
+    // -- Fuzz ValueGenerator tests -------------------------------------------
+
+    #[test]
+    fn fuzz_ipv4_tcp_dst_port_pinned() {
+        bolero::check!()
+            .with_generator(header_chain().eth(|_| {}).ipv4(|_| {}).tcp(|tcp| {
+                tcp.set_destination(TcpPort::new_checked(80).unwrap());
+            }))
+            .cloned()
+            .for_each(|headers| {
+                let Transport::Tcp(tcp) = headers.transport().unwrap() else {
+                    panic!("expected Tcp");
+                };
+                assert_eq!(
+                    tcp.destination(),
+                    TcpPort::new_checked(80).unwrap(),
+                    "destination port should have been pinned by the mutation"
+                );
+            });
+    }
+
+    #[test]
+    fn fuzz_ipv6_udp_vxlan_conforms() {
+        let generator = ChainBase::new()
+            .eth(|_| {})
+            .ipv6(|_| {})
+            .udp(|_| {})
+            .vxlan(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .cloned()
+            .for_each(|headers| {
+                // Eth -> IPV6
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
+                // UDP -> VXLAN port
+                let Transport::Udp(udp) = headers.transport().unwrap() else {
+                    panic!("expected Udp");
+                };
+                assert_eq!(udp.destination(), Vxlan::PORT);
+            });
+    }
+
+    #[test]
+    fn fuzz_round_trips_through_parse() {
+        let generator = ChainBase::new().eth(|_| {}).ipv4(|_| {}).tcp(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .cloned()
+            .for_each(|headers| {
+                let mut test_buffer = vec![0u8; headers.size().get() as usize];
+                headers.deparse(&mut test_buffer).unwrap();
+                let (headers2, consumed) = Headers::parse(test_buffer.as_ref()).unwrap();
+                assert_eq!(consumed.get() as usize, headers.size().get() as usize);
+                assert_eq!(headers, headers2, "fuzz round-trip failed");
+            });
     }
 }

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -220,6 +220,7 @@ fn fixup_embedded(
     mut net: Option<Net>,
     transport: Option<EmbeddedTransport>,
 ) -> super::EmbeddedHeaders {
+    // Set NextHeader based on transport type.
     let nh = match &transport {
         Some(EmbeddedTransport::Tcp(_)) => Some(NextHeader::TCP),
         Some(EmbeddedTransport::Udp(_)) => Some(NextHeader::UDP),
@@ -235,6 +236,7 @@ fn fixup_embedded(
 
     match &mut net {
         Some(Net::Ipv4(ip)) => {
+            // transport_size is always small enough; ignore the error.
             let _ = ip.set_payload_len(transport_size);
             ip.update_checksum(&()).unwrap_or_else(|()| unreachable!());
         }
@@ -425,6 +427,65 @@ where
     layer_method!(
         /// Push a `Vxlan` layer.
         vxlan, Vxlan
+    );
+
+    // ICMPv4 subtype layers -- available after `.icmp4()`
+
+    layer_method!(
+        /// Specialize as `ICMPv4` Destination Unreachable (type 3).
+        dest_unreachable, Icmp4DestUnreachable
+    );
+    layer_method!(
+        /// Specialize as `ICMPv4` Redirect (type 5).
+        redirect, Icmp4Redirect
+    );
+    layer_method!(
+        /// Specialize as `ICMPv4` Time Exceeded (type 11).
+        time_exceeded, Icmp4TimeExceeded
+    );
+    layer_method!(
+        /// Specialize as `ICMPv4` Parameter Problem (type 12).
+        param_problem, Icmp4ParamProblem
+    );
+    layer_method!(
+        /// Specialize as `ICMPv4` Echo Request (type 8).
+        echo_request, Icmp4EchoRequest
+    );
+    layer_method!(
+        /// Specialize as `ICMPv4` Echo Reply (type 0).
+        echo_reply, Icmp4EchoReply
+    );
+
+    // ICMPv6 subtype layers -- available after `.icmp6()`
+    //
+    // ICMPv6 subtypes use a `6` suffix to avoid ambiguity with
+    // the ICMPv4 methods above. Both sets live in the same generic impl
+    // block, and Rust resolves the correct one via the `Within<T>` bound
+    // on `T` (the current top-of-stack).
+
+    layer_method!(
+        /// Specialize as `ICMPv6` Destination Unreachable (type 1).
+        dest_unreachable6, Icmp6DestUnreachable
+    );
+    layer_method!(
+        /// Specialize as `ICMPv6` Packet Too Big (type 2).
+        packet_too_big6, Icmp6PacketTooBig
+    );
+    layer_method!(
+        /// Specialize as `ICMPv6` Time Exceeded (type 3).
+        time_exceeded6, Icmp6TimeExceeded
+    );
+    layer_method!(
+        /// Specialize as `ICMPv6` Parameter Problem (type 4).
+        param_problem6, Icmp6ParamProblem
+    );
+    layer_method!(
+        /// Specialize as `ICMPv6` Echo Request (type 128).
+        echo_request6, Icmp6EchoRequest
+    );
+    layer_method!(
+        /// Specialize as `ICMPv6` Echo Reply (type 129).
+        echo_reply6, Icmp6EchoReply
     );
 }
 
@@ -635,7 +696,7 @@ impl Blank for Udp {
 impl Blank for Icmp4 {
     fn blank() -> Self {
         Icmp4::with_type(crate::icmp4::Icmp4Type::EchoRequest(
-            crate::icmp4::Icmp4EchoRequest { id: 0, seq: 0 },
+            Icmp4EchoRequest::blank(),
         ))
     }
 }
@@ -643,7 +704,7 @@ impl Blank for Icmp4 {
 impl Blank for Icmp6 {
     fn blank() -> Self {
         Icmp6::with_type(crate::icmp6::Icmp6Type::EchoRequest(
-            crate::icmp6::Icmp6EchoRequest { id: 0, seq: 0 },
+            Icmp6EchoRequest::blank(),
         ))
     }
 }
@@ -655,10 +716,211 @@ impl Blank for Vxlan {
     }
 }
 
-// Embedded ICMP headers -- modifier on HeaderStack<Icmp4> / HeaderStack<Icmp6>
+// ---------------------------------------------------------------------------
+// ICMP subtype newtypes
+// ---------------------------------------------------------------------------
+//
+// Each newtype wraps the etherparse inner header/code for one ICMP message
+// type.  They participate in the builder chain via `Within<Icmp4>` (or
+// `Icmp6`) and `Install` -- conform sets the variant on the parent ICMP
+// header, then install patches the inner value into the already-stored
+// transport slot.
+//
+// Error subtypes enable `.embedded()` / `.embed_*()` for attaching the
+// offending original packet.  Query subtypes (echo) are terminal.
+
+use crate::icmp4::{
+    Icmp4DestUnreachable, Icmp4EchoReply, Icmp4EchoRequest, Icmp4ParamProblem, Icmp4Redirect,
+    Icmp4RedirectCode, Icmp4TimeExceeded,
+};
+use crate::icmp6::{
+    Icmp6DestUnreachable, Icmp6EchoReply, Icmp6EchoRequest, Icmp6PacketTooBig, Icmp6ParamProblem,
+    Icmp6ParamProblemCode, Icmp6TimeExceeded,
+};
+
+// -- Within impls: ICMP subtypes after Icmp4 / Icmp6 ------------------------
+
+macro_rules! within_icmp4_subtype {
+    ($subtype:ty, $to_icmp4_type:expr) => {
+        impl Within<Icmp4> for $subtype {
+            fn conform(parent: &mut Icmp4) {
+                parent.set_type($to_icmp4_type(<$subtype>::blank()));
+            }
+        }
+    };
+}
+
+within_icmp4_subtype!(
+    Icmp4DestUnreachable,
+    crate::icmp4::Icmp4Type::DestUnreachable
+);
+within_icmp4_subtype!(Icmp4Redirect, crate::icmp4::Icmp4Type::Redirect);
+within_icmp4_subtype!(Icmp4TimeExceeded, crate::icmp4::Icmp4Type::TimeExceeded);
+within_icmp4_subtype!(Icmp4ParamProblem, crate::icmp4::Icmp4Type::ParamProblem);
+within_icmp4_subtype!(Icmp4EchoRequest, crate::icmp4::Icmp4Type::EchoRequest);
+within_icmp4_subtype!(Icmp4EchoReply, crate::icmp4::Icmp4Type::EchoReply);
+
+macro_rules! within_icmp6_subtype {
+    ($subtype:ty, $to_icmp6_type:expr) => {
+        impl Within<Icmp6> for $subtype {
+            fn conform(parent: &mut Icmp6) {
+                parent.set_type($to_icmp6_type(<$subtype>::blank()));
+            }
+        }
+    };
+}
+
+within_icmp6_subtype!(
+    Icmp6DestUnreachable,
+    crate::icmp6::Icmp6Type::DestUnreachable
+);
+within_icmp6_subtype!(Icmp6PacketTooBig, crate::icmp6::Icmp6Type::PacketTooBig);
+within_icmp6_subtype!(Icmp6TimeExceeded, crate::icmp6::Icmp6Type::TimeExceeded);
+within_icmp6_subtype!(Icmp6ParamProblem, crate::icmp6::Icmp6Type::ParamProblem);
+within_icmp6_subtype!(Icmp6EchoRequest, crate::icmp6::Icmp6Type::EchoRequest);
+within_icmp6_subtype!(Icmp6EchoReply, crate::icmp6::Icmp6Type::EchoReply);
+
+// -- Install impls: set the ICMP type on the already-stored transport --------
+
+macro_rules! install_icmp4_subtype {
+    ($subtype:ty, $to_icmp4_type:expr) => {
+        impl Install<$subtype> for Headers {
+            fn install(&mut self, value: $subtype) {
+                match &mut self.transport {
+                    Some(Transport::Icmp4(icmp)) => {
+                        icmp.set_type($to_icmp4_type(value));
+                    }
+                    _ => unreachable!("conform should have installed Icmp4 transport"),
+                }
+            }
+        }
+    };
+}
+
+install_icmp4_subtype!(
+    Icmp4DestUnreachable,
+    crate::icmp4::Icmp4Type::DestUnreachable
+);
+install_icmp4_subtype!(Icmp4Redirect, crate::icmp4::Icmp4Type::Redirect);
+install_icmp4_subtype!(Icmp4TimeExceeded, crate::icmp4::Icmp4Type::TimeExceeded);
+install_icmp4_subtype!(Icmp4ParamProblem, crate::icmp4::Icmp4Type::ParamProblem);
+install_icmp4_subtype!(Icmp4EchoRequest, crate::icmp4::Icmp4Type::EchoRequest);
+install_icmp4_subtype!(Icmp4EchoReply, crate::icmp4::Icmp4Type::EchoReply);
+
+macro_rules! install_icmp6_subtype {
+    ($subtype:ty, $to_icmp6_type:expr) => {
+        impl Install<$subtype> for Headers {
+            fn install(&mut self, value: $subtype) {
+                match &mut self.transport {
+                    Some(Transport::Icmp6(icmp)) => {
+                        icmp.set_type($to_icmp6_type(value));
+                    }
+                    _ => unreachable!("conform should have installed Icmp6 transport"),
+                }
+            }
+        }
+    };
+}
+
+install_icmp6_subtype!(
+    Icmp6DestUnreachable,
+    crate::icmp6::Icmp6Type::DestUnreachable
+);
+install_icmp6_subtype!(Icmp6PacketTooBig, crate::icmp6::Icmp6Type::PacketTooBig);
+install_icmp6_subtype!(Icmp6TimeExceeded, crate::icmp6::Icmp6Type::TimeExceeded);
+install_icmp6_subtype!(Icmp6ParamProblem, crate::icmp6::Icmp6Type::ParamProblem);
+install_icmp6_subtype!(Icmp6EchoRequest, crate::icmp6::Icmp6Type::EchoRequest);
+install_icmp6_subtype!(Icmp6EchoReply, crate::icmp6::Icmp6Type::EchoReply);
+
+// -- Blank impls -------------------------------------------------------------
+
+impl Blank for Icmp4DestUnreachable {
+    fn blank() -> Self {
+        Self::Network
+    }
+}
+
+impl Blank for Icmp4Redirect {
+    fn blank() -> Self {
+        #[allow(clippy::unwrap_used)] // 10.0.0.1 is always unicast
+        Self::new(
+            Icmp4RedirectCode::Network,
+            crate::ipv4::UnicastIpv4Addr::new(std::net::Ipv4Addr::new(10, 0, 0, 1)).unwrap(),
+        )
+    }
+}
+
+impl Blank for Icmp4TimeExceeded {
+    fn blank() -> Self {
+        Self::TtlExceeded
+    }
+}
+
+impl Blank for Icmp4ParamProblem {
+    fn blank() -> Self {
+        Self::PointerIndicatesError(0)
+    }
+}
+
+impl Blank for Icmp4EchoRequest {
+    fn blank() -> Self {
+        Self { id: 0, seq: 0 }
+    }
+}
+
+impl Blank for Icmp4EchoReply {
+    fn blank() -> Self {
+        Self { id: 0, seq: 0 }
+    }
+}
+
+impl Blank for Icmp6DestUnreachable {
+    fn blank() -> Self {
+        Self::NoRoute
+    }
+}
+
+impl Blank for Icmp6PacketTooBig {
+    fn blank() -> Self {
+        Self::new(1280).unwrap_or_else(|_| unreachable!())
+    }
+}
+
+impl Blank for Icmp6TimeExceeded {
+    fn blank() -> Self {
+        Self::HopLimitExceeded
+    }
+}
+
+impl Blank for Icmp6ParamProblem {
+    fn blank() -> Self {
+        Self {
+            code: Icmp6ParamProblemCode::ErroneousHeaderField,
+            pointer: 0,
+        }
+    }
+}
+
+impl Blank for Icmp6EchoRequest {
+    fn blank() -> Self {
+        Self { id: 0, seq: 0 }
+    }
+}
+
+impl Blank for Icmp6EchoReply {
+    fn blank() -> Self {
+        Self { id: 0, seq: 0 }
+    }
+}
+
+// -- Embedded ICMP headers (HeaderStack) -------------------------------------
+//
+// `.embedded()` is only available on error subtype layers, not on bare
+// `Icmp4` / `Icmp6`.
+
 macro_rules! impl_embedded {
-    ($icmp_ty:ty) => {
-        impl HeaderStack<$icmp_ty> {
+    ($subtype:ty) => {
+        impl HeaderStack<$subtype> {
             /// Attach ICMP-error embedded headers.
             ///
             /// The closure receives a fresh [`EmbeddedAssembler`] and should
@@ -677,8 +939,17 @@ macro_rules! impl_embedded {
     };
 }
 
-impl_embedded!(Icmp4);
-impl_embedded!(Icmp6);
+// ICMPv4 error subtypes
+impl_embedded!(Icmp4DestUnreachable);
+impl_embedded!(Icmp4Redirect);
+impl_embedded!(Icmp4TimeExceeded);
+impl_embedded!(Icmp4ParamProblem);
+
+// ICMPv6 error subtypes
+impl_embedded!(Icmp6DestUnreachable);
+impl_embedded!(Icmp6PacketTooBig);
+impl_embedded!(Icmp6TimeExceeded);
+impl_embedded!(Icmp6ParamProblem);
 
 /// Compute length fields over the fully-assembled headers.
 ///
@@ -736,7 +1007,6 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
 
     Ok(())
 }
-
 // ---------------------------------------------------------------------------
 // Fuzz header-stack generator (bolero integration)
 // ---------------------------------------------------------------------------
@@ -752,24 +1022,18 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
 ///
 /// Where [`HeaderStack`] eagerly builds headers using [`Blank`] values,
 /// a fuzz chain stores a *recipe* -- a chain of
-/// `(TypeGenerator, Fn(&mut T))` pairs.  At generation time the chain
-/// walks itself recursively:
-///
-/// 1. Generate the inner (preceding) layers -> `(Headers, PrevLayer)`.
-/// 2. Conform `PrevLayer` and install it into `Headers`.
-/// 3. Generate the current layer via `TypeGenerator`.
-/// 4. Apply the mutation closure.
-/// 5. Return `(Headers, CurrentLayer)`.
+/// `(TypeGenerator::generate, mutation)` pairs -- and replays it each time
+/// the fuzzer calls [`ValueGenerator::generate`](bolero::ValueGenerator::generate).
 ///
 /// The chain is encoded in nested generics ([`ChainBase`] -> [`FuzzLayer`] -> ...),
-/// so each variant of the chain is a unique type -- Rust monomorphizes the
-/// entire build at compile time.
+/// so all closure types are monomorphised and the hot path is zero-overhead.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use net::headers::builder::*;
 ///
+/// // All TCP packets with dst port 80, everything else fuzzed.
 /// bolero::check!()
 ///     .with_generator(
 ///         ChainBase::new()
@@ -799,22 +1063,18 @@ mod fuzz {
 
     /// Recursive generation of the fuzz header chain.
     ///
-    /// Each implementor can produce a `(Headers, Top)` pair from a
-    /// [`Driver`], where `Top` is the layer that has been generated
-    /// but **not yet installed** (so the next layer can [`Within::conform`]
-    /// it first).
+    /// Each link generates all preceding layers, installs them into
+    /// [`Headers`], and returns the not-yet-installed top layer so the
+    /// next link can [`conform`](Within::conform) and install it.
     ///
-    /// This trait is used internally by the
+    /// This trait is sealed --
     /// only [`ChainBase`]
     /// and [`FuzzLayer`] implement it.
     pub trait GenerateChain: sealed::Sealed {
-        /// The type of the layer currently held at the top of the chain.
-        ///
-        /// For [`ChainBase`] this is `()` (no layer yet).
+        /// The header type sitting at the top of the stack (not yet installed).
         type Top;
 
-        /// Walk the chain, producing a [`Headers`] and the not-yet-installed
-        /// top layer.
+        /// Generate all layers up to and including the top.
         fn generate_chain<D: Driver>(&self, driver: &mut D) -> Option<(Headers, Self::Top)>;
     }
 
@@ -827,24 +1087,25 @@ mod fuzz {
         ChainBase::new()
     }
 
-    /// The starting point for a fuzz chain -- analogous to [`super::HeaderStack<()>`].
+    /// Base of a fuzz header stack - no layers yet.
+    ///
+    /// Start here, then chain layer methods (`.eth(...)`, `.ipv4(...)`, ...).
+    /// The resulting chain implements [`ValueGenerator`] directly.
     #[derive(Default)]
     #[non_exhaustive]
     pub struct ChainBase;
 
     impl ChainBase {
-        /// Create a new fuzz chain.
-        ///
-        /// Always starts empty, just like [`super::HeaderStack::new`].
+        /// Create a new, empty fuzz header stack.
         #[must_use]
         pub const fn new() -> Self {
-            ChainBase
+            Self
         }
 
-        /// Push a new layer onto the chain.
+        /// Push a layer onto the stack.
         ///
-        /// This is the generic version; most callers use the named
-        /// convenience methods (`.eth(...)`, `.ipv4(...)`, ...).
+        /// The layer type `U` is created via [`TypeGenerator::generate`] at
+        /// generation time, then `mutate` is applied to pin specific fields.
         pub fn stack<U, N>(self, mutate: N) -> FuzzLayer<Self, U, N>
         where
             U: TypeGenerator + Within<()>,
@@ -860,9 +1121,9 @@ mod fuzz {
         /// Push an `Eth` layer.
         pub fn eth(
             self,
-            mutate: impl Fn(&mut crate::eth::Eth),
+            f: impl Fn(&mut crate::eth::Eth),
         ) -> FuzzLayer<Self, crate::eth::Eth, impl Fn(&mut crate::eth::Eth)> {
-            self.stack(mutate)
+            self.stack(f)
         }
     }
 
@@ -874,11 +1135,12 @@ mod fuzz {
         }
     }
 
-    /// One link in a fuzz header chain.
+    /// One layer in a fuzz header stack recipe.
     ///
     /// - `Inner` -- the preceding chain ([`ChainBase`] or another `FuzzLayer`).
-    /// - `Layer` -- the header type held at this position.
-    /// - `Mutation`     -- the mutation closure `Fn(&mut Layer)`.
+    /// - `Layer` -- the header type at this position.
+    /// - `Mutation` -- the mutation closure that pins field values after
+    ///   [`TypeGenerator`] produces a fuzzed instance.
     pub struct FuzzLayer<Inner, Layer, Mutation> {
         inner: Inner,
         mutate: Mutation,
@@ -890,7 +1152,7 @@ mod fuzz {
         Inner: GenerateChain,
         Layer: TypeGenerator + Within<Inner::Top>,
         Mutation: Fn(&mut Layer),
-        Headers: Install<Inner::Top> + Install<Layer>,
+        Headers: Install<Inner::Top>,
     {
         type Top = Layer;
 
@@ -898,8 +1160,7 @@ mod fuzz {
             let (mut headers, mut prev) = self.inner.generate_chain(driver)?;
             Layer::conform(&mut prev);
             headers.install(prev);
-
-            let mut layer: Layer = driver.produce()?;
+            let mut layer = Layer::generate(driver)?;
             (self.mutate)(&mut layer);
             Some((headers, layer))
         }
@@ -908,7 +1169,7 @@ mod fuzz {
     /// Helper macro to generate named layer methods on [`FuzzLayer`].
     ///
     /// Each method delegates to [`FuzzLayer::stack`] with the concrete
-    /// header type, enforcing the `TypeGenerator + Within<Layer>` bound.
+    /// header type, mirroring the named methods on [`super::HeaderStack`].
     macro_rules! fuzz_layer_method {
         ($(#[$meta:meta])* $method:ident, $header:ty) => {
             $(#[$meta])*
@@ -1008,9 +1269,11 @@ mod fuzz {
     {
         type Output = Headers;
 
-        fn generate<D: Driver>(&self, driver: &mut D) -> Option<Headers> {
+        fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
             let (mut headers, top) = self.generate_chain(driver)?;
             headers.install(top);
+            // Discard packets whose lengths overflow u16 -- the fuzzer will
+            // try again with different inputs.
             fixup_lengths(&mut headers, &[]).ok()?;
             Some(headers)
         }
@@ -1023,15 +1286,12 @@ mod fuzz {
         Mutation: Fn(&mut Layer),
         Headers: Install<Inner::Top> + Install<Layer>,
     {
-        /// Generate headers with an explicit payload.
+        /// Generate headers with an explicit payload for length computation.
         ///
-        /// Unlike the `ValueGenerator` impl (which uses an empty payload),
-        /// this method takes a `payload` slice and passes it to
-        /// [`fixup_lengths`](super::fixup_lengths) so that IP/UDP length
-        /// fields account for the trailing data.
-        ///
-        /// Returns `None` if generation fails, or `Some(Err(...))` if
-        /// length fixup overflows.
+        /// Unlike the [`ValueGenerator`] impl (which silently discards
+        /// packets whose lengths overflow `u16`), this method propagates
+        /// length errors as `Some(Err(...))`, returning `None` only when
+        /// the driver cannot produce enough bytes.
         #[must_use]
         pub fn generate_with_payload<D: Driver>(
             &self,
@@ -1051,6 +1311,7 @@ pub use fuzz::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::headers::TryInnerIpv4;
     use crate::ipv4::UnicastIpv4Addr;
     use std::net::Ipv4Addr;
 
@@ -1150,6 +1411,7 @@ mod tests {
                 ip.set_destination(Ipv4Addr::new(10, 0, 0, 1));
             })
             .icmp4(|_| {})
+            .dest_unreachable(|_| {})
             .embedded(|inner| {
                 inner
                     .ipv4(|ip| {
@@ -1230,6 +1492,7 @@ mod tests {
             .eth(|_| {})
             .ipv4(|_| {})
             .icmp4(|_| {})
+            .time_exceeded(|_| {})
             .embedded(|inner| {
                 inner.ipv4(|_| {}).tcp(
                     TcpPort::new_checked(1).unwrap(),
@@ -1256,6 +1519,7 @@ mod tests {
             .eth(|_| {})
             .ipv6(|_| {})
             .icmp6(|_| {})
+            .dest_unreachable6(|_| {})
             .embedded(|inner| {
                 inner.ipv6(|_| {}).udp(
                     UdpPort::new_checked(1).unwrap(),
@@ -1439,64 +1703,5 @@ mod tests {
                 );
             },
         );
-    }
-
-    // -- Fuzz ValueGenerator tests -------------------------------------------
-
-    #[test]
-    fn fuzz_ipv4_tcp_dst_port_pinned() {
-        bolero::check!()
-            .with_generator(header_chain().eth(|_| {}).ipv4(|_| {}).tcp(|tcp| {
-                tcp.set_destination(TcpPort::new_checked(80).unwrap());
-            }))
-            .cloned()
-            .for_each(|headers| {
-                let Transport::Tcp(tcp) = headers.transport().unwrap() else {
-                    panic!("expected Tcp");
-                };
-                assert_eq!(
-                    tcp.destination(),
-                    TcpPort::new_checked(80).unwrap(),
-                    "destination port should have been pinned by the mutation"
-                );
-            });
-    }
-
-    #[test]
-    fn fuzz_ipv6_udp_vxlan_conforms() {
-        let generator = ChainBase::new()
-            .eth(|_| {})
-            .ipv6(|_| {})
-            .udp(|_| {})
-            .vxlan(|_| {});
-
-        bolero::check!()
-            .with_generator(generator)
-            .cloned()
-            .for_each(|headers| {
-                // Eth -> IPV6
-                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
-                // UDP -> VXLAN port
-                let Transport::Udp(udp) = headers.transport().unwrap() else {
-                    panic!("expected Udp");
-                };
-                assert_eq!(udp.destination(), Vxlan::PORT);
-            });
-    }
-
-    #[test]
-    fn fuzz_round_trips_through_parse() {
-        let generator = ChainBase::new().eth(|_| {}).ipv4(|_| {}).tcp(|_| {});
-
-        bolero::check!()
-            .with_generator(generator)
-            .cloned()
-            .for_each(|headers| {
-                let mut test_buffer = vec![0u8; headers.size().get() as usize];
-                headers.deparse(&mut test_buffer).unwrap();
-                let (headers2, consumed) = Headers::parse(test_buffer.as_ref()).unwrap();
-                assert_eq!(consumed.get() as usize, headers.size().get() as usize);
-                assert_eq!(headers, headers2, "fuzz round-trip failed");
-            });
     }
 }

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -325,22 +325,46 @@ impl ParseWith for EmbeddedHeaders {
                     this.net = Some(Net::Ipv6(ipv6));
                 }
                 EmbeddedHeader::Ipv4Auth(h) => {
-                    this.net_ext.push(NetExt::Ipv4Auth(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv4Auth(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Ipv6Auth(h) => {
-                    this.net_ext.push(NetExt::Ipv6Auth(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv6Auth(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::HopByHop(h) => {
-                    this.net_ext.push(NetExt::HopByHop(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::HopByHop(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::DestOpts(h) => {
-                    this.net_ext.push(NetExt::DestOpts(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::DestOpts(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Routing(h) => {
-                    this.net_ext.push(NetExt::Routing(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Routing(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Fragment(h) => {
-                    this.net_ext.push(NetExt::Fragment(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Fragment(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Tcp(tcp) => {
                     this.transport = Some(EmbeddedTransport::Tcp(tcp));

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -8,9 +8,9 @@ use crate::icmp_any::TruncatedIcmpAny;
 use crate::icmp4::{Icmp4Checksum, TruncatedIcmp4};
 use crate::icmp6::{Icmp6Checksum, TruncatedIcmp6};
 use crate::impl_from_for_enum;
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{Ipv6, Ipv6Ext};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, ParseError,
     ParseHeader, ParseWith, Reader, Writer,
@@ -324,11 +324,23 @@ impl ParseWith for EmbeddedHeaders {
                 EmbeddedHeader::Ipv6(ipv6) => {
                     this.net = Some(Net::Ipv6(ipv6));
                 }
-                EmbeddedHeader::IpAuth(auth) => {
-                    this.net_ext.push(NetExt::IpAuth(auth));
+                EmbeddedHeader::Ipv4Auth(h) => {
+                    this.net_ext.push(NetExt::Ipv4Auth(h));
                 }
-                EmbeddedHeader::IpV6Ext(ext) => {
-                    this.net_ext.push(NetExt::Ipv6Ext(ext));
+                EmbeddedHeader::Ipv6Auth(h) => {
+                    this.net_ext.push(NetExt::Ipv6Auth(h));
+                }
+                EmbeddedHeader::HopByHop(h) => {
+                    this.net_ext.push(NetExt::HopByHop(h));
+                }
+                EmbeddedHeader::DestOpts(h) => {
+                    this.net_ext.push(NetExt::DestOpts(h));
+                }
+                EmbeddedHeader::Routing(h) => {
+                    this.net_ext.push(NetExt::Routing(h));
+                }
+                EmbeddedHeader::Fragment(h) => {
+                    this.net_ext.push(NetExt::Fragment(h));
                 }
                 EmbeddedHeader::Tcp(tcp) => {
                     this.transport = Some(EmbeddedTransport::Tcp(tcp));
@@ -435,25 +447,33 @@ pub(crate) enum EmbeddedHeader {
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext), // TODO: break out nested enum.  Nesting is counter productive here
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl EmbeddedHeader {
     fn parse_payload(&self, cursor: &mut Reader) -> Option<EmbeddedHeader> {
-        use EmbeddedHeader::{Icmp4, Icmp6, IpAuth, IpV6Ext, Ipv4, Ipv6, Tcp, Udp};
         match self {
-            Ipv4(ipv4) => ipv4
+            EmbeddedHeader::Ipv4(ipv4) => ipv4
                 .parse_embedded_payload(cursor)
                 .map(EmbeddedHeader::from),
-            Ipv6(ipv6) => ipv6
+            EmbeddedHeader::Ipv6(ipv6) => ipv6
                 .parse_embedded_payload(cursor)
                 .map(EmbeddedHeader::from),
-            IpAuth(auth) => auth
-                .parse_embedded_payload(cursor)
-                .map(EmbeddedHeader::from),
-            IpV6Ext(ext) => ext.parse_embedded_payload(cursor).map(EmbeddedHeader::from),
-            Tcp(_) | Udp(_) | Icmp4(_) | Icmp6(_) => None,
+            EmbeddedHeader::Ipv4Auth(auth) => auth.parse_embedded_payload(cursor),
+            EmbeddedHeader::Ipv6Auth(auth) => auth.parse_embedded_payload(cursor),
+            EmbeddedHeader::HopByHop(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::DestOpts(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Routing(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Fragment(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Tcp(_)
+            | EmbeddedHeader::Udp(_)
+            | EmbeddedHeader::Icmp4(_)
+            | EmbeddedHeader::Icmp6(_) => None,
         }
     }
 }
@@ -466,8 +486,12 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Icmp4(TruncatedIcmp4),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext)
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 #[derive(Debug, thiserror::Error)]

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -12,9 +12,9 @@ use crate::icmp4::Icmp4;
 use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::{IpAuth, Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{Ipv6, Ipv6Ext};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Ipv6Ext, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
@@ -43,7 +43,7 @@ pub use embedded::*;
 pub mod builder;
 
 const MAX_VLANS: usize = 4;
-const MAX_NET_EXTENSIONS: usize = 2;
+const MAX_NET_EXTENSIONS: usize = 6;
 
 /// A parsed set of network packet headers.
 ///
@@ -162,8 +162,25 @@ impl DeParse for Net {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetExt {
+    // -- legacy variants (used by the current parser, will be removed) --
+    /// Untyped IP Authentication Header (legacy -- prefer [`Ipv4Auth`]/[`Ipv6Auth`]).
     IpAuth(IpAuth),
+    /// Monolithic IPv6 extension header chain (legacy -- prefer individual types).
     Ipv6Ext(Ipv6Ext),
+
+    // -- new individual extension header variants --
+    /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3).
+    HopByHop(HopByHop),
+    /// IPv6 Destination Options (RFC 8200 section 4.6).
+    DestOpts(DestOpts),
+    /// IPv6 Routing Header (RFC 8200 section 4.4).
+    Routing(Routing),
+    /// IPv6 Fragment Header (RFC 8200 section 4.5).
+    Fragment(Fragment),
+    /// IP Authentication Header in IPv4 context (RFC 4302).
+    Ipv4Auth(Ipv4Auth),
+    /// IP Authentication Header in IPv6 context (RFC 4302).
+    Ipv6Auth(Ipv6Auth),
 }
 
 impl DeParse for NetExt {
@@ -171,15 +188,27 @@ impl DeParse for NetExt {
 
     fn size(&self) -> NonZero<u16> {
         match self {
-            NetExt::IpAuth(auth) => auth.size(),
-            NetExt::Ipv6Ext(ext) => ext.size(),
+            NetExt::IpAuth(h) => h.size(),
+            NetExt::Ipv6Ext(h) => h.size(),
+            NetExt::HopByHop(h) => h.size(),
+            NetExt::DestOpts(h) => h.size(),
+            NetExt::Routing(h) => h.size(),
+            NetExt::Fragment(h) => h.size(),
+            NetExt::Ipv4Auth(h) => h.size(),
+            NetExt::Ipv6Auth(h) => h.size(),
         }
     }
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
         match self {
-            NetExt::IpAuth(auth) => auth.deparse(buf),
-            NetExt::Ipv6Ext(ext) => ext.deparse(buf),
+            NetExt::IpAuth(h) => h.deparse(buf),
+            NetExt::Ipv6Ext(h) => h.deparse(buf),
+            NetExt::HopByHop(h) => h.deparse(buf),
+            NetExt::DestOpts(h) => h.deparse(buf),
+            NetExt::Routing(h) => h.deparse(buf),
+            NetExt::Fragment(h) => h.deparse(buf),
+            NetExt::Ipv4Auth(h) => h.deparse(buf),
+            NetExt::Ipv6Auth(h) => h.deparse(buf),
         }
     }
 }
@@ -400,6 +429,7 @@ impl DeParse for Transport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Header {
     Eth(Eth),
     Vlan(Vlan),

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -43,7 +43,7 @@ pub use embedded::*;
 pub mod builder;
 
 const MAX_VLANS: usize = 4;
-const MAX_NET_EXTENSIONS: usize = 6;
+const MAX_NET_EXTENSIONS: usize = 3;
 
 /// A parsed set of network packet headers.
 ///
@@ -475,6 +475,17 @@ impl Parse for Headers {
             udp_encap: None,
             embedded_ip: None,
         };
+        // TODO: after parsing, validate RFC 8200 section 4.1 extension header
+        // ordering constraints (e.g. HopByHop must be first and appear at most
+        // once, DestOpts may appear at most twice, etc.).  The parser currently
+        // accepts any ordering from the wire.  A validate() method or post-parse
+        // check would catch malformed chains without rejecting packets outright.
+        //
+        // TODO: consider returning a parse error instead of silently stopping
+        // when MAX_NET_EXTENSIONS is exceeded.  The current `break` exits the
+        // entire parse loop, so transport and embedded headers that follow the
+        // overflow point are also not parsed.  This matches the MAX_VLANS
+        // handling but the caller has no way to detect a partial parse.
         let mut prior = Header::Eth(eth);
         loop {
             let header = prior.parse_payload(&mut cursor);

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -1298,6 +1298,7 @@ mod test {
         use crate::icmp4::Icmp4;
         use crate::icmp4::{Icmp4EchoRequest, Icmp4Type};
         use crate::icmp6::Icmp6;
+        use crate::icmp6::{Icmp6EchoRequest, Icmp6Type};
         use crate::ip::NextHeader;
         use crate::ip::dscp::Dscp;
         use crate::ip::ecn::Ecn;
@@ -1306,7 +1307,6 @@ mod test {
         use crate::parse::DeParse;
         use crate::tcp::Tcp;
         use crate::udp::Udp;
-        use etherparse::{IcmpEchoHeader, Icmpv6Type};
         use std::net::{Ipv4Addr, Ipv6Addr};
 
         pub(super) fn eth(ethertype: EthType) -> Eth {
@@ -1366,7 +1366,7 @@ mod test {
 
         pub(super) fn icmp6() -> Icmp6 {
             let mut icmp6 =
-                Icmp6::with_type(Icmpv6Type::EchoRequest(IcmpEchoHeader { id: 18, seq: 2 }));
+                Icmp6::with_type(Icmp6Type::EchoRequest(Icmp6EchoRequest { id: 18, seq: 2 }));
             icmp6.set_checksum(1234.into()).unwrap();
             icmp6
         }

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -1296,6 +1296,7 @@ mod test {
         use crate::eth::mac::{DestinationMac, Mac, SourceMac};
         use crate::headers::{Headers, HeadersBuilder, Net, Transport};
         use crate::icmp4::Icmp4;
+        use crate::icmp4::{Icmp4EchoRequest, Icmp4Type};
         use crate::icmp6::Icmp6;
         use crate::ip::NextHeader;
         use crate::ip::dscp::Dscp;
@@ -1305,7 +1306,7 @@ mod test {
         use crate::parse::DeParse;
         use crate::tcp::Tcp;
         use crate::udp::Udp;
-        use etherparse::{IcmpEchoHeader, Icmpv4Type, Icmpv6Type};
+        use etherparse::{IcmpEchoHeader, Icmpv6Type};
         use std::net::{Ipv4Addr, Ipv6Addr};
 
         pub(super) fn eth(ethertype: EthType) -> Eth {
@@ -1358,7 +1359,7 @@ mod test {
 
         pub(super) fn icmp4() -> Icmp4 {
             let mut icmp4 =
-                Icmp4::with_type(Icmpv4Type::EchoRequest(IcmpEchoHeader { id: 18, seq: 2 }));
+                Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 18, seq: 2 }));
             icmp4.set_checksum(1234.into()).unwrap();
             icmp4
         }

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -12,9 +12,9 @@ use crate::icmp4::Icmp4;
 use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
-use crate::ip_auth::{IpAuth, Ipv4Auth, Ipv6Auth};
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Ipv6Ext, Routing};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
@@ -162,13 +162,6 @@ impl DeParse for Net {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetExt {
-    // -- legacy variants (used by the current parser, will be removed) --
-    /// Untyped IP Authentication Header (legacy -- prefer [`Ipv4Auth`]/[`Ipv6Auth`]).
-    IpAuth(IpAuth),
-    /// Monolithic IPv6 extension header chain (legacy -- prefer individual types).
-    Ipv6Ext(Ipv6Ext),
-
-    // -- new individual extension header variants --
     /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3).
     HopByHop(HopByHop),
     /// IPv6 Destination Options (RFC 8200 section 4.6).
@@ -188,8 +181,6 @@ impl DeParse for NetExt {
 
     fn size(&self) -> NonZero<u16> {
         match self {
-            NetExt::IpAuth(h) => h.size(),
-            NetExt::Ipv6Ext(h) => h.size(),
             NetExt::HopByHop(h) => h.size(),
             NetExt::DestOpts(h) => h.size(),
             NetExt::Routing(h) => h.size(),
@@ -201,8 +192,6 @@ impl DeParse for NetExt {
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
         match self {
-            NetExt::IpAuth(h) => h.deparse(buf),
-            NetExt::Ipv6Ext(h) => h.deparse(buf),
             NetExt::HopByHop(h) => h.deparse(buf),
             NetExt::DestOpts(h) => h.deparse(buf),
             NetExt::Routing(h) => h.deparse(buf),
@@ -439,28 +428,33 @@ pub enum Header {
     Udp(Udp),
     Icmp4(Icmp4),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext), // TODO: break out nested enum.  Nesting is counter productive here
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
     Encap(UdpEncap),
     EmbeddedIp(EmbeddedHeaders),
 }
 
 impl Header {
     fn parse_payload(&self, cursor: &mut Reader) -> Option<Header> {
-        use Header::{
-            EmbeddedIp, Encap, Eth, Icmp4, Icmp6, IpAuth, IpV6Ext, Ipv4, Ipv6, Tcp, Udp, Vlan,
-        };
         match self {
-            Eth(eth) => eth.parse_payload(cursor).map(Header::from),
-            Vlan(vlan) => vlan.parse_payload(cursor).map(Header::from),
-            Ipv4(ipv4) => ipv4.parse_payload(cursor).map(Header::from),
-            Ipv6(ipv6) => ipv6.parse_payload(cursor).map(Header::from),
-            IpAuth(auth) => auth.parse_payload(cursor).map(Header::from),
-            IpV6Ext(ext) => ext.parse_payload(cursor).map(Header::from),
-            Icmp4(icmp4) => icmp4.parse_payload(cursor).map(Header::from),
-            Icmp6(icmp6) => icmp6.parse_payload(cursor).map(Header::from),
-            Udp(udp) => udp.parse_payload(cursor).map(Header::from),
-            Encap(_) | Tcp(_) | EmbeddedIp(_) => None,
+            Header::Eth(eth) => eth.parse_payload(cursor).map(Header::from),
+            Header::Vlan(vlan) => vlan.parse_payload(cursor).map(Header::from),
+            Header::Ipv4(ipv4) => ipv4.parse_payload(cursor).map(Header::from),
+            Header::Ipv6(ipv6) => ipv6.parse_payload(cursor).map(Header::from),
+            Header::Ipv4Auth(auth) => auth.parse_payload(cursor),
+            Header::Ipv6Auth(auth) => auth.parse_payload(cursor),
+            Header::HopByHop(h) => h.parse_payload(cursor),
+            Header::DestOpts(h) => h.parse_payload(cursor),
+            Header::Routing(h) => h.parse_payload(cursor),
+            Header::Fragment(h) => h.parse_payload(cursor),
+            Header::Icmp4(icmp4) => icmp4.parse_payload(cursor).map(Header::from),
+            Header::Icmp6(icmp6) => icmp6.parse_payload(cursor).map(Header::from),
+            Header::Udp(udp) => udp.parse_payload(cursor).map(Header::from),
+            Header::Encap(_) | Header::Tcp(_) | Header::EmbeddedIp(_) => None,
         }
     }
 }
@@ -500,16 +494,44 @@ impl Parse for Headers {
                         break;
                     }
                 }
-                Header::IpAuth(auth) => {
+                Header::HopByHop(h) => {
                     if this.net_ext.len() < MAX_NET_EXTENSIONS {
-                        this.net_ext.push(NetExt::IpAuth(auth));
+                        this.net_ext.push(NetExt::HopByHop(h));
                     } else {
                         break;
                     }
                 }
-                Header::IpV6Ext(ext) => {
+                Header::DestOpts(h) => {
                     if this.net_ext.len() < MAX_NET_EXTENSIONS {
-                        this.net_ext.push(NetExt::Ipv6Ext(ext));
+                        this.net_ext.push(NetExt::DestOpts(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Routing(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Routing(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Fragment(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Fragment(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Ipv4Auth(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv4Auth(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Ipv6Auth(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv6Auth(h));
                     } else {
                         break;
                     }
@@ -942,8 +964,12 @@ impl_from_for_enum![
     Udp(Udp),
     Icmp4(Icmp4),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
     Encap(UdpEncap),
     EmbeddedIp(EmbeddedHeaders),
 ];
@@ -1994,8 +2020,8 @@ mod test {
             "expected one IPv6 extension header"
         );
         assert!(
-            matches!(headers.net_ext[0], super::NetExt::Ipv6Ext(_)),
-            "expected Ipv6Ext variant in net_ext"
+            matches!(headers.net_ext[0], super::NetExt::HopByHop(_)),
+            "expected HopByHop variant in net_ext"
         );
 
         // IPv6 and TCP should be present.

--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -11,11 +11,13 @@ pub use truncated::*;
 
 use crate::headers::{AbstractEmbeddedHeaders, EmbeddedHeaders, EmbeddedIpVersion};
 use crate::icmp_any::get_payload_for_checksum;
+use crate::ipv4::UnicastIpv4Addr;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseWith, Reader,
 };
-use etherparse::{Icmpv4Header, Icmpv4Type};
+use etherparse::{IcmpEchoHeader, Icmpv4Header, Icmpv4Type, icmpv4};
 use std::num::NonZero;
+use tracing::debug;
 
 #[allow(unused_imports)] // re-export
 #[cfg(any(test, feature = "bolero"))]
@@ -33,68 +35,488 @@ pub enum Icmp4Error {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Icmp4(pub(crate) Icmpv4Header);
 
-impl Icmp4 {
-    /// Get the icmp type (reference) field value
+// -- ICMPv4 message subtypes ------------------------------------------------
+//
+// Each type corresponds to one ICMPv4 message variant with native Rust
+// fields.  Used by the header builder to enforce valid layer ordering at
+// compile time (e.g. `.embedded()` is only available on error subtypes).
+
+/// `ICMPv4` Destination Unreachable (type 3).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Icmp4DestUnreachable {
+    /// Code 0.
+    Network,
+    /// Code 1.
+    Host,
+    /// Code 2.
+    Protocol,
+    /// Code 3.
+    Port,
+    /// Code 4.
+    FragmentationNeeded {
+        /// The MTU of the next-hop link, or `None` if the sender does
+        /// not support Path MTU Discovery (RFC 1191 -- indicated by a
+        /// zero value on the wire).
+        next_hop_mtu: Option<NonZero<u16>>,
+    },
+    /// Code 5.
+    SourceRouteFailed,
+    /// Code 6.
+    NetworkUnknown,
+    /// Code 7.
+    HostUnknown,
+    /// Code 8.
+    Isolated,
+    /// Code 9.
+    NetworkProhibited,
+    /// Code 10.
+    HostProhibited,
+    /// Code 11.
+    TosNetwork,
+    /// Code 12.
+    TosHost,
+    /// Code 13.
+    FilterProhibited,
+    /// Code 14.
+    HostPrecedenceViolation,
+    /// Code 15.
+    PrecedenceCutoff,
+}
+
+impl From<icmpv4::DestUnreachableHeader> for Icmp4DestUnreachable {
+    fn from(h: icmpv4::DestUnreachableHeader) -> Self {
+        match h {
+            icmpv4::DestUnreachableHeader::Network => Self::Network,
+            icmpv4::DestUnreachableHeader::Host => Self::Host,
+            icmpv4::DestUnreachableHeader::Protocol => Self::Protocol,
+            icmpv4::DestUnreachableHeader::Port => Self::Port,
+            icmpv4::DestUnreachableHeader::FragmentationNeeded { next_hop_mtu } => {
+                Self::FragmentationNeeded {
+                    next_hop_mtu: NonZero::new(next_hop_mtu),
+                }
+            }
+            icmpv4::DestUnreachableHeader::SourceRouteFailed => Self::SourceRouteFailed,
+            icmpv4::DestUnreachableHeader::NetworkUnknown => Self::NetworkUnknown,
+            icmpv4::DestUnreachableHeader::HostUnknown => Self::HostUnknown,
+            icmpv4::DestUnreachableHeader::Isolated => Self::Isolated,
+            icmpv4::DestUnreachableHeader::NetworkProhibited => Self::NetworkProhibited,
+            icmpv4::DestUnreachableHeader::HostProhibited => Self::HostProhibited,
+            icmpv4::DestUnreachableHeader::TosNetwork => Self::TosNetwork,
+            icmpv4::DestUnreachableHeader::TosHost => Self::TosHost,
+            icmpv4::DestUnreachableHeader::FilterProhibited => Self::FilterProhibited,
+            icmpv4::DestUnreachableHeader::HostPrecedenceViolation => Self::HostPrecedenceViolation,
+            icmpv4::DestUnreachableHeader::PrecedenceCutoff => Self::PrecedenceCutoff,
+        }
+    }
+}
+
+impl From<Icmp4DestUnreachable> for icmpv4::DestUnreachableHeader {
+    fn from(v: Icmp4DestUnreachable) -> Self {
+        match v {
+            Icmp4DestUnreachable::Network => Self::Network,
+            Icmp4DestUnreachable::Host => Self::Host,
+            Icmp4DestUnreachable::Protocol => Self::Protocol,
+            Icmp4DestUnreachable::Port => Self::Port,
+            Icmp4DestUnreachable::FragmentationNeeded { next_hop_mtu } => {
+                Self::FragmentationNeeded {
+                    next_hop_mtu: next_hop_mtu.map_or(0, NonZero::get),
+                }
+            }
+            Icmp4DestUnreachable::SourceRouteFailed => Self::SourceRouteFailed,
+            Icmp4DestUnreachable::NetworkUnknown => Self::NetworkUnknown,
+            Icmp4DestUnreachable::HostUnknown => Self::HostUnknown,
+            Icmp4DestUnreachable::Isolated => Self::Isolated,
+            Icmp4DestUnreachable::NetworkProhibited => Self::NetworkProhibited,
+            Icmp4DestUnreachable::HostProhibited => Self::HostProhibited,
+            Icmp4DestUnreachable::TosNetwork => Self::TosNetwork,
+            Icmp4DestUnreachable::TosHost => Self::TosHost,
+            Icmp4DestUnreachable::FilterProhibited => Self::FilterProhibited,
+            Icmp4DestUnreachable::HostPrecedenceViolation => Self::HostPrecedenceViolation,
+            Icmp4DestUnreachable::PrecedenceCutoff => Self::PrecedenceCutoff,
+        }
+    }
+}
+
+/// `ICMPv4` Redirect code (type 5).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Icmp4RedirectCode {
+    /// Code 0: Redirect for the Network.
+    Network,
+    /// Code 1: Redirect for the Host.
+    Host,
+    /// Code 2: Redirect for Type-of-Service and Network.
+    TosNetwork,
+    /// Code 3: Redirect for Type-of-Service and Host.
+    TosHost,
+}
+
+impl From<icmpv4::RedirectCode> for Icmp4RedirectCode {
+    fn from(c: icmpv4::RedirectCode) -> Self {
+        match c {
+            icmpv4::RedirectCode::RedirectForNetwork => Self::Network,
+            icmpv4::RedirectCode::RedirectForHost => Self::Host,
+            icmpv4::RedirectCode::RedirectForTypeOfServiceAndNetwork => Self::TosNetwork,
+            icmpv4::RedirectCode::RedirectForTypeOfServiceAndHost => Self::TosHost,
+        }
+    }
+}
+
+impl From<Icmp4RedirectCode> for icmpv4::RedirectCode {
+    fn from(c: Icmp4RedirectCode) -> Self {
+        match c {
+            Icmp4RedirectCode::Network => Self::RedirectForNetwork,
+            Icmp4RedirectCode::Host => Self::RedirectForHost,
+            Icmp4RedirectCode::TosNetwork => Self::RedirectForTypeOfServiceAndNetwork,
+            Icmp4RedirectCode::TosHost => Self::RedirectForTypeOfServiceAndHost,
+        }
+    }
+}
+
+/// `ICMPv4` Redirect (type 5).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp4Redirect {
+    code: Icmp4RedirectCode,
+    gateway: crate::ipv4::UnicastIpv4Addr,
+}
+
+impl Icmp4Redirect {
+    /// Create a new redirect.
     #[must_use]
-    pub const fn icmp_type(&self) -> &Icmpv4Type {
-        &self.0.icmp_type
+    pub fn new(code: Icmp4RedirectCode, gateway: crate::ipv4::UnicastIpv4Addr) -> Self {
+        Self { code, gateway }
     }
 
-    /// Return a mutable reference to the icmp type field value
+    /// The redirect code.
     #[must_use]
-    pub const fn icmp_type_mut(&mut self) -> &mut Icmpv4Type {
+    pub fn code(&self) -> Icmp4RedirectCode {
+        self.code
+    }
+
+    /// The gateway to which traffic should be sent.
+    ///
+    /// Per RFC 1122 section 3.2.2.2, this MUST be a unicast address of
+    /// a directly reachable neighbor.  Packets with a non-unicast
+    /// gateway are rejected during parsing and treated as unknown ICMP.
+    #[must_use]
+    pub fn gateway(&self) -> crate::ipv4::UnicastIpv4Addr {
+        self.gateway
+    }
+}
+
+/// `ICMPv4` Time Exceeded code (type 11).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Icmp4TimeExceeded {
+    /// Code 0: TTL exceeded in transit.
+    TtlExceeded,
+    /// Code 1: Fragment reassembly time exceeded.
+    FragmentReassembly,
+}
+
+impl From<icmpv4::TimeExceededCode> for Icmp4TimeExceeded {
+    fn from(c: icmpv4::TimeExceededCode) -> Self {
+        match c {
+            icmpv4::TimeExceededCode::TtlExceededInTransit => Self::TtlExceeded,
+            icmpv4::TimeExceededCode::FragmentReassemblyTimeExceeded => Self::FragmentReassembly,
+        }
+    }
+}
+
+impl From<Icmp4TimeExceeded> for icmpv4::TimeExceededCode {
+    fn from(c: Icmp4TimeExceeded) -> Self {
+        match c {
+            Icmp4TimeExceeded::TtlExceeded => Self::TtlExceededInTransit,
+            Icmp4TimeExceeded::FragmentReassembly => Self::FragmentReassemblyTimeExceeded,
+        }
+    }
+}
+
+/// `ICMPv4` Parameter Problem (type 12).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Icmp4ParamProblem {
+    /// Code 0: Pointer indicates the error.
+    PointerIndicatesError(u8),
+    /// Code 1: Missing required option.
+    MissingRequiredOption,
+    /// Code 2: Bad length.
+    BadLength,
+}
+
+impl From<icmpv4::ParameterProblemHeader> for Icmp4ParamProblem {
+    fn from(h: icmpv4::ParameterProblemHeader) -> Self {
+        match h {
+            icmpv4::ParameterProblemHeader::PointerIndicatesError(p) => {
+                Self::PointerIndicatesError(p)
+            }
+            icmpv4::ParameterProblemHeader::MissingRequiredOption => Self::MissingRequiredOption,
+            icmpv4::ParameterProblemHeader::BadLength => Self::BadLength,
+        }
+    }
+}
+
+impl From<Icmp4ParamProblem> for icmpv4::ParameterProblemHeader {
+    fn from(v: Icmp4ParamProblem) -> Self {
+        match v {
+            Icmp4ParamProblem::PointerIndicatesError(p) => Self::PointerIndicatesError(p),
+            Icmp4ParamProblem::MissingRequiredOption => Self::MissingRequiredOption,
+            Icmp4ParamProblem::BadLength => Self::BadLength,
+        }
+    }
+}
+
+/// `ICMPv4` Echo Request (type 8).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp4EchoRequest {
+    /// Identifier.
+    pub id: u16,
+    /// Sequence number.
+    pub seq: u16,
+}
+
+/// `ICMPv4` Echo Reply (type 0).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp4EchoReply {
+    /// Identifier.
+    pub id: u16,
+    /// Sequence number.
+    pub seq: u16,
+}
+
+/// `ICMPv4` Timestamp (types 13, 14).
+///
+/// Timestamps are deprecated (RFC 6918) but we model them for
+/// round-trip fidelity during parse/deparse.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp4Timestamp {
+    /// Identifier.
+    pub id: u16,
+    /// Sequence number.
+    pub seq: u16,
+    /// Originate timestamp (milliseconds since midnight UTC).
+    ///
+    /// Stored as a raw `u32` rather than `Duration` to preserve
+    /// lossless round-tripping through parse/deparse.
+    pub originate: u32,
+    /// Receive timestamp (milliseconds since midnight UTC).
+    ///
+    /// Raw `u32` for the same round-trip reason as [`originate`](Self::originate).
+    pub receive: u32,
+    /// Transmit timestamp (milliseconds since midnight UTC).
+    ///
+    /// Raw `u32` for the same round-trip reason as [`originate`](Self::originate).
+    pub transmit: u32,
+}
+
+/// The type of an `ICMPv4` message.
+///
+/// This enum mirrors the protocol-level `ICMPv4` type/code space using
+/// native Rust types.  No etherparse types appear in the public API.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Icmp4Type {
+    /// Destination Unreachable (type 3).
+    DestUnreachable(Icmp4DestUnreachable),
+    /// Redirect (type 5).
+    Redirect(Icmp4Redirect),
+    /// Time Exceeded (type 11).
+    TimeExceeded(Icmp4TimeExceeded),
+    /// Parameter Problem (type 12).
+    ParamProblem(Icmp4ParamProblem),
+    /// Echo Request (type 8).
+    EchoRequest(Icmp4EchoRequest),
+    /// Echo Reply (type 0).
+    EchoReply(Icmp4EchoReply),
+    /// Timestamp Request (type 13).
+    TimestampRequest(Icmp4Timestamp),
+    /// Timestamp Reply (type 14).
+    TimestampReply(Icmp4Timestamp),
+    /// Unrecognized type/code.
+    Unknown {
+        /// Raw type byte.
+        type_u8: u8,
+        /// Raw code byte.
+        code_u8: u8,
+        /// Bytes 5-8 of the ICMP header.
+        bytes5to8: [u8; 4],
+    },
+}
+
+impl From<&Icmpv4Type> for Icmp4Type {
+    fn from(et: &Icmpv4Type) -> Self {
+        match et {
+            Icmpv4Type::DestinationUnreachable(h) => {
+                Self::DestUnreachable(Icmp4DestUnreachable::from(h.clone()))
+            }
+            Icmpv4Type::Redirect(h) => {
+                let addr = std::net::Ipv4Addr::from(h.gateway_internet_address);
+                if let Ok(gateway) = UnicastIpv4Addr::new(addr) {
+                    Self::Redirect(Icmp4Redirect::new(Icmp4RedirectCode::from(h.code), gateway))
+                } else {
+                    debug!(
+                        gateway = %addr,
+                        "ICMP redirect with non-unicast gateway, treating as unknown"
+                    );
+                    Self::Unknown {
+                        type_u8: 5,
+                        code_u8: h.code.code_u8(),
+                        bytes5to8: h.gateway_internet_address,
+                    }
+                }
+            }
+            Icmpv4Type::TimeExceeded(c) => Self::TimeExceeded(Icmp4TimeExceeded::from(*c)),
+            Icmpv4Type::ParameterProblem(h) => {
+                Self::ParamProblem(Icmp4ParamProblem::from(h.clone()))
+            }
+            Icmpv4Type::EchoRequest(h) => Self::EchoRequest(Icmp4EchoRequest {
+                id: h.id,
+                seq: h.seq,
+            }),
+            Icmpv4Type::EchoReply(h) => Self::EchoReply(Icmp4EchoReply {
+                id: h.id,
+                seq: h.seq,
+            }),
+            Icmpv4Type::TimestampRequest(h) => Self::TimestampRequest(Icmp4Timestamp {
+                id: h.id,
+                seq: h.seq,
+                originate: h.originate_timestamp,
+                receive: h.receive_timestamp,
+                transmit: h.transmit_timestamp,
+            }),
+            Icmpv4Type::TimestampReply(h) => Self::TimestampReply(Icmp4Timestamp {
+                id: h.id,
+                seq: h.seq,
+                originate: h.originate_timestamp,
+                receive: h.receive_timestamp,
+                transmit: h.transmit_timestamp,
+            }),
+            Icmpv4Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            } => Self::Unknown {
+                type_u8: *type_u8,
+                code_u8: *code_u8,
+                bytes5to8: *bytes5to8,
+            },
+        }
+    }
+}
+
+impl From<Icmp4Type> for Icmpv4Type {
+    fn from(native: Icmp4Type) -> Self {
+        match native {
+            Icmp4Type::DestUnreachable(v) => {
+                Icmpv4Type::DestinationUnreachable(icmpv4::DestUnreachableHeader::from(v))
+            }
+            Icmp4Type::Redirect(v) => Icmpv4Type::Redirect(icmpv4::RedirectHeader {
+                code: icmpv4::RedirectCode::from(v.code()),
+                gateway_internet_address: v.gateway().inner().octets(),
+            }),
+            Icmp4Type::TimeExceeded(v) => {
+                Icmpv4Type::TimeExceeded(icmpv4::TimeExceededCode::from(v))
+            }
+            Icmp4Type::ParamProblem(v) => {
+                Icmpv4Type::ParameterProblem(icmpv4::ParameterProblemHeader::from(v))
+            }
+            Icmp4Type::EchoRequest(v) => Icmpv4Type::EchoRequest(IcmpEchoHeader {
+                id: v.id,
+                seq: v.seq,
+            }),
+            Icmp4Type::EchoReply(v) => Icmpv4Type::EchoReply(IcmpEchoHeader {
+                id: v.id,
+                seq: v.seq,
+            }),
+            Icmp4Type::TimestampRequest(v) => {
+                Icmpv4Type::TimestampRequest(icmpv4::TimestampMessage {
+                    id: v.id,
+                    seq: v.seq,
+                    originate_timestamp: v.originate,
+                    receive_timestamp: v.receive,
+                    transmit_timestamp: v.transmit,
+                })
+            }
+            Icmp4Type::TimestampReply(v) => Icmpv4Type::TimestampReply(icmpv4::TimestampMessage {
+                id: v.id,
+                seq: v.seq,
+                originate_timestamp: v.originate,
+                receive_timestamp: v.receive,
+                transmit_timestamp: v.transmit,
+            }),
+            Icmp4Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            } => Icmpv4Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            },
+        }
+    }
+}
+
+impl Icmp4 {
+    /// Get the ICMP message type.
+    #[must_use]
+    pub fn icmp_type(&self) -> Icmp4Type {
+        Icmp4Type::from(&self.0.icmp_type)
+    }
+
+    /// Return a mutable reference to the raw etherparse type field.
+    ///
+    /// This is `pub(crate)` to keep etherparse out of the public API.
+    /// External callers should use [`set_type`](Self::set_type) instead.
+    #[must_use]
+    pub(crate) const fn icmp_type_mut(&mut self) -> &mut Icmpv4Type {
         &mut self.0.icmp_type
     }
 
-    /// Returns true if the ICMP type is a query message
-    #[must_use]
-    pub fn is_query_message(&self) -> bool {
-        // List all types to make it sure we catch any new addition to the enum
-        match self.icmp_type() {
-            Icmpv4Type::EchoRequest(_)
-            | Icmpv4Type::EchoReply(_)
-            | Icmpv4Type::TimestampReply(_)
-            | Icmpv4Type::TimestampRequest(_) => true,
-            Icmpv4Type::Unknown { .. }
-            | Icmpv4Type::DestinationUnreachable(_)
-            | Icmpv4Type::Redirect(_)
-            | Icmpv4Type::TimeExceeded(_)
-            | Icmpv4Type::ParameterProblem(_) => false,
-        }
+    /// Set the ICMP message type.
+    pub fn set_type(&mut self, icmp_type: Icmp4Type) {
+        self.0.icmp_type = icmp_type.into();
     }
 
-    /// Returns true if the ICMP type is an error message
+    /// Returns true if the ICMP type is a query message.
+    #[must_use]
+    pub fn is_query_message(&self) -> bool {
+        matches!(
+            self.icmp_type(),
+            Icmp4Type::EchoRequest(_)
+                | Icmp4Type::EchoReply(_)
+                | Icmp4Type::TimestampRequest(_)
+                | Icmp4Type::TimestampReply(_)
+        )
+    }
+
+    /// Returns true if the ICMP type is an error message.
     #[must_use]
     pub fn is_error_message(&self) -> bool {
-        // List all types to make it sure we catch any new addition to the enum
-        match self.icmp_type() {
-            Icmpv4Type::DestinationUnreachable(_)
-            | Icmpv4Type::Redirect(_)
-            | Icmpv4Type::TimeExceeded(_)
-            | Icmpv4Type::ParameterProblem(_) => true,
-            Icmpv4Type::Unknown { .. }
-            | Icmpv4Type::EchoRequest(_)
-            | Icmpv4Type::EchoReply(_)
-            | Icmpv4Type::TimestampReply(_)
-            | Icmpv4Type::TimestampRequest(_) => false,
-        }
+        matches!(
+            self.icmp_type(),
+            Icmp4Type::DestUnreachable(_)
+                | Icmp4Type::Redirect(_)
+                | Icmp4Type::TimeExceeded(_)
+                | Icmp4Type::ParamProblem(_)
+        )
     }
 
     /// Returns the identifier field value if the ICMP type allows it.
     #[must_use]
     pub fn identifier(&self) -> Option<u16> {
         match self.icmp_type() {
-            Icmpv4Type::EchoRequest(msg) | Icmpv4Type::EchoReply(msg) => Some(msg.id),
-            Icmpv4Type::TimestampReply(msg) | Icmpv4Type::TimestampRequest(msg) => Some(msg.id),
+            Icmp4Type::EchoRequest(v) => Some(v.id),
+            Icmp4Type::EchoReply(v) => Some(v.id),
+            #[allow(clippy::match_same_arms)]
+            Icmp4Type::TimestampRequest(v) => Some(v.id),
+            Icmp4Type::TimestampReply(v) => Some(v.id),
             _ => None,
         }
     }
 
-    /// Set the identifier field value
+    /// Set the identifier field value.
     ///
     /// # Errors
     ///
-    /// This method returns [`Icmp4Error::InvalidIcmpType`] if the ICMP type does not allow setting an identifier.
+    /// Returns [`Icmp4Error::InvalidIcmpType`] if the ICMP type does not
+    /// support an identifier field.
     pub fn try_set_identifier(&mut self, id: u16) -> Result<(), Icmp4Error> {
         match self.icmp_type_mut() {
             Icmpv4Type::EchoRequest(msg) | Icmpv4Type::EchoReply(msg) => {
@@ -109,24 +531,23 @@ impl Icmp4 {
         }
     }
 
-    /// Create a new `Icmp4` with the given icmp type.
-    /// The checksum will be set to 0.
+    /// Create a new `Icmp4` with the given ICMP type.
+    ///
+    /// The checksum will be set to zero.
     #[must_use]
-    pub const fn with_type(icmp_type: Icmpv4Type) -> Self {
+    pub fn with_type(icmp_type: Icmp4Type) -> Self {
         Icmp4(Icmpv4Header {
-            icmp_type,
+            icmp_type: icmp_type.into(),
             checksum: 0,
         })
     }
 
     #[must_use]
     pub(crate) fn supports_extensions(&self) -> bool {
-        // See RFC 4884. Icmpv4Type::Redirect does not get an optional length field.
+        // See RFC 4884. Redirect does not get an optional length field.
         matches!(
             self.icmp_type(),
-            Icmpv4Type::DestinationUnreachable(_)
-                | Icmpv4Type::TimeExceeded(_)
-                | Icmpv4Type::ParameterProblem(_)
+            Icmp4Type::DestUnreachable(_) | Icmp4Type::TimeExceeded(_) | Icmp4Type::ParamProblem(_)
         )
     }
 
@@ -283,10 +704,11 @@ mod contract {
 
         #[allow(clippy::unwrap_used)]
         fn generate<D: Driver>(&self, driver: &mut D) -> Option<Self::Output> {
+            let gateway: crate::ipv4::UnicastIpv4Addr = driver.produce()?;
             let icmp_header = Icmpv4Header {
                 icmp_type: Icmpv4Type::Redirect(RedirectHeader {
                     code: RedirectCode::from_u8(driver.produce::<u8>()? % 4).unwrap(),
-                    gateway_internet_address: driver.produce()?,
+                    gateway_internet_address: gateway.inner().octets(),
                 }),
                 checksum: driver.produce()?,
             };
@@ -479,8 +901,29 @@ mod contract {
 
 #[cfg(test)]
 mod test {
-    use crate::icmp4::Icmp4;
+    use crate::icmp4::{Icmp4, Icmp4Type};
     use crate::parse::{DeParse, DeParseError, Parse, ParseError};
+
+    /// A redirect with a multicast gateway should be treated as unknown
+    /// ICMP, since RFC 1122 section 3.2.2.2 requires unicast.
+    #[test]
+    fn redirect_with_multicast_gateway_is_unknown() {
+        use etherparse::{Icmpv4Header, Icmpv4Type, icmpv4};
+
+        let multicast_gateway: [u8; 4] = [224, 0, 0, 1];
+        let header = Icmpv4Header {
+            icmp_type: Icmpv4Type::Redirect(icmpv4::RedirectHeader {
+                code: icmpv4::RedirectCode::RedirectForNetwork,
+                gateway_internet_address: multicast_gateway,
+            }),
+            checksum: 0,
+        };
+        let icmp = Icmp4(header);
+        assert!(
+            matches!(icmp.icmp_type(), Icmp4Type::Unknown { type_u8: 5, .. }),
+            "multicast gateway should cause redirect to be treated as unknown"
+        );
+    }
 
     #[test]
     fn parse_back() {

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-//! `Icmp6` header type and logic.
+//! `ICMPv6` header type and logic.
 
 mod checksum;
 mod truncated;
@@ -14,8 +14,9 @@ use crate::icmp_any::get_payload_for_checksum;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseWith, Reader,
 };
-use etherparse::{Icmpv6Header, Icmpv6Type};
+use etherparse::{IcmpEchoHeader, Icmpv6Header, Icmpv6Type, icmpv6};
 use std::num::NonZero;
+use tracing::debug;
 
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;
@@ -32,72 +33,483 @@ pub enum Icmp6Error {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Icmp6(pub(crate) Icmpv6Header);
 
-impl Icmp6 {
-    /// Returns the type of the `Icmp6` message.
+// -- ICMPv6 message subtypes ------------------------------------------------
+
+/// `ICMPv6` Destination Unreachable (type 1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Icmp6DestUnreachable {
+    /// Code 0: No Route to Destination.
+    NoRoute,
+    /// Code 1: Administratively Prohibited.
+    Prohibited,
+    /// Code 2: Beyond Scope of Source Address.
+    BeyondScope,
+    /// Code 3: Address Unreachable.
+    Address,
+    /// Code 4: Port Unreachable.
+    Port,
+    /// Code 5: Source Address Failed Ingress/Egress Policy.
+    SourceAddressFailedPolicy,
+    /// Code 6: Reject Route to Destination.
+    RejectRoute,
+}
+
+impl From<icmpv6::DestUnreachableCode> for Icmp6DestUnreachable {
+    fn from(c: icmpv6::DestUnreachableCode) -> Self {
+        match c {
+            icmpv6::DestUnreachableCode::NoRoute => Self::NoRoute,
+            icmpv6::DestUnreachableCode::Prohibited => Self::Prohibited,
+            icmpv6::DestUnreachableCode::BeyondScope => Self::BeyondScope,
+            icmpv6::DestUnreachableCode::Address => Self::Address,
+            icmpv6::DestUnreachableCode::Port => Self::Port,
+            icmpv6::DestUnreachableCode::SourceAddressFailedPolicy => {
+                Self::SourceAddressFailedPolicy
+            }
+            icmpv6::DestUnreachableCode::RejectRoute => Self::RejectRoute,
+        }
+    }
+}
+
+impl From<Icmp6DestUnreachable> for icmpv6::DestUnreachableCode {
+    fn from(v: Icmp6DestUnreachable) -> Self {
+        match v {
+            Icmp6DestUnreachable::NoRoute => Self::NoRoute,
+            Icmp6DestUnreachable::Prohibited => Self::Prohibited,
+            Icmp6DestUnreachable::BeyondScope => Self::BeyondScope,
+            Icmp6DestUnreachable::Address => Self::Address,
+            Icmp6DestUnreachable::Port => Self::Port,
+            Icmp6DestUnreachable::SourceAddressFailedPolicy => Self::SourceAddressFailedPolicy,
+            Icmp6DestUnreachable::RejectRoute => Self::RejectRoute,
+        }
+    }
+}
+
+/// `ICMPv6` Packet Too Big (type 2).
+///
+/// The MTU must be at least 1280 per [RFC 8200 section 5].
+/// Packets with a smaller MTU on the wire are rejected during parsing
+/// and treated as unknown `ICMPv6`.
+///
+/// [RFC 8200 section 5]: https://datatracker.ietf.org/doc/html/rfc8200#section-5
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6PacketTooBig {
+    mtu: u32,
+}
+
+/// Error returned when constructing an [`Icmp6PacketTooBig`] with an
+/// MTU below the IPv6 minimum of 1280.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("MTU {} is below the IPv6 minimum of 1280 (RFC 8200 section 5)", .0)]
+pub struct Icmp6MtuTooSmall(u32);
+
+impl Icmp6MtuTooSmall {
+    /// The rejected MTU value.
     #[must_use]
-    pub const fn icmp_type(&self) -> Icmpv6Type {
-        self.0.icmp_type
+    pub fn mtu(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Icmp6PacketTooBig {
+    /// IPv6 minimum MTU per [RFC 8200 section 5].
+    pub const MIN_MTU: u32 = 1280;
+
+    /// Create a new Packet Too Big message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Icmp6MtuTooSmall`] if `mtu < 1280`.
+    pub fn new(mtu: u32) -> Result<Self, Icmp6MtuTooSmall> {
+        if mtu < Self::MIN_MTU {
+            return Err(Icmp6MtuTooSmall(mtu));
+        }
+        Ok(Self { mtu })
     }
 
-    /// Returns a mutable reference to the type of the `Icmp6` message.
+    /// The MTU of the next-hop link.
     #[must_use]
-    pub const fn icmp_type_mut(&mut self) -> &mut Icmpv6Type {
+    pub fn mtu(&self) -> u32 {
+        self.mtu
+    }
+}
+
+/// `ICMPv6` Time Exceeded (type 3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Icmp6TimeExceeded {
+    /// Code 0: Hop Limit Exceeded in Transit.
+    HopLimitExceeded,
+    /// Code 1: Fragment Reassembly Time Exceeded.
+    FragmentReassembly,
+}
+
+impl From<icmpv6::TimeExceededCode> for Icmp6TimeExceeded {
+    fn from(c: icmpv6::TimeExceededCode) -> Self {
+        match c {
+            icmpv6::TimeExceededCode::HopLimitExceeded => Self::HopLimitExceeded,
+            icmpv6::TimeExceededCode::FragmentReassemblyTimeExceeded => Self::FragmentReassembly,
+        }
+    }
+}
+
+impl From<Icmp6TimeExceeded> for icmpv6::TimeExceededCode {
+    fn from(v: Icmp6TimeExceeded) -> Self {
+        match v {
+            Icmp6TimeExceeded::HopLimitExceeded => Self::HopLimitExceeded,
+            Icmp6TimeExceeded::FragmentReassembly => Self::FragmentReassemblyTimeExceeded,
+        }
+    }
+}
+
+/// `ICMPv6` Parameter Problem code (type 4).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Icmp6ParamProblemCode {
+    /// Code 0: Erroneous Header Field Encountered.
+    ErroneousHeaderField = 0,
+    /// Code 1: Unrecognized Next Header Type Encountered.
+    UnrecognizedNextHeader = 1,
+    /// Code 2: Unrecognized IPv6 Option Encountered.
+    UnrecognizedIpv6Option = 2,
+    /// Code 3: IPv6 First Fragment has incomplete IPv6 Header Chain.
+    Ipv6FirstFragmentIncompleteHeaderChain = 3,
+    /// Code 4: SR Upper-layer Header Error.
+    SrUpperLayerHeaderError = 4,
+    /// Code 5: Unrecognized Next Header type encountered by intermediate node.
+    UnrecognizedNextHeaderByIntermediateNode = 5,
+    /// Code 6: Extension header too big.
+    ExtensionHeaderTooBig = 6,
+    /// Code 7: Extension header chain too long.
+    ExtensionHeaderChainTooLong = 7,
+    /// Code 8: Too many extension headers.
+    TooManyExtensionHeaders = 8,
+    /// Code 9: Too many options in extension header.
+    TooManyOptionsInExtensionHeader = 9,
+    /// Code 10: Option too big.
+    OptionTooBig = 10,
+}
+
+impl From<icmpv6::ParameterProblemCode> for Icmp6ParamProblemCode {
+    fn from(c: icmpv6::ParameterProblemCode) -> Self {
+        match c {
+            icmpv6::ParameterProblemCode::ErroneousHeaderField => Self::ErroneousHeaderField,
+            icmpv6::ParameterProblemCode::UnrecognizedNextHeader => Self::UnrecognizedNextHeader,
+            icmpv6::ParameterProblemCode::UnrecognizedIpv6Option => Self::UnrecognizedIpv6Option,
+            icmpv6::ParameterProblemCode::Ipv6FirstFragmentIncompleteHeaderChain => {
+                Self::Ipv6FirstFragmentIncompleteHeaderChain
+            }
+            icmpv6::ParameterProblemCode::SrUpperLayerHeaderError => Self::SrUpperLayerHeaderError,
+            icmpv6::ParameterProblemCode::UnrecognizedNextHeaderByIntermediateNode => {
+                Self::UnrecognizedNextHeaderByIntermediateNode
+            }
+            icmpv6::ParameterProblemCode::ExtensionHeaderTooBig => Self::ExtensionHeaderTooBig,
+            icmpv6::ParameterProblemCode::ExtensionHeaderChainTooLong => {
+                Self::ExtensionHeaderChainTooLong
+            }
+            icmpv6::ParameterProblemCode::TooManyExtensionHeaders => Self::TooManyExtensionHeaders,
+            icmpv6::ParameterProblemCode::TooManyOptionsInExtensionHeader => {
+                Self::TooManyOptionsInExtensionHeader
+            }
+            icmpv6::ParameterProblemCode::OptionTooBig => Self::OptionTooBig,
+        }
+    }
+}
+
+impl From<Icmp6ParamProblemCode> for icmpv6::ParameterProblemCode {
+    fn from(v: Icmp6ParamProblemCode) -> Self {
+        match v {
+            Icmp6ParamProblemCode::ErroneousHeaderField => Self::ErroneousHeaderField,
+            Icmp6ParamProblemCode::UnrecognizedNextHeader => Self::UnrecognizedNextHeader,
+            Icmp6ParamProblemCode::UnrecognizedIpv6Option => Self::UnrecognizedIpv6Option,
+            Icmp6ParamProblemCode::Ipv6FirstFragmentIncompleteHeaderChain => {
+                Self::Ipv6FirstFragmentIncompleteHeaderChain
+            }
+            Icmp6ParamProblemCode::SrUpperLayerHeaderError => Self::SrUpperLayerHeaderError,
+            Icmp6ParamProblemCode::UnrecognizedNextHeaderByIntermediateNode => {
+                Self::UnrecognizedNextHeaderByIntermediateNode
+            }
+            Icmp6ParamProblemCode::ExtensionHeaderTooBig => Self::ExtensionHeaderTooBig,
+            Icmp6ParamProblemCode::ExtensionHeaderChainTooLong => Self::ExtensionHeaderChainTooLong,
+            Icmp6ParamProblemCode::TooManyExtensionHeaders => Self::TooManyExtensionHeaders,
+            Icmp6ParamProblemCode::TooManyOptionsInExtensionHeader => {
+                Self::TooManyOptionsInExtensionHeader
+            }
+            Icmp6ParamProblemCode::OptionTooBig => Self::OptionTooBig,
+        }
+    }
+}
+
+/// `ICMPv6` Parameter Problem (type 4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6ParamProblem {
+    /// The problem code.
+    pub code: Icmp6ParamProblemCode,
+    /// Byte offset in the original packet where the problem was found.
+    pub pointer: u32,
+}
+
+/// `ICMPv6` Echo Request (type 128).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6EchoRequest {
+    /// Identifier.
+    pub id: u16,
+    /// Sequence number.
+    pub seq: u16,
+}
+
+/// `ICMPv6` Echo Reply (type 129).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6EchoReply {
+    /// Identifier.
+    pub id: u16,
+    /// Sequence number.
+    pub seq: u16,
+}
+
+/// `ICMPv6` Router Advertisement (type 134).
+///
+/// Preserved for round-trip fidelity; not modeled as a builder subtype.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6RouterAdvertisement {
+    /// Default hop limit for outgoing packets. `None` means unspecified.
+    pub cur_hop_limit: Option<NonZero<u8>>,
+    /// "Managed address configuration" flag (`DHCPv6`).
+    pub managed_address_config: bool,
+    /// "Other configuration" flag (`DHCPv6`).
+    pub other_config: bool,
+    /// Lifetime of this router as a default router, in seconds.
+    pub router_lifetime: u16,
+}
+
+/// `ICMPv6` Neighbor Advertisement (type 136).
+///
+/// Preserved for round-trip fidelity; not modeled as a builder subtype.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Icmp6NeighborAdvertisement {
+    /// Router flag.
+    pub router: bool,
+    /// Solicited flag.
+    pub solicited: bool,
+    /// Override flag.
+    pub override_flag: bool,
+}
+
+/// The type of an `ICMPv6` message.
+///
+/// This enum mirrors the protocol-level `ICMPv6` type/code space using
+/// native Rust types.  No etherparse types appear in the public API.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Icmp6Type {
+    /// Destination Unreachable (type 1).
+    DestUnreachable(Icmp6DestUnreachable),
+    /// Packet Too Big (type 2).
+    PacketTooBig(Icmp6PacketTooBig),
+    /// Time Exceeded (type 3).
+    TimeExceeded(Icmp6TimeExceeded),
+    /// Parameter Problem (type 4).
+    ParamProblem(Icmp6ParamProblem),
+    /// Echo Request (type 128).
+    EchoRequest(Icmp6EchoRequest),
+    /// Echo Reply (type 129).
+    EchoReply(Icmp6EchoReply),
+    /// Router Solicitation (type 133).  Unit variant -- no header data.
+    RouterSolicitation,
+    /// Router Advertisement (type 134).
+    RouterAdvertisement(Icmp6RouterAdvertisement),
+    /// Neighbor Solicitation (type 135).  Unit variant -- no header data.
+    NeighborSolicitation,
+    /// Neighbor Advertisement (type 136).
+    NeighborAdvertisement(Icmp6NeighborAdvertisement),
+    /// Redirect (type 137).  Unit variant -- no header data.
+    Redirect,
+    /// Unrecognized or unsupported type.
+    Unknown {
+        /// Raw type byte.
+        type_u8: u8,
+        /// Raw code byte.
+        code_u8: u8,
+        /// Bytes 5-8 of the ICMP header.
+        bytes5to8: [u8; 4],
+    },
+}
+
+impl From<Icmpv6Type> for Icmp6Type {
+    fn from(et: Icmpv6Type) -> Self {
+        match et {
+            Icmpv6Type::DestinationUnreachable(c) => {
+                Self::DestUnreachable(Icmp6DestUnreachable::from(c))
+            }
+            Icmpv6Type::PacketTooBig { mtu } => {
+                if let Ok(v) = Icmp6PacketTooBig::new(mtu) {
+                    Self::PacketTooBig(v)
+                } else {
+                    debug!(
+                        mtu,
+                        "ICMPv6 Packet Too Big with MTU below 1280, treating as unknown"
+                    );
+                    Self::Unknown {
+                        type_u8: 2,
+                        code_u8: 0,
+                        bytes5to8: mtu.to_be_bytes(),
+                    }
+                }
+            }
+            Icmpv6Type::TimeExceeded(c) => Self::TimeExceeded(Icmp6TimeExceeded::from(c)),
+            Icmpv6Type::ParameterProblem(h) => Self::ParamProblem(Icmp6ParamProblem {
+                code: Icmp6ParamProblemCode::from(h.code),
+                pointer: h.pointer,
+            }),
+            Icmpv6Type::EchoRequest(h) => Self::EchoRequest(Icmp6EchoRequest {
+                id: h.id,
+                seq: h.seq,
+            }),
+            Icmpv6Type::EchoReply(h) => Self::EchoReply(Icmp6EchoReply {
+                id: h.id,
+                seq: h.seq,
+            }),
+            Icmpv6Type::RouterSolicitation => Self::RouterSolicitation,
+            Icmpv6Type::RouterAdvertisement(h) => {
+                Self::RouterAdvertisement(Icmp6RouterAdvertisement {
+                    cur_hop_limit: NonZero::new(h.cur_hop_limit),
+                    managed_address_config: h.managed_address_config,
+                    other_config: h.other_config,
+                    router_lifetime: h.router_lifetime,
+                })
+            }
+            Icmpv6Type::NeighborSolicitation => Self::NeighborSolicitation,
+            Icmpv6Type::NeighborAdvertisement(h) => {
+                Self::NeighborAdvertisement(Icmp6NeighborAdvertisement {
+                    router: h.router,
+                    solicited: h.solicited,
+                    override_flag: h.r#override,
+                })
+            }
+            Icmpv6Type::Redirect => Self::Redirect,
+            Icmpv6Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            } => Self::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            },
+        }
+    }
+}
+
+impl From<Icmp6Type> for Icmpv6Type {
+    fn from(native: Icmp6Type) -> Self {
+        match native {
+            Icmp6Type::DestUnreachable(v) => {
+                Icmpv6Type::DestinationUnreachable(icmpv6::DestUnreachableCode::from(v))
+            }
+            Icmp6Type::PacketTooBig(v) => Icmpv6Type::PacketTooBig { mtu: v.mtu() },
+            Icmp6Type::TimeExceeded(v) => {
+                Icmpv6Type::TimeExceeded(icmpv6::TimeExceededCode::from(v))
+            }
+            Icmp6Type::ParamProblem(v) => {
+                Icmpv6Type::ParameterProblem(icmpv6::ParameterProblemHeader {
+                    code: icmpv6::ParameterProblemCode::from(v.code),
+                    pointer: v.pointer,
+                })
+            }
+            Icmp6Type::EchoRequest(v) => Icmpv6Type::EchoRequest(IcmpEchoHeader {
+                id: v.id,
+                seq: v.seq,
+            }),
+            Icmp6Type::EchoReply(v) => Icmpv6Type::EchoReply(IcmpEchoHeader {
+                id: v.id,
+                seq: v.seq,
+            }),
+            Icmp6Type::RouterSolicitation => Icmpv6Type::RouterSolicitation,
+            Icmp6Type::RouterAdvertisement(v) => {
+                Icmpv6Type::RouterAdvertisement(etherparse::icmpv6::RouterAdvertisementHeader {
+                    cur_hop_limit: v.cur_hop_limit.map_or(0, NonZero::get),
+                    managed_address_config: v.managed_address_config,
+                    other_config: v.other_config,
+                    router_lifetime: v.router_lifetime,
+                })
+            }
+            Icmp6Type::NeighborSolicitation => Icmpv6Type::NeighborSolicitation,
+            Icmp6Type::NeighborAdvertisement(v) => {
+                Icmpv6Type::NeighborAdvertisement(etherparse::icmpv6::NeighborAdvertisementHeader {
+                    router: v.router,
+                    solicited: v.solicited,
+                    r#override: v.override_flag,
+                })
+            }
+            Icmp6Type::Redirect => Icmpv6Type::Redirect,
+            Icmp6Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            } => Icmpv6Type::Unknown {
+                type_u8,
+                code_u8,
+                bytes5to8,
+            },
+        }
+    }
+}
+
+impl Icmp6 {
+    /// Get the ICMP message type.
+    #[must_use]
+    pub fn icmp_type(&self) -> Icmp6Type {
+        Icmp6Type::from(self.0.icmp_type)
+    }
+
+    /// Return a mutable reference to the raw etherparse type field.
+    ///
+    /// This is `pub(crate)` to keep etherparse out of the public API.
+    /// External callers should use [`set_type`](Self::set_type) instead.
+    #[must_use]
+    pub(crate) const fn icmp_type_mut(&mut self) -> &mut Icmpv6Type {
         &mut self.0.icmp_type
     }
 
-    /// Returns true if the ICMP type is a query message
-    #[must_use]
-    pub fn is_query_message(&self) -> bool {
-        // List all types to make it sure we catch any new addition to the enum
-        match self.icmp_type() {
-            Icmpv6Type::EchoRequest(_) | Icmpv6Type::EchoReply(_) => true,
-            Icmpv6Type::Unknown { .. }
-            | Icmpv6Type::DestinationUnreachable(_)
-            | Icmpv6Type::PacketTooBig { .. }
-            | Icmpv6Type::TimeExceeded(_)
-            | Icmpv6Type::ParameterProblem(_)
-            | Icmpv6Type::RouterSolicitation
-            | Icmpv6Type::RouterAdvertisement(_)
-            | Icmpv6Type::NeighborSolicitation
-            | Icmpv6Type::NeighborAdvertisement(_)
-            | Icmpv6Type::Redirect => false,
-        }
+    /// Set the ICMP message type.
+    pub fn set_type(&mut self, icmp_type: Icmp6Type) {
+        self.0.icmp_type = icmp_type.into();
     }
 
-    /// Returns true if the ICMP type is an error message
+    /// Returns true if the ICMP type is a query message.
+    #[must_use]
+    pub fn is_query_message(&self) -> bool {
+        matches!(
+            self.icmp_type(),
+            Icmp6Type::EchoRequest(_) | Icmp6Type::EchoReply(_)
+        )
+    }
+
+    /// Returns true if the ICMP type is an error message.
     #[must_use]
     pub fn is_error_message(&self) -> bool {
-        // List all types to make it sure we catch any new addition to the enum
-        match self.icmp_type() {
-            Icmpv6Type::DestinationUnreachable(_)
-            | Icmpv6Type::PacketTooBig { .. }
-            | Icmpv6Type::TimeExceeded(_)
-            | Icmpv6Type::ParameterProblem(_) => true,
-            Icmpv6Type::Unknown { .. }
-            | Icmpv6Type::EchoRequest(_)
-            | Icmpv6Type::EchoReply(_)
-            | Icmpv6Type::RouterSolicitation
-            | Icmpv6Type::RouterAdvertisement(_)
-            | Icmpv6Type::NeighborSolicitation
-            | Icmpv6Type::NeighborAdvertisement(_)
-            | Icmpv6Type::Redirect => false,
-        }
+        matches!(
+            self.icmp_type(),
+            Icmp6Type::DestUnreachable(_)
+                | Icmp6Type::PacketTooBig(_)
+                | Icmp6Type::TimeExceeded(_)
+                | Icmp6Type::ParamProblem(_)
+        )
     }
 
     /// Returns the identifier field value if the ICMP type allows it.
     #[must_use]
     pub fn identifier(&self) -> Option<u16> {
         match self.icmp_type() {
-            Icmpv6Type::EchoRequest(msg) | Icmpv6Type::EchoReply(msg) => Some(msg.id),
+            Icmp6Type::EchoRequest(v) => Some(v.id),
+            Icmp6Type::EchoReply(v) => Some(v.id),
             _ => None,
         }
     }
 
-    /// Set the identifier field value
+    /// Set the identifier field value.
     ///
     /// # Errors
     ///
-    /// This method returns [`Icmp6Error::InvalidIcmpType`] if the ICMP type does not allow setting an identifier.
+    /// Returns [`Icmp6Error::InvalidIcmpType`] if the ICMP type does not
+    /// support an identifier field.
     pub fn try_set_identifier(&mut self, id: u16) -> Result<(), Icmp6Error> {
         match self.icmp_type_mut() {
             Icmpv6Type::EchoRequest(msg) | Icmpv6Type::EchoReply(msg) => {
@@ -112,9 +524,9 @@ impl Icmp6 {
     ///
     /// The checksum will be set to zero.
     #[must_use]
-    pub const fn with_type(icmp_type: Icmpv6Type) -> Self {
+    pub fn with_type(icmp_type: Icmp6Type) -> Self {
         Self(Icmpv6Header {
-            icmp_type,
+            icmp_type: icmp_type.into(),
             checksum: 0,
         })
     }
@@ -124,9 +536,7 @@ impl Icmp6 {
         // See RFC 4884.
         matches!(
             self.icmp_type(),
-            Icmpv6Type::DestinationUnreachable(_)
-                | Icmpv6Type::TimeExceeded(_)
-                | Icmpv6Type::ParameterProblem(_)
+            Icmp6Type::DestUnreachable(_) | Icmp6Type::TimeExceeded(_) | Icmp6Type::ParamProblem(_)
         )
     }
 
@@ -459,8 +869,25 @@ mod contract {
 
 #[cfg(test)]
 mod test {
-    use crate::icmp6::Icmp6;
+    use crate::icmp6::{Icmp6, Icmp6Type};
     use crate::parse::{DeParse, Parse};
+
+    /// A Packet Too Big with MTU below 1280 should be treated as unknown
+    /// `ICMPv6`, since RFC 8200 section 5 sets 1280 as the IPv6 minimum.
+    #[test]
+    fn packet_too_big_below_min_mtu_is_unknown() {
+        use etherparse::{Icmpv6Header, Icmpv6Type};
+
+        let header = Icmpv6Header {
+            icmp_type: Icmpv6Type::PacketTooBig { mtu: 1000 },
+            checksum: 0,
+        };
+        let icmp = Icmp6(header);
+        assert!(
+            matches!(icmp.icmp_type(), Icmp6Type::Unknown { type_u8: 2, .. }),
+            "sub-minimum MTU should cause PacketTooBig to be treated as unknown"
+        );
+    }
 
     fn parse_back_test_helper(header: &Icmp6) {
         let mut buf = [0; super::contract::BYTE_SLICE_SIZE];

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -45,6 +45,21 @@ impl NextHeader {
     /// ICMP6 next header
     pub const ICMP6: NextHeader = NextHeader(IpNumber::IPV6_ICMP);
 
+    /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3)
+    pub const HOP_BY_HOP: NextHeader = NextHeader(IpNumber::IPV6_HEADER_HOP_BY_HOP);
+
+    /// IPv6 Routing Header (RFC 8200 section 4.4)
+    pub const ROUTING: NextHeader = NextHeader(IpNumber::IPV6_ROUTE_HEADER);
+
+    /// IPv6 Fragment Header (RFC 8200 section 4.5)
+    pub const FRAGMENT: NextHeader = NextHeader(IpNumber::IPV6_FRAGMENTATION_HEADER);
+
+    /// IPv6 Destination Options (RFC 8200 section 4.6)
+    pub const DEST_OPTS: NextHeader = NextHeader(IpNumber::IPV6_DESTINATION_OPTIONS);
+
+    /// IP Authentication Header (RFC 4302)
+    pub const AUTH: NextHeader = NextHeader(IpNumber::AUTHENTICATION_HEADER);
+
     /// Generate a new [`NextHeader`]
     #[must_use]
     pub fn new(inner: u8) -> Self {

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -3,6 +3,12 @@
 
 //! IP authentication header type and logic.
 
+pub mod v4;
+pub mod v6;
+
+pub use v4::Ipv4Auth;
+pub use v6::Ipv6Auth;
+
 use crate::headers::{EmbeddedHeader, Header};
 use crate::icmp4::Icmp4;
 use crate::icmp6::Icmp6;

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -14,7 +14,7 @@ use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, 
 use etherparse::IpAuthHeader;
 use std::num::NonZero;
 
-/// An Ip authentication header.
+/// An IP authentication header.
 ///
 /// This may appear in IPv4 and IPv6 headers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,8 +90,11 @@ mod contract {
     use bolero::{Driver, TypeGenerator};
     use etherparse::{IpAuthHeader, IpNumber};
 
-    /// Valid ICV lengths (multiples of 4, capped to keep fuzz inputs small).
-    const VALID_ICV_LENS: [usize; 4] = [0, 4, 8, 12];
+    /// Valid ICV lengths (multiples of 4).
+    ///
+    /// Includes the boundaries: 0 (minimum), small values for fast fuzzing,
+    /// and `MAX_ICV_LEN` (1016) to cover the upper limit.
+    const VALID_ICV_LENS: [usize; 5] = [0, 4, 8, 12, IpAuthHeader::MAX_ICV_LEN];
 
     impl TypeGenerator for IpAuth {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -13,6 +13,7 @@ use crate::headers::{EmbeddedHeader, Header};
 use crate::icmp4::Icmp4;
 use crate::icmp6::Icmp6;
 use crate::impl_from_for_enum;
+use crate::ip::NextHeader;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
 };
@@ -28,7 +29,24 @@ use tracing::{debug, trace};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IpAuth(Box<IpAuthHeader>);
 
+impl From<Box<IpAuthHeader>> for IpAuth {
+    fn from(inner: Box<IpAuthHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl IpAuth {
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
     /// Parse the payload of the IP authentication header.
     ///
     /// # Returns

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -188,3 +188,34 @@ impl From<EmbeddedIpAuthNext> for EmbeddedHeader {
         }
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::IpAuth;
+    use bolero::{Driver, TypeGenerator};
+    use etherparse::{IpAuthHeader, IpNumber};
+
+    /// Valid ICV lengths (multiples of 4, capped to keep fuzz inputs small).
+    const VALID_ICV_LENS: [usize; 4] = [0, 4, 8, 12];
+
+    impl TypeGenerator for IpAuth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let next_header: u8 = driver.produce()?;
+            let spi: u32 = driver.produce()?;
+            let sequence_number: u32 = driver.produce()?;
+            let idx = driver.gen_usize(
+                std::ops::Bound::Included(&0),
+                std::ops::Bound::Excluded(&VALID_ICV_LENS.len()),
+            )?;
+            let icv_len = VALID_ICV_LENS[idx];
+            let mut icv = vec![0u8; icv_len];
+            for byte in &mut icv {
+                *byte = driver.produce()?;
+            }
+            #[allow(clippy::unwrap_used)] // lengths are valid by construction
+            let header =
+                IpAuthHeader::new(IpNumber(next_header), spi, sequence_number, &icv).unwrap();
+            Some(IpAuth::from(Box::new(header)))
+        }
+    }
+}

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -9,19 +9,10 @@ pub mod v6;
 pub use v4::Ipv4Auth;
 pub use v6::Ipv6Auth;
 
-use crate::headers::{EmbeddedHeader, Header};
-use crate::icmp4::Icmp4;
-use crate::icmp6::Icmp6;
-use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
-use crate::parse::{
-    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
-};
-use crate::tcp::{Tcp, TruncatedTcp};
-use crate::udp::{TruncatedUdp, Udp};
-use etherparse::{IpAuthHeader, IpNumber};
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::IpAuthHeader;
 use std::num::NonZero;
-use tracing::{debug, trace};
 
 /// An Ip authentication header.
 ///
@@ -45,50 +36,6 @@ impl IpAuth {
     /// Set the next-header protocol number.
     pub fn set_next_header(&mut self, nh: NextHeader) {
         self.0.next_header = nh.into();
-    }
-
-    /// Parse the payload of the IP authentication header.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(IpAuthNext)`: the parsed next header, if supported.
-    /// * `None`: if parsing the next header is not supported.
-    pub(crate) fn parse_payload(&self, cursor: &mut Reader) -> Option<IpAuthNext> {
-        match self.0.next_header {
-            IpNumber::TCP => cursor.parse_header::<Tcp, IpAuthNext>(),
-            IpNumber::UDP => cursor.parse_header::<Udp, IpAuthNext>(),
-            IpNumber::ICMP => cursor.parse_header::<Icmp4, IpAuthNext>(),
-            IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, IpAuthNext>(),
-            IpNumber::AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, IpAuthNext>()
-            }
-            _ => {
-                trace!("unsupported protocol: {:?}", self.0.next_header);
-                None
-            }
-        }
-    }
-
-    /// Parse the payload of the IP authentication header embedded in an ICMP Error message.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(EmbeddedIpAuthNext)`: the parsed next header, if supported.
-    /// * `None`: if parsing the next header is not supported.
-    pub(crate) fn parse_embedded_payload(&self, cursor: &mut Reader) -> Option<EmbeddedIpAuthNext> {
-        match self.0.next_header {
-            IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpAuthNext>(),
-            IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpAuthNext>(),
-            IpNumber::AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, EmbeddedIpAuthNext>()
-            }
-            _ => {
-                trace!("unsupported protocol: {:?}", self.0.next_header);
-                None
-            }
-        }
     }
 }
 
@@ -134,58 +81,6 @@ impl DeParse for IpAuth {
         let bytes = self.0.to_bytes();
         buf[..bytes.len()].copy_from_slice(&bytes);
         Ok(self.size())
-    }
-}
-
-pub(crate) enum IpAuthNext {
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp4(Icmp4),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-}
-
-impl_from_for_enum![
-    IpAuthNext,
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp4(Icmp4),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth)
-];
-
-impl From<IpAuthNext> for Header {
-    fn from(value: IpAuthNext) -> Self {
-        match value {
-            IpAuthNext::Tcp(x) => Header::Tcp(x),
-            IpAuthNext::Udp(x) => Header::Udp(x),
-            IpAuthNext::Icmp4(x) => Header::Icmp4(x),
-            IpAuthNext::Icmp6(x) => Header::Icmp6(x),
-            IpAuthNext::IpAuth(x) => Header::IpAuth(x),
-        }
-    }
-}
-
-pub(crate) enum EmbeddedIpAuthNext {
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    IpAuth(IpAuth),
-}
-
-impl_from_for_enum![
-    EmbeddedIpAuthNext,
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    IpAuth(IpAuth)
-];
-
-impl From<EmbeddedIpAuthNext> for EmbeddedHeader {
-    fn from(value: EmbeddedIpAuthNext) -> Self {
-        match value {
-            EmbeddedIpAuthNext::Tcp(x) => EmbeddedHeader::Tcp(x),
-            EmbeddedIpAuthNext::Udp(x) => EmbeddedHeader::Udp(x),
-            EmbeddedIpAuthNext::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-        }
     }
 }
 

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -37,6 +37,54 @@ impl Ipv4Auth {
     pub fn into_inner(self) -> IpAuth {
         self.0
     }
+
+    /// Parse the next header after this one (IPv4 context).
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        use crate::headers::Header;
+        use crate::icmp4::Icmp4;
+        use crate::parse::ParseHeader;
+        use crate::tcp::Tcp;
+        use crate::udp::Udp;
+        use etherparse::IpNumber;
+        use tracing::trace;
+
+        match self.next_header().into() {
+            IpNumber::TCP => cursor.parse_header::<Tcp, Header>(),
+            IpNumber::UDP => cursor.parse_header::<Udp, Header>(),
+            IpNumber::ICMP => cursor.parse_header::<Icmp4, Header>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, Header>(),
+            _ => {
+                trace!("unsupported protocol: {:?}", self.next_header());
+                None
+            }
+        }
+    }
+
+    /// Parse the next header in an ICMP-embedded context (IPv4).
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        use crate::headers::EmbeddedHeader;
+        use crate::parse::ParseHeader;
+        use crate::tcp::TruncatedTcp;
+        use crate::udp::TruncatedUdp;
+        use etherparse::IpNumber;
+        use tracing::trace;
+
+        match self.next_header().into() {
+            IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
+            IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedHeader>(),
+            _ => {
+                trace!("unsupported protocol: {:?}", self.next_header());
+                None
+            }
+        }
+    }
 }
 
 impl Deref for Ipv4Auth {

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -85,3 +85,15 @@ impl DeParse for Ipv4Auth {
         self.0.deparse(buf)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Ipv4Auth;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Ipv4Auth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Ipv4Auth::new(driver.produce()?))
+        }
+    }
+}

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv4-context IP Authentication Header.
+//!
+//! This is a [`repr(transparent)`] newtype over [`IpAuth`] that marks the
+//! header as appearing in an IPv4 extension chain.  The builder uses this
+//! type to restrict `Within` impls so that `Ipv4Auth` can only follow
+//! IPv4-legal parents (e.g. `Ipv4`), preventing it from being stacked
+//! after IPv6-only extension headers like `HopByHop`.
+
+use crate::ip_auth::IpAuth;
+use crate::parse::{DeParse, DeParseError, Parse, ParseError};
+use std::num::NonZero;
+use std::ops::Deref;
+
+/// IP Authentication Header in an IPv4 context ([RFC 4302]).
+///
+/// Structurally identical to [`IpAuth`] on the wire -- the type distinction
+/// exists purely to give the builder different `Within` bounds for IPv4
+/// vs IPv6 extension header chains.
+///
+/// [RFC 4302]: https://datatracker.ietf.org/doc/html/rfc4302
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv4Auth(IpAuth);
+
+impl Ipv4Auth {
+    /// Wrap an [`IpAuth`] as an IPv4-context authentication header.
+    #[must_use]
+    pub fn new(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+
+    /// Unwrap into the inner [`IpAuth`].
+    #[must_use]
+    pub fn into_inner(self) -> IpAuth {
+        self.0
+    }
+}
+
+impl Deref for Ipv4Auth {
+    type Target = IpAuth;
+
+    fn deref(&self) -> &IpAuth {
+        &self.0
+    }
+}
+
+impl From<IpAuth> for Ipv4Auth {
+    fn from(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+}
+
+impl From<Ipv4Auth> for IpAuth {
+    fn from(outer: Ipv4Auth) -> Self {
+        outer.0
+    }
+}
+
+impl Parse for Ipv4Auth {
+    type Error = <IpAuth as Parse>::Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let (inner, consumed) = IpAuth::parse(buf)?;
+        Ok((Self(inner), consumed))
+    }
+}
+
+impl DeParse for Ipv4Auth {
+    type Error = <IpAuth as DeParse>::Error;
+
+    fn size(&self) -> NonZero<u16> {
+        self.0.size()
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        self.0.deparse(buf)
+    }
+}

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -12,7 +12,7 @@
 use crate::ip_auth::IpAuth;
 use crate::parse::{DeParse, DeParseError, Parse, ParseError};
 use std::num::NonZero;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// IP Authentication Header in an IPv4 context ([RFC 4302]).
 ///
@@ -44,6 +44,12 @@ impl Deref for Ipv4Auth {
 
     fn deref(&self) -> &IpAuth {
         &self.0
+    }
+}
+
+impl DerefMut for Ipv4Auth {
+    fn deref_mut(&mut self) -> &mut IpAuth {
+        &mut self.0
     }
 }
 

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -69,6 +69,7 @@ impl Ipv4Auth {
         cursor: &mut crate::parse::Reader,
     ) -> Option<crate::headers::EmbeddedHeader> {
         use crate::headers::EmbeddedHeader;
+        use crate::icmp4::TruncatedIcmp4;
         use crate::parse::ParseHeader;
         use crate::tcp::TruncatedTcp;
         use crate::udp::TruncatedUdp;
@@ -78,6 +79,7 @@ impl Ipv4Auth {
         match self.next_header().into() {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+            IpNumber::ICMP => cursor.parse_header::<TruncatedIcmp4, EmbeddedHeader>(),
             IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedHeader>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.next_header());

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -11,7 +11,7 @@
 use crate::ip_auth::IpAuth;
 use crate::parse::{DeParse, DeParseError, Parse, ParseError};
 use std::num::NonZero;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// IP Authentication Header in an IPv6 context ([RFC 4302]).
 ///
@@ -43,6 +43,12 @@ impl Deref for Ipv6Auth {
 
     fn deref(&self) -> &IpAuth {
         &self.0
+    }
+}
+
+impl DerefMut for Ipv6Auth {
+    fn deref_mut(&mut self) -> &mut IpAuth {
+        &mut self.0
     }
 }
 

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6-context IP Authentication Header.
+//!
+//! This is a [`repr(transparent)`] newtype over [`IpAuth`] that marks the
+//! header as appearing in an IPv6 extension chain.  The builder uses this
+//! type to restrict `Within` impls so that `Ipv6Auth` can only follow
+//! IPv6-legal parents (e.g. `Ipv6`, `Fragment`, `Routing`).
+
+use crate::ip_auth::IpAuth;
+use crate::parse::{DeParse, DeParseError, Parse, ParseError};
+use std::num::NonZero;
+use std::ops::Deref;
+
+/// IP Authentication Header in an IPv6 context ([RFC 4302]).
+///
+/// Structurally identical to [`IpAuth`] on the wire -- the type distinction
+/// exists purely to give the builder different `Within` bounds for IPv4
+/// vs IPv6 extension header chains.
+///
+/// [RFC 4302]: https://datatracker.ietf.org/doc/html/rfc4302
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv6Auth(IpAuth);
+
+impl Ipv6Auth {
+    /// Wrap an [`IpAuth`] as an IPv6-context authentication header.
+    #[must_use]
+    pub fn new(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+
+    /// Unwrap into the inner [`IpAuth`].
+    #[must_use]
+    pub fn into_inner(self) -> IpAuth {
+        self.0
+    }
+}
+
+impl Deref for Ipv6Auth {
+    type Target = IpAuth;
+
+    fn deref(&self) -> &IpAuth {
+        &self.0
+    }
+}
+
+impl From<IpAuth> for Ipv6Auth {
+    fn from(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+}
+
+impl From<Ipv6Auth> for IpAuth {
+    fn from(outer: Ipv6Auth) -> Self {
+        outer.0
+    }
+}
+
+impl Parse for Ipv6Auth {
+    type Error = <IpAuth as Parse>::Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let (inner, consumed) = IpAuth::parse(buf)?;
+        Ok((Self(inner), consumed))
+    }
+}
+
+impl DeParse for Ipv6Auth {
+    type Error = <IpAuth as DeParse>::Error;
+
+    fn size(&self) -> NonZero<u16> {
+        self.0.size()
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        self.0.deparse(buf)
+    }
+}

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -36,6 +36,22 @@ impl Ipv6Auth {
     pub fn into_inner(self) -> IpAuth {
         self.0
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        crate::ipv6::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        crate::ipv6::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl Deref for Ipv6Auth {

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -84,3 +84,15 @@ impl DeParse for Ipv6Auth {
         self.0.deparse(buf)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Ipv6Auth;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Ipv6Auth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Ipv6Auth::new(driver.produce()?))
+        }
+    }
+}

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -179,8 +179,8 @@ impl Ipv4 {
     ///
     /// Note(manish) Why do we even have this function?
     #[allow(unsafe_code)]
-    pub unsafe fn set_source_unchecked(&mut self, source: Ipv4Addr) -> &mut Self {
-        self.0.source = source.octets();
+    pub unsafe fn set_source_unchecked(&mut self, source: impl Into<Ipv4Addr>) -> &mut Self {
+        self.0.source = source.into().octets();
         self
     }
 

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -9,7 +9,7 @@ use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
 use crate::ip::dscp::Dscp;
 use crate::ip::ecn::Ecn;
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::Ipv4Auth;
 pub use crate::ipv4::addr::UnicastIpv4Addr;
 use crate::ipv4::frag_offset::FragOffset;
 use crate::parse::{
@@ -303,7 +303,7 @@ impl Ipv4 {
             IpNumber::TCP => cursor.parse_header::<Tcp, Ipv4Next>(),
             IpNumber::UDP => cursor.parse_header::<Udp, Ipv4Next>(),
             IpNumber::ICMP => cursor.parse_header::<Icmp4, Ipv4Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, Ipv4Next>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, Ipv4Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.protocol);
                 None
@@ -322,7 +322,7 @@ impl Ipv4 {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv4Next>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv4Next>(),
             IpNumber::ICMP => cursor.parse_header::<TruncatedIcmp4, EmbeddedIpv4Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, EmbeddedIpv4Next>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedIpv4Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.protocol);
                 None
@@ -400,10 +400,16 @@ pub(crate) enum Ipv4Next {
     Tcp(Tcp),
     Udp(Udp),
     Icmp4(Icmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 }
 
-impl_from_for_enum![Ipv4Next, Tcp(Tcp), Udp(Udp), Icmp4(Icmp4), IpAuth(IpAuth)];
+impl_from_for_enum![
+    Ipv4Next,
+    Tcp(Tcp),
+    Udp(Udp),
+    Icmp4(Icmp4),
+    Ipv4Auth(Ipv4Auth)
+];
 
 impl From<Ipv4Next> for Header {
     fn from(value: Ipv4Next) -> Self {
@@ -411,7 +417,7 @@ impl From<Ipv4Next> for Header {
             Ipv4Next::Tcp(x) => Header::Tcp(x),
             Ipv4Next::Udp(x) => Header::Udp(x),
             Ipv4Next::Icmp4(x) => Header::Icmp4(x),
-            Ipv4Next::IpAuth(x) => Header::IpAuth(x),
+            Ipv4Next::Ipv4Auth(x) => Header::Ipv4Auth(x),
         }
     }
 }
@@ -420,7 +426,7 @@ pub(crate) enum EmbeddedIpv4Next {
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 }
 
 impl_from_for_enum![
@@ -428,7 +434,7 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 ];
 
 impl From<EmbeddedIpv4Next> for EmbeddedHeader {
@@ -437,7 +443,7 @@ impl From<EmbeddedIpv4Next> for EmbeddedHeader {
             EmbeddedIpv4Next::Tcp(x) => EmbeddedHeader::Tcp(x),
             EmbeddedIpv4Next::Udp(x) => EmbeddedHeader::Udp(x),
             EmbeddedIpv4Next::Icmp4(x) => EmbeddedHeader::Icmp4(x),
-            EmbeddedIpv4Next::IpAuth(x) => EmbeddedHeader::IpAuth(x),
+            EmbeddedIpv4Next::Ipv4Auth(x) => EmbeddedHeader::Ipv4Auth(x),
         }
     }
 }

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -52,6 +52,12 @@ impl DestOpts {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for DestOpts {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for DestOpts {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Destination Options header ([RFC 8200 section 4.6]).
+//!
+//! Destination Options carry optional information examined only by the
+//! packet's destination node(s).  Per [RFC 8200 section 4.1], Destination Options
+//! may appear in **two** positions:
+//!
+//! 1. Before the Routing header -- examined by the first destination plus
+//!    subsequent destinations listed in the Routing header.
+//! 2. After the Routing / Fragment / AH headers -- examined only by the
+//!    final destination.
+//!
+//! Both positions use the same wire format and the same [`DestOpts`] type.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
+//! [RFC 8200 section 4.6]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.6
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Destination Options header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestOpts(Box<Ipv6RawExtHeader>);
+
+impl DestOpts {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw TLV payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for DestOpts {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for DestOpts {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -68,14 +68,23 @@ impl DestOpts {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for DestOpts {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl DestOpts {
+    /// Wrap a raw extension header as a `DestOpts`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 60 (`IPV6_DESTINATION_OPTIONS`),
+    /// confirming these bytes are a Destination Options header and not
+    /// some other extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for DestOpts {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -87,7 +96,12 @@ impl Parse for DestOpts {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -130,7 +144,9 @@ mod contract {
 
     impl TypeGenerator for DestOpts {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(DestOpts::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: we are declaring the generated raw header to be DestOpts.
+            Some(unsafe { DestOpts::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -50,6 +50,22 @@ impl DestOpts {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for DestOpts {

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -105,3 +105,34 @@ impl DeParse for DestOpts {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::DestOpts;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for DestOpts {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(DestOpts::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DestOpts;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &DestOpts| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                DestOpts::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/ext_parse.rs
+++ b/net/src/ipv6/ext_parse.rs
@@ -5,7 +5,7 @@
 //!
 //! Every extension header carries a `next_header` field that identifies
 //! the type following it.  The dispatch logic is the same for all of
-//! `HopByHop`, `DestOpts`, Routing, Fragment, and `Ipv6Auth`.
+//! `HopByHop`, `DestOpts`, `Routing`, `Fragment`, and `Ipv6Auth`.
 
 use crate::headers::Header;
 use crate::icmp6::Icmp6;

--- a/net/src/ipv6/ext_parse.rs
+++ b/net/src/ipv6/ext_parse.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Shared parsing dispatch for IPv6 extension header payloads.
+//!
+//! Every extension header carries a `next_header` field that identifies
+//! the type following it.  The dispatch logic is the same for all of
+//! `HopByHop`, `DestOpts`, Routing, Fragment, and `Ipv6Auth`.
+
+use crate::headers::Header;
+use crate::icmp6::Icmp6;
+use crate::ip::NextHeader;
+use crate::ip_auth::Ipv6Auth;
+use crate::ipv6::dest_opts::DestOpts;
+use crate::ipv6::fragment::Fragment;
+use crate::ipv6::hop_by_hop::HopByHop;
+use crate::ipv6::routing::Routing;
+use crate::parse::{ParseHeader, Reader};
+use crate::tcp::Tcp;
+use crate::udp::Udp;
+use etherparse::IpNumber;
+use tracing::trace;
+
+/// Dispatch the next header after an IPv6 extension header.
+///
+/// This is called by the `parse_payload` method on each extension header
+/// type.  The `nh` parameter is the extension header's `next_header` field.
+pub(crate) fn parse_ext_payload(nh: NextHeader, cursor: &mut Reader) -> Option<Header> {
+    match nh.into() {
+        IpNumber::TCP => cursor.parse_header::<Tcp, Header>(),
+        IpNumber::UDP => cursor.parse_header::<Udp, Header>(),
+        IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, Header>(),
+        IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv6Auth, Header>(),
+        IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, Header>(),
+        IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, Header>(),
+        IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, Header>(),
+        IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, Header>(),
+        _ => {
+            trace!("unsupported protocol: {:?}", nh);
+            None
+        }
+    }
+}
+
+/// Embedded-payload variant for ICMP error messages.
+pub(crate) fn parse_ext_embedded_payload(
+    nh: NextHeader,
+    cursor: &mut Reader,
+) -> Option<crate::headers::EmbeddedHeader> {
+    use crate::headers::EmbeddedHeader;
+    use crate::icmp6::TruncatedIcmp6;
+    use crate::tcp::TruncatedTcp;
+    use crate::udp::TruncatedUdp;
+
+    match nh.into() {
+        IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
+        IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+        IpNumber::IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedHeader>(),
+        IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv6Auth, EmbeddedHeader>(),
+        IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, EmbeddedHeader>(),
+        IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, EmbeddedHeader>(),
+        IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, EmbeddedHeader>(),
+        IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, EmbeddedHeader>(),
+        _ => {
+            trace!("unsupported protocol: {:?}", nh);
+            None
+        }
+    }
+}

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -119,3 +119,49 @@ impl DeParse for Fragment {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Fragment;
+    use bolero::{Driver, TypeGenerator};
+    use etherparse::{IpFragOffset, IpNumber, Ipv6FragmentHeader};
+
+    impl TypeGenerator for Fragment {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let next_header: u8 = driver.produce()?;
+            let offset_raw: u16 = driver.gen_u16(
+                std::ops::Bound::Included(&0),
+                std::ops::Bound::Included(&IpFragOffset::MAX_U16),
+            )?;
+            #[allow(unsafe_code)]
+            // SAFETY: offset_raw is bounded to <= MAX_U16 by gen_u16 above.
+            let offset = unsafe { IpFragOffset::new_unchecked(offset_raw) };
+            let more_fragments: bool = driver.produce()?;
+            let identification: u32 = driver.produce()?;
+            Some(Fragment::from(Ipv6FragmentHeader::new(
+                IpNumber(next_header),
+                offset,
+                more_fragments,
+                identification,
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Fragment;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &Fragment| {
+            let mut buf = [0u8; 8];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                Fragment::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -84,14 +84,22 @@ impl Fragment {
     }
 }
 
-impl From<Ipv6FragmentHeader> for Fragment {
-    fn from(inner: Ipv6FragmentHeader) -> Self {
+impl Fragment {
+    /// Wrap a fragment header as a `Fragment`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 44 (`IPV6_FRAGMENTATION_HEADER`),
+    /// confirming these bytes are a Fragment header.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Ipv6FragmentHeader) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for Fragment {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -103,7 +111,12 @@ impl Parse for Fragment {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -154,12 +167,16 @@ mod contract {
             let offset = unsafe { IpFragOffset::new_unchecked(offset_raw) };
             let more_fragments: bool = driver.produce()?;
             let identification: u32 = driver.produce()?;
-            Some(Fragment::from(Ipv6FragmentHeader::new(
-                IpNumber(next_header),
-                offset,
-                more_fragments,
-                identification,
-            )))
+            #[allow(unsafe_code)]
+            // SAFETY: we are constructing this as a Fragment by definition.
+            Some(unsafe {
+                Fragment::from_raw_unchecked(Ipv6FragmentHeader::new(
+                    IpNumber(next_header),
+                    offset,
+                    more_fragments,
+                    identification,
+                ))
+            })
         }
     }
 }

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -66,6 +66,22 @@ impl Fragment {
     pub fn is_fragmenting_payload(&self) -> bool {
         self.0.is_fragmenting_payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Ipv6FragmentHeader> for Fragment {

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -68,6 +68,12 @@ impl Fragment {
     }
 }
 
+impl From<Ipv6FragmentHeader> for Fragment {
+    fn from(inner: Ipv6FragmentHeader) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for Fragment {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Fragment header ([RFC 8200 section 4.5]).
+//!
+//! The Fragment header is used by an IPv6 source to send a packet larger
+//! than would fit in the path MTU.  Unlike the other extension headers,
+//! the Fragment header has a fixed 8-byte wire format and is small enough
+//! to store inline (no boxing required).
+//!
+//! [RFC 8200 section 4.5]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.5
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6FragmentHeader;
+use std::num::NonZero;
+
+/// IPv6 Fragment header.
+///
+/// Wraps an [`Ipv6FragmentHeader`] from etherparse.  At 8 bytes this is
+/// small enough to store inline -- no heap allocation needed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fragment(Ipv6FragmentHeader);
+
+impl Fragment {
+    /// The fixed header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const LEN: NonZero<u16> = NonZero::new(Ipv6FragmentHeader::LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The 13-bit fragment offset in 8-octet units.
+    #[must_use]
+    pub fn fragment_offset(&self) -> etherparse::IpFragOffset {
+        self.0.fragment_offset
+    }
+
+    /// Whether more fragments follow this one.
+    #[must_use]
+    pub fn more_fragments(&self) -> bool {
+        self.0.more_fragments
+    }
+
+    /// The identification value for fragment reassembly.
+    #[must_use]
+    pub fn identification(&self) -> u32 {
+        self.0.identification
+    }
+
+    /// Returns `true` if this fragment header actually fragments the payload.
+    ///
+    /// A fragment header with offset 0 and `more_fragments == false` does not
+    /// fragment -- it represents a whole datagram (see [RFC 6946]).
+    ///
+    /// [RFC 6946]: https://datatracker.ietf.org/doc/html/rfc6946
+    #[must_use]
+    pub fn is_fragmenting_payload(&self) -> bool {
+        self.0.is_fragmenting_payload()
+    }
+}
+
+impl Parse for Fragment {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(inner), consumed?))
+    }
+}
+
+impl DeParse for Fragment {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        Self::LEN
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        buf[..size.get() as usize].copy_from_slice(&self.0.to_bytes());
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -62,14 +62,23 @@ impl HopByHop {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for HopByHop {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl HopByHop {
+    /// Wrap a raw extension header as a `HopByHop`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 0 (`IPV6_HEADER_HOP_BY_HOP`),
+    /// confirming these bytes are a Hop-by-Hop Options header and not
+    /// some other extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for HopByHop {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -81,7 +90,12 @@ impl Parse for HopByHop {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -124,7 +138,10 @@ mod contract {
 
     impl TypeGenerator for HopByHop {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(HopByHop::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: gen_raw_ext_header produces a valid raw header and we are
+            // declaring it to be a HopByHop, which is the type we're generating.
+            Some(unsafe { HopByHop::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -44,6 +44,22 @@ impl HopByHop {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for HopByHop {

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -46,6 +46,12 @@ impl HopByHop {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for HopByHop {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for HopByHop {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Hop-by-Hop Options header ([RFC 8200 section 4.3]).
+//!
+//! The Hop-by-Hop Options header carries optional information that **must** be
+//! examined by every node along a packet's delivery path.  Per [RFC 8200 section 4.1],
+//! it **must** immediately follow the IPv6 header when present -- the builder
+//! enforces this via [`Within`] bounds.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
+//! [RFC 8200 section 4.3]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.3
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Hop-by-Hop Options header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HopByHop(Box<Ipv6RawExtHeader>);
+
+impl HopByHop {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw TLV payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for HopByHop {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for HopByHop {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -99,3 +99,34 @@ impl DeParse for HopByHop {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::HopByHop;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for HopByHop {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(HopByHop::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HopByHop;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &HopByHop| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                HopByHop::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -9,23 +9,21 @@ use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
 use crate::ip::dscp::Dscp;
 use crate::ip::ecn::Ecn;
-use crate::ip_auth::IpAuth;
 pub use crate::ipv6::addr::UnicastIpv6Addr;
 use crate::ipv6::flow_label::FlowLabel;
 use crate::parse::{
-    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader,
-    ParseWith, Reader,
+    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
 };
 use crate::tcp::{Tcp, TruncatedTcp};
 use crate::udp::{TruncatedUdp, Udp};
-use etherparse::{IpDscp, IpEcn, IpNumber, Ipv6Extensions, Ipv6Header};
-use std::io::Cursor;
+use etherparse::{IpDscp, IpEcn, IpNumber, Ipv6Header};
 use std::net::Ipv6Addr;
 use std::num::NonZero;
-use tracing::{debug, trace};
+use tracing::trace;
 
 pub mod addr;
 pub mod dest_opts;
+pub(crate) mod ext_parse;
 pub mod flow_label;
 pub mod fragment;
 pub mod hop_by_hop;
@@ -245,13 +243,13 @@ impl Ipv6 {
             IpNumber::TCP => cursor.parse_header::<Tcp, Ipv6Next>(),
             IpNumber::UDP => cursor.parse_header::<Udp, Ipv6Next>(),
             IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, Ipv6Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, Ipv6Next>(),
-            IpNumber::IPV6_HEADER_HOP_BY_HOP
-            | IpNumber::IPV6_ROUTE_HEADER
-            | IpNumber::IPV6_FRAGMENTATION_HEADER
-            | IpNumber::IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, Ipv6Next>(self.0.next_header)
+            IpNumber::AUTHENTICATION_HEADER => {
+                cursor.parse_header::<crate::ip_auth::Ipv6Auth, Ipv6Next>()
             }
+            IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, Ipv6Next>(),
+            IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, Ipv6Next>(),
+            IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, Ipv6Next>(),
+            IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, Ipv6Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.next_header);
                 None
@@ -270,12 +268,16 @@ impl Ipv6 {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv6Next>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv6Next>(),
             IpNumber::IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedIpv6Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, EmbeddedIpv6Next>(),
-            IpNumber::IPV6_HEADER_HOP_BY_HOP
-            | IpNumber::IPV6_ROUTE_HEADER
-            | IpNumber::IPV6_FRAGMENTATION_HEADER
-            | IpNumber::IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, EmbeddedIpv6Next>(self.0.next_header)
+            IpNumber::AUTHENTICATION_HEADER => {
+                cursor.parse_header::<crate::ip_auth::Ipv6Auth, EmbeddedIpv6Next>()
+            }
+            IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, EmbeddedIpv6Next>(),
+            IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, EmbeddedIpv6Next>(),
+            IpNumber::IPV6_FRAGMENTATION_HEADER => {
+                cursor.parse_header::<Fragment, EmbeddedIpv6Next>()
+            }
+            IpNumber::IPV6_DESTINATION_OPTIONS => {
+                cursor.parse_header::<DestOpts, EmbeddedIpv6Next>()
             }
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.next_header);
@@ -357,8 +359,11 @@ pub(crate) enum Ipv6Next {
     Tcp(Tcp),
     Udp(Udp),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl_from_for_enum![
@@ -366,16 +371,22 @@ impl_from_for_enum![
     Tcp(Tcp),
     Udp(Udp),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 pub(crate) enum EmbeddedIpv6Next {
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl_from_for_enum![
@@ -383,175 +394,11 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
-];
-
-/// An IPv6 extension header.
-///
-/// TODO: break this into multiple types (one per each header type).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Ipv6Ext {
-    inner: Box<Ipv6Extensions>,
-    /// The IP protocol number that introduced the first extension header in
-    /// this chain (i.e. the `next_header` value from the IPv6 base header or
-    /// a preceding extension).  Needed by [`Ipv6Extensions::write`] during
-    /// serialization.
-    first_ip_number: IpNumber,
-}
-
-impl ParseWith for Ipv6Ext {
-    type Error = etherparse::err::ipv6_exts::HeaderSliceError;
-    type Param = IpNumber;
-
-    fn parse_with(
-        ip_number: IpNumber,
-        buf: &[u8],
-    ) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
-        if buf.len() > u16::MAX as usize {
-            return Err(ParseError::BufferTooLong(buf.len()));
-        }
-        let (inner, rest) = Ipv6Extensions::from_slice(ip_number, buf)
-            .map(|(h, _, rest)| (Box::new(h), rest))
-            .map_err(ParseError::Invalid)?;
-        assert!(
-            rest.len() < buf.len(),
-            "rest.len() >= buf.len() ({rest} >= {buf})",
-            rest = rest.len(),
-            buf = buf.len()
-        );
-        #[allow(clippy::cast_possible_truncation)] // buffer length bounded above
-        let consumed =
-            NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!())?;
-        Ok((
-            Self {
-                inner,
-                first_ip_number: ip_number,
-            },
-            consumed,
-        ))
-    }
-}
-
-impl DeParse for Ipv6Ext {
-    type Error = ();
-
-    fn size(&self) -> NonZero<u16> {
-        #[allow(clippy::cast_possible_truncation)] // extension header length is bounded
-        NonZero::new(self.inner.header_len() as u16).unwrap_or_else(|| unreachable!())
-    }
-
-    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
-        let size = self.size();
-        let len = buf.len();
-        if len < size.into_non_zero_usize().get() {
-            return Err(DeParseError::Length(LengthError {
-                expected: size.into_non_zero_usize(),
-                actual: len,
-            }));
-        }
-        let mut cursor = Cursor::new(&mut buf[..size.get() as usize]);
-        self.inner
-            .write(&mut cursor, self.first_ip_number)
-            .map_err(|_| DeParseError::Invalid(()))?;
-        Ok(size)
-    }
-}
-
-impl Ipv6Ext {
-    /// Parse the payload of this extension header.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Ipv6ExtNext)` variant if the payload was successfully parsed as a next header.
-    /// * `None` if the next header is not supported.
-    pub(crate) fn parse_payload(&self, cursor: &mut Reader) -> Option<Ipv6ExtNext> {
-        use etherparse::ip_number::{
-            AUTHENTICATION_HEADER, IPV6_DESTINATION_OPTIONS, IPV6_FRAGMENTATION_HEADER,
-            IPV6_HEADER_HOP_BY_HOP, IPV6_ICMP, IPV6_ROUTE_HEADER, TCP, UDP,
-        };
-        let next_header = self
-            .inner
-            .next_header(self.first_ip_number)
-            .map_err(|e| debug!("failed to parse: {e:?}"))
-            .ok()?;
-        match next_header {
-            TCP => cursor.parse_header::<Tcp, Ipv6ExtNext>(),
-            UDP => cursor.parse_header::<Udp, Ipv6ExtNext>(),
-            IPV6_ICMP => cursor.parse_header::<Icmp6, Ipv6ExtNext>(),
-            AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, Ipv6ExtNext>()
-            }
-            IPV6_HEADER_HOP_BY_HOP
-            | IPV6_ROUTE_HEADER
-            | IPV6_FRAGMENTATION_HEADER
-            | IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, Ipv6ExtNext>(next_header)
-            }
-            _ => {
-                trace!("unsupported protocol: {next_header:?}");
-                None
-            }
-        }
-    }
-
-    /// Parse the payload of an IPv6 extension header embedded in an ICMP Error message.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(EmbeddedIpv6ExtNext)` variant if the payload was successfully parsed as a next header.
-    /// * `None` if the next header is not supported.
-    pub(crate) fn parse_embedded_payload(
-        &self,
-        cursor: &mut Reader,
-    ) -> Option<EmbeddedIpv6ExtNext> {
-        use etherparse::ip_number::{
-            AUTHENTICATION_HEADER, IPV6_DESTINATION_OPTIONS, IPV6_FRAGMENTATION_HEADER,
-            IPV6_HEADER_HOP_BY_HOP, IPV6_ICMP, IPV6_ROUTE_HEADER, TCP, UDP,
-        };
-        let next_header = self
-            .inner
-            .next_header(self.first_ip_number)
-            .map_err(|e| debug!("failed to parse: {e:?}"))
-            .ok()?;
-        match next_header {
-            TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv6ExtNext>(),
-            UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv6ExtNext>(),
-            IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedIpv6ExtNext>(),
-            AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, EmbeddedIpv6ExtNext>()
-            }
-            IPV6_HEADER_HOP_BY_HOP
-            | IPV6_ROUTE_HEADER
-            | IPV6_FRAGMENTATION_HEADER
-            | IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, EmbeddedIpv6ExtNext>(next_header)
-            }
-            _ => {
-                trace!("unsupported protocol: {next_header:?}");
-                None
-            }
-        }
-    }
-}
-
-pub(crate) enum Ipv6ExtNext {
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
-}
-
-impl_from_for_enum![
-    Ipv6ExtNext,
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 impl From<Ipv6Next> for Header {
@@ -560,40 +407,14 @@ impl From<Ipv6Next> for Header {
             Ipv6Next::Tcp(x) => Header::Tcp(x),
             Ipv6Next::Udp(x) => Header::Udp(x),
             Ipv6Next::Icmp6(x) => Header::Icmp6(x),
-            Ipv6Next::IpAuth(x) => Header::IpAuth(x),
-            Ipv6Next::Ipv6Ext(x) => Header::IpV6Ext(x),
+            Ipv6Next::Ipv6Auth(x) => Header::Ipv6Auth(x),
+            Ipv6Next::HopByHop(x) => Header::HopByHop(x),
+            Ipv6Next::DestOpts(x) => Header::DestOpts(x),
+            Ipv6Next::Routing(x) => Header::Routing(x),
+            Ipv6Next::Fragment(x) => Header::Fragment(x),
         }
     }
 }
-
-impl From<Ipv6ExtNext> for Header {
-    fn from(value: Ipv6ExtNext) -> Self {
-        match value {
-            Ipv6ExtNext::Tcp(x) => Header::Tcp(x),
-            Ipv6ExtNext::Udp(x) => Header::Udp(x),
-            Ipv6ExtNext::Icmp6(x) => Header::Icmp6(x),
-            Ipv6ExtNext::IpAuth(x) => Header::IpAuth(x),
-            Ipv6ExtNext::Ipv6Ext(x) => Header::IpV6Ext(x),
-        }
-    }
-}
-
-pub(crate) enum EmbeddedIpv6ExtNext {
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
-}
-
-impl_from_for_enum![
-    EmbeddedIpv6ExtNext,
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
-];
 
 impl From<EmbeddedIpv6Next> for EmbeddedHeader {
     fn from(value: EmbeddedIpv6Next) -> Self {
@@ -601,20 +422,11 @@ impl From<EmbeddedIpv6Next> for EmbeddedHeader {
             EmbeddedIpv6Next::Tcp(x) => EmbeddedHeader::Tcp(x),
             EmbeddedIpv6Next::Udp(x) => EmbeddedHeader::Udp(x),
             EmbeddedIpv6Next::Icmp6(x) => EmbeddedHeader::Icmp6(x),
-            EmbeddedIpv6Next::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-            EmbeddedIpv6Next::Ipv6Ext(x) => EmbeddedHeader::IpV6Ext(x),
-        }
-    }
-}
-
-impl From<EmbeddedIpv6ExtNext> for EmbeddedHeader {
-    fn from(value: EmbeddedIpv6ExtNext) -> Self {
-        match value {
-            EmbeddedIpv6ExtNext::Tcp(x) => EmbeddedHeader::Tcp(x),
-            EmbeddedIpv6ExtNext::Udp(x) => EmbeddedHeader::Udp(x),
-            EmbeddedIpv6ExtNext::Icmp6(x) => EmbeddedHeader::Icmp6(x),
-            EmbeddedIpv6ExtNext::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-            EmbeddedIpv6ExtNext::Ipv6Ext(x) => EmbeddedHeader::IpV6Ext(x),
+            EmbeddedIpv6Next::Ipv6Auth(x) => EmbeddedHeader::Ipv6Auth(x),
+            EmbeddedIpv6Next::HopByHop(x) => EmbeddedHeader::HopByHop(x),
+            EmbeddedIpv6Next::DestOpts(x) => EmbeddedHeader::DestOpts(x),
+            EmbeddedIpv6Next::Routing(x) => EmbeddedHeader::Routing(x),
+            EmbeddedIpv6Next::Fragment(x) => EmbeddedHeader::Fragment(x),
         }
     }
 }

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -25,7 +25,16 @@ use std::num::NonZero;
 use tracing::{debug, trace};
 
 pub mod addr;
+pub mod dest_opts;
 pub mod flow_label;
+pub mod fragment;
+pub mod hop_by_hop;
+pub mod routing;
+
+pub use dest_opts::DestOpts;
+pub use fragment::Fragment;
+pub use hop_by_hop::HopByHop;
+pub use routing::Routing;
 
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -29,6 +29,8 @@ pub mod dest_opts;
 pub mod flow_label;
 pub mod fragment;
 pub mod hop_by_hop;
+#[cfg(any(test, feature = "bolero"))]
+pub(crate) mod raw_ext_gen;
 pub mod routing;
 
 pub use dest_opts::DestOpts;

--- a/net/src/ipv6/raw_ext_gen.rs
+++ b/net/src/ipv6/raw_ext_gen.rs
@@ -13,11 +13,11 @@ use etherparse::{IpNumber, Ipv6RawExtHeader};
 /// Valid payload lengths for [`Ipv6RawExtHeader`].
 ///
 /// The payload must be at least 6 bytes and `(len + 2) % 8 == 0`,
-/// giving lengths 6, 14, 22, 30, ...  We cap at a handful of small
-/// sizes to keep fuzz inputs tractable (the `payload_buffer` is 2 KiB,
-/// but generating huge headers is unlikely to find interesting bugs
-/// and slows the fuzzer).
-const VALID_PAYLOAD_LENS: [usize; 4] = [6, 14, 22, 30];
+/// giving lengths 6, 14, 22, 30, ...
+///
+/// Includes small values for fast fuzzing plus the maximum
+/// (`MAX_PAYLOAD_LEN` = 2046) to cover the upper boundary.
+const VALID_PAYLOAD_LENS: [usize; 5] = [6, 14, 22, 30, Ipv6RawExtHeader::MAX_PAYLOAD_LEN];
 
 /// Generate an arbitrary boxed [`Ipv6RawExtHeader`].
 ///

--- a/net/src/ipv6/raw_ext_gen.rs
+++ b/net/src/ipv6/raw_ext_gen.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Shared [`bolero`] generator for IPv6 raw extension headers.
+//!
+//! [`HopByHop`](super::HopByHop), [`DestOpts`](super::DestOpts), and
+//! [`Routing`](super::Routing) all wrap an [`Ipv6RawExtHeader`] and share
+//! the same generation logic.
+
+use bolero::Driver;
+use etherparse::{IpNumber, Ipv6RawExtHeader};
+
+/// Valid payload lengths for [`Ipv6RawExtHeader`].
+///
+/// The payload must be at least 6 bytes and `(len + 2) % 8 == 0`,
+/// giving lengths 6, 14, 22, 30, ...  We cap at a handful of small
+/// sizes to keep fuzz inputs tractable (the `payload_buffer` is 2 KiB,
+/// but generating huge headers is unlikely to find interesting bugs
+/// and slows the fuzzer).
+const VALID_PAYLOAD_LENS: [usize; 4] = [6, 14, 22, 30];
+
+/// Generate an arbitrary boxed [`Ipv6RawExtHeader`].
+///
+/// The `next_header` field is set to an arbitrary value; the builder's
+/// `Within::conform` will overwrite it when the header is stacked.
+pub fn gen_raw_ext_header<D: Driver>(driver: &mut D) -> Option<Box<Ipv6RawExtHeader>> {
+    let idx = driver.gen_usize(
+        std::ops::Bound::Included(&0),
+        std::ops::Bound::Excluded(&VALID_PAYLOAD_LENS.len()),
+    )?;
+    let payload_len = VALID_PAYLOAD_LENS[idx];
+    let mut payload = vec![0u8; payload_len];
+    for byte in &mut payload {
+        *byte = driver.produce()?;
+    }
+    let next_header: u8 = driver.produce()?;
+    #[allow(clippy::unwrap_used)] // lengths are valid by construction
+    let header = Ipv6RawExtHeader::new_raw(IpNumber(next_header), &payload).unwrap();
+    Some(Box::new(header))
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -46,6 +46,22 @@ impl Routing {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for Routing {

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -64,14 +64,23 @@ impl Routing {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for Routing {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl Routing {
+    /// Wrap a raw extension header as a `Routing`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 43 (`IPV6_ROUTE_HEADER`),
+    /// confirming these bytes are a Routing header and not some other
+    /// extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for Routing {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -83,7 +92,12 @@ impl Parse for Routing {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -126,7 +140,9 @@ mod contract {
 
     impl TypeGenerator for Routing {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(Routing::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: we are declaring the generated raw header to be Routing.
+            Some(unsafe { Routing::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -101,3 +101,34 @@ impl DeParse for Routing {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Routing;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Routing {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Routing::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Routing;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &Routing| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                Routing::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Routing header ([RFC 8200 section 4.4]).
+//!
+//! The Routing header is used by an IPv6 source to list one or more
+//! intermediate nodes to be "visited" on the way to a packet's destination.
+//!
+//! Note: etherparse bundles the Routing header with an optional trailing
+//! Destination Options header in `Ipv6RoutingExtensions`.  We flatten that --
+//! the Routing header is represented here as a standalone [`Routing`] type,
+//! and the trailing Destination Options (if any) is a separate [`super::DestOpts`].
+//!
+//! [RFC 8200 section 4.4]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.4
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Routing header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Routing(Box<Ipv6RawExtHeader>);
+
+impl Routing {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for Routing {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for Routing {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -48,6 +48,12 @@ impl Routing {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for Routing {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for Routing {
     type Error = etherparse::err::LenError;
 


### PR DESCRIPTION
Add a trait-driven fuzz builder (`ChainBase`/`FuzzLayer`) that mirrors `HeaderStack` but defers construction to bolero's `ValueGenerator`, enabling property-based testing with arbitrary-but-constrained packets.

Each layer uses `TypeGenerator` for fuzz generation, then applies a caller-supplied `Fn(&mut T)` mutation closure to pin specific field values.  Chains can be passed directly to `bolero::check!().with_generator(...)`.

Also extracts `fixup_embedded()` from `EmbeddedAssembler::finish()` into a shared helper.