### PR TITLE
ipv6 ext headers

### DIFF
--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -311,7 +311,7 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp4Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp4Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp4Type::TimeExceeded(_) | Icmp4Type::DestUnreachable(_) => {
+            _ if icmp.is_error_message() => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -322,7 +322,7 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp6Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp6Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp6Type::TimeExceeded(_) | Icmp6Type::DestUnreachable(_) => {
+            _ if icmp.is_error_message() => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -1025,22 +1025,20 @@ mod tests {
                     src_port: driver.produce()?,
                     dst_port: driver.produce()?,
                 })),
-                // To keep in sync with IcmpProtoKey::new_icmp_v4()
                 Transport::Icmp4(icmp) => match icmp.icmp_type() {
                     Icmp4Type::EchoRequest(_) | Icmp4Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp4Type::DestUnreachable(_) | Icmp4Type::TimeExceeded(_) => {
+                    _ if icmp.is_error_message() => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),
                 },
-                // To keep in sync with IcmpProtoKey::new_icmp_v6()
                 Transport::Icmp6(icmp) => match icmp.icmp_type() {
                     Icmp6Type::EchoRequest(_) | Icmp6Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp6Type::DestUnreachable(_) | Icmp6Type::TimeExceeded(_) => {
+                    _ if icmp.is_error_message() => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -55,8 +55,10 @@
 //!
 //! Extension headers are supported as individual typed layers:
 //! [`HopByHop`], [`DestOpts`], [`Routing`], [`Fragment`], [`Ipv6Auth`].
-//! [`Within`] bounds enforce [RFC 8200 section 4.1] ordering at compile time
-//! (e.g. `HopByHop` may only follow `Ipv6`).
+//! [`Within`] bounds enforce key [RFC 8200 section 4.1] ordering constraints
+//! at compile time (e.g. `HopByHop` may only follow `Ipv6`).  The bounds
+//! prevent clearly invalid chains but do not enforce the full recommended
+//! ordering -- for example, two `DestOpts` layers are both permitted.
 //!
 //! IPv4 authentication headers use [`Ipv4Auth`], which can only follow `Ipv4`.
 //!
@@ -466,7 +468,7 @@ where
     // ICMPv4 subtype layers -- available after `.icmp4()`
 
     layer_method!(
-        /// Specialize as `ICMPv4` Destination Unreachable (type 3).
+        /// Specialize as `Icmp4` Destination Unreachable (type 3).
         dest_unreachable, Icmp4DestUnreachable
     );
     layer_method!(
@@ -626,7 +628,9 @@ impl Within<Ipv6> for HopByHop {
     }
 }
 
-// -- DestOpts: after Ipv6, HopByHop, or Routing (two legal positions) --
+// -- DestOpts: after Ipv6, HopByHop, Routing, Fragment, or Ipv6Auth --
+// RFC 8200 section 4.1 allows DestOpts in two positions: before Routing
+// (first occurrence) and as the final extension before the upper layer.
 impl Within<Ipv6> for DestOpts {
     fn conform(parent: &mut Ipv6) {
         parent.set_next_header(NextHeader::DEST_OPTS);
@@ -641,6 +645,18 @@ impl Within<HopByHop> for DestOpts {
 
 impl Within<Routing> for DestOpts {
     fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Fragment> for DestOpts {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Ipv6Auth> for DestOpts {
+    fn conform(parent: &mut Ipv6Auth) {
         parent.set_next_header(NextHeader::DEST_OPTS);
     }
 }
@@ -1058,42 +1074,55 @@ impl Blank for HopByHop {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
         // Minimum valid payload: 6 zero bytes (8-byte aligned with the 2-byte header prefix).
-        #[allow(clippy::unwrap_used)]
-        HopByHop::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a HopByHop by definition.
+        unsafe {
+            HopByHop::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for DestOpts {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
-        #[allow(clippy::unwrap_used)]
-        DestOpts::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a DestOpts by definition.
+        unsafe {
+            DestOpts::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for Routing {
     fn blank() -> Self {
         use etherparse::Ipv6RawExtHeader;
-        #[allow(clippy::unwrap_used)]
-        Routing::from(Box::new(
-            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
-        ))
+        #[allow(clippy::unwrap_used, unsafe_code)]
+        // SAFETY: we are constructing this as a Routing by definition.
+        unsafe {
+            Routing::from_raw_unchecked(Box::new(
+                Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+            ))
+        }
     }
 }
 
 impl Blank for Fragment {
     fn blank() -> Self {
         use etherparse::{IpFragOffset, Ipv6FragmentHeader};
-        Fragment::from(Ipv6FragmentHeader::new(
-            IpNumber::TCP,
-            IpFragOffset::ZERO,
-            false,
-            0,
-        ))
+        #[allow(unsafe_code)]
+        // SAFETY: we are constructing this as a Fragment by definition.
+        unsafe {
+            Fragment::from_raw_unchecked(Ipv6FragmentHeader::new(
+                IpNumber::TCP,
+                IpFragOffset::ZERO,
+                false,
+                0,
+            ))
+        }
     }
 }
 
@@ -1367,21 +1396,26 @@ fn fixup_lengths(headers: &mut Headers, payload: &[u8]) -> Result<(), BuildError
 
     let payload_u16 = u16::try_from(payload.len()).map_err(|_| BuildError::PayloadTooLarge)?;
 
-    // It is safe to combine values this way because the mutually exclusive values are mapped back
-    // to zero (e.g. embedded_size is 0 when transport is UDP, encap_size is 0 when transport is
-    // ICMP, etc.).
-    // TODO: include net_ext size once IPv6 extension headers are supported.
-    let ip_payload = transport_size
+    let net_ext_size: u16 = headers.net_ext.iter().map(|e| e.size().get()).sum();
+
+    // Transport payload (used for UDP length -- excludes extension headers
+    // since they sit between IP and transport, not inside UDP).
+    let base_payload = transport_size
         .checked_add(payload_u16)
         .and_then(|v| v.checked_add(encap_size))
         .and_then(|v| v.checked_add(embedded_size))
         .ok_or(BuildError::PayloadTooLarge)?;
 
+    // IP payload includes extension headers + transport payload.
+    let ip_payload = base_payload
+        .checked_add(net_ext_size)
+        .ok_or(BuildError::PayloadTooLarge)?;
+
     match headers.transport {
         Some(Transport::Udp(ref mut udp)) => {
-            // SAFETY: `transport_size >= Udp::MIN_LENGTH` when transport is UDP, so `ip_payload`
-            // is guaranteed non-zero.
-            let udp_len = NonZero::new(ip_payload).unwrap_or_else(|| unreachable!());
+            // SAFETY: `transport_size >= Udp::MIN_LENGTH` when transport is UDP, so
+            // `base_payload` is guaranteed non-zero.
+            let udp_len = NonZero::new(base_payload).unwrap_or_else(|| unreachable!());
             #[allow(unsafe_code)]
             // SAFETY: `udp_len >= Udp::MIN_LENGTH` by construction.
             unsafe {
@@ -1651,6 +1685,38 @@ mod fuzz {
             /// Push a `Vxlan` layer.
             vxlan,
             crate::vxlan::Vxlan
+        );
+
+        // IPv6 extension header layers
+        fuzz_layer_method!(
+            /// Push a `HopByHop` extension header.
+            hop_by_hop,
+            crate::ipv6::HopByHop
+        );
+        fuzz_layer_method!(
+            /// Push a `DestOpts` extension header.
+            dest_opts,
+            crate::ipv6::DestOpts
+        );
+        fuzz_layer_method!(
+            /// Push a `Routing` extension header.
+            routing,
+            crate::ipv6::Routing
+        );
+        fuzz_layer_method!(
+            /// Push a `Fragment` extension header.
+            fragment,
+            crate::ipv6::Fragment
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv4Auth` extension header.
+            ipv4_auth,
+            crate::ip_auth::Ipv4Auth
+        );
+        fuzz_layer_method!(
+            /// Push an `Ipv6Auth` extension header.
+            ipv6_auth,
+            crate::ip_auth::Ipv6Auth
         );
 
         // ICMPv4 subtype layers
@@ -2766,6 +2832,27 @@ mod tests {
                     panic!("no embedded ipv4");
                 };
                 assert_eq!(inner_ip.destination().octets(), [169, 254, 32, 53]);
+            });
+    }
+
+    #[test]
+    fn fuzz_ipv6_ext_headers() {
+        let generator = ChainBase::new().eth(|_| {}).ipv6(|_| {}).hop_by_hop(|_| {});
+
+        bolero::check!()
+            .with_generator(generator)
+            .cloned()
+            .for_each(|headers| {
+                assert_eq!(headers.eth().unwrap().ether_type(), EthType::IPV6);
+                assert!(
+                    !headers.net_ext().is_empty(),
+                    "should have extension headers"
+                );
+                let mut buf = vec![0u8; headers.size().get() as usize];
+                headers.deparse(&mut buf).unwrap();
+                let (reparsed, consumed) = Headers::parse(&buf).unwrap();
+                assert_eq!(consumed.get() as usize, buf.len());
+                assert_eq!(headers, reparsed, "deparse->parse round-trip failed");
             });
     }
 }

--- a/net/src/headers/builder.rs
+++ b/net/src/headers/builder.rs
@@ -51,14 +51,20 @@
 //!   fields only.  Use when checksums are irrelevant (e.g., ACL matching
 //!   tests).
 //!
-//! # Not yet supported
+//! # IPv6 Extension Headers
 //!
-//! - **IPv6 extension headers** (`Ipv6Ext`, `IpAuth`).  These chain via
-//!   `net_ext` on [`Headers`] and need their own `next_header` management
-//!   (the extension's `next_header` field, not the base `Ipv6` header's).
-//!   Requires constructors and `TypeGenerator` impls that don't exist yet.
+//! Extension headers are supported as individual typed layers:
+//! [`HopByHop`], [`DestOpts`], [`Routing`], [`Fragment`], [`Ipv6Auth`].
+//! [`Within`] bounds enforce [RFC 8200 section 4.1] ordering at compile time
+//! (e.g. `HopByHop` may only follow `Ipv6`).
+//!
+//! IPv4 authentication headers use [`Ipv4Auth`], which can only follow `Ipv4`.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
 
 use std::num::NonZero;
+
+use etherparse::IpNumber;
 
 use crate::checksum::Checksum;
 use crate::eth::Eth;
@@ -70,9 +76,10 @@ use crate::icmp4::TruncatedIcmp4;
 use crate::icmp6::Icmp6;
 use crate::icmp6::TruncatedIcmp6;
 use crate::ip::NextHeader;
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
 use crate::ipv4::Ipv4LengthError;
-use crate::ipv6::Ipv6;
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::DeParse;
 use crate::tcp::port::TcpPort;
 use crate::tcp::{Tcp, TruncatedTcp};
@@ -81,7 +88,7 @@ use crate::udp::{Udp, UdpChecksum, UdpEncap};
 use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::{Vni, Vxlan};
 
-use super::{Net, Transport};
+use super::{Net, NetExt, Transport};
 
 /// Errors that can occur when finalizing a header stack.
 ///
@@ -429,6 +436,33 @@ where
         vxlan, Vxlan
     );
 
+    // IPv6 extension header layers
+
+    layer_method!(
+        /// Push a `HopByHop` extension header (RFC 8200 section 4.3).
+        hop_by_hop, HopByHop
+    );
+    layer_method!(
+        /// Push a `DestOpts` extension header (RFC 8200 section 4.6).
+        dest_opts, DestOpts
+    );
+    layer_method!(
+        /// Push a `Routing` extension header (RFC 8200 section 4.4).
+        routing, Routing
+    );
+    layer_method!(
+        /// Push a `Fragment` extension header (RFC 8200 section 4.5).
+        fragment, Fragment
+    );
+    layer_method!(
+        /// Push an `Ipv4Auth` extension header (RFC 4302, IPv4 context).
+        ipv4_auth, Ipv4Auth
+    );
+    layer_method!(
+        /// Push an `Ipv6Auth` extension header (RFC 4302, IPv6 context).
+        ipv6_auth, Ipv6Auth
+    );
+
     // ICMPv4 subtype layers -- available after `.icmp4()`
 
     layer_method!(
@@ -573,6 +607,238 @@ impl Within<Udp> for Vxlan {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Within impls for IPv6 extension headers (RFC 8200 section 4.1 ordering)
+// ---------------------------------------------------------------------------
+//
+// Recommended order:
+//   IPv6 -> HopByHop -> DestOpts -> Routing -> Fragment -> AH -> DestOpts -> upper
+//
+// HopByHop MUST immediately follow IPv6 when present.
+// DestOpts may appear in two positions (before Routing, and after AH).
+// The `Within` bounds encode valid parent->child transitions; absence of
+// an impl = compile error = invalid ordering.
+
+// -- HopByHop: only after Ipv6 --
+impl Within<Ipv6> for HopByHop {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::HOP_BY_HOP);
+    }
+}
+
+// -- DestOpts: after Ipv6, HopByHop, or Routing (two legal positions) --
+impl Within<Ipv6> for DestOpts {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<HopByHop> for DestOpts {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+impl Within<Routing> for DestOpts {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::DEST_OPTS);
+    }
+}
+
+// -- Routing: after Ipv6, HopByHop, or DestOpts --
+impl Within<Ipv6> for Routing {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+impl Within<HopByHop> for Routing {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+impl Within<DestOpts> for Routing {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::ROUTING);
+    }
+}
+
+// -- Fragment: after Ipv6, HopByHop, DestOpts, or Routing --
+impl Within<Ipv6> for Fragment {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<HopByHop> for Fragment {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<DestOpts> for Fragment {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+impl Within<Routing> for Fragment {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::FRAGMENT);
+    }
+}
+
+// -- Ipv4Auth: after Ipv4 only --
+impl Within<Ipv4> for Ipv4Auth {
+    fn conform(parent: &mut Ipv4) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+// -- Ipv6Auth: after Ipv6, HopByHop, DestOpts, Routing, or Fragment --
+impl Within<Ipv6> for Ipv6Auth {
+    fn conform(parent: &mut Ipv6) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<HopByHop> for Ipv6Auth {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<DestOpts> for Ipv6Auth {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<Routing> for Ipv6Auth {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+impl Within<Fragment> for Ipv6Auth {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::AUTH);
+    }
+}
+
+// -- Transport after extension headers --
+// Tcp, Udp, Icmp6 can follow any IPv6 extension header.
+// Icmp4 can follow Ipv4Auth (IPv4 context).
+
+impl Within<HopByHop> for Tcp {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<DestOpts> for Tcp {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Routing> for Tcp {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Fragment> for Tcp {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Ipv4Auth> for Tcp {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<Ipv6Auth> for Tcp {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::TCP);
+    }
+}
+
+impl Within<HopByHop> for Udp {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<DestOpts> for Udp {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Routing> for Udp {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Fragment> for Udp {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv4Auth> for Udp {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv6Auth> for Udp {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::UDP);
+    }
+}
+
+impl Within<Ipv4Auth> for Icmp4 {
+    fn conform(parent: &mut Ipv4Auth) {
+        parent.set_next_header(NextHeader::ICMP);
+    }
+}
+
+impl Within<HopByHop> for Icmp6 {
+    fn conform(parent: &mut HopByHop) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<DestOpts> for Icmp6 {
+    fn conform(parent: &mut DestOpts) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Routing> for Icmp6 {
+    fn conform(parent: &mut Routing) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Fragment> for Icmp6 {
+    fn conform(parent: &mut Fragment) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
+impl Within<Ipv6Auth> for Icmp6 {
+    fn conform(parent: &mut Ipv6Auth) {
+        parent.set_next_header(NextHeader::ICMP6);
+    }
+}
+
 // Install impls -- how Headers absorbs each layer
 
 impl Install<()> for Headers {
@@ -637,6 +903,78 @@ impl Install<Icmp6> for Headers {
 impl Install<Vxlan> for Headers {
     fn install(&mut self, vxlan: Vxlan) {
         self.udp_encap = Some(UdpEncap::Vxlan(vxlan));
+    }
+}
+
+impl Install<HopByHop> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, hbh: HopByHop) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::HopByHop(hbh))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<DestOpts> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, d: DestOpts) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::DestOpts(d))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Routing> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, r: Routing) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Routing(r))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Fragment> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, f: Fragment) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Fragment(f))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Ipv4Auth> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, a: Ipv4Auth) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Ipv4Auth(a))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
+    }
+}
+
+impl Install<Ipv6Auth> for Headers {
+    /// # Panics
+    ///
+    /// Panics if the extension header stack is full.
+    fn install(&mut self, a: Ipv6Auth) {
+        #[allow(clippy::expect_used)]
+        self.net_ext
+            .try_push(NetExt::Ipv6Auth(a))
+            .expect("too many extension headers (exceeded MAX_NET_EXTENSIONS)");
     }
 }
 
@@ -713,6 +1051,66 @@ impl Blank for Vxlan {
     fn blank() -> Self {
         #[allow(clippy::unwrap_used)] // VNI 1 is always valid
         Vxlan::new(Vni::new_checked(1).unwrap())
+    }
+}
+
+impl Blank for HopByHop {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        // Minimum valid payload: 6 zero bytes (8-byte aligned with the 2-byte header prefix).
+        #[allow(clippy::unwrap_used)]
+        HopByHop::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for DestOpts {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        #[allow(clippy::unwrap_used)]
+        DestOpts::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for Routing {
+    fn blank() -> Self {
+        use etherparse::Ipv6RawExtHeader;
+        #[allow(clippy::unwrap_used)]
+        Routing::from(Box::new(
+            Ipv6RawExtHeader::new_raw(IpNumber::TCP, &[0; 6]).unwrap(),
+        ))
+    }
+}
+
+impl Blank for Fragment {
+    fn blank() -> Self {
+        use etherparse::{IpFragOffset, Ipv6FragmentHeader};
+        Fragment::from(Ipv6FragmentHeader::new(
+            IpNumber::TCP,
+            IpFragOffset::ZERO,
+            false,
+            0,
+        ))
+    }
+}
+
+impl Blank for Ipv4Auth {
+    fn blank() -> Self {
+        use crate::ip_auth::IpAuth;
+        use etherparse::IpAuthHeader;
+        // Default IpAuthHeader has zero-length ICV -- the minimum valid AH.
+        Ipv4Auth::new(IpAuth::from(Box::new(IpAuthHeader::default())))
+    }
+}
+
+impl Blank for Ipv6Auth {
+    fn blank() -> Self {
+        use crate::ip_auth::IpAuth;
+        use etherparse::IpAuthHeader;
+        Ipv6Auth::new(IpAuth::from(Box::new(IpAuthHeader::default())))
     }
 }
 

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -325,22 +325,46 @@ impl ParseWith for EmbeddedHeaders {
                     this.net = Some(Net::Ipv6(ipv6));
                 }
                 EmbeddedHeader::Ipv4Auth(h) => {
-                    this.net_ext.push(NetExt::Ipv4Auth(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv4Auth(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Ipv6Auth(h) => {
-                    this.net_ext.push(NetExt::Ipv6Auth(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv6Auth(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::HopByHop(h) => {
-                    this.net_ext.push(NetExt::HopByHop(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::HopByHop(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::DestOpts(h) => {
-                    this.net_ext.push(NetExt::DestOpts(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::DestOpts(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Routing(h) => {
-                    this.net_ext.push(NetExt::Routing(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Routing(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Fragment(h) => {
-                    this.net_ext.push(NetExt::Fragment(h));
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Fragment(h));
+                    } else {
+                        break;
+                    }
                 }
                 EmbeddedHeader::Tcp(tcp) => {
                     this.transport = Some(EmbeddedTransport::Tcp(tcp));

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -8,9 +8,9 @@ use crate::icmp_any::TruncatedIcmpAny;
 use crate::icmp4::{Icmp4Checksum, TruncatedIcmp4};
 use crate::icmp6::{Icmp6Checksum, TruncatedIcmp6};
 use crate::impl_from_for_enum;
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{Ipv6, Ipv6Ext};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, ParseError,
     ParseHeader, ParseWith, Reader, Writer,
@@ -324,11 +324,23 @@ impl ParseWith for EmbeddedHeaders {
                 EmbeddedHeader::Ipv6(ipv6) => {
                     this.net = Some(Net::Ipv6(ipv6));
                 }
-                EmbeddedHeader::IpAuth(auth) => {
-                    this.net_ext.push(NetExt::IpAuth(auth));
+                EmbeddedHeader::Ipv4Auth(h) => {
+                    this.net_ext.push(NetExt::Ipv4Auth(h));
                 }
-                EmbeddedHeader::IpV6Ext(ext) => {
-                    this.net_ext.push(NetExt::Ipv6Ext(ext));
+                EmbeddedHeader::Ipv6Auth(h) => {
+                    this.net_ext.push(NetExt::Ipv6Auth(h));
+                }
+                EmbeddedHeader::HopByHop(h) => {
+                    this.net_ext.push(NetExt::HopByHop(h));
+                }
+                EmbeddedHeader::DestOpts(h) => {
+                    this.net_ext.push(NetExt::DestOpts(h));
+                }
+                EmbeddedHeader::Routing(h) => {
+                    this.net_ext.push(NetExt::Routing(h));
+                }
+                EmbeddedHeader::Fragment(h) => {
+                    this.net_ext.push(NetExt::Fragment(h));
                 }
                 EmbeddedHeader::Tcp(tcp) => {
                     this.transport = Some(EmbeddedTransport::Tcp(tcp));
@@ -435,25 +447,33 @@ pub(crate) enum EmbeddedHeader {
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext), // TODO: break out nested enum.  Nesting is counter productive here
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl EmbeddedHeader {
     fn parse_payload(&self, cursor: &mut Reader) -> Option<EmbeddedHeader> {
-        use EmbeddedHeader::{Icmp4, Icmp6, IpAuth, IpV6Ext, Ipv4, Ipv6, Tcp, Udp};
         match self {
-            Ipv4(ipv4) => ipv4
+            EmbeddedHeader::Ipv4(ipv4) => ipv4
                 .parse_embedded_payload(cursor)
                 .map(EmbeddedHeader::from),
-            Ipv6(ipv6) => ipv6
+            EmbeddedHeader::Ipv6(ipv6) => ipv6
                 .parse_embedded_payload(cursor)
                 .map(EmbeddedHeader::from),
-            IpAuth(auth) => auth
-                .parse_embedded_payload(cursor)
-                .map(EmbeddedHeader::from),
-            IpV6Ext(ext) => ext.parse_embedded_payload(cursor).map(EmbeddedHeader::from),
-            Tcp(_) | Udp(_) | Icmp4(_) | Icmp6(_) => None,
+            EmbeddedHeader::Ipv4Auth(auth) => auth.parse_embedded_payload(cursor),
+            EmbeddedHeader::Ipv6Auth(auth) => auth.parse_embedded_payload(cursor),
+            EmbeddedHeader::HopByHop(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::DestOpts(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Routing(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Fragment(h) => h.parse_embedded_payload(cursor),
+            EmbeddedHeader::Tcp(_)
+            | EmbeddedHeader::Udp(_)
+            | EmbeddedHeader::Icmp4(_)
+            | EmbeddedHeader::Icmp6(_) => None,
         }
     }
 }
@@ -466,8 +486,12 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Icmp4(TruncatedIcmp4),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext)
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 #[derive(Debug, thiserror::Error)]

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -12,9 +12,9 @@ use crate::icmp4::Icmp4;
 use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::{IpAuth, Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{Ipv6, Ipv6Ext};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Ipv6Ext, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
@@ -43,7 +43,7 @@ pub use embedded::*;
 pub mod builder;
 
 const MAX_VLANS: usize = 4;
-const MAX_NET_EXTENSIONS: usize = 2;
+const MAX_NET_EXTENSIONS: usize = 6;
 
 /// A parsed set of network packet headers.
 ///
@@ -162,8 +162,25 @@ impl DeParse for Net {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetExt {
+    // -- legacy variants (used by the current parser, will be removed) --
+    /// Untyped IP Authentication Header (legacy -- prefer [`Ipv4Auth`]/[`Ipv6Auth`]).
     IpAuth(IpAuth),
+    /// Monolithic IPv6 extension header chain (legacy -- prefer individual types).
     Ipv6Ext(Ipv6Ext),
+
+    // -- new individual extension header variants --
+    /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3).
+    HopByHop(HopByHop),
+    /// IPv6 Destination Options (RFC 8200 section 4.6).
+    DestOpts(DestOpts),
+    /// IPv6 Routing Header (RFC 8200 section 4.4).
+    Routing(Routing),
+    /// IPv6 Fragment Header (RFC 8200 section 4.5).
+    Fragment(Fragment),
+    /// IP Authentication Header in IPv4 context (RFC 4302).
+    Ipv4Auth(Ipv4Auth),
+    /// IP Authentication Header in IPv6 context (RFC 4302).
+    Ipv6Auth(Ipv6Auth),
 }
 
 impl DeParse for NetExt {
@@ -171,15 +188,27 @@ impl DeParse for NetExt {
 
     fn size(&self) -> NonZero<u16> {
         match self {
-            NetExt::IpAuth(auth) => auth.size(),
-            NetExt::Ipv6Ext(ext) => ext.size(),
+            NetExt::IpAuth(h) => h.size(),
+            NetExt::Ipv6Ext(h) => h.size(),
+            NetExt::HopByHop(h) => h.size(),
+            NetExt::DestOpts(h) => h.size(),
+            NetExt::Routing(h) => h.size(),
+            NetExt::Fragment(h) => h.size(),
+            NetExt::Ipv4Auth(h) => h.size(),
+            NetExt::Ipv6Auth(h) => h.size(),
         }
     }
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
         match self {
-            NetExt::IpAuth(auth) => auth.deparse(buf),
-            NetExt::Ipv6Ext(ext) => ext.deparse(buf),
+            NetExt::IpAuth(h) => h.deparse(buf),
+            NetExt::Ipv6Ext(h) => h.deparse(buf),
+            NetExt::HopByHop(h) => h.deparse(buf),
+            NetExt::DestOpts(h) => h.deparse(buf),
+            NetExt::Routing(h) => h.deparse(buf),
+            NetExt::Fragment(h) => h.deparse(buf),
+            NetExt::Ipv4Auth(h) => h.deparse(buf),
+            NetExt::Ipv6Auth(h) => h.deparse(buf),
         }
     }
 }
@@ -400,6 +429,7 @@ impl DeParse for Transport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Header {
     Eth(Eth),
     Vlan(Vlan),

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -43,7 +43,7 @@ pub use embedded::*;
 pub mod builder;
 
 const MAX_VLANS: usize = 4;
-const MAX_NET_EXTENSIONS: usize = 6;
+const MAX_NET_EXTENSIONS: usize = 3;
 
 /// A parsed set of network packet headers.
 ///
@@ -475,6 +475,17 @@ impl Parse for Headers {
             udp_encap: None,
             embedded_ip: None,
         };
+        // TODO: after parsing, validate RFC 8200 section 4.1 extension header
+        // ordering constraints (e.g. HopByHop must be first and appear at most
+        // once, DestOpts may appear at most twice, etc.).  The parser currently
+        // accepts any ordering from the wire.  A validate() method or post-parse
+        // check would catch malformed chains without rejecting packets outright.
+        //
+        // TODO: consider returning a parse error instead of silently stopping
+        // when MAX_NET_EXTENSIONS is exceeded.  The current `break` exits the
+        // entire parse loop, so transport and embedded headers that follow the
+        // overflow point are also not parsed.  This matches the MAX_VLANS
+        // handling but the caller has no way to detect a partial parse.
         let mut prior = Header::Eth(eth);
         loop {
             let header = prior.parse_payload(&mut cursor);

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -12,9 +12,9 @@ use crate::icmp4::Icmp4;
 use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
-use crate::ip_auth::{IpAuth, Ipv4Auth, Ipv6Auth};
+use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
 use crate::ipv4::Ipv4;
-use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Ipv6Ext, Routing};
+use crate::ipv6::{DestOpts, Fragment, HopByHop, Ipv6, Routing};
 use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
@@ -162,13 +162,6 @@ impl DeParse for Net {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetExt {
-    // -- legacy variants (used by the current parser, will be removed) --
-    /// Untyped IP Authentication Header (legacy -- prefer [`Ipv4Auth`]/[`Ipv6Auth`]).
-    IpAuth(IpAuth),
-    /// Monolithic IPv6 extension header chain (legacy -- prefer individual types).
-    Ipv6Ext(Ipv6Ext),
-
-    // -- new individual extension header variants --
     /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3).
     HopByHop(HopByHop),
     /// IPv6 Destination Options (RFC 8200 section 4.6).
@@ -188,8 +181,6 @@ impl DeParse for NetExt {
 
     fn size(&self) -> NonZero<u16> {
         match self {
-            NetExt::IpAuth(h) => h.size(),
-            NetExt::Ipv6Ext(h) => h.size(),
             NetExt::HopByHop(h) => h.size(),
             NetExt::DestOpts(h) => h.size(),
             NetExt::Routing(h) => h.size(),
@@ -201,8 +192,6 @@ impl DeParse for NetExt {
 
     fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
         match self {
-            NetExt::IpAuth(h) => h.deparse(buf),
-            NetExt::Ipv6Ext(h) => h.deparse(buf),
             NetExt::HopByHop(h) => h.deparse(buf),
             NetExt::DestOpts(h) => h.deparse(buf),
             NetExt::Routing(h) => h.deparse(buf),
@@ -439,28 +428,33 @@ pub enum Header {
     Udp(Udp),
     Icmp4(Icmp4),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext), // TODO: break out nested enum.  Nesting is counter productive here
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
     Encap(UdpEncap),
     EmbeddedIp(EmbeddedHeaders),
 }
 
 impl Header {
     fn parse_payload(&self, cursor: &mut Reader) -> Option<Header> {
-        use Header::{
-            EmbeddedIp, Encap, Eth, Icmp4, Icmp6, IpAuth, IpV6Ext, Ipv4, Ipv6, Tcp, Udp, Vlan,
-        };
         match self {
-            Eth(eth) => eth.parse_payload(cursor).map(Header::from),
-            Vlan(vlan) => vlan.parse_payload(cursor).map(Header::from),
-            Ipv4(ipv4) => ipv4.parse_payload(cursor).map(Header::from),
-            Ipv6(ipv6) => ipv6.parse_payload(cursor).map(Header::from),
-            IpAuth(auth) => auth.parse_payload(cursor).map(Header::from),
-            IpV6Ext(ext) => ext.parse_payload(cursor).map(Header::from),
-            Icmp4(icmp4) => icmp4.parse_payload(cursor).map(Header::from),
-            Icmp6(icmp6) => icmp6.parse_payload(cursor).map(Header::from),
-            Udp(udp) => udp.parse_payload(cursor).map(Header::from),
-            Encap(_) | Tcp(_) | EmbeddedIp(_) => None,
+            Header::Eth(eth) => eth.parse_payload(cursor).map(Header::from),
+            Header::Vlan(vlan) => vlan.parse_payload(cursor).map(Header::from),
+            Header::Ipv4(ipv4) => ipv4.parse_payload(cursor).map(Header::from),
+            Header::Ipv6(ipv6) => ipv6.parse_payload(cursor).map(Header::from),
+            Header::Ipv4Auth(auth) => auth.parse_payload(cursor),
+            Header::Ipv6Auth(auth) => auth.parse_payload(cursor),
+            Header::HopByHop(h) => h.parse_payload(cursor),
+            Header::DestOpts(h) => h.parse_payload(cursor),
+            Header::Routing(h) => h.parse_payload(cursor),
+            Header::Fragment(h) => h.parse_payload(cursor),
+            Header::Icmp4(icmp4) => icmp4.parse_payload(cursor).map(Header::from),
+            Header::Icmp6(icmp6) => icmp6.parse_payload(cursor).map(Header::from),
+            Header::Udp(udp) => udp.parse_payload(cursor).map(Header::from),
+            Header::Encap(_) | Header::Tcp(_) | Header::EmbeddedIp(_) => None,
         }
     }
 }
@@ -500,16 +494,44 @@ impl Parse for Headers {
                         break;
                     }
                 }
-                Header::IpAuth(auth) => {
+                Header::HopByHop(h) => {
                     if this.net_ext.len() < MAX_NET_EXTENSIONS {
-                        this.net_ext.push(NetExt::IpAuth(auth));
+                        this.net_ext.push(NetExt::HopByHop(h));
                     } else {
                         break;
                     }
                 }
-                Header::IpV6Ext(ext) => {
+                Header::DestOpts(h) => {
                     if this.net_ext.len() < MAX_NET_EXTENSIONS {
-                        this.net_ext.push(NetExt::Ipv6Ext(ext));
+                        this.net_ext.push(NetExt::DestOpts(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Routing(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Routing(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Fragment(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Fragment(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Ipv4Auth(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv4Auth(h));
+                    } else {
+                        break;
+                    }
+                }
+                Header::Ipv6Auth(h) => {
+                    if this.net_ext.len() < MAX_NET_EXTENSIONS {
+                        this.net_ext.push(NetExt::Ipv6Auth(h));
                     } else {
                         break;
                     }
@@ -942,8 +964,12 @@ impl_from_for_enum![
     Udp(Udp),
     Icmp4(Icmp4),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    IpV6Ext(Ipv6Ext),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
+    Ipv4Auth(Ipv4Auth),
+    Ipv6Auth(Ipv6Auth),
     Encap(UdpEncap),
     EmbeddedIp(EmbeddedHeaders),
 ];
@@ -1994,8 +2020,8 @@ mod test {
             "expected one IPv6 extension header"
         );
         assert!(
-            matches!(headers.net_ext[0], super::NetExt::Ipv6Ext(_)),
-            "expected Ipv6Ext variant in net_ext"
+            matches!(headers.net_ext[0], super::NetExt::HopByHop(_)),
+            "expected HopByHop variant in net_ext"
         );
 
         // IPv6 and TCP should be present.

--- a/net/src/ip/mod.rs
+++ b/net/src/ip/mod.rs
@@ -45,6 +45,21 @@ impl NextHeader {
     /// ICMP6 next header
     pub const ICMP6: NextHeader = NextHeader(IpNumber::IPV6_ICMP);
 
+    /// IPv6 Hop-by-Hop Options (RFC 8200 section 4.3)
+    pub const HOP_BY_HOP: NextHeader = NextHeader(IpNumber::IPV6_HEADER_HOP_BY_HOP);
+
+    /// IPv6 Routing Header (RFC 8200 section 4.4)
+    pub const ROUTING: NextHeader = NextHeader(IpNumber::IPV6_ROUTE_HEADER);
+
+    /// IPv6 Fragment Header (RFC 8200 section 4.5)
+    pub const FRAGMENT: NextHeader = NextHeader(IpNumber::IPV6_FRAGMENTATION_HEADER);
+
+    /// IPv6 Destination Options (RFC 8200 section 4.6)
+    pub const DEST_OPTS: NextHeader = NextHeader(IpNumber::IPV6_DESTINATION_OPTIONS);
+
+    /// IP Authentication Header (RFC 4302)
+    pub const AUTH: NextHeader = NextHeader(IpNumber::AUTHENTICATION_HEADER);
+
     /// Generate a new [`NextHeader`]
     #[must_use]
     pub fn new(inner: u8) -> Self {

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -3,6 +3,12 @@
 
 //! IP authentication header type and logic.
 
+pub mod v4;
+pub mod v6;
+
+pub use v4::Ipv4Auth;
+pub use v6::Ipv6Auth;
+
 use crate::headers::{EmbeddedHeader, Header};
 use crate::icmp4::Icmp4;
 use crate::icmp6::Icmp6;

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -14,7 +14,7 @@ use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, 
 use etherparse::IpAuthHeader;
 use std::num::NonZero;
 
-/// An Ip authentication header.
+/// An IP authentication header.
 ///
 /// This may appear in IPv4 and IPv6 headers.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,8 +90,11 @@ mod contract {
     use bolero::{Driver, TypeGenerator};
     use etherparse::{IpAuthHeader, IpNumber};
 
-    /// Valid ICV lengths (multiples of 4, capped to keep fuzz inputs small).
-    const VALID_ICV_LENS: [usize; 4] = [0, 4, 8, 12];
+    /// Valid ICV lengths (multiples of 4).
+    ///
+    /// Includes the boundaries: 0 (minimum), small values for fast fuzzing,
+    /// and `MAX_ICV_LEN` (1016) to cover the upper limit.
+    const VALID_ICV_LENS: [usize; 5] = [0, 4, 8, 12, IpAuthHeader::MAX_ICV_LEN];
 
     impl TypeGenerator for IpAuth {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -13,6 +13,7 @@ use crate::headers::{EmbeddedHeader, Header};
 use crate::icmp4::Icmp4;
 use crate::icmp6::Icmp6;
 use crate::impl_from_for_enum;
+use crate::ip::NextHeader;
 use crate::parse::{
     DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
 };
@@ -28,7 +29,24 @@ use tracing::{debug, trace};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IpAuth(Box<IpAuthHeader>);
 
+impl From<Box<IpAuthHeader>> for IpAuth {
+    fn from(inner: Box<IpAuthHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl IpAuth {
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
     /// Parse the payload of the IP authentication header.
     ///
     /// # Returns

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -188,3 +188,34 @@ impl From<EmbeddedIpAuthNext> for EmbeddedHeader {
         }
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::IpAuth;
+    use bolero::{Driver, TypeGenerator};
+    use etherparse::{IpAuthHeader, IpNumber};
+
+    /// Valid ICV lengths (multiples of 4, capped to keep fuzz inputs small).
+    const VALID_ICV_LENS: [usize; 4] = [0, 4, 8, 12];
+
+    impl TypeGenerator for IpAuth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let next_header: u8 = driver.produce()?;
+            let spi: u32 = driver.produce()?;
+            let sequence_number: u32 = driver.produce()?;
+            let idx = driver.gen_usize(
+                std::ops::Bound::Included(&0),
+                std::ops::Bound::Excluded(&VALID_ICV_LENS.len()),
+            )?;
+            let icv_len = VALID_ICV_LENS[idx];
+            let mut icv = vec![0u8; icv_len];
+            for byte in &mut icv {
+                *byte = driver.produce()?;
+            }
+            #[allow(clippy::unwrap_used)] // lengths are valid by construction
+            let header =
+                IpAuthHeader::new(IpNumber(next_header), spi, sequence_number, &icv).unwrap();
+            Some(IpAuth::from(Box::new(header)))
+        }
+    }
+}

--- a/net/src/ip_auth/mod.rs
+++ b/net/src/ip_auth/mod.rs
@@ -9,19 +9,10 @@ pub mod v6;
 pub use v4::Ipv4Auth;
 pub use v6::Ipv6Auth;
 
-use crate::headers::{EmbeddedHeader, Header};
-use crate::icmp4::Icmp4;
-use crate::icmp6::Icmp6;
-use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
-use crate::parse::{
-    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
-};
-use crate::tcp::{Tcp, TruncatedTcp};
-use crate::udp::{TruncatedUdp, Udp};
-use etherparse::{IpAuthHeader, IpNumber};
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::IpAuthHeader;
 use std::num::NonZero;
-use tracing::{debug, trace};
 
 /// An Ip authentication header.
 ///
@@ -45,50 +36,6 @@ impl IpAuth {
     /// Set the next-header protocol number.
     pub fn set_next_header(&mut self, nh: NextHeader) {
         self.0.next_header = nh.into();
-    }
-
-    /// Parse the payload of the IP authentication header.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(IpAuthNext)`: the parsed next header, if supported.
-    /// * `None`: if parsing the next header is not supported.
-    pub(crate) fn parse_payload(&self, cursor: &mut Reader) -> Option<IpAuthNext> {
-        match self.0.next_header {
-            IpNumber::TCP => cursor.parse_header::<Tcp, IpAuthNext>(),
-            IpNumber::UDP => cursor.parse_header::<Udp, IpAuthNext>(),
-            IpNumber::ICMP => cursor.parse_header::<Icmp4, IpAuthNext>(),
-            IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, IpAuthNext>(),
-            IpNumber::AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, IpAuthNext>()
-            }
-            _ => {
-                trace!("unsupported protocol: {:?}", self.0.next_header);
-                None
-            }
-        }
-    }
-
-    /// Parse the payload of the IP authentication header embedded in an ICMP Error message.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(EmbeddedIpAuthNext)`: the parsed next header, if supported.
-    /// * `None`: if parsing the next header is not supported.
-    pub(crate) fn parse_embedded_payload(&self, cursor: &mut Reader) -> Option<EmbeddedIpAuthNext> {
-        match self.0.next_header {
-            IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpAuthNext>(),
-            IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpAuthNext>(),
-            IpNumber::AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, EmbeddedIpAuthNext>()
-            }
-            _ => {
-                trace!("unsupported protocol: {:?}", self.0.next_header);
-                None
-            }
-        }
     }
 }
 
@@ -134,58 +81,6 @@ impl DeParse for IpAuth {
         let bytes = self.0.to_bytes();
         buf[..bytes.len()].copy_from_slice(&bytes);
         Ok(self.size())
-    }
-}
-
-pub(crate) enum IpAuthNext {
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp4(Icmp4),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-}
-
-impl_from_for_enum![
-    IpAuthNext,
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp4(Icmp4),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth)
-];
-
-impl From<IpAuthNext> for Header {
-    fn from(value: IpAuthNext) -> Self {
-        match value {
-            IpAuthNext::Tcp(x) => Header::Tcp(x),
-            IpAuthNext::Udp(x) => Header::Udp(x),
-            IpAuthNext::Icmp4(x) => Header::Icmp4(x),
-            IpAuthNext::Icmp6(x) => Header::Icmp6(x),
-            IpAuthNext::IpAuth(x) => Header::IpAuth(x),
-        }
-    }
-}
-
-pub(crate) enum EmbeddedIpAuthNext {
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    IpAuth(IpAuth),
-}
-
-impl_from_for_enum![
-    EmbeddedIpAuthNext,
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    IpAuth(IpAuth)
-];
-
-impl From<EmbeddedIpAuthNext> for EmbeddedHeader {
-    fn from(value: EmbeddedIpAuthNext) -> Self {
-        match value {
-            EmbeddedIpAuthNext::Tcp(x) => EmbeddedHeader::Tcp(x),
-            EmbeddedIpAuthNext::Udp(x) => EmbeddedHeader::Udp(x),
-            EmbeddedIpAuthNext::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-        }
     }
 }
 

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -37,6 +37,54 @@ impl Ipv4Auth {
     pub fn into_inner(self) -> IpAuth {
         self.0
     }
+
+    /// Parse the next header after this one (IPv4 context).
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        use crate::headers::Header;
+        use crate::icmp4::Icmp4;
+        use crate::parse::ParseHeader;
+        use crate::tcp::Tcp;
+        use crate::udp::Udp;
+        use etherparse::IpNumber;
+        use tracing::trace;
+
+        match self.next_header().into() {
+            IpNumber::TCP => cursor.parse_header::<Tcp, Header>(),
+            IpNumber::UDP => cursor.parse_header::<Udp, Header>(),
+            IpNumber::ICMP => cursor.parse_header::<Icmp4, Header>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, Header>(),
+            _ => {
+                trace!("unsupported protocol: {:?}", self.next_header());
+                None
+            }
+        }
+    }
+
+    /// Parse the next header in an ICMP-embedded context (IPv4).
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        use crate::headers::EmbeddedHeader;
+        use crate::parse::ParseHeader;
+        use crate::tcp::TruncatedTcp;
+        use crate::udp::TruncatedUdp;
+        use etherparse::IpNumber;
+        use tracing::trace;
+
+        match self.next_header().into() {
+            IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
+            IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedHeader>(),
+            _ => {
+                trace!("unsupported protocol: {:?}", self.next_header());
+                None
+            }
+        }
+    }
 }
 
 impl Deref for Ipv4Auth {

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -85,3 +85,15 @@ impl DeParse for Ipv4Auth {
         self.0.deparse(buf)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Ipv4Auth;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Ipv4Auth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Ipv4Auth::new(driver.produce()?))
+        }
+    }
+}

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv4-context IP Authentication Header.
+//!
+//! This is a [`repr(transparent)`] newtype over [`IpAuth`] that marks the
+//! header as appearing in an IPv4 extension chain.  The builder uses this
+//! type to restrict `Within` impls so that `Ipv4Auth` can only follow
+//! IPv4-legal parents (e.g. `Ipv4`), preventing it from being stacked
+//! after IPv6-only extension headers like `HopByHop`.
+
+use crate::ip_auth::IpAuth;
+use crate::parse::{DeParse, DeParseError, Parse, ParseError};
+use std::num::NonZero;
+use std::ops::Deref;
+
+/// IP Authentication Header in an IPv4 context ([RFC 4302]).
+///
+/// Structurally identical to [`IpAuth`] on the wire -- the type distinction
+/// exists purely to give the builder different `Within` bounds for IPv4
+/// vs IPv6 extension header chains.
+///
+/// [RFC 4302]: https://datatracker.ietf.org/doc/html/rfc4302
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv4Auth(IpAuth);
+
+impl Ipv4Auth {
+    /// Wrap an [`IpAuth`] as an IPv4-context authentication header.
+    #[must_use]
+    pub fn new(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+
+    /// Unwrap into the inner [`IpAuth`].
+    #[must_use]
+    pub fn into_inner(self) -> IpAuth {
+        self.0
+    }
+}
+
+impl Deref for Ipv4Auth {
+    type Target = IpAuth;
+
+    fn deref(&self) -> &IpAuth {
+        &self.0
+    }
+}
+
+impl From<IpAuth> for Ipv4Auth {
+    fn from(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+}
+
+impl From<Ipv4Auth> for IpAuth {
+    fn from(outer: Ipv4Auth) -> Self {
+        outer.0
+    }
+}
+
+impl Parse for Ipv4Auth {
+    type Error = <IpAuth as Parse>::Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let (inner, consumed) = IpAuth::parse(buf)?;
+        Ok((Self(inner), consumed))
+    }
+}
+
+impl DeParse for Ipv4Auth {
+    type Error = <IpAuth as DeParse>::Error;
+
+    fn size(&self) -> NonZero<u16> {
+        self.0.size()
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        self.0.deparse(buf)
+    }
+}

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -12,7 +12,7 @@
 use crate::ip_auth::IpAuth;
 use crate::parse::{DeParse, DeParseError, Parse, ParseError};
 use std::num::NonZero;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// IP Authentication Header in an IPv4 context ([RFC 4302]).
 ///
@@ -44,6 +44,12 @@ impl Deref for Ipv4Auth {
 
     fn deref(&self) -> &IpAuth {
         &self.0
+    }
+}
+
+impl DerefMut for Ipv4Auth {
+    fn deref_mut(&mut self) -> &mut IpAuth {
+        &mut self.0
     }
 }
 

--- a/net/src/ip_auth/v4.rs
+++ b/net/src/ip_auth/v4.rs
@@ -69,6 +69,7 @@ impl Ipv4Auth {
         cursor: &mut crate::parse::Reader,
     ) -> Option<crate::headers::EmbeddedHeader> {
         use crate::headers::EmbeddedHeader;
+        use crate::icmp4::TruncatedIcmp4;
         use crate::parse::ParseHeader;
         use crate::tcp::TruncatedTcp;
         use crate::udp::TruncatedUdp;
@@ -78,6 +79,7 @@ impl Ipv4Auth {
         match self.next_header().into() {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+            IpNumber::ICMP => cursor.parse_header::<TruncatedIcmp4, EmbeddedHeader>(),
             IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedHeader>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.next_header());

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -11,7 +11,7 @@
 use crate::ip_auth::IpAuth;
 use crate::parse::{DeParse, DeParseError, Parse, ParseError};
 use std::num::NonZero;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// IP Authentication Header in an IPv6 context ([RFC 4302]).
 ///
@@ -43,6 +43,12 @@ impl Deref for Ipv6Auth {
 
     fn deref(&self) -> &IpAuth {
         &self.0
+    }
+}
+
+impl DerefMut for Ipv6Auth {
+    fn deref_mut(&mut self) -> &mut IpAuth {
+        &mut self.0
     }
 }
 

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6-context IP Authentication Header.
+//!
+//! This is a [`repr(transparent)`] newtype over [`IpAuth`] that marks the
+//! header as appearing in an IPv6 extension chain.  The builder uses this
+//! type to restrict `Within` impls so that `Ipv6Auth` can only follow
+//! IPv6-legal parents (e.g. `Ipv6`, `Fragment`, `Routing`).
+
+use crate::ip_auth::IpAuth;
+use crate::parse::{DeParse, DeParseError, Parse, ParseError};
+use std::num::NonZero;
+use std::ops::Deref;
+
+/// IP Authentication Header in an IPv6 context ([RFC 4302]).
+///
+/// Structurally identical to [`IpAuth`] on the wire -- the type distinction
+/// exists purely to give the builder different `Within` bounds for IPv4
+/// vs IPv6 extension header chains.
+///
+/// [RFC 4302]: https://datatracker.ietf.org/doc/html/rfc4302
+#[repr(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv6Auth(IpAuth);
+
+impl Ipv6Auth {
+    /// Wrap an [`IpAuth`] as an IPv6-context authentication header.
+    #[must_use]
+    pub fn new(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+
+    /// Unwrap into the inner [`IpAuth`].
+    #[must_use]
+    pub fn into_inner(self) -> IpAuth {
+        self.0
+    }
+}
+
+impl Deref for Ipv6Auth {
+    type Target = IpAuth;
+
+    fn deref(&self) -> &IpAuth {
+        &self.0
+    }
+}
+
+impl From<IpAuth> for Ipv6Auth {
+    fn from(inner: IpAuth) -> Self {
+        Self(inner)
+    }
+}
+
+impl From<Ipv6Auth> for IpAuth {
+    fn from(outer: Ipv6Auth) -> Self {
+        outer.0
+    }
+}
+
+impl Parse for Ipv6Auth {
+    type Error = <IpAuth as Parse>::Error;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        let (inner, consumed) = IpAuth::parse(buf)?;
+        Ok((Self(inner), consumed))
+    }
+}
+
+impl DeParse for Ipv6Auth {
+    type Error = <IpAuth as DeParse>::Error;
+
+    fn size(&self) -> NonZero<u16> {
+        self.0.size()
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        self.0.deparse(buf)
+    }
+}

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -36,6 +36,22 @@ impl Ipv6Auth {
     pub fn into_inner(self) -> IpAuth {
         self.0
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        crate::ipv6::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        crate::ipv6::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl Deref for Ipv6Auth {

--- a/net/src/ip_auth/v6.rs
+++ b/net/src/ip_auth/v6.rs
@@ -84,3 +84,15 @@ impl DeParse for Ipv6Auth {
         self.0.deparse(buf)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Ipv6Auth;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Ipv6Auth {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Ipv6Auth::new(driver.produce()?))
+        }
+    }
+}

--- a/net/src/ipv4/mod.rs
+++ b/net/src/ipv4/mod.rs
@@ -9,7 +9,7 @@ use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
 use crate::ip::dscp::Dscp;
 use crate::ip::ecn::Ecn;
-use crate::ip_auth::IpAuth;
+use crate::ip_auth::Ipv4Auth;
 pub use crate::ipv4::addr::UnicastIpv4Addr;
 use crate::ipv4::frag_offset::FragOffset;
 use crate::parse::{
@@ -303,7 +303,7 @@ impl Ipv4 {
             IpNumber::TCP => cursor.parse_header::<Tcp, Ipv4Next>(),
             IpNumber::UDP => cursor.parse_header::<Udp, Ipv4Next>(),
             IpNumber::ICMP => cursor.parse_header::<Icmp4, Ipv4Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, Ipv4Next>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, Ipv4Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.protocol);
                 None
@@ -322,7 +322,7 @@ impl Ipv4 {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv4Next>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv4Next>(),
             IpNumber::ICMP => cursor.parse_header::<TruncatedIcmp4, EmbeddedIpv4Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, EmbeddedIpv4Next>(),
+            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv4Auth, EmbeddedIpv4Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.protocol);
                 None
@@ -400,10 +400,16 @@ pub(crate) enum Ipv4Next {
     Tcp(Tcp),
     Udp(Udp),
     Icmp4(Icmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 }
 
-impl_from_for_enum![Ipv4Next, Tcp(Tcp), Udp(Udp), Icmp4(Icmp4), IpAuth(IpAuth)];
+impl_from_for_enum![
+    Ipv4Next,
+    Tcp(Tcp),
+    Udp(Udp),
+    Icmp4(Icmp4),
+    Ipv4Auth(Ipv4Auth)
+];
 
 impl From<Ipv4Next> for Header {
     fn from(value: Ipv4Next) -> Self {
@@ -411,7 +417,7 @@ impl From<Ipv4Next> for Header {
             Ipv4Next::Tcp(x) => Header::Tcp(x),
             Ipv4Next::Udp(x) => Header::Udp(x),
             Ipv4Next::Icmp4(x) => Header::Icmp4(x),
-            Ipv4Next::IpAuth(x) => Header::IpAuth(x),
+            Ipv4Next::Ipv4Auth(x) => Header::Ipv4Auth(x),
         }
     }
 }
@@ -420,7 +426,7 @@ pub(crate) enum EmbeddedIpv4Next {
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 }
 
 impl_from_for_enum![
@@ -428,7 +434,7 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp4(TruncatedIcmp4),
-    IpAuth(IpAuth),
+    Ipv4Auth(Ipv4Auth),
 ];
 
 impl From<EmbeddedIpv4Next> for EmbeddedHeader {
@@ -437,7 +443,7 @@ impl From<EmbeddedIpv4Next> for EmbeddedHeader {
             EmbeddedIpv4Next::Tcp(x) => EmbeddedHeader::Tcp(x),
             EmbeddedIpv4Next::Udp(x) => EmbeddedHeader::Udp(x),
             EmbeddedIpv4Next::Icmp4(x) => EmbeddedHeader::Icmp4(x),
-            EmbeddedIpv4Next::IpAuth(x) => EmbeddedHeader::IpAuth(x),
+            EmbeddedIpv4Next::Ipv4Auth(x) => EmbeddedHeader::Ipv4Auth(x),
         }
     }
 }

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -52,6 +52,12 @@ impl DestOpts {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for DestOpts {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for DestOpts {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Destination Options header ([RFC 8200 section 4.6]).
+//!
+//! Destination Options carry optional information examined only by the
+//! packet's destination node(s).  Per [RFC 8200 section 4.1], Destination Options
+//! may appear in **two** positions:
+//!
+//! 1. Before the Routing header -- examined by the first destination plus
+//!    subsequent destinations listed in the Routing header.
+//! 2. After the Routing / Fragment / AH headers -- examined only by the
+//!    final destination.
+//!
+//! Both positions use the same wire format and the same [`DestOpts`] type.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
+//! [RFC 8200 section 4.6]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.6
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Destination Options header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestOpts(Box<Ipv6RawExtHeader>);
+
+impl DestOpts {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw TLV payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for DestOpts {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for DestOpts {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -68,14 +68,23 @@ impl DestOpts {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for DestOpts {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl DestOpts {
+    /// Wrap a raw extension header as a `DestOpts`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 60 (`IPV6_DESTINATION_OPTIONS`),
+    /// confirming these bytes are a Destination Options header and not
+    /// some other extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for DestOpts {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -87,7 +96,12 @@ impl Parse for DestOpts {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -130,7 +144,9 @@ mod contract {
 
     impl TypeGenerator for DestOpts {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(DestOpts::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: we are declaring the generated raw header to be DestOpts.
+            Some(unsafe { DestOpts::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -50,6 +50,22 @@ impl DestOpts {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for DestOpts {

--- a/net/src/ipv6/dest_opts.rs
+++ b/net/src/ipv6/dest_opts.rs
@@ -105,3 +105,34 @@ impl DeParse for DestOpts {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::DestOpts;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for DestOpts {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(DestOpts::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DestOpts;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &DestOpts| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                DestOpts::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/ext_parse.rs
+++ b/net/src/ipv6/ext_parse.rs
@@ -5,7 +5,7 @@
 //!
 //! Every extension header carries a `next_header` field that identifies
 //! the type following it.  The dispatch logic is the same for all of
-//! `HopByHop`, `DestOpts`, Routing, Fragment, and `Ipv6Auth`.
+//! `HopByHop`, `DestOpts`, `Routing`, `Fragment`, and `Ipv6Auth`.
 
 use crate::headers::Header;
 use crate::icmp6::Icmp6;

--- a/net/src/ipv6/ext_parse.rs
+++ b/net/src/ipv6/ext_parse.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Shared parsing dispatch for IPv6 extension header payloads.
+//!
+//! Every extension header carries a `next_header` field that identifies
+//! the type following it.  The dispatch logic is the same for all of
+//! `HopByHop`, `DestOpts`, Routing, Fragment, and `Ipv6Auth`.
+
+use crate::headers::Header;
+use crate::icmp6::Icmp6;
+use crate::ip::NextHeader;
+use crate::ip_auth::Ipv6Auth;
+use crate::ipv6::dest_opts::DestOpts;
+use crate::ipv6::fragment::Fragment;
+use crate::ipv6::hop_by_hop::HopByHop;
+use crate::ipv6::routing::Routing;
+use crate::parse::{ParseHeader, Reader};
+use crate::tcp::Tcp;
+use crate::udp::Udp;
+use etherparse::IpNumber;
+use tracing::trace;
+
+/// Dispatch the next header after an IPv6 extension header.
+///
+/// This is called by the `parse_payload` method on each extension header
+/// type.  The `nh` parameter is the extension header's `next_header` field.
+pub(crate) fn parse_ext_payload(nh: NextHeader, cursor: &mut Reader) -> Option<Header> {
+    match nh.into() {
+        IpNumber::TCP => cursor.parse_header::<Tcp, Header>(),
+        IpNumber::UDP => cursor.parse_header::<Udp, Header>(),
+        IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, Header>(),
+        IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv6Auth, Header>(),
+        IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, Header>(),
+        IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, Header>(),
+        IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, Header>(),
+        IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, Header>(),
+        _ => {
+            trace!("unsupported protocol: {:?}", nh);
+            None
+        }
+    }
+}
+
+/// Embedded-payload variant for ICMP error messages.
+pub(crate) fn parse_ext_embedded_payload(
+    nh: NextHeader,
+    cursor: &mut Reader,
+) -> Option<crate::headers::EmbeddedHeader> {
+    use crate::headers::EmbeddedHeader;
+    use crate::icmp6::TruncatedIcmp6;
+    use crate::tcp::TruncatedTcp;
+    use crate::udp::TruncatedUdp;
+
+    match nh.into() {
+        IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedHeader>(),
+        IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedHeader>(),
+        IpNumber::IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedHeader>(),
+        IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<Ipv6Auth, EmbeddedHeader>(),
+        IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, EmbeddedHeader>(),
+        IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, EmbeddedHeader>(),
+        IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, EmbeddedHeader>(),
+        IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, EmbeddedHeader>(),
+        _ => {
+            trace!("unsupported protocol: {:?}", nh);
+            None
+        }
+    }
+}

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -119,3 +119,49 @@ impl DeParse for Fragment {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Fragment;
+    use bolero::{Driver, TypeGenerator};
+    use etherparse::{IpFragOffset, IpNumber, Ipv6FragmentHeader};
+
+    impl TypeGenerator for Fragment {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let next_header: u8 = driver.produce()?;
+            let offset_raw: u16 = driver.gen_u16(
+                std::ops::Bound::Included(&0),
+                std::ops::Bound::Included(&IpFragOffset::MAX_U16),
+            )?;
+            #[allow(unsafe_code)]
+            // SAFETY: offset_raw is bounded to <= MAX_U16 by gen_u16 above.
+            let offset = unsafe { IpFragOffset::new_unchecked(offset_raw) };
+            let more_fragments: bool = driver.produce()?;
+            let identification: u32 = driver.produce()?;
+            Some(Fragment::from(Ipv6FragmentHeader::new(
+                IpNumber(next_header),
+                offset,
+                more_fragments,
+                identification,
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Fragment;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &Fragment| {
+            let mut buf = [0u8; 8];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                Fragment::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -84,14 +84,22 @@ impl Fragment {
     }
 }
 
-impl From<Ipv6FragmentHeader> for Fragment {
-    fn from(inner: Ipv6FragmentHeader) -> Self {
+impl Fragment {
+    /// Wrap a fragment header as a `Fragment`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 44 (`IPV6_FRAGMENTATION_HEADER`),
+    /// confirming these bytes are a Fragment header.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Ipv6FragmentHeader) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for Fragment {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -103,7 +111,12 @@ impl Parse for Fragment {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -154,12 +167,16 @@ mod contract {
             let offset = unsafe { IpFragOffset::new_unchecked(offset_raw) };
             let more_fragments: bool = driver.produce()?;
             let identification: u32 = driver.produce()?;
-            Some(Fragment::from(Ipv6FragmentHeader::new(
-                IpNumber(next_header),
-                offset,
-                more_fragments,
-                identification,
-            )))
+            #[allow(unsafe_code)]
+            // SAFETY: we are constructing this as a Fragment by definition.
+            Some(unsafe {
+                Fragment::from_raw_unchecked(Ipv6FragmentHeader::new(
+                    IpNumber(next_header),
+                    offset,
+                    more_fragments,
+                    identification,
+                ))
+            })
         }
     }
 }

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -66,6 +66,22 @@ impl Fragment {
     pub fn is_fragmenting_payload(&self) -> bool {
         self.0.is_fragmenting_payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Ipv6FragmentHeader> for Fragment {

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -68,6 +68,12 @@ impl Fragment {
     }
 }
 
+impl From<Ipv6FragmentHeader> for Fragment {
+    fn from(inner: Ipv6FragmentHeader) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for Fragment {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/fragment.rs
+++ b/net/src/ipv6/fragment.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Fragment header ([RFC 8200 section 4.5]).
+//!
+//! The Fragment header is used by an IPv6 source to send a packet larger
+//! than would fit in the path MTU.  Unlike the other extension headers,
+//! the Fragment header has a fixed 8-byte wire format and is small enough
+//! to store inline (no boxing required).
+//!
+//! [RFC 8200 section 4.5]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.5
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6FragmentHeader;
+use std::num::NonZero;
+
+/// IPv6 Fragment header.
+///
+/// Wraps an [`Ipv6FragmentHeader`] from etherparse.  At 8 bytes this is
+/// small enough to store inline -- no heap allocation needed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fragment(Ipv6FragmentHeader);
+
+impl Fragment {
+    /// The fixed header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const LEN: NonZero<u16> = NonZero::new(Ipv6FragmentHeader::LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The 13-bit fragment offset in 8-octet units.
+    #[must_use]
+    pub fn fragment_offset(&self) -> etherparse::IpFragOffset {
+        self.0.fragment_offset
+    }
+
+    /// Whether more fragments follow this one.
+    #[must_use]
+    pub fn more_fragments(&self) -> bool {
+        self.0.more_fragments
+    }
+
+    /// The identification value for fragment reassembly.
+    #[must_use]
+    pub fn identification(&self) -> u32 {
+        self.0.identification
+    }
+
+    /// Returns `true` if this fragment header actually fragments the payload.
+    ///
+    /// A fragment header with offset 0 and `more_fragments == false` does not
+    /// fragment -- it represents a whole datagram (see [RFC 6946]).
+    ///
+    /// [RFC 6946]: https://datatracker.ietf.org/doc/html/rfc6946
+    #[must_use]
+    pub fn is_fragmenting_payload(&self) -> bool {
+        self.0.is_fragmenting_payload()
+    }
+}
+
+impl Parse for Fragment {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6FragmentHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(inner), consumed?))
+    }
+}
+
+impl DeParse for Fragment {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        Self::LEN
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        buf[..size.get() as usize].copy_from_slice(&self.0.to_bytes());
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -62,14 +62,23 @@ impl HopByHop {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for HopByHop {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl HopByHop {
+    /// Wrap a raw extension header as a `HopByHop`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 0 (`IPV6_HEADER_HOP_BY_HOP`),
+    /// confirming these bytes are a Hop-by-Hop Options header and not
+    /// some other extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for HopByHop {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -81,7 +90,12 @@ impl Parse for HopByHop {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -124,7 +138,10 @@ mod contract {
 
     impl TypeGenerator for HopByHop {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(HopByHop::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: gen_raw_ext_header produces a valid raw header and we are
+            // declaring it to be a HopByHop, which is the type we're generating.
+            Some(unsafe { HopByHop::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -44,6 +44,22 @@ impl HopByHop {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for HopByHop {

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -46,6 +46,12 @@ impl HopByHop {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for HopByHop {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for HopByHop {
     type Error = etherparse::err::LenError;
 

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Hop-by-Hop Options header ([RFC 8200 section 4.3]).
+//!
+//! The Hop-by-Hop Options header carries optional information that **must** be
+//! examined by every node along a packet's delivery path.  Per [RFC 8200 section 4.1],
+//! it **must** immediately follow the IPv6 header when present -- the builder
+//! enforces this via [`Within`] bounds.
+//!
+//! [RFC 8200 section 4.1]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.1
+//! [RFC 8200 section 4.3]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.3
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Hop-by-Hop Options header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HopByHop(Box<Ipv6RawExtHeader>);
+
+impl HopByHop {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw TLV payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for HopByHop {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for HopByHop {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/hop_by_hop.rs
+++ b/net/src/ipv6/hop_by_hop.rs
@@ -99,3 +99,34 @@ impl DeParse for HopByHop {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::HopByHop;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for HopByHop {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(HopByHop::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HopByHop;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &HopByHop| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                HopByHop::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -9,23 +9,21 @@ use crate::impl_from_for_enum;
 use crate::ip::NextHeader;
 use crate::ip::dscp::Dscp;
 use crate::ip::ecn::Ecn;
-use crate::ip_auth::IpAuth;
 pub use crate::ipv6::addr::UnicastIpv6Addr;
 use crate::ipv6::flow_label::FlowLabel;
 use crate::parse::{
-    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader,
-    ParseWith, Reader,
+    DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError, ParseHeader, Reader,
 };
 use crate::tcp::{Tcp, TruncatedTcp};
 use crate::udp::{TruncatedUdp, Udp};
-use etherparse::{IpDscp, IpEcn, IpNumber, Ipv6Extensions, Ipv6Header};
-use std::io::Cursor;
+use etherparse::{IpDscp, IpEcn, IpNumber, Ipv6Header};
 use std::net::Ipv6Addr;
 use std::num::NonZero;
-use tracing::{debug, trace};
+use tracing::trace;
 
 pub mod addr;
 pub mod dest_opts;
+pub(crate) mod ext_parse;
 pub mod flow_label;
 pub mod fragment;
 pub mod hop_by_hop;
@@ -245,13 +243,13 @@ impl Ipv6 {
             IpNumber::TCP => cursor.parse_header::<Tcp, Ipv6Next>(),
             IpNumber::UDP => cursor.parse_header::<Udp, Ipv6Next>(),
             IpNumber::IPV6_ICMP => cursor.parse_header::<Icmp6, Ipv6Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, Ipv6Next>(),
-            IpNumber::IPV6_HEADER_HOP_BY_HOP
-            | IpNumber::IPV6_ROUTE_HEADER
-            | IpNumber::IPV6_FRAGMENTATION_HEADER
-            | IpNumber::IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, Ipv6Next>(self.0.next_header)
+            IpNumber::AUTHENTICATION_HEADER => {
+                cursor.parse_header::<crate::ip_auth::Ipv6Auth, Ipv6Next>()
             }
+            IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, Ipv6Next>(),
+            IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, Ipv6Next>(),
+            IpNumber::IPV6_FRAGMENTATION_HEADER => cursor.parse_header::<Fragment, Ipv6Next>(),
+            IpNumber::IPV6_DESTINATION_OPTIONS => cursor.parse_header::<DestOpts, Ipv6Next>(),
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.next_header);
                 None
@@ -270,12 +268,16 @@ impl Ipv6 {
             IpNumber::TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv6Next>(),
             IpNumber::UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv6Next>(),
             IpNumber::IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedIpv6Next>(),
-            IpNumber::AUTHENTICATION_HEADER => cursor.parse_header::<IpAuth, EmbeddedIpv6Next>(),
-            IpNumber::IPV6_HEADER_HOP_BY_HOP
-            | IpNumber::IPV6_ROUTE_HEADER
-            | IpNumber::IPV6_FRAGMENTATION_HEADER
-            | IpNumber::IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, EmbeddedIpv6Next>(self.0.next_header)
+            IpNumber::AUTHENTICATION_HEADER => {
+                cursor.parse_header::<crate::ip_auth::Ipv6Auth, EmbeddedIpv6Next>()
+            }
+            IpNumber::IPV6_HEADER_HOP_BY_HOP => cursor.parse_header::<HopByHop, EmbeddedIpv6Next>(),
+            IpNumber::IPV6_ROUTE_HEADER => cursor.parse_header::<Routing, EmbeddedIpv6Next>(),
+            IpNumber::IPV6_FRAGMENTATION_HEADER => {
+                cursor.parse_header::<Fragment, EmbeddedIpv6Next>()
+            }
+            IpNumber::IPV6_DESTINATION_OPTIONS => {
+                cursor.parse_header::<DestOpts, EmbeddedIpv6Next>()
             }
             _ => {
                 trace!("unsupported protocol: {:?}", self.0.next_header);
@@ -357,8 +359,11 @@ pub(crate) enum Ipv6Next {
     Tcp(Tcp),
     Udp(Udp),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl_from_for_enum![
@@ -366,16 +371,22 @@ impl_from_for_enum![
     Tcp(Tcp),
     Udp(Udp),
     Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 pub(crate) enum EmbeddedIpv6Next {
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment),
 }
 
 impl_from_for_enum![
@@ -383,175 +394,11 @@ impl_from_for_enum![
     Tcp(TruncatedTcp),
     Udp(TruncatedUdp),
     Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
-];
-
-/// An IPv6 extension header.
-///
-/// TODO: break this into multiple types (one per each header type).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Ipv6Ext {
-    inner: Box<Ipv6Extensions>,
-    /// The IP protocol number that introduced the first extension header in
-    /// this chain (i.e. the `next_header` value from the IPv6 base header or
-    /// a preceding extension).  Needed by [`Ipv6Extensions::write`] during
-    /// serialization.
-    first_ip_number: IpNumber,
-}
-
-impl ParseWith for Ipv6Ext {
-    type Error = etherparse::err::ipv6_exts::HeaderSliceError;
-    type Param = IpNumber;
-
-    fn parse_with(
-        ip_number: IpNumber,
-        buf: &[u8],
-    ) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
-        if buf.len() > u16::MAX as usize {
-            return Err(ParseError::BufferTooLong(buf.len()));
-        }
-        let (inner, rest) = Ipv6Extensions::from_slice(ip_number, buf)
-            .map(|(h, _, rest)| (Box::new(h), rest))
-            .map_err(ParseError::Invalid)?;
-        assert!(
-            rest.len() < buf.len(),
-            "rest.len() >= buf.len() ({rest} >= {buf})",
-            rest = rest.len(),
-            buf = buf.len()
-        );
-        #[allow(clippy::cast_possible_truncation)] // buffer length bounded above
-        let consumed =
-            NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!())?;
-        Ok((
-            Self {
-                inner,
-                first_ip_number: ip_number,
-            },
-            consumed,
-        ))
-    }
-}
-
-impl DeParse for Ipv6Ext {
-    type Error = ();
-
-    fn size(&self) -> NonZero<u16> {
-        #[allow(clippy::cast_possible_truncation)] // extension header length is bounded
-        NonZero::new(self.inner.header_len() as u16).unwrap_or_else(|| unreachable!())
-    }
-
-    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
-        let size = self.size();
-        let len = buf.len();
-        if len < size.into_non_zero_usize().get() {
-            return Err(DeParseError::Length(LengthError {
-                expected: size.into_non_zero_usize(),
-                actual: len,
-            }));
-        }
-        let mut cursor = Cursor::new(&mut buf[..size.get() as usize]);
-        self.inner
-            .write(&mut cursor, self.first_ip_number)
-            .map_err(|_| DeParseError::Invalid(()))?;
-        Ok(size)
-    }
-}
-
-impl Ipv6Ext {
-    /// Parse the payload of this extension header.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(Ipv6ExtNext)` variant if the payload was successfully parsed as a next header.
-    /// * `None` if the next header is not supported.
-    pub(crate) fn parse_payload(&self, cursor: &mut Reader) -> Option<Ipv6ExtNext> {
-        use etherparse::ip_number::{
-            AUTHENTICATION_HEADER, IPV6_DESTINATION_OPTIONS, IPV6_FRAGMENTATION_HEADER,
-            IPV6_HEADER_HOP_BY_HOP, IPV6_ICMP, IPV6_ROUTE_HEADER, TCP, UDP,
-        };
-        let next_header = self
-            .inner
-            .next_header(self.first_ip_number)
-            .map_err(|e| debug!("failed to parse: {e:?}"))
-            .ok()?;
-        match next_header {
-            TCP => cursor.parse_header::<Tcp, Ipv6ExtNext>(),
-            UDP => cursor.parse_header::<Udp, Ipv6ExtNext>(),
-            IPV6_ICMP => cursor.parse_header::<Icmp6, Ipv6ExtNext>(),
-            AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, Ipv6ExtNext>()
-            }
-            IPV6_HEADER_HOP_BY_HOP
-            | IPV6_ROUTE_HEADER
-            | IPV6_FRAGMENTATION_HEADER
-            | IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, Ipv6ExtNext>(next_header)
-            }
-            _ => {
-                trace!("unsupported protocol: {next_header:?}");
-                None
-            }
-        }
-    }
-
-    /// Parse the payload of an IPv6 extension header embedded in an ICMP Error message.
-    ///
-    /// # Returns
-    ///
-    /// * `Some(EmbeddedIpv6ExtNext)` variant if the payload was successfully parsed as a next header.
-    /// * `None` if the next header is not supported.
-    pub(crate) fn parse_embedded_payload(
-        &self,
-        cursor: &mut Reader,
-    ) -> Option<EmbeddedIpv6ExtNext> {
-        use etherparse::ip_number::{
-            AUTHENTICATION_HEADER, IPV6_DESTINATION_OPTIONS, IPV6_FRAGMENTATION_HEADER,
-            IPV6_HEADER_HOP_BY_HOP, IPV6_ICMP, IPV6_ROUTE_HEADER, TCP, UDP,
-        };
-        let next_header = self
-            .inner
-            .next_header(self.first_ip_number)
-            .map_err(|e| debug!("failed to parse: {e:?}"))
-            .ok()?;
-        match next_header {
-            TCP => cursor.parse_header::<TruncatedTcp, EmbeddedIpv6ExtNext>(),
-            UDP => cursor.parse_header::<TruncatedUdp, EmbeddedIpv6ExtNext>(),
-            IPV6_ICMP => cursor.parse_header::<TruncatedIcmp6, EmbeddedIpv6ExtNext>(),
-            AUTHENTICATION_HEADER => {
-                debug!("nested ip auth header");
-                cursor.parse_header::<IpAuth, EmbeddedIpv6ExtNext>()
-            }
-            IPV6_HEADER_HOP_BY_HOP
-            | IPV6_ROUTE_HEADER
-            | IPV6_FRAGMENTATION_HEADER
-            | IPV6_DESTINATION_OPTIONS => {
-                cursor.parse_header_with::<Ipv6Ext, EmbeddedIpv6ExtNext>(next_header)
-            }
-            _ => {
-                trace!("unsupported protocol: {next_header:?}");
-                None
-            }
-        }
-    }
-}
-
-pub(crate) enum Ipv6ExtNext {
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
-}
-
-impl_from_for_enum![
-    Ipv6ExtNext,
-    Tcp(Tcp),
-    Udp(Udp),
-    Icmp6(Icmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
+    Ipv6Auth(crate::ip_auth::Ipv6Auth),
+    HopByHop(HopByHop),
+    DestOpts(DestOpts),
+    Routing(Routing),
+    Fragment(Fragment)
 ];
 
 impl From<Ipv6Next> for Header {
@@ -560,40 +407,14 @@ impl From<Ipv6Next> for Header {
             Ipv6Next::Tcp(x) => Header::Tcp(x),
             Ipv6Next::Udp(x) => Header::Udp(x),
             Ipv6Next::Icmp6(x) => Header::Icmp6(x),
-            Ipv6Next::IpAuth(x) => Header::IpAuth(x),
-            Ipv6Next::Ipv6Ext(x) => Header::IpV6Ext(x),
+            Ipv6Next::Ipv6Auth(x) => Header::Ipv6Auth(x),
+            Ipv6Next::HopByHop(x) => Header::HopByHop(x),
+            Ipv6Next::DestOpts(x) => Header::DestOpts(x),
+            Ipv6Next::Routing(x) => Header::Routing(x),
+            Ipv6Next::Fragment(x) => Header::Fragment(x),
         }
     }
 }
-
-impl From<Ipv6ExtNext> for Header {
-    fn from(value: Ipv6ExtNext) -> Self {
-        match value {
-            Ipv6ExtNext::Tcp(x) => Header::Tcp(x),
-            Ipv6ExtNext::Udp(x) => Header::Udp(x),
-            Ipv6ExtNext::Icmp6(x) => Header::Icmp6(x),
-            Ipv6ExtNext::IpAuth(x) => Header::IpAuth(x),
-            Ipv6ExtNext::Ipv6Ext(x) => Header::IpV6Ext(x),
-        }
-    }
-}
-
-pub(crate) enum EmbeddedIpv6ExtNext {
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext),
-}
-
-impl_from_for_enum![
-    EmbeddedIpv6ExtNext,
-    Tcp(TruncatedTcp),
-    Udp(TruncatedUdp),
-    Icmp6(TruncatedIcmp6),
-    IpAuth(IpAuth),
-    Ipv6Ext(Ipv6Ext)
-];
 
 impl From<EmbeddedIpv6Next> for EmbeddedHeader {
     fn from(value: EmbeddedIpv6Next) -> Self {
@@ -601,20 +422,11 @@ impl From<EmbeddedIpv6Next> for EmbeddedHeader {
             EmbeddedIpv6Next::Tcp(x) => EmbeddedHeader::Tcp(x),
             EmbeddedIpv6Next::Udp(x) => EmbeddedHeader::Udp(x),
             EmbeddedIpv6Next::Icmp6(x) => EmbeddedHeader::Icmp6(x),
-            EmbeddedIpv6Next::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-            EmbeddedIpv6Next::Ipv6Ext(x) => EmbeddedHeader::IpV6Ext(x),
-        }
-    }
-}
-
-impl From<EmbeddedIpv6ExtNext> for EmbeddedHeader {
-    fn from(value: EmbeddedIpv6ExtNext) -> Self {
-        match value {
-            EmbeddedIpv6ExtNext::Tcp(x) => EmbeddedHeader::Tcp(x),
-            EmbeddedIpv6ExtNext::Udp(x) => EmbeddedHeader::Udp(x),
-            EmbeddedIpv6ExtNext::Icmp6(x) => EmbeddedHeader::Icmp6(x),
-            EmbeddedIpv6ExtNext::IpAuth(x) => EmbeddedHeader::IpAuth(x),
-            EmbeddedIpv6ExtNext::Ipv6Ext(x) => EmbeddedHeader::IpV6Ext(x),
+            EmbeddedIpv6Next::Ipv6Auth(x) => EmbeddedHeader::Ipv6Auth(x),
+            EmbeddedIpv6Next::HopByHop(x) => EmbeddedHeader::HopByHop(x),
+            EmbeddedIpv6Next::DestOpts(x) => EmbeddedHeader::DestOpts(x),
+            EmbeddedIpv6Next::Routing(x) => EmbeddedHeader::Routing(x),
+            EmbeddedIpv6Next::Fragment(x) => EmbeddedHeader::Fragment(x),
         }
     }
 }

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -25,7 +25,16 @@ use std::num::NonZero;
 use tracing::{debug, trace};
 
 pub mod addr;
+pub mod dest_opts;
 pub mod flow_label;
+pub mod fragment;
+pub mod hop_by_hop;
+pub mod routing;
+
+pub use dest_opts::DestOpts;
+pub use fragment::Fragment;
+pub use hop_by_hop::HopByHop;
+pub use routing::Routing;
 
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;

--- a/net/src/ipv6/mod.rs
+++ b/net/src/ipv6/mod.rs
@@ -29,6 +29,8 @@ pub mod dest_opts;
 pub mod flow_label;
 pub mod fragment;
 pub mod hop_by_hop;
+#[cfg(any(test, feature = "bolero"))]
+pub(crate) mod raw_ext_gen;
 pub mod routing;
 
 pub use dest_opts::DestOpts;

--- a/net/src/ipv6/raw_ext_gen.rs
+++ b/net/src/ipv6/raw_ext_gen.rs
@@ -13,11 +13,11 @@ use etherparse::{IpNumber, Ipv6RawExtHeader};
 /// Valid payload lengths for [`Ipv6RawExtHeader`].
 ///
 /// The payload must be at least 6 bytes and `(len + 2) % 8 == 0`,
-/// giving lengths 6, 14, 22, 30, ...  We cap at a handful of small
-/// sizes to keep fuzz inputs tractable (the `payload_buffer` is 2 KiB,
-/// but generating huge headers is unlikely to find interesting bugs
-/// and slows the fuzzer).
-const VALID_PAYLOAD_LENS: [usize; 4] = [6, 14, 22, 30];
+/// giving lengths 6, 14, 22, 30, ...
+///
+/// Includes small values for fast fuzzing plus the maximum
+/// (`MAX_PAYLOAD_LEN` = 2046) to cover the upper boundary.
+const VALID_PAYLOAD_LENS: [usize; 5] = [6, 14, 22, 30, Ipv6RawExtHeader::MAX_PAYLOAD_LEN];
 
 /// Generate an arbitrary boxed [`Ipv6RawExtHeader`].
 ///

--- a/net/src/ipv6/raw_ext_gen.rs
+++ b/net/src/ipv6/raw_ext_gen.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Shared [`bolero`] generator for IPv6 raw extension headers.
+//!
+//! [`HopByHop`](super::HopByHop), [`DestOpts`](super::DestOpts), and
+//! [`Routing`](super::Routing) all wrap an [`Ipv6RawExtHeader`] and share
+//! the same generation logic.
+
+use bolero::Driver;
+use etherparse::{IpNumber, Ipv6RawExtHeader};
+
+/// Valid payload lengths for [`Ipv6RawExtHeader`].
+///
+/// The payload must be at least 6 bytes and `(len + 2) % 8 == 0`,
+/// giving lengths 6, 14, 22, 30, ...  We cap at a handful of small
+/// sizes to keep fuzz inputs tractable (the `payload_buffer` is 2 KiB,
+/// but generating huge headers is unlikely to find interesting bugs
+/// and slows the fuzzer).
+const VALID_PAYLOAD_LENS: [usize; 4] = [6, 14, 22, 30];
+
+/// Generate an arbitrary boxed [`Ipv6RawExtHeader`].
+///
+/// The `next_header` field is set to an arbitrary value; the builder's
+/// `Within::conform` will overwrite it when the header is stacked.
+pub fn gen_raw_ext_header<D: Driver>(driver: &mut D) -> Option<Box<Ipv6RawExtHeader>> {
+    let idx = driver.gen_usize(
+        std::ops::Bound::Included(&0),
+        std::ops::Bound::Excluded(&VALID_PAYLOAD_LENS.len()),
+    )?;
+    let payload_len = VALID_PAYLOAD_LENS[idx];
+    let mut payload = vec![0u8; payload_len];
+    for byte in &mut payload {
+        *byte = driver.produce()?;
+    }
+    let next_header: u8 = driver.produce()?;
+    #[allow(clippy::unwrap_used)] // lengths are valid by construction
+    let header = Ipv6RawExtHeader::new_raw(IpNumber(next_header), &payload).unwrap();
+    Some(Box::new(header))
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -46,6 +46,22 @@ impl Routing {
     pub fn payload(&self) -> &[u8] {
         self.0.payload()
     }
+
+    /// Parse the next header after this one.
+    pub(crate) fn parse_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::Header> {
+        super::ext_parse::parse_ext_payload(self.next_header(), cursor)
+    }
+
+    /// Parse the next header in an ICMP-embedded context.
+    pub(crate) fn parse_embedded_payload(
+        &self,
+        cursor: &mut crate::parse::Reader,
+    ) -> Option<crate::headers::EmbeddedHeader> {
+        super::ext_parse::parse_ext_embedded_payload(self.next_header(), cursor)
+    }
 }
 
 impl From<Box<Ipv6RawExtHeader>> for Routing {

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -64,14 +64,23 @@ impl Routing {
     }
 }
 
-impl From<Box<Ipv6RawExtHeader>> for Routing {
-    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+impl Routing {
+    /// Wrap a raw extension header as a `Routing`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `inner` was reached via a preceding
+    /// header whose `next_header` field was 43 (`IPV6_ROUTE_HEADER`),
+    /// confirming these bytes are a Routing header and not some other
+    /// extension header sharing the [`Ipv6RawExtHeader`] format.
+    #[allow(unsafe_code, dead_code)] // only called from test/builder cfg
+    pub(crate) unsafe fn from_raw_unchecked(inner: Box<Ipv6RawExtHeader>) -> Self {
         Self(inner)
     }
 }
 
 impl Parse for Routing {
-    type Error = etherparse::err::LenError;
+    type Error = std::convert::Infallible;
 
     fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
         if buf.len() > u16::MAX as usize {
@@ -83,7 +92,12 @@ impl Parse for Routing {
                 actual: buf.len(),
             }));
         }
-        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(|e| {
+            ParseError::Length(LengthError {
+                expected: NonZero::new(e.required_len).unwrap_or_else(|| unreachable!()),
+                actual: e.len,
+            })
+        })?;
         assert!(
             rest.len() < buf.len(),
             "rest.len() >= buf.len() ({rest} >= {buf})",
@@ -126,7 +140,9 @@ mod contract {
 
     impl TypeGenerator for Routing {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(Routing::from(gen_raw_ext_header(driver)?))
+            #[allow(unsafe_code)]
+            // SAFETY: we are declaring the generated raw header to be Routing.
+            Some(unsafe { Routing::from_raw_unchecked(gen_raw_ext_header(driver)?) })
         }
     }
 }

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -101,3 +101,34 @@ impl DeParse for Routing {
         Ok(size)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::Routing;
+    use crate::ipv6::raw_ext_gen::gen_raw_ext_header;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for Routing {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            Some(Routing::from(gen_raw_ext_header(driver)?))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Routing;
+    use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+
+    #[test]
+    fn parse_back() {
+        bolero::check!().with_type().for_each(|header: &Routing| {
+            let mut buf = [0u8; 2048];
+            let len = header.deparse(&mut buf).unwrap();
+            let (header2, consumed) =
+                Routing::parse(&buf[..len.into_non_zero_usize().get()]).unwrap();
+            assert_eq!(consumed, len);
+            assert_eq!(header, &header2);
+        });
+    }
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! IPv6 Routing header ([RFC 8200 section 4.4]).
+//!
+//! The Routing header is used by an IPv6 source to list one or more
+//! intermediate nodes to be "visited" on the way to a packet's destination.
+//!
+//! Note: etherparse bundles the Routing header with an optional trailing
+//! Destination Options header in `Ipv6RoutingExtensions`.  We flatten that --
+//! the Routing header is represented here as a standalone [`Routing`] type,
+//! and the trailing Destination Options (if any) is a separate [`super::DestOpts`].
+//!
+//! [RFC 8200 section 4.4]: https://datatracker.ietf.org/doc/html/rfc8200#section-4.4
+
+use crate::ip::NextHeader;
+use crate::parse::{DeParse, DeParseError, IntoNonZeroUSize, LengthError, Parse, ParseError};
+use etherparse::Ipv6RawExtHeader;
+use std::num::NonZero;
+
+/// IPv6 Routing header.
+///
+/// Wraps an [`Ipv6RawExtHeader`] from etherparse.  The inner type is boxed
+/// because `Ipv6RawExtHeader` is ~2 KiB (variable-length payload buffer).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Routing(Box<Ipv6RawExtHeader>);
+
+impl Routing {
+    /// The minimum header length in bytes.
+    #[allow(clippy::unwrap_used, clippy::cast_possible_truncation)]
+    pub const MIN_LEN: NonZero<u16> = NonZero::new(Ipv6RawExtHeader::MIN_LEN as u16).unwrap();
+
+    /// Get the next-header protocol number.
+    #[must_use]
+    pub fn next_header(&self) -> NextHeader {
+        NextHeader::from(self.0.next_header)
+    }
+
+    /// Set the next-header protocol number.
+    pub fn set_next_header(&mut self, nh: NextHeader) {
+        self.0.next_header = nh.into();
+    }
+
+    /// The raw payload (excluding next-header and length fields).
+    #[must_use]
+    pub fn payload(&self) -> &[u8] {
+        self.0.payload()
+    }
+}
+
+impl Parse for Routing {
+    type Error = etherparse::err::LenError;
+
+    fn parse(buf: &[u8]) -> Result<(Self, NonZero<u16>), ParseError<Self::Error>> {
+        if buf.len() > u16::MAX as usize {
+            return Err(ParseError::BufferTooLong(buf.len()));
+        }
+        if buf.len() < Self::MIN_LEN.get() as usize {
+            return Err(ParseError::Length(LengthError {
+                expected: Self::MIN_LEN.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let (inner, rest) = Ipv6RawExtHeader::from_slice(buf).map_err(ParseError::Invalid)?;
+        assert!(
+            rest.len() < buf.len(),
+            "rest.len() >= buf.len() ({rest} >= {buf})",
+            rest = rest.len(),
+            buf = buf.len()
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        let consumed = NonZero::new((buf.len() - rest.len()) as u16).ok_or_else(|| unreachable!());
+        Ok((Self(Box::new(inner)), consumed?))
+    }
+}
+
+impl DeParse for Routing {
+    type Error = ();
+
+    fn size(&self) -> NonZero<u16> {
+        #[allow(clippy::cast_possible_truncation)]
+        NonZero::new(self.0.header_len() as u16).unwrap_or_else(|| unreachable!())
+    }
+
+    fn deparse(&self, buf: &mut [u8]) -> Result<NonZero<u16>, DeParseError<Self::Error>> {
+        let size = self.size();
+        if buf.len() < size.into_non_zero_usize().get() {
+            return Err(DeParseError::Length(LengthError {
+                expected: size.into_non_zero_usize(),
+                actual: buf.len(),
+            }));
+        }
+        let bytes = self.0.to_bytes();
+        buf[..size.get() as usize].copy_from_slice(&bytes[..size.get() as usize]);
+        Ok(size)
+    }
+}

--- a/net/src/ipv6/routing.rs
+++ b/net/src/ipv6/routing.rs
@@ -48,6 +48,12 @@ impl Routing {
     }
 }
 
+impl From<Box<Ipv6RawExtHeader>> for Routing {
+    fn from(inner: Box<Ipv6RawExtHeader>) -> Self {
+        Self(inner)
+    }
+}
+
 impl Parse for Routing {
     type Error = etherparse::err::LenError;
 


### PR DESCRIPTION
An absolutely arduous PR which correctly implements IPv6 extension header parse, deparse, generation, and so on.

This is actually necessary for the ACL work.