### PR TITLE
fix(net): correlate all ICMP error types in flow key (ai assisted, undergoing extra human review by coauthor)

### DIFF
--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -1036,7 +1036,10 @@ mod tests {
                     Icmp4Type::EchoRequest(_) | Icmp4Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp4Type::DestUnreachable(_) | Icmp4Type::TimeExceeded(_) => {
+                    Icmp4Type::DestUnreachable(_)
+                    | Icmp4Type::Redirect(_)
+                    | Icmp4Type::TimeExceeded(_)
+                    | Icmp4Type::ParamProblem(_) => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),
@@ -1046,7 +1049,10 @@ mod tests {
                     Icmp6Type::EchoRequest(_) | Icmp6Type::EchoReply(_) => Some(IpProtoKey::Icmp(
                         IcmpProtoKey::QueryMsgData(driver.produce()?),
                     )),
-                    Icmp6Type::DestUnreachable(_) | Icmp6Type::TimeExceeded(_) => {
+                    Icmp6Type::DestUnreachable(_)
+                    | Icmp6Type::PacketTooBig(_)
+                    | Icmp6Type::TimeExceeded(_)
+                    | Icmp6Type::ParamProblem(_) => {
                         Some(IpProtoKey::Icmp(IcmpProtoKey::ErrorMsgData(None)))
                     }
                     _ => Some(IpProtoKey::Icmp(IcmpProtoKey::Unsupported)),

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -311,7 +311,10 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp4Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp4Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp4Type::TimeExceeded(_) | Icmp4Type::DestUnreachable(_) => {
+            Icmp4Type::DestUnreachable(_)
+            | Icmp4Type::Redirect(_)
+            | Icmp4Type::TimeExceeded(_)
+            | Icmp4Type::ParamProblem(_) => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,
@@ -322,7 +325,10 @@ impl IcmpProtoKey {
         match icmp.icmp_type() {
             Icmp6Type::EchoRequest(v) => IcmpProtoKey::QueryMsgData(v.id),
             Icmp6Type::EchoReply(v) => IcmpProtoKey::QueryMsgData(v.id),
-            Icmp6Type::TimeExceeded(_) | Icmp6Type::DestUnreachable(_) => {
+            Icmp6Type::DestUnreachable(_)
+            | Icmp6Type::PacketTooBig(_)
+            | Icmp6Type::TimeExceeded(_)
+            | Icmp6Type::ParamProblem(_) => {
                 IcmpProtoKey::ErrorMsgData(EmbeddedPacketData::try_from_packet(packet))
             }
             _ => IcmpProtoKey::Unsupported,


### PR DESCRIPTION
Per RFC 4443 (ICMPv6) and RFC 792 (ICMPv4), all error messages carry the invoking packet and must be correlatable to the originating flow. Omitting `PacketTooBig` breaks PMTUD; omitting `ParamProblem` and `Redirect` prevents stateful firewalls from associating those errors with their flows. Linux `nf_conntrack_proto_icmpv6` correlates all error types uniformly.

This issue was found when I asked GPT 5.4 to do a code review of #1446 

GPT was incorrect in its review (it classified this as a regression, but we were just always wrong).

I looked up the RFCs and yeah, we were always wrong.  So here is the fix.