### PR TITLE
test(nat): Remove unnecessary "tests" submodules

### DIFF
--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -1,1507 +1,1502 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-#[cfg(test)]
-mod tests {
-    use crate::stateful::NatAllocatorWriter;
-    use crate::{IcmpErrorHandler, StatefulNat};
-    use concurrency::sync::Arc;
-    use config::ConfigError;
-    use config::external::overlay::Overlay;
-    use config::external::overlay::vpc::{Vpc, VpcTable};
-    use config::external::overlay::vpcpeering::{
-        VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable,
-    };
-    use flow_entry::flow_table::{FlowLookup, FlowTable};
-    use flow_filter::{FlowFilter, FlowFilterTable, FlowFilterTableWriter};
-    use net::buffer::{PacketBufferMut, TestBuffer};
-    use net::eth::mac::Mac;
-    use net::flow_key::Uni;
-    use net::headers::{
-        EmbeddedTransport, TryEmbeddedTransport as _, TryIcmp4, TryInnerIpv4, TryIpv4, TryUdp,
-    };
-    use net::icmp4::Icmp4Type;
-    use net::icmp4::TruncatedIcmp4;
-    use net::ip::NextHeader;
-    use net::packet::test_utils::{
-        IcmpEchoDirection, build_test_icmp4_destination_unreachable_packet, build_test_icmp4_echo,
-        build_test_udp_ipv4_frame,
-    };
-    use net::packet::{DoneReason, Packet, VpcDiscriminant};
-    use net::tcp::TruncatedTcp;
-    use net::udp::{TruncatedUdp, UdpPort};
-    use net::vxlan::Vni;
-    use net::{FlowKey, IpProtoKey, UdpProtoKey};
-    use pipeline::NetworkFunction;
-    use std::net::{IpAddr, Ipv4Addr};
-    use std::str::FromStr;
-    use std::time::Duration;
-    use tracectl::get_trace_ctl;
-    use tracing_test::traced_test;
+#![cfg(test)]
 
-    const ONE_MINUTE: Duration = Duration::from_secs(60);
-    use crate::stateless::test::tests::build_gwconfig_from_overlay;
+use crate::stateful::NatAllocatorWriter;
+use crate::{IcmpErrorHandler, StatefulNat};
+use concurrency::sync::Arc;
+use config::ConfigError;
+use config::external::overlay::Overlay;
+use config::external::overlay::vpc::{Vpc, VpcTable};
+use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable};
+use flow_entry::flow_table::{FlowLookup, FlowTable};
+use flow_filter::{FlowFilter, FlowFilterTable, FlowFilterTableWriter};
+use net::buffer::{PacketBufferMut, TestBuffer};
+use net::eth::mac::Mac;
+use net::flow_key::Uni;
+use net::headers::{
+    EmbeddedTransport, TryEmbeddedTransport as _, TryIcmp4, TryInnerIpv4, TryIpv4, TryUdp,
+};
+use net::icmp4::Icmp4Type;
+use net::icmp4::TruncatedIcmp4;
+use net::ip::NextHeader;
+use net::packet::test_utils::{
+    IcmpEchoDirection, build_test_icmp4_destination_unreachable_packet, build_test_icmp4_echo,
+    build_test_udp_ipv4_frame,
+};
+use net::packet::{DoneReason, Packet, VpcDiscriminant};
+use net::tcp::TruncatedTcp;
+use net::udp::{TruncatedUdp, UdpPort};
+use net::vxlan::Vni;
+use net::{FlowKey, IpProtoKey, UdpProtoKey};
+use pipeline::NetworkFunction;
+use std::net::{IpAddr, Ipv4Addr};
+use std::str::FromStr;
+use std::time::Duration;
+use tracectl::get_trace_ctl;
+use tracing_test::traced_test;
 
-    fn addr_v4(addr: &str) -> Ipv4Addr {
-        Ipv4Addr::from_str(addr).expect("Failed to create IPv4 address")
+const ONE_MINUTE: Duration = Duration::from_secs(60);
+use crate::stateless::test::build_gwconfig_from_overlay;
+
+fn addr_v4(addr: &str) -> Ipv4Addr {
+    Ipv4Addr::from_str(addr).expect("Failed to create IPv4 address")
+}
+
+fn vni(vni: u32) -> Vni {
+    Vni::new_checked(vni).expect("Failed to create VNI")
+}
+
+fn vpcd(vni_id: u32) -> VpcDiscriminant {
+    VpcDiscriminant::from_vni(vni(vni_id))
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_overlay_4vpcs() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    fn vni(vni: u32) -> Vni {
-        Vni::new_checked(vni).expect("Failed to create VNI")
-    }
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-4", "DDDDD", 400).expect("Failed to add VPC"));
 
-    fn vpcd(vni_id: u32) -> VpcDiscriminant {
-        VpcDiscriminant::from_vni(vni(vni_id))
-    }
+    // VPC1 --------- VPC 2
+    //  |    \           |
+    //  |      \         |
+    //  |        \       |
+    //  |          \     |
+    //  |            \   |
+    // VPC3 --------- VPC 4
 
-    #[allow(clippy::too_many_lines)]
-    fn build_overlay_4vpcs() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
-
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-4", "DDDDD", 400).expect("Failed to add VPC"));
-
-        // VPC1 --------- VPC 2
-        //  |    \           |
-        //  |      \         |
-        //  |        \       |
-        //  |          \     |
-        //  |            \   |
-        // VPC3 --------- VPC 4
-
-        // VPC1 <-> VPC2
-        let expose121 = VpcExpose::empty()
-            .make_stateful_nat(Some(ONE_MINUTE))
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("10.12.0.0/16".into())
-            .unwrap();
-        let expose122 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.2.0.0/16".into())
-            .as_range("10.98.128.0/17".into())
-            .unwrap()
-            .as_range("10.99.0.0/17".into())
-            .unwrap();
-        let expose123 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.3.0.0/24".into())
-            .as_range("10.100.0.0/24".into())
-            .unwrap();
-        let expose211 = VpcExpose::empty().ip("10.201.201.0/24".into());
-        let expose212 = VpcExpose::empty().ip("10.201.202.0/24".into());
-        let expose213 = VpcExpose::empty().ip("10.201.203.0/24".into());
-        let expose214 = VpcExpose::empty().ip("10.201.204.192/28".into());
-
-        // VPC1 <-> VPC3
-        let expose131 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("3.3.0.0/16".into())
-            .unwrap();
-        let expose132 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.2.0.0/16".into())
-            .as_range("3.1.0.0/16".into())
-            .unwrap()
-            .not_as("3.1.128.0/17".into())
-            .unwrap()
-            .as_range("3.2.0.0/17".into())
-            .unwrap();
-        let expose311 = VpcExpose::empty().ip("3.3.3.0/24".into());
-
-        // VPC1 <-> VPC4
-        let expose141 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("4.4.0.0/16".into())
-            .unwrap();
-        let expose411 = VpcExpose::empty().ip("4.5.0.0/16".into());
-
-        // VPC2 <-> VPC4
-        let expose241 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("2.4.0.0/16".into())
-            .not("2.4.1.0/24".into())
-            .as_range("44.0.0.0/16".into())
-            .unwrap()
-            .not_as("44.0.200.0/24".into())
-            .unwrap();
-        let expose421 = VpcExpose::empty()
-            .ip("44.4.0.0/16".into())
-            .not("44.4.64.0/18".into());
-
-        // VPC3 <-> VPC4
-        let expose341 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("192.168.100.0/24".into())
-            .as_range("34.34.34.0/24".into())
-            .unwrap();
-        let expose431 = VpcExpose::empty().ip("4.4.0.0/24".into());
-
-        // VPC1 <-> VPC2
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose121);
-        add_expose(&mut manifest12, expose122);
-        add_expose(&mut manifest12, expose123);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose211);
-        add_expose(&mut manifest21, expose212);
-        add_expose(&mut manifest21, expose213);
-        add_expose(&mut manifest21, expose214);
-
-        // VPC1 <-> VPC3
-        let mut manifest13 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest13, expose131);
-        add_expose(&mut manifest13, expose132);
-        let mut manifest31 = VpcManifest::new("VPC-3");
-        add_expose(&mut manifest31, expose311);
-
-        // VPC1 <-> VPC4
-        let mut manifest14 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest14, expose141);
-        let mut manifest41 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest41, expose411);
-
-        // VPC2 <-> VPC4
-        let mut manifest24 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest24, expose241);
-        let mut manifest42 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest42, expose421);
-
-        // VPC3 <-> VPC4
-        let mut manifest34 = VpcManifest::new("VPC-3");
-        add_expose(&mut manifest34, expose341);
-        let mut manifest43 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest43, expose431);
-
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-        let peering31 = VpcPeering::with_default_group("VPC-3--VPC-1", manifest31, manifest13);
-        let peering14 = VpcPeering::with_default_group("VPC-1--VPC-4", manifest14, manifest41);
-        let peering24 = VpcPeering::with_default_group("VPC-2--VPC-4", manifest24, manifest42);
-        let peering34 = VpcPeering::with_default_group("VPC-3--VPC-4", manifest34, manifest43);
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
-        peering_table.add(peering31).expect("Failed to add peering");
-        peering_table.add(peering14).expect("Failed to add peering");
-        peering_table.add(peering24).expect("Failed to add peering");
-        peering_table.add(peering34).expect("Failed to add peering");
-
-        Overlay::new(vpc_table, peering_table)
-    }
-
-    fn build_overlay_2vpcs() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
-
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
-
-        let expose121 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("2.2.0.0/16".into())
-            .unwrap();
-        let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
-
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose121);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose211);
-
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
-
-        Overlay::new(vpc_table, peering_table)
-    }
-
-    fn check_packet(
-        nat: &mut StatefulNat,
-        src_vni: Vni,
-        dst_vni: Vni,
-        src_ip: &str,
-        dst_ip: &str,
-        sport: u16,
-        dport: u16,
-    ) -> (Ipv4Addr, Ipv4Addr, u16, u16, Option<DoneReason>) {
-        let mut packet: Packet<TestBuffer> = build_test_udp_ipv4_frame(
-            Mac([0x2, 0, 0, 0, 0, 1]),
-            Mac([0x2, 0, 0, 0, 0, 2]),
-            src_ip,
-            dst_ip,
-            sport,
-            dport,
-        );
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateful_nat(true);
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
-
-        flow_lookup(nat.sessions(), &mut packet);
-
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        let hdr_out = packets_out[0].try_ipv4().unwrap();
-        let udp_out = packets_out[0].try_udp().unwrap();
-        let done_reason = packets_out[0].get_done();
-
-        (
-            hdr_out.source().inner(),
-            hdr_out.destination(),
-            udp_out.source().into(),
-            udp_out.destination().into(),
-            done_reason,
-        )
-    }
-
-    fn flow_lookup<Buf: PacketBufferMut>(flow_table: &FlowTable, packet: &mut Packet<Buf>) {
-        let flow_key = FlowKey::try_from(Uni(&*packet)).unwrap();
-        if let Some(flow_info) = flow_table.lookup(&flow_key) {
-            packet.meta_mut().flow_info = Some(flow_info);
-        }
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    #[allow(clippy::too_many_lines)]
-    async fn test_full_config() {
-        let mut config = build_gwconfig_from_overlay(build_overlay_4vpcs());
-        config.validate().unwrap();
-
-        // Check that we can validate the allocator
-        let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
-
-        // No NAT
-        let (orig_src, orig_dst) = ("8.8.8.8", "9.9.9.9");
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
-        assert_eq!(output_src, addr_v4(orig_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert_eq!(output_src_port, 9998);
-        assert_eq!(output_dst_port, 443);
-        assert_eq!(done_reason, Some(DoneReason::Filtered));
-
-        // NAT: expose121 <-> expose211
-        let (orig_src, orig_dst) = ("1.1.2.3", "10.201.201.18");
-        let target_src = "10.12.0.0";
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
-        assert_eq!(done_reason, None);
-
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        // Reverse path
-        let (
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            done_reason,
-        ) = check_packet(
-            &mut nat,
-            vni(200),
-            vni(100),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, 443);
-        assert_eq!(return_output_dst_port, 9998);
-        assert_eq!(done_reason, None);
-
-        // Get corresponding session table entries and check idle timeout
-        let Some((_, idle_timeout)) = nat.get_session::<Ipv4Addr>(
-            Some(vpcd(100)),
-            IpAddr::from_str(orig_src).unwrap(),
-            IpAddr::from_str(orig_dst).unwrap(),
-            IpProtoKey::Udp(UdpProtoKey {
-                src_port: UdpPort::new_checked(9998).unwrap(),
-                dst_port: UdpPort::new_checked(443).unwrap(),
-            }),
-        ) else {
-            unreachable!()
-        };
-        assert_eq!(idle_timeout, ONE_MINUTE);
-        // Reverse path
-        let Some((_, idle_timeout)) = nat.get_session::<Ipv4Addr>(
-            Some(vpcd(200)),
-            IpAddr::from_str(orig_dst).unwrap(),
-            IpAddr::from_str(target_src).unwrap(),
-            IpProtoKey::Udp(UdpProtoKey {
-                src_port: UdpPort::new_checked(output_dst_port).unwrap(),
-                dst_port: UdpPort::new_checked(output_src_port).unwrap(),
-            }),
-        ) else {
-            unreachable!()
-        };
-        assert_eq!(idle_timeout, ONE_MINUTE);
-
-        // Update config and allocator
-        let mut new_config = build_gwconfig_from_overlay(build_overlay_2vpcs());
-        new_config.validate().unwrap();
-        allocator
-            .update_allocator(&new_config.external.overlay.vpc_table)
-            .unwrap();
-
-        // Check existing connection
-        // TODO: We should drop this connection after updating the allocator in the future, as a
-        // result these steps should fail
-        let (orig_src, orig_dst) = ("1.1.2.3", "10.201.201.18");
-        let target_src = "10.12.0.0";
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            done_reason,
-        ) = check_packet(
-            &mut nat,
-            vni(200),
-            vni(100),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, 443);
-        assert_eq!(return_output_dst_port, 9998);
-        assert_eq!(done_reason, None);
-
-        // Check new valid connection
-        let (orig_src, orig_dst) = ("1.1.2.3", "3.3.3.3");
-        let target_src = "2.2.0.0";
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 80);
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            done_reason,
-        ) = check_packet(
-            &mut nat,
-            vni(200),
-            vni(100),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, 80);
-        assert_eq!(return_output_dst_port, 9998);
-        assert_eq!(done_reason, None);
-    }
-
-    fn build_overlay_2vpcs_no_nat() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
-
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
-
-        let expose121 = VpcExpose::empty().ip("1.1.0.0/16".into());
-        let expose211 = VpcExpose::empty().ip("2.2.0.0/16".into());
-
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose121);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose211);
-
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
-
-        Overlay::new(vpc_table, peering_table)
-    }
-
-    #[test]
-    #[traced_test]
-    fn test_full_config_no_nat() {
-        let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_no_nat());
-        config.validate().unwrap();
-
-        // Check that we can validate the allocator
-        let (_, mut allocator) = StatefulNat::new_with_defaults();
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
-    }
-
-    fn check_packet_icmp_echo(
-        nat: &mut StatefulNat,
-        src_vni: Vni,
-        dst_vni: Vni,
-        src_ip: Ipv4Addr,
-        dst_ip: Ipv4Addr,
-        direction: IcmpEchoDirection,
-        identifier: u16,
-    ) -> (Ipv4Addr, Ipv4Addr, u16, Option<DoneReason>) {
-        let mut packet: Packet<TestBuffer> =
-            build_test_icmp4_echo(src_ip, dst_ip, identifier, direction).unwrap();
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateful_nat(true);
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
-
-        flow_lookup(nat.sessions(), &mut packet);
-
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        let hdr_out = packets_out[0].try_ipv4().unwrap();
-        let icmp_out = packets_out[0].try_icmp4().unwrap();
-        let done_reason = packets_out[0].get_done();
-
-        (
-            hdr_out.source().inner(),
-            hdr_out.destination(),
-            icmp_out.identifier().unwrap(),
-            done_reason,
-        )
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_icmp_echo_nat() {
-        let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs());
-        config.validate().unwrap();
-
-        // Check that we can validate the allocator
-        let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
-
-        // No NAT
-        let (orig_src, orig_dst, orig_identifier) = (addr_v4("8.8.8.8"), addr_v4("9.9.9.9"), 1337);
-        let (output_src, output_dst, output_identifier, done_reason) = check_packet_icmp_echo(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            IcmpEchoDirection::Request,
-            orig_identifier,
-        );
-        assert_eq!(output_src, orig_src);
-        assert_eq!(output_dst, orig_dst);
-        assert_eq!(output_identifier, orig_identifier);
-        assert_eq!(done_reason, Some(DoneReason::Filtered));
-
-        // NAT: expose121 <-> expose211
-        let (orig_src, orig_dst, orig_identifier) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"), 1337);
-        let target_src = addr_v4("2.2.0.0");
-        let (output_src, output_dst, output_identifier_1, done_reason) = check_packet_icmp_echo(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            IcmpEchoDirection::Request,
-            orig_identifier,
-        );
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, orig_dst);
-        assert!(output_identifier_1.is_multiple_of(256)); // First port of a 256-port "port block" from allocator
-        assert_eq!(done_reason, None);
-
-        // Reverse path
-        let (return_output_src, return_output_dst, return_output_identifier, done_reason) =
-            check_packet_icmp_echo(
-                &mut nat,
-                vni(200),
-                vni(100),
-                orig_dst,
-                target_src,
-                IcmpEchoDirection::Reply,
-                output_identifier_1,
-            );
-        assert_eq!(return_output_src, orig_dst);
-        assert_eq!(return_output_dst, orig_src);
-        assert_eq!(return_output_identifier, orig_identifier);
-        assert_eq!(done_reason, None);
-
-        // Second request with same identifier: no reallocation
-        let (orig_src, orig_dst) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"));
-        let target_src = addr_v4("2.2.0.0");
-        let (output_src, output_dst, output_identifier_2, done_reason) = check_packet_icmp_echo(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            IcmpEchoDirection::Request,
-            orig_identifier,
-        );
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, orig_dst);
-        assert_eq!(output_identifier_2, output_identifier_1); // Same identifier as before
-        assert_eq!(done_reason, None);
-
-        // NAT: expose121 <-> expose211 again, but with identifier 0 (corner case)
-        let (orig_src, orig_dst, orig_identifier) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"), 0);
-        let target_src = addr_v4("2.2.0.0");
-        let (output_src, output_dst, output_identifier_3, done_reason) = check_packet_icmp_echo(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            IcmpEchoDirection::Request,
-            orig_identifier,
-        );
-
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, orig_dst);
-        assert_eq!(output_identifier_3, output_identifier_1 + 1); // Second port of the same 256-port "port block" from allocator
-        assert_eq!(done_reason, None);
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn check_packet_icmp_error(
-        nat: &mut StatefulNat,
-        src_vni: Vni,
-        dst_vni: Vni,
-        outer_src_ip: Ipv4Addr,
-        outer_dst_ip: Ipv4Addr,
-        inner_src_ip: Ipv4Addr,
-        inner_dst_ip: Ipv4Addr,
-        next_header: NextHeader,
-        inner_param_1: u16,
-        inner_param_2: u16,
-    ) -> (
-        Ipv4Addr,
-        Ipv4Addr,
-        Ipv4Addr,
-        Ipv4Addr,
-        u16,
-        u16,
-        Option<DoneReason>,
-    ) {
-        let mut packet: Packet<TestBuffer> = build_test_icmp4_destination_unreachable_packet(
-            outer_src_ip,
-            outer_dst_ip,
-            inner_src_ip,
-            inner_dst_ip,
-            next_header,
-            inner_param_1,
-            inner_param_2,
-        )
+    // VPC1 <-> VPC2
+    let expose121 = VpcExpose::empty()
+        .make_stateful_nat(Some(ONE_MINUTE))
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("10.12.0.0/16".into())
         .unwrap();
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateful_nat(true); // set to false since ICMP error handler will take care
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
-        packet.meta_mut().dst_vpcd.take(); // remove to force processing by stateful
+    let expose122 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.2.0.0/16".into())
+        .as_range("10.98.128.0/17".into())
+        .unwrap()
+        .as_range("10.99.0.0/17".into())
+        .unwrap();
+    let expose123 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.3.0.0/24".into())
+        .as_range("10.100.0.0/24".into())
+        .unwrap();
+    let expose211 = VpcExpose::empty().ip("10.201.201.0/24".into());
+    let expose212 = VpcExpose::empty().ip("10.201.202.0/24".into());
+    let expose213 = VpcExpose::empty().ip("10.201.203.0/24".into());
+    let expose214 = VpcExpose::empty().ip("10.201.204.192/28".into());
 
-        flow_lookup(nat.sessions(), &mut packet);
+    // VPC1 <-> VPC3
+    let expose131 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("3.3.0.0/16".into())
+        .unwrap();
+    let expose132 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.2.0.0/16".into())
+        .as_range("3.1.0.0/16".into())
+        .unwrap()
+        .not_as("3.1.128.0/17".into())
+        .unwrap()
+        .as_range("3.2.0.0/17".into())
+        .unwrap();
+    let expose311 = VpcExpose::empty().ip("3.3.3.0/24".into());
 
-        let mut icmp_handler = IcmpErrorHandler::new(nat.sessions().clone());
-        let packets_out = icmp_handler.process(vec![packet].into_iter());
-        let packets_out: Vec<_> = nat.process(packets_out).collect();
+    // VPC1 <-> VPC4
+    let expose141 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("4.4.0.0/16".into())
+        .unwrap();
+    let expose411 = VpcExpose::empty().ip("4.5.0.0/16".into());
 
-        let hdr_out = packets_out[0].try_ipv4().unwrap();
-        let inner_ip_out = packets_out[0].try_inner_ipv4().unwrap();
-        let inner_transport_out = packets_out[0].try_embedded_transport().unwrap();
-        let (out_inner_param_1, out_inner_param_2) = match inner_transport_out {
-            EmbeddedTransport::Tcp(TruncatedTcp::FullHeader(tcp)) => {
-                (tcp.source().into(), tcp.destination().into())
-            }
-            EmbeddedTransport::Udp(TruncatedUdp::FullHeader(udp)) => {
-                (udp.source().into(), udp.destination().into())
-            }
-            EmbeddedTransport::Icmp4(TruncatedIcmp4::FullHeader(icmp)) => {
-                let Icmp4Type::EchoRequest(echo) = icmp.icmp_type() else {
-                    unreachable!();
-                };
-                (echo.id, echo.seq)
-            }
-            _ => unreachable!(),
-        };
-        let done_reason = packets_out[0].get_done();
+    // VPC2 <-> VPC4
+    let expose241 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("2.4.0.0/16".into())
+        .not("2.4.1.0/24".into())
+        .as_range("44.0.0.0/16".into())
+        .unwrap()
+        .not_as("44.0.200.0/24".into())
+        .unwrap();
+    let expose421 = VpcExpose::empty()
+        .ip("44.4.0.0/16".into())
+        .not("44.4.64.0/18".into());
 
-        (
-            hdr_out.source().inner(),
-            hdr_out.destination(),
-            inner_ip_out.source().inner(),
-            inner_ip_out.destination(),
-            out_inner_param_1,
-            out_inner_param_2,
-            done_reason,
-        )
+    // VPC3 <-> VPC4
+    let expose341 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("192.168.100.0/24".into())
+        .as_range("34.34.34.0/24".into())
+        .unwrap();
+    let expose431 = VpcExpose::empty().ip("4.4.0.0/24".into());
+
+    // VPC1 <-> VPC2
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose121);
+    add_expose(&mut manifest12, expose122);
+    add_expose(&mut manifest12, expose123);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose211);
+    add_expose(&mut manifest21, expose212);
+    add_expose(&mut manifest21, expose213);
+    add_expose(&mut manifest21, expose214);
+
+    // VPC1 <-> VPC3
+    let mut manifest13 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest13, expose131);
+    add_expose(&mut manifest13, expose132);
+    let mut manifest31 = VpcManifest::new("VPC-3");
+    add_expose(&mut manifest31, expose311);
+
+    // VPC1 <-> VPC4
+    let mut manifest14 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest14, expose141);
+    let mut manifest41 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest41, expose411);
+
+    // VPC2 <-> VPC4
+    let mut manifest24 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest24, expose241);
+    let mut manifest42 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest42, expose421);
+
+    // VPC3 <-> VPC4
+    let mut manifest34 = VpcManifest::new("VPC-3");
+    add_expose(&mut manifest34, expose341);
+    let mut manifest43 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest43, expose431);
+
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
+    let peering31 = VpcPeering::with_default_group("VPC-3--VPC-1", manifest31, manifest13);
+    let peering14 = VpcPeering::with_default_group("VPC-1--VPC-4", manifest14, manifest41);
+    let peering24 = VpcPeering::with_default_group("VPC-2--VPC-4", manifest24, manifest42);
+    let peering34 = VpcPeering::with_default_group("VPC-3--VPC-4", manifest34, manifest43);
+
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
+    peering_table.add(peering31).expect("Failed to add peering");
+    peering_table.add(peering14).expect("Failed to add peering");
+    peering_table.add(peering24).expect("Failed to add peering");
+    peering_table.add(peering34).expect("Failed to add peering");
+
+    Overlay::new(vpc_table, peering_table)
+}
+
+fn build_overlay_2vpcs() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    #[tokio::test]
-    #[traced_test]
-    async fn test_icmp_error_nat() {
-        let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs());
-        config.validate().unwrap();
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
 
-        // Check that we can validate the allocator
-        let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
+    let expose121 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("2.2.0.0/16".into())
+        .unwrap();
+    let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
 
-        // ICMP Error msg: expose211 -> expose121, no previous session for inner packet
-        let (
-            router_src,
-            orig_outer_dst,
-            orig_inner_src,
-            orig_inner_dst,
-            orig_echo_identifier,
-            orig_echo_seq_number,
-        ) = (
-            // Host 1.1.2.3 in VPC1 sent imaginary ICMP Echo packet to 3.3.3.3 in VPC2,
-            // which imaginarily got translated as 2.2.0.0 -> 3.3.3.3.
-            // Router 1.2.2.18 from VPC2 returns Destination Unreachable to 2.2.0.0 with initial
-            // datagram embedded in it
-            addr_v4("1.2.2.18"),
-            addr_v4("2.2.0.0"),
-            addr_v4("2.2.0.0"),
-            addr_v4("3.3.3.3"),
-            1337,
-            0,
-        );
-        let (
-            output_outer_src,
-            output_outer_dst,
-            output_inner_src,
-            output_inner_dst,
-            output_inner_identifier,
-            output_inner_seq_number,
-            done_reason,
-        ) = check_packet_icmp_error(
-            &mut nat,
-            vni(200),
-            vni(100),
-            router_src,
-            orig_outer_dst,
-            orig_inner_src,
-            orig_inner_dst,
-            NextHeader::ICMP,
-            orig_echo_identifier,
-            orig_echo_seq_number,
-        );
-        assert_eq!(output_outer_src, router_src);
-        assert_eq!(output_outer_dst, orig_outer_dst);
-        assert_eq!(output_inner_src, orig_inner_src);
-        assert_eq!(output_inner_dst, orig_inner_dst);
-        assert_eq!(output_inner_identifier, orig_echo_identifier);
-        assert_eq!(output_inner_seq_number, orig_echo_seq_number);
-        assert_eq!(done_reason, Some(DoneReason::Filtered));
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose121);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose211);
 
-        // ICMP Echo Request expose121 -> expose211
-        let (orig_echo_src, orig_echo_dst, target_echo_src, target_echo_dst) = (
-            addr_v4("1.1.2.3"),
-            addr_v4("3.3.3.3"),
-            addr_v4("2.2.0.0"),
-            addr_v4("3.3.3.3"),
-        );
-        let (output_echo_src, output_echo_dst, output_echo_identifier, done_reason) =
-            check_packet_icmp_echo(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_echo_src,
-                orig_echo_dst,
-                IcmpEchoDirection::Request,
-                orig_echo_identifier,
-            );
-        assert_eq!(output_echo_src, target_echo_src);
-        assert_eq!(output_echo_dst, target_echo_dst);
-        assert!(output_echo_identifier.is_multiple_of(256)); // First port of a 256-port "port block" from allocator
-        assert_eq!(done_reason, None);
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
 
-        // ICMP Error message: expose211 -> expose121, after establishing session for inner packet
-        //
-        // Same IPs as before, this time we've actually sent the ICMP Echo Request from 1.1.2.3 to
-        // 3.3.3.3 and we have a session for the inner packet
-        //
-        // Output packet received by Echo Request emitter should be:
-        // - Outer source IP: 3.3.3.3 (original destination for Echo Request)
-        // - Outer destination IP: 1.1.2.3 (original emitter of Echo Request)
-        // - Inner source IP: 1.1.2.3 (original emitter of Echo Request)
-        // - Inner destination IP: 3.3.3.3 (original destination for Echo Request)
-        // - Inner identifier: original identifier from Echo Request
-        // - Inner sequence number: always unchanged
-        let (
-            output_outer_src,
-            output_outer_dst,
-            output_inner_src,
-            output_inner_dst,
-            output_inner_identifier,
-            output_inner_seq_number,
-            done_reason,
-        ) = check_packet_icmp_error(
-            &mut nat,
-            vni(200),
-            vni(100),
-            router_src,
-            target_echo_src,
-            target_echo_src,
-            target_echo_dst,
-            NextHeader::ICMP,
-            output_echo_identifier,
-            orig_echo_seq_number,
-        );
-        // Outer source remains unchanged, see comments in deal_with_icmp_error_msg()
-        assert_eq!(output_outer_src, router_src);
-        assert_eq!(output_outer_dst, orig_echo_src);
-        assert_eq!(output_inner_src, orig_echo_src);
-        assert_eq!(output_inner_dst, orig_echo_dst);
-        assert_eq!(output_inner_identifier, orig_echo_identifier);
-        assert_eq!(output_inner_seq_number, orig_echo_seq_number);
-        assert_eq!(done_reason, None);
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
+
+    Overlay::new(vpc_table, peering_table)
+}
+
+fn check_packet(
+    nat: &mut StatefulNat,
+    src_vni: Vni,
+    dst_vni: Vni,
+    src_ip: &str,
+    dst_ip: &str,
+    sport: u16,
+    dport: u16,
+) -> (Ipv4Addr, Ipv4Addr, u16, u16, Option<DoneReason>) {
+    let mut packet: Packet<TestBuffer> = build_test_udp_ipv4_frame(
+        Mac([0x2, 0, 0, 0, 0, 1]),
+        Mac([0x2, 0, 0, 0, 0, 2]),
+        src_ip,
+        dst_ip,
+        sport,
+        dport,
+    );
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateful_nat(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+
+    flow_lookup(nat.sessions(), &mut packet);
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let hdr_out = packets_out[0].try_ipv4().unwrap();
+    let udp_out = packets_out[0].try_udp().unwrap();
+    let done_reason = packets_out[0].get_done();
+
+    (
+        hdr_out.source().inner(),
+        hdr_out.destination(),
+        udp_out.source().into(),
+        udp_out.destination().into(),
+        done_reason,
+    )
+}
+
+fn flow_lookup<Buf: PacketBufferMut>(flow_table: &FlowTable, packet: &mut Packet<Buf>) {
+    let flow_key = FlowKey::try_from(Uni(&*packet)).unwrap();
+    if let Some(flow_info) = flow_table.lookup(&flow_key) {
+        packet.meta_mut().flow_info = Some(flow_info);
+    }
+}
+
+#[tokio::test]
+#[traced_test]
+#[allow(clippy::too_many_lines)]
+async fn test_full_config() {
+    let mut config = build_gwconfig_from_overlay(build_overlay_4vpcs());
+    config.validate().unwrap();
+
+    // Check that we can validate the allocator
+    let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+
+    // No NAT
+    let (orig_src, orig_dst) = ("8.8.8.8", "9.9.9.9");
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
+    assert_eq!(output_src, addr_v4(orig_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert_eq!(output_src_port, 9998);
+    assert_eq!(output_dst_port, 443);
+    assert_eq!(done_reason, Some(DoneReason::Filtered));
+
+    // NAT: expose121 <-> expose211
+    let (orig_src, orig_dst) = ("1.1.2.3", "10.201.201.18");
+    let target_src = "10.12.0.0";
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
+    assert_eq!(done_reason, None);
+
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    // Reverse path
+    let (
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        done_reason,
+    ) = check_packet(
+        &mut nat,
+        vni(200),
+        vni(100),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, 443);
+    assert_eq!(return_output_dst_port, 9998);
+    assert_eq!(done_reason, None);
+
+    // Get corresponding session table entries and check idle timeout
+    let Some((_, idle_timeout)) = nat.get_session::<Ipv4Addr>(
+        Some(vpcd(100)),
+        IpAddr::from_str(orig_src).unwrap(),
+        IpAddr::from_str(orig_dst).unwrap(),
+        IpProtoKey::Udp(UdpProtoKey {
+            src_port: UdpPort::new_checked(9998).unwrap(),
+            dst_port: UdpPort::new_checked(443).unwrap(),
+        }),
+    ) else {
+        unreachable!()
+    };
+    assert_eq!(idle_timeout, ONE_MINUTE);
+    // Reverse path
+    let Some((_, idle_timeout)) = nat.get_session::<Ipv4Addr>(
+        Some(vpcd(200)),
+        IpAddr::from_str(orig_dst).unwrap(),
+        IpAddr::from_str(target_src).unwrap(),
+        IpProtoKey::Udp(UdpProtoKey {
+            src_port: UdpPort::new_checked(output_dst_port).unwrap(),
+            dst_port: UdpPort::new_checked(output_src_port).unwrap(),
+        }),
+    ) else {
+        unreachable!()
+    };
+    assert_eq!(idle_timeout, ONE_MINUTE);
+
+    // Update config and allocator
+    let mut new_config = build_gwconfig_from_overlay(build_overlay_2vpcs());
+    new_config.validate().unwrap();
+    allocator
+        .update_allocator(&new_config.external.overlay.vpc_table)
+        .unwrap();
+
+    // Check existing connection
+    // TODO: We should drop this connection after updating the allocator in the future, as a
+    // result these steps should fail
+    let (orig_src, orig_dst) = ("1.1.2.3", "10.201.201.18");
+    let target_src = "10.12.0.0";
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 443);
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        done_reason,
+    ) = check_packet(
+        &mut nat,
+        vni(200),
+        vni(100),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, 443);
+    assert_eq!(return_output_dst_port, 9998);
+    assert_eq!(done_reason, None);
+
+    // Check new valid connection
+    let (orig_src, orig_dst) = ("1.1.2.3", "3.3.3.3");
+    let target_src = "2.2.0.0";
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst, 9998, 80);
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        done_reason,
+    ) = check_packet(
+        &mut nat,
+        vni(200),
+        vni(100),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, 80);
+    assert_eq!(return_output_dst_port, 9998);
+    assert_eq!(done_reason, None);
+}
+
+fn build_overlay_2vpcs_no_nat() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    fn build_overlay_2vpcs_with_default() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
 
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
+    let expose121 = VpcExpose::empty().ip("1.1.0.0/16".into());
+    let expose211 = VpcExpose::empty().ip("2.2.0.0/16".into());
 
-        let expose121 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("2.2.0.0/16".into())
-            .unwrap();
-        let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
-        let expose212 = VpcExpose::empty().set_default();
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose121);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose211);
 
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose121);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose211);
-        add_expose(&mut manifest21, expose212);
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
 
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
 
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
+    Overlay::new(vpc_table, peering_table)
+}
 
-        Overlay::new(vpc_table, peering_table)
-    }
+#[test]
+#[traced_test]
+fn test_full_config_no_nat() {
+    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_no_nat());
+    config.validate().unwrap();
 
-    #[tokio::test]
-    async fn test_default_expose() {
-        let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_with_default());
-        config.validate().unwrap();
+    // Check that we can validate the allocator
+    let (_, mut allocator) = StatefulNat::new_with_defaults();
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+}
 
-        // Check that we can validate the allocator
-        let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
+fn check_packet_icmp_echo(
+    nat: &mut StatefulNat,
+    src_vni: Vni,
+    dst_vni: Vni,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    direction: IcmpEchoDirection,
+    identifier: u16,
+) -> (Ipv4Addr, Ipv4Addr, u16, Option<DoneReason>) {
+    let mut packet: Packet<TestBuffer> =
+        build_test_icmp4_echo(src_ip, dst_ip, identifier, direction).unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateful_nat(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
 
-        // Using the expose with a prefix
-        let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.1.0.1", "3.3.3.3", 9999, 443);
-        let target_src = "2.2.0.0";
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) = check_packet(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            orig_src_port,
-            orig_dst_port,
-        );
-        assert_eq!(done_reason, None);
+    flow_lookup(nat.sessions(), &mut packet);
 
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        // Reverse path
-        let (
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            done_reason,
-        ) = check_packet(
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let hdr_out = packets_out[0].try_ipv4().unwrap();
+    let icmp_out = packets_out[0].try_icmp4().unwrap();
+    let done_reason = packets_out[0].get_done();
+
+    (
+        hdr_out.source().inner(),
+        hdr_out.destination(),
+        icmp_out.identifier().unwrap(),
+        done_reason,
+    )
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_icmp_echo_nat() {
+    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs());
+    config.validate().unwrap();
+
+    // Check that we can validate the allocator
+    let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+
+    // No NAT
+    let (orig_src, orig_dst, orig_identifier) = (addr_v4("8.8.8.8"), addr_v4("9.9.9.9"), 1337);
+    let (output_src, output_dst, output_identifier, done_reason) = check_packet_icmp_echo(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        IcmpEchoDirection::Request,
+        orig_identifier,
+    );
+    assert_eq!(output_src, orig_src);
+    assert_eq!(output_dst, orig_dst);
+    assert_eq!(output_identifier, orig_identifier);
+    assert_eq!(done_reason, Some(DoneReason::Filtered));
+
+    // NAT: expose121 <-> expose211
+    let (orig_src, orig_dst, orig_identifier) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"), 1337);
+    let target_src = addr_v4("2.2.0.0");
+    let (output_src, output_dst, output_identifier_1, done_reason) = check_packet_icmp_echo(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        IcmpEchoDirection::Request,
+        orig_identifier,
+    );
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, orig_dst);
+    assert!(output_identifier_1.is_multiple_of(256)); // First port of a 256-port "port block" from allocator
+    assert_eq!(done_reason, None);
+
+    // Reverse path
+    let (return_output_src, return_output_dst, return_output_identifier, done_reason) =
+        check_packet_icmp_echo(
             &mut nat,
             vni(200),
             vni(100),
             orig_dst,
             target_src,
-            output_dst_port,
-            output_src_port,
+            IcmpEchoDirection::Reply,
+            output_identifier_1,
         );
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
+    assert_eq!(return_output_src, orig_dst);
+    assert_eq!(return_output_dst, orig_src);
+    assert_eq!(return_output_identifier, orig_identifier);
+    assert_eq!(done_reason, None);
 
-        // Using the default expose
-        let (orig_src, orig_dst, orig_src_port, orig_dst_port) =
-            ("1.1.0.1", "10.11.12.13", 9999, 443);
-        let target_src = "2.2.0.0";
-        let (output_src, output_dst, output_src_port, output_dst_port, done_reason) = check_packet(
-            &mut nat,
-            vni(100),
-            vni(200),
-            orig_src,
-            orig_dst,
-            orig_src_port,
-            orig_dst_port,
-        );
-        assert_eq!(done_reason, None);
+    // Second request with same identifier: no reallocation
+    let (orig_src, orig_dst) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"));
+    let target_src = addr_v4("2.2.0.0");
+    let (output_src, output_dst, output_identifier_2, done_reason) = check_packet_icmp_echo(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        IcmpEchoDirection::Request,
+        orig_identifier,
+    );
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, orig_dst);
+    assert_eq!(output_identifier_2, output_identifier_1); // Same identifier as before
+    assert_eq!(done_reason, None);
 
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        // Reverse path
-        let (
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            done_reason,
-        ) = check_packet(
-            &mut nat,
-            vni(200),
-            vni(100),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
-    }
+    // NAT: expose121 <-> expose211 again, but with identifier 0 (corner case)
+    let (orig_src, orig_dst, orig_identifier) = (addr_v4("1.1.2.3"), addr_v4("3.3.3.3"), 0);
+    let target_src = addr_v4("2.2.0.0");
+    let (output_src, output_dst, output_identifier_3, done_reason) = check_packet_icmp_echo(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        IcmpEchoDirection::Request,
+        orig_identifier,
+    );
 
-    fn build_overlay_3vpcs_unidirectional_nat_overlapping_addr() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, orig_dst);
+    assert_eq!(output_identifier_3, output_identifier_1 + 1); // Second port of the same 256-port "port block" from allocator
+    assert_eq!(done_reason, None);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_packet_icmp_error(
+    nat: &mut StatefulNat,
+    src_vni: Vni,
+    dst_vni: Vni,
+    outer_src_ip: Ipv4Addr,
+    outer_dst_ip: Ipv4Addr,
+    inner_src_ip: Ipv4Addr,
+    inner_dst_ip: Ipv4Addr,
+    next_header: NextHeader,
+    inner_param_1: u16,
+    inner_param_2: u16,
+) -> (
+    Ipv4Addr,
+    Ipv4Addr,
+    Ipv4Addr,
+    Ipv4Addr,
+    u16,
+    u16,
+    Option<DoneReason>,
+) {
+    let mut packet: Packet<TestBuffer> = build_test_icmp4_destination_unreachable_packet(
+        outer_src_ip,
+        outer_dst_ip,
+        inner_src_ip,
+        inner_dst_ip,
+        next_header,
+        inner_param_1,
+        inner_param_2,
+    )
+    .unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateful_nat(true); // set to false since ICMP error handler will take care
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+    packet.meta_mut().dst_vpcd.take(); // remove to force processing by stateful
+
+    flow_lookup(nat.sessions(), &mut packet);
+
+    let mut icmp_handler = IcmpErrorHandler::new(nat.sessions().clone());
+    let packets_out = icmp_handler.process(vec![packet].into_iter());
+    let packets_out: Vec<_> = nat.process(packets_out).collect();
+
+    let hdr_out = packets_out[0].try_ipv4().unwrap();
+    let inner_ip_out = packets_out[0].try_inner_ipv4().unwrap();
+    let inner_transport_out = packets_out[0].try_embedded_transport().unwrap();
+    let (out_inner_param_1, out_inner_param_2) = match inner_transport_out {
+        EmbeddedTransport::Tcp(TruncatedTcp::FullHeader(tcp)) => {
+            (tcp.source().into(), tcp.destination().into())
         }
+        EmbeddedTransport::Udp(TruncatedUdp::FullHeader(udp)) => {
+            (udp.source().into(), udp.destination().into())
+        }
+        EmbeddedTransport::Icmp4(TruncatedIcmp4::FullHeader(icmp)) => {
+            let Icmp4Type::EchoRequest(echo) = icmp.icmp_type() else {
+                unreachable!();
+            };
+            (echo.id, echo.seq)
+        }
+        _ => unreachable!(),
+    };
+    let done_reason = packets_out[0].get_done();
 
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).unwrap());
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).unwrap());
-        let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).unwrap());
+    (
+        hdr_out.source().inner(),
+        hdr_out.destination(),
+        inner_ip_out.source().inner(),
+        inner_ip_out.destination(),
+        out_inner_param_1,
+        out_inner_param_2,
+        done_reason,
+    )
+}
 
-        // VPC-1 <-> VPC-2 <-> VPC-3; No connection between VPC-1 and VPC-3
+#[tokio::test]
+#[traced_test]
+async fn test_icmp_error_nat() {
+    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs());
+    config.validate().unwrap();
 
-        // VPC-1 (NAT) <-> VPC-2 (no NAT)
-        let expose12 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into())
-            .unwrap();
-        let expose21 = VpcExpose::empty().ip("5.0.0.0/24".into());
+    // Check that we can validate the allocator
+    let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
 
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose12);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose21);
+    // ICMP Error msg: expose211 -> expose121, no previous session for inner packet
+    let (
+        router_src,
+        orig_outer_dst,
+        orig_inner_src,
+        orig_inner_dst,
+        orig_echo_identifier,
+        orig_echo_seq_number,
+    ) = (
+        // Host 1.1.2.3 in VPC1 sent imaginary ICMP Echo packet to 3.3.3.3 in VPC2,
+        // which imaginarily got translated as 2.2.0.0 -> 3.3.3.3.
+        // Router 1.2.2.18 from VPC2 returns Destination Unreachable to 2.2.0.0 with initial
+        // datagram embedded in it
+        addr_v4("1.2.2.18"),
+        addr_v4("2.2.0.0"),
+        addr_v4("2.2.0.0"),
+        addr_v4("3.3.3.3"),
+        1337,
+        0,
+    );
+    let (
+        output_outer_src,
+        output_outer_dst,
+        output_inner_src,
+        output_inner_dst,
+        output_inner_identifier,
+        output_inner_seq_number,
+        done_reason,
+    ) = check_packet_icmp_error(
+        &mut nat,
+        vni(200),
+        vni(100),
+        router_src,
+        orig_outer_dst,
+        orig_inner_src,
+        orig_inner_dst,
+        NextHeader::ICMP,
+        orig_echo_identifier,
+        orig_echo_seq_number,
+    );
+    assert_eq!(output_outer_src, router_src);
+    assert_eq!(output_outer_dst, orig_outer_dst);
+    assert_eq!(output_inner_src, orig_inner_src);
+    assert_eq!(output_inner_dst, orig_inner_dst);
+    assert_eq!(output_inner_identifier, orig_echo_identifier);
+    assert_eq!(output_inner_seq_number, orig_echo_seq_number);
+    assert_eq!(done_reason, Some(DoneReason::Filtered));
 
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-
-        // VPC-2 (no NAT) <-> VPC-3 (NAT)
-        let expose32 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into())
-            .unwrap();
-        let expose23 = VpcExpose::empty().ip("5.0.0.0/24".into());
-
-        let mut manifest23 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest23, expose23);
-        let mut manifest32 = VpcManifest::new("VPC-3");
-        add_expose(&mut manifest32, expose32);
-
-        let peering23 = VpcPeering::with_default_group("VPC-2--VPC-3", manifest23, manifest32);
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).unwrap();
-        peering_table.add(peering23).unwrap();
-
-        Overlay::new(vpc_table, peering_table)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn check_packet_with_vpcd_lookup(
-        nat: &mut StatefulNat,
-        vpcdlookup: &mut FlowFilter,
-        flow_lookup_stage: Option<&mut FlowLookup>,
-        src_vni: Vni,
-        src_ip: &str,
-        dst_ip: &str,
-        sport: u16,
-        dport: u16,
-    ) -> (
-        Option<VpcDiscriminant>,
-        Ipv4Addr,
-        Ipv4Addr,
-        u16,
-        u16,
-        Option<DoneReason>,
-    ) {
-        let mut packet: Packet<TestBuffer> = build_test_udp_ipv4_frame(
-            Mac([0x2, 0, 0, 0, 0, 1]),
-            Mac([0x2, 0, 0, 0, 0, 2]),
-            src_ip,
-            dst_ip,
-            sport,
-            dport,
+    // ICMP Echo Request expose121 -> expose211
+    let (orig_echo_src, orig_echo_dst, target_echo_src, target_echo_dst) = (
+        addr_v4("1.1.2.3"),
+        addr_v4("3.3.3.3"),
+        addr_v4("2.2.0.0"),
+        addr_v4("3.3.3.3"),
+    );
+    let (output_echo_src, output_echo_dst, output_echo_identifier, done_reason) =
+        check_packet_icmp_echo(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_echo_src,
+            orig_echo_dst,
+            IcmpEchoDirection::Request,
+            orig_echo_identifier,
         );
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    assert_eq!(output_echo_src, target_echo_src);
+    assert_eq!(output_echo_dst, target_echo_dst);
+    assert!(output_echo_identifier.is_multiple_of(256)); // First port of a 256-port "port block" from allocator
+    assert_eq!(done_reason, None);
 
-        // Flow table lookup
-        let packets_from_flow_lookup: Vec<_> = if let Some(stage) = flow_lookup_stage {
-            // Use dedicated stage, which attaches the destination VPC discriminant to the packet,
-            // if any is found from the flow table.
-            stage
-                .process::<std::vec::IntoIter<Packet<TestBuffer>>>(vec![packet].into_iter())
-                .collect()
-        } else {
-            // Simple flow lookup, without attaching the destination VPC discriminant to the packet.
-            flow_lookup(nat.sessions(), &mut packet.clone());
-            vec![packet]
-        };
+    // ICMP Error message: expose211 -> expose121, after establishing session for inner packet
+    //
+    // Same IPs as before, this time we've actually sent the ICMP Echo Request from 1.1.2.3 to
+    // 3.3.3.3 and we have a session for the inner packet
+    //
+    // Output packet received by Echo Request emitter should be:
+    // - Outer source IP: 3.3.3.3 (original destination for Echo Request)
+    // - Outer destination IP: 1.1.2.3 (original emitter of Echo Request)
+    // - Inner source IP: 1.1.2.3 (original emitter of Echo Request)
+    // - Inner destination IP: 3.3.3.3 (original destination for Echo Request)
+    // - Inner identifier: original identifier from Echo Request
+    // - Inner sequence number: always unchanged
+    let (
+        output_outer_src,
+        output_outer_dst,
+        output_inner_src,
+        output_inner_dst,
+        output_inner_identifier,
+        output_inner_seq_number,
+        done_reason,
+    ) = check_packet_icmp_error(
+        &mut nat,
+        vni(200),
+        vni(100),
+        router_src,
+        target_echo_src,
+        target_echo_src,
+        target_echo_dst,
+        NextHeader::ICMP,
+        output_echo_identifier,
+        orig_echo_seq_number,
+    );
+    // Outer source remains unchanged, see comments in deal_with_icmp_error_msg()
+    assert_eq!(output_outer_src, router_src);
+    assert_eq!(output_outer_dst, orig_echo_src);
+    assert_eq!(output_inner_src, orig_echo_src);
+    assert_eq!(output_inner_dst, orig_echo_dst);
+    assert_eq!(output_inner_identifier, orig_echo_identifier);
+    assert_eq!(output_inner_seq_number, orig_echo_seq_number);
+    assert_eq!(done_reason, None);
+}
 
-        // VPC discriminant lookup
-        let packets_from_vpcd_lookup: Vec<_> = vpcdlookup
-            .process::<std::vec::IntoIter<Packet<TestBuffer>>>(packets_from_flow_lookup.into_iter())
-            .collect();
-
-        // NAT
-        let packets_out: Vec<_> = nat
-            .process::<std::vec::IntoIter<Packet<TestBuffer>>>(packets_from_vpcd_lookup.into_iter())
-            .collect();
-
-        let dst_vpcd = packets_out[0].meta().dst_vpcd;
-        let hdr_out = packets_out[0].try_ipv4().unwrap();
-        let udp_out = packets_out[0].try_udp().unwrap();
-        let done_reason = packets_out[0].get_done();
-
-        (
-            dst_vpcd,
-            hdr_out.source().inner(),
-            hdr_out.destination(),
-            udp_out.source().into(),
-            udp_out.destination().into(),
-            done_reason,
-        )
+fn build_overlay_2vpcs_with_default() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    #[tokio::test]
-    #[allow(clippy::too_many_lines)]
-    async fn test_full_config_unidirectional_nat_overlapping_destination() {
-        let tctl = get_trace_ctl();
-        let _ = tctl.setup_from_string("vpc-routing=debug,flow-lookup=debug,stateful-nat=debug");
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
 
-        let mut config =
-            build_gwconfig_from_overlay(build_overlay_3vpcs_unidirectional_nat_overlapping_addr());
-        config.validate().unwrap();
+    let expose121 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("2.2.0.0/16".into())
+        .unwrap();
+    let expose211 = VpcExpose::empty().ip("3.3.3.0/24".into());
+    let expose212 = VpcExpose::empty().set_default();
 
-        // Build VPC discriminant lookup stage
-        let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
-        let mut vpcdtablesw = FlowFilterTableWriter::new();
-        vpcdtablesw.update_flow_filter_table(vpcd_tables);
-        let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose121);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose211);
+    add_expose(&mut manifest21, expose212);
 
-        /////////////////////////////////////////////////////////////////
-        // First NAT stage: We do not search for the destination VPC discriminant in the flow table.
-        // We expect return packets to fail to find a destination VPC ID due to the conflicts
-        // between the IPs exposed by VPC-2 for both VPC-1 and VPC-3, and to be dropped.
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
 
-        // Build NAT stage
-        let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
 
-        // Check that we can validate the allocator
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
+    Overlay::new(vpc_table, peering_table)
+}
 
-        // NAT: expose12 <-> expose21
-        let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
-        let target_src = "2.0.0.0";
-        let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet_with_vpcd_lookup(
-                &mut nat,
-                &mut vpcdlookup,
-                // Simple lookup without attaching the destination VPC ID to the packet.
-                None,
-                vni(100),
-                orig_src,
-                orig_dst,
-                orig_src_port,
-                orig_dst_port,
-            );
-        assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert!(
-            output_src_port.is_multiple_of(256) || output_src_port == 1,
-            "{output_src_port}"
-        ); // We never use port 0
-        assert_eq!(output_dst_port, orig_dst_port);
-        assert_eq!(done_reason, None);
+#[tokio::test]
+async fn test_default_expose() {
+    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_with_default());
+    config.validate().unwrap();
 
-        // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be VPC-1 or VPC-3)
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
+    // Check that we can validate the allocator
+    let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+
+    // Using the expose with a prefix
+    let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.1.0.1", "3.3.3.3", 9999, 443);
+    let target_src = "2.2.0.0";
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) = check_packet(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        orig_src_port,
+        orig_dst_port,
+    );
+    assert_eq!(done_reason, None);
+
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    // Reverse path
+    let (
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        done_reason,
+    ) = check_packet(
+        &mut nat,
+        vni(200),
+        vni(100),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
+
+    // Using the default expose
+    let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.1.0.1", "10.11.12.13", 9999, 443);
+    let target_src = "2.2.0.0";
+    let (output_src, output_dst, output_src_port, output_dst_port, done_reason) = check_packet(
+        &mut nat,
+        vni(100),
+        vni(200),
+        orig_src,
+        orig_dst,
+        orig_src_port,
+        orig_dst_port,
+    );
+    assert_eq!(done_reason, None);
+
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    // Reverse path
+    let (
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        done_reason,
+    ) = check_packet(
+        &mut nat,
+        vni(200),
+        vni(100),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
+}
+
+fn build_overlay_3vpcs_unidirectional_nat_overlapping_addr() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
+    }
+
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).unwrap());
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).unwrap());
+    let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).unwrap());
+
+    // VPC-1 <-> VPC-2 <-> VPC-3; No connection between VPC-1 and VPC-3
+
+    // VPC-1 (NAT) <-> VPC-2 (no NAT)
+    let expose12 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.0.0.0/24".into())
+        .as_range("2.0.0.0/24".into())
+        .unwrap();
+    let expose21 = VpcExpose::empty().ip("5.0.0.0/24".into());
+
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose12);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose21);
+
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
+
+    // VPC-2 (no NAT) <-> VPC-3 (NAT)
+    let expose32 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.0.0.0/24".into())
+        .as_range("2.0.0.0/24".into())
+        .unwrap();
+    let expose23 = VpcExpose::empty().ip("5.0.0.0/24".into());
+
+    let mut manifest23 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest23, expose23);
+    let mut manifest32 = VpcManifest::new("VPC-3");
+    add_expose(&mut manifest32, expose32);
+
+    let peering23 = VpcPeering::with_default_group("VPC-2--VPC-3", manifest23, manifest32);
+
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).unwrap();
+    peering_table.add(peering23).unwrap();
+
+    Overlay::new(vpc_table, peering_table)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn check_packet_with_vpcd_lookup(
+    nat: &mut StatefulNat,
+    vpcdlookup: &mut FlowFilter,
+    flow_lookup_stage: Option<&mut FlowLookup>,
+    src_vni: Vni,
+    src_ip: &str,
+    dst_ip: &str,
+    sport: u16,
+    dport: u16,
+) -> (
+    Option<VpcDiscriminant>,
+    Ipv4Addr,
+    Ipv4Addr,
+    u16,
+    u16,
+    Option<DoneReason>,
+) {
+    let mut packet: Packet<TestBuffer> = build_test_udp_ipv4_frame(
+        Mac([0x2, 0, 0, 0, 0, 1]),
+        Mac([0x2, 0, 0, 0, 0, 2]),
+        src_ip,
+        dst_ip,
+        sport,
+        dport,
+    );
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+
+    // Flow table lookup
+    let packets_from_flow_lookup: Vec<_> = if let Some(stage) = flow_lookup_stage {
+        // Use dedicated stage, which attaches the destination VPC discriminant to the packet,
+        // if any is found from the flow table.
+        stage
+            .process::<std::vec::IntoIter<Packet<TestBuffer>>>(vec![packet].into_iter())
+            .collect()
+    } else {
+        // Simple flow lookup, without attaching the destination VPC discriminant to the packet.
+        flow_lookup(nat.sessions(), &mut packet.clone());
+        vec![packet]
+    };
+
+    // VPC discriminant lookup
+    let packets_from_vpcd_lookup: Vec<_> = vpcdlookup
+        .process::<std::vec::IntoIter<Packet<TestBuffer>>>(packets_from_flow_lookup.into_iter())
+        .collect();
+
+    // NAT
+    let packets_out: Vec<_> = nat
+        .process::<std::vec::IntoIter<Packet<TestBuffer>>>(packets_from_vpcd_lookup.into_iter())
+        .collect();
+
+    let dst_vpcd = packets_out[0].meta().dst_vpcd;
+    let hdr_out = packets_out[0].try_ipv4().unwrap();
+    let udp_out = packets_out[0].try_udp().unwrap();
+    let done_reason = packets_out[0].get_done();
+
+    (
+        dst_vpcd,
+        hdr_out.source().inner(),
+        hdr_out.destination(),
+        udp_out.source().into(),
+        udp_out.destination().into(),
+        done_reason,
+    )
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_full_config_unidirectional_nat_overlapping_destination() {
+    let tctl = get_trace_ctl();
+    let _ = tctl.setup_from_string("vpc-routing=debug,flow-lookup=debug,stateful-nat=debug");
+
+    let mut config =
+        build_gwconfig_from_overlay(build_overlay_3vpcs_unidirectional_nat_overlapping_addr());
+    config.validate().unwrap();
+
+    // Build VPC discriminant lookup stage
+    let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
+    let mut vpcdtablesw = FlowFilterTableWriter::new();
+    vpcdtablesw.update_flow_filter_table(vpcd_tables);
+    let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
+
+    /////////////////////////////////////////////////////////////////
+    // First NAT stage: We do not search for the destination VPC discriminant in the flow table.
+    // We expect return packets to fail to find a destination VPC ID due to the conflicts
+    // between the IPs exposed by VPC-2 for both VPC-1 and VPC-3, and to be dropped.
+
+    // Build NAT stage
+    let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
+
+    // Check that we can validate the allocator
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+
+    // NAT: expose12 <-> expose21
+    let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
+    let target_src = "2.0.0.0";
+    let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet_with_vpcd_lookup(
             &mut nat,
             &mut vpcdlookup,
             // Simple lookup without attaching the destination VPC ID to the packet.
             None,
-            vni(200),
+            vni(100),
+            orig_src,
             orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
+            orig_src_port,
+            orig_dst_port,
         );
-        assert_eq!(return_vpcd, None);
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(target_src));
-        assert_eq!(return_output_src_port, output_dst_port);
-        assert_eq!(return_output_dst_port, output_src_port);
-        assert_eq!(return_done_reason, Some(DoneReason::Filtered));
+    assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert!(
+        output_src_port.is_multiple_of(256) || output_src_port == 1,
+        "{output_src_port}"
+    ); // We never use port 0
+    assert_eq!(output_dst_port, orig_dst_port);
+    assert_eq!(done_reason, None);
 
-        /////////////////////////////////////////////////////////////////
-        // Second NAT stage: We update the VPC discriminant lookup table.
-        // Check that we can NAT and route the return packet.
+    // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be VPC-1 or VPC-3)
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        // Simple lookup without attaching the destination VPC ID to the packet.
+        None,
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_vpcd, None);
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(target_src));
+    assert_eq!(return_output_src_port, output_dst_port);
+    assert_eq!(return_output_dst_port, output_src_port);
+    assert_eq!(return_done_reason, Some(DoneReason::Filtered));
 
-        // Build flow table lookup stage
-        let flow_table = Arc::new(FlowTable::default());
-        let mut flow_lookup = FlowLookup::new("flow-lookup", flow_table.clone());
+    /////////////////////////////////////////////////////////////////
+    // Second NAT stage: We update the VPC discriminant lookup table.
+    // Check that we can NAT and route the return packet.
 
-        // Build a new NAT stage
-        let mut allocator = NatAllocatorWriter::new();
-        let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
+    // Build flow table lookup stage
+    let flow_table = Arc::new(FlowTable::default());
+    let mut flow_lookup = FlowLookup::new("flow-lookup", flow_table.clone());
 
-        // Check that we can validate the allocator
-        //
-        // When we build the allocator, turn off randomness to check whether we may get collisions
-        // for port allocation
-        allocator
-            .update_allocator_and_turn_off_randomness(&config.external.overlay.vpc_table)
-            .unwrap();
+    // Build a new NAT stage
+    let mut allocator = NatAllocatorWriter::new();
+    let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
 
-        // NAT: expose12 <-> expose21
-        let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
-        let target_src = "2.0.0.0";
-        let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet_with_vpcd_lookup(
-                &mut nat,
-                &mut vpcdlookup,
-                Some(&mut flow_lookup),
-                vni(100),
-                orig_src,
-                orig_dst,
-                orig_src_port,
-                orig_dst_port,
-            );
-        assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert!(
-            output_src_port.is_multiple_of(256) || output_src_port == 1,
-            "{output_src_port}"
-        );
-        assert_eq!(output_dst_port, orig_dst_port);
-        assert_eq!(done_reason, None);
+    // Check that we can validate the allocator
+    //
+    // When we build the allocator, turn off randomness to check whether we may get collisions
+    // for port allocation
+    allocator
+        .update_allocator_and_turn_off_randomness(&config.external.overlay.vpc_table)
+        .unwrap();
 
-        // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be VPC-1 or VPC-3) but
-        // the flow table lookup should resolve it to VPC-1
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(200),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        println!("{flow_table}");
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-
-        /////////////////////////////////////////////////////////////////
-        // Still with the second NAT stage, send a packet from VPC-3 to VPC-2, using same IPs and
-        // ports as for VPC-1 to VPC-2.
-        // Check that updating the flow table for this new connection does not affect destination
-        // VPC discriminant lookup from the flow table for the previous connection; in other words,
-        // check that there's no session or allocation conflict.
-
-        // Reverse path from previous connection: 5.0.0.5 -> 2.0.0.0, session is still valid
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(200),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        println!("{flow_table}");
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-
-        // NAT: expose32 <-> expose23 - Connection from VPC-3 to VPC-2, using the same IPs and ports
-        // as for VPC-1 to VPC-2 connection
-        let (orig_src_32, orig_dst_32, orig_src_port_32, orig_dst_port_32) =
-            ("1.0.0.18", "5.0.0.5", 9998, 443);
-        let target_src_32 = "2.0.0.0";
-        let (
-            dst_vpcd_32,
-            output_src_32,
-            output_dst_32,
-            output_src_port_32,
-            output_dst_port_32,
-            done_reason_32,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(300), // from VPC-3
-            orig_src_32,
-            orig_dst_32,
-            orig_src_port_32,
-            orig_dst_port_32,
-        );
-        println!("{flow_table}");
-        assert_eq!(dst_vpcd_32, Some(VpcDiscriminant::VNI(vni(200))));
-        assert_eq!(output_src_32, addr_v4(target_src_32));
-        assert_eq!(output_dst_32, addr_v4(orig_dst_32));
-        assert!(
-            output_src_port_32 % 256 == 1 || output_src_port_32 != 1 && output_src_port_32 == 2,
-            "{output_src_port_32}"
-        );
-        assert_eq!(output_dst_port_32, orig_dst_port_32);
-        assert_eq!(done_reason_32, None);
-
-        // Back to 5.0.0.5 -> 2.0.0.0 from VPC-2 to VPC-1
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(200), // from VPC-2 again
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-
-        println!("{flow_table}");
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-    }
-
-    fn build_overlay_2vpcs_unidirectional_nat_overlapping_exposes() -> Overlay {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
-
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).unwrap());
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).unwrap());
-
-        // Peering 1
-
-        let expose1_1 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("1.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into())
-            .unwrap();
-        let expose1_2 = VpcExpose::empty().ip("5.0.0.0/24".into());
-
-        let mut manifest1_1 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest1_1, expose1_1);
-        let mut manifest1_2 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest1_2, expose1_2);
-
-        let peering1 = VpcPeering::with_default_group("VPC-1--VPC-2--1", manifest1_1, manifest1_2);
-
-        // Peering 2 - Overlap with Peering 1
-
-        let expose2_1 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
-            .ip("3.0.0.0/24".into())
-            .as_range("2.0.0.0/24".into()) // Overlap
-            .unwrap();
-        let expose2_2 = VpcExpose::empty().ip("6.0.0.0/24".into());
-
-        let mut manifest2_1 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest2_1, expose2_1);
-        let mut manifest2_2 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest2_2, expose2_2);
-
-        let peering2 = VpcPeering::with_default_group("VPC-1--VPC-2--2", manifest2_1, manifest2_2);
-
-        // Peering table
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering1).unwrap();
-        peering_table.add(peering2).unwrap();
-
-        Overlay::new(vpc_table, peering_table)
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    #[allow(clippy::too_many_lines)]
-    async fn test_full_config_unidirectional_nat_overlapping_exposes_for_single_peering() {
-        let mut config = build_gwconfig_from_overlay(
-            build_overlay_2vpcs_unidirectional_nat_overlapping_exposes(),
-        );
-        // Validation fails - We currently forbid multiple peerings between any pair of VPCs. We
-        // could probably allow them for stateful NAT, but we still need the restriction for
-        // stateless NAT. We can carry on with the test anyway.
-        assert_eq!(
-            config.validate(),
-            Err(ConfigError::DuplicateVpcPeerings(
-                "VPC-1--VPC-2--2".to_owned()
-            ))
-        );
-
-        // Build VPC discriminant lookup stage
-        let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
-        let mut vpcdtablesw = FlowFilterTableWriter::new();
-        vpcdtablesw.update_flow_filter_table(vpcd_tables);
-        let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
-
-        // Build flow table lookup stage
-        let flow_table = Arc::new(FlowTable::default());
-        let mut flow_lookup = FlowLookup::new("flow-lookup", flow_table.clone());
-
-        /////////////////////////////////////////////////////////////////
-        // Build a NAT stage and send a packet through peering1.
-        // Check that NAT occurs as expected.
-
-        // Build a new NAT stage
-        let mut allocator = NatAllocatorWriter::new();
-        let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
-
-        // Check that we can validate the allocator
-        allocator
-            .update_allocator(&config.external.overlay.vpc_table)
-            .unwrap();
-
-        // NAT: expose1_1 -> expose1_2
-        let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
-        let target_src = "2.0.0.0";
-        let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
-            check_packet_with_vpcd_lookup(
-                &mut nat,
-                &mut vpcdlookup,
-                Some(&mut flow_lookup),
-                vni(100),
-                orig_src,
-                orig_dst,
-                orig_src_port,
-                orig_dst_port,
-            );
-        assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
-        assert_eq!(output_src, addr_v4(target_src));
-        assert_eq!(output_dst, addr_v4(orig_dst));
-        assert!(
-            output_src_port.is_multiple_of(256) || output_src_port == 1,
-            "{output_src_port}"
-        );
-        assert_eq!(output_dst_port, orig_dst_port);
-        assert_eq!(done_reason, None);
-
-        // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be peering1 or peering2)
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(200),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-
-        /////////////////////////////////////////////////////////////////
-        // With the same NAT stage, send a packet through peering2.
-        // Check that updating the flow table for this new connection does not affect
-        // translation for the previous connection.
-
-        // Reverse path from previous connection: 5.0.0.5 -> 2.0.0.0, session is still valid
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
-            &mut nat,
-            &mut vpcdlookup,
-            Some(&mut flow_lookup),
-            vni(200),
-            orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
-        );
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-
-        // NAT: expose2_1 <-> expose2_2 - Connection through peering2
-        let (orig_src_2, orig_dst_2, orig_src_port_2, orig_dst_port_2) =
-            ("3.0.0.4", "6.0.0.12", 8887, 800);
-        let target_src_2 = "2.0.0.0";
-        let (
-            dst_vpcd_2,
-            output_src_2,
-            output_dst_2,
-            output_src_port_2,
-            output_dst_port_2,
-            done_reason_2,
-        ) = check_packet_with_vpcd_lookup(
+    // NAT: expose12 <-> expose21
+    let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
+    let target_src = "2.0.0.0";
+    let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet_with_vpcd_lookup(
             &mut nat,
             &mut vpcdlookup,
             Some(&mut flow_lookup),
             vni(100),
-            orig_src_2,
-            orig_dst_2,
-            orig_src_port_2,
-            orig_dst_port_2,
+            orig_src,
+            orig_dst,
+            orig_src_port,
+            orig_dst_port,
         );
-        assert_eq!(dst_vpcd_2, Some(VpcDiscriminant::VNI(vni(200))));
-        assert_eq!(output_src_2, addr_v4(target_src_2));
-        assert_eq!(output_dst_2, addr_v4(orig_dst_2));
-        assert!(
-            output_src_port_2.is_multiple_of(256) || output_src_port_2 == 1,
-            "{output_src_port_2}"
-        );
-        assert_eq!(output_dst_port_2, orig_dst_port_2);
-        assert_eq!(done_reason_2, None);
+    assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert!(
+        output_src_port.is_multiple_of(256) || output_src_port == 1,
+        "{output_src_port}"
+    );
+    assert_eq!(output_dst_port, orig_dst_port);
+    assert_eq!(done_reason, None);
 
-        // Back to 5.0.0.5 -> 2.0.0.0 through peering1
-        let (
-            return_vpcd,
-            return_output_src,
-            return_output_dst,
-            return_output_src_port,
-            return_output_dst_port,
-            return_done_reason,
-        ) = check_packet_with_vpcd_lookup(
+    // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be VPC-1 or VPC-3) but
+    // the flow table lookup should resolve it to VPC-1
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    println!("{flow_table}");
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
+
+    /////////////////////////////////////////////////////////////////
+    // Still with the second NAT stage, send a packet from VPC-3 to VPC-2, using same IPs and
+    // ports as for VPC-1 to VPC-2.
+    // Check that updating the flow table for this new connection does not affect destination
+    // VPC discriminant lookup from the flow table for the previous connection; in other words,
+    // check that there's no session or allocation conflict.
+
+    // Reverse path from previous connection: 5.0.0.5 -> 2.0.0.0, session is still valid
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    println!("{flow_table}");
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
+
+    // NAT: expose32 <-> expose23 - Connection from VPC-3 to VPC-2, using the same IPs and ports
+    // as for VPC-1 to VPC-2 connection
+    let (orig_src_32, orig_dst_32, orig_src_port_32, orig_dst_port_32) =
+        ("1.0.0.18", "5.0.0.5", 9998, 443);
+    let target_src_32 = "2.0.0.0";
+    let (
+        dst_vpcd_32,
+        output_src_32,
+        output_dst_32,
+        output_src_port_32,
+        output_dst_port_32,
+        done_reason_32,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(300), // from VPC-3
+        orig_src_32,
+        orig_dst_32,
+        orig_src_port_32,
+        orig_dst_port_32,
+    );
+    println!("{flow_table}");
+    assert_eq!(dst_vpcd_32, Some(VpcDiscriminant::VNI(vni(200))));
+    assert_eq!(output_src_32, addr_v4(target_src_32));
+    assert_eq!(output_dst_32, addr_v4(orig_dst_32));
+    assert!(
+        output_src_port_32 % 256 == 1 || output_src_port_32 != 1 && output_src_port_32 == 2,
+        "{output_src_port_32}"
+    );
+    assert_eq!(output_dst_port_32, orig_dst_port_32);
+    assert_eq!(done_reason_32, None);
+
+    // Back to 5.0.0.5 -> 2.0.0.0 from VPC-2 to VPC-1
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200), // from VPC-2 again
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+
+    println!("{flow_table}");
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
+}
+
+fn build_overlay_2vpcs_unidirectional_nat_overlapping_exposes() -> Overlay {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
+    }
+
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).unwrap());
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).unwrap());
+
+    // Peering 1
+
+    let expose1_1 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("1.0.0.0/24".into())
+        .as_range("2.0.0.0/24".into())
+        .unwrap();
+    let expose1_2 = VpcExpose::empty().ip("5.0.0.0/24".into());
+
+    let mut manifest1_1 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest1_1, expose1_1);
+    let mut manifest1_2 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest1_2, expose1_2);
+
+    let peering1 = VpcPeering::with_default_group("VPC-1--VPC-2--1", manifest1_1, manifest1_2);
+
+    // Peering 2 - Overlap with Peering 1
+
+    let expose2_1 = VpcExpose::empty()
+        .make_stateful_nat(None)
+        .unwrap()
+        .ip("3.0.0.0/24".into())
+        .as_range("2.0.0.0/24".into()) // Overlap
+        .unwrap();
+    let expose2_2 = VpcExpose::empty().ip("6.0.0.0/24".into());
+
+    let mut manifest2_1 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest2_1, expose2_1);
+    let mut manifest2_2 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest2_2, expose2_2);
+
+    let peering2 = VpcPeering::with_default_group("VPC-1--VPC-2--2", manifest2_1, manifest2_2);
+
+    // Peering table
+
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering1).unwrap();
+    peering_table.add(peering2).unwrap();
+
+    Overlay::new(vpc_table, peering_table)
+}
+
+#[tokio::test]
+#[traced_test]
+#[allow(clippy::too_many_lines)]
+async fn test_full_config_unidirectional_nat_overlapping_exposes_for_single_peering() {
+    let mut config =
+        build_gwconfig_from_overlay(build_overlay_2vpcs_unidirectional_nat_overlapping_exposes());
+    // Validation fails - We currently forbid multiple peerings between any pair of VPCs. We
+    // could probably allow them for stateful NAT, but we still need the restriction for
+    // stateless NAT. We can carry on with the test anyway.
+    assert_eq!(
+        config.validate(),
+        Err(ConfigError::DuplicateVpcPeerings(
+            "VPC-1--VPC-2--2".to_owned()
+        ))
+    );
+
+    // Build VPC discriminant lookup stage
+    let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
+    let mut vpcdtablesw = FlowFilterTableWriter::new();
+    vpcdtablesw.update_flow_filter_table(vpcd_tables);
+    let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
+
+    // Build flow table lookup stage
+    let flow_table = Arc::new(FlowTable::default());
+    let mut flow_lookup = FlowLookup::new("flow-lookup", flow_table.clone());
+
+    /////////////////////////////////////////////////////////////////
+    // Build a NAT stage and send a packet through peering1.
+    // Check that NAT occurs as expected.
+
+    // Build a new NAT stage
+    let mut allocator = NatAllocatorWriter::new();
+    let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
+
+    // Check that we can validate the allocator
+    allocator
+        .update_allocator(&config.external.overlay.vpc_table)
+        .unwrap();
+
+    // NAT: expose1_1 -> expose1_2
+    let (orig_src, orig_dst, orig_src_port, orig_dst_port) = ("1.0.0.18", "5.0.0.5", 9998, 443);
+    let target_src = "2.0.0.0";
+    let (dst_vpcd, output_src, output_dst, output_src_port, output_dst_port, done_reason) =
+        check_packet_with_vpcd_lookup(
             &mut nat,
             &mut vpcdlookup,
             Some(&mut flow_lookup),
-            vni(200),
+            vni(100),
+            orig_src,
             orig_dst,
-            target_src,
-            output_dst_port,
-            output_src_port,
+            orig_src_port,
+            orig_dst_port,
         );
-        assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
-        assert_eq!(return_output_src, addr_v4(orig_dst));
-        assert_eq!(return_output_dst, addr_v4(orig_src));
-        assert_eq!(return_output_src_port, orig_dst_port);
-        assert_eq!(return_output_dst_port, orig_src_port);
-        assert_eq!(return_done_reason, None);
-    }
+    assert_eq!(dst_vpcd, Some(VpcDiscriminant::VNI(vni(200))));
+    assert_eq!(output_src, addr_v4(target_src));
+    assert_eq!(output_dst, addr_v4(orig_dst));
+    assert!(
+        output_src_port.is_multiple_of(256) || output_src_port == 1,
+        "{output_src_port}"
+    );
+    assert_eq!(output_dst_port, orig_dst_port);
+    assert_eq!(done_reason, None);
+
+    // Reverse path - 5.0.0.5 -> 2.0.0.0, destination is ambiguous (could be peering1 or peering2)
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
+
+    /////////////////////////////////////////////////////////////////
+    // With the same NAT stage, send a packet through peering2.
+    // Check that updating the flow table for this new connection does not affect
+    // translation for the previous connection.
+
+    // Reverse path from previous connection: 5.0.0.5 -> 2.0.0.0, session is still valid
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
+
+    // NAT: expose2_1 <-> expose2_2 - Connection through peering2
+    let (orig_src_2, orig_dst_2, orig_src_port_2, orig_dst_port_2) =
+        ("3.0.0.4", "6.0.0.12", 8887, 800);
+    let target_src_2 = "2.0.0.0";
+    let (
+        dst_vpcd_2,
+        output_src_2,
+        output_dst_2,
+        output_src_port_2,
+        output_dst_port_2,
+        done_reason_2,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(100),
+        orig_src_2,
+        orig_dst_2,
+        orig_src_port_2,
+        orig_dst_port_2,
+    );
+    assert_eq!(dst_vpcd_2, Some(VpcDiscriminant::VNI(vni(200))));
+    assert_eq!(output_src_2, addr_v4(target_src_2));
+    assert_eq!(output_dst_2, addr_v4(orig_dst_2));
+    assert!(
+        output_src_port_2.is_multiple_of(256) || output_src_port_2 == 1,
+        "{output_src_port_2}"
+    );
+    assert_eq!(output_dst_port_2, orig_dst_port_2);
+    assert_eq!(done_reason_2, None);
+
+    // Back to 5.0.0.5 -> 2.0.0.0 through peering1
+    let (
+        return_vpcd,
+        return_output_src,
+        return_output_dst,
+        return_output_src_port,
+        return_output_dst_port,
+        return_done_reason,
+    ) = check_packet_with_vpcd_lookup(
+        &mut nat,
+        &mut vpcdlookup,
+        Some(&mut flow_lookup),
+        vni(200),
+        orig_dst,
+        target_src,
+        output_dst_port,
+        output_src_port,
+    );
+    assert_eq!(return_vpcd, Some(VpcDiscriminant::VNI(vni(100))));
+    assert_eq!(return_output_src, addr_v4(orig_dst));
+    assert_eq!(return_output_dst, addr_v4(orig_src));
+    assert_eq!(return_output_src_port, orig_dst_port);
+    assert_eq!(return_output_dst_port, orig_src_port);
+    assert_eq!(return_done_reason, None);
 }

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -1,1257 +1,1253 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-//! NAT configuration tests .. and actual NAT function
+//! NAT configuration tests
 
-#[cfg(test)]
-pub(crate) mod tests {
-    use config::GwConfig;
-    use config::external::ExternalConfigBuilder;
-    use config::external::communities::PriorityCommunityTable;
-    use config::external::gwgroup::{GwGroup, GwGroupTable};
-    use config::external::overlay::Overlay;
-    use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
-    use config::external::overlay::vpcpeering::{
-        VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable,
-    };
-    use config::external::underlay::Underlay;
-    use config::internal::device::DeviceConfig;
-    use config::internal::interfaces::interface::InterfaceConfig;
-    use config::internal::interfaces::interface::{IfVtepConfig, InterfaceType};
-    use config::internal::routing::bgp::BgpConfig;
-    use config::internal::routing::vrf::VrfConfig;
+#![cfg(test)]
 
-    use crate::StatelessNat;
-    use crate::stateless::setup::build_nat_configuration;
-    use crate::stateless::setup::tables::{NatTables, PerVniTable};
+use config::GwConfig;
+use config::external::ExternalConfigBuilder;
+use config::external::communities::PriorityCommunityTable;
+use config::external::gwgroup::{GwGroup, GwGroupTable};
+use config::external::overlay::Overlay;
+use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
+use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable};
+use config::external::underlay::Underlay;
+use config::internal::device::DeviceConfig;
+use config::internal::interfaces::interface::InterfaceConfig;
+use config::internal::interfaces::interface::{IfVtepConfig, InterfaceType};
+use config::internal::routing::bgp::BgpConfig;
+use config::internal::routing::vrf::VrfConfig;
 
-    use lpm::prefix::{PortRange, PrefixWithOptionalPorts};
-    use net::buffer::PacketBufferMut;
-    use net::eth::mac::Mac;
-    use net::headers::{TryHeaders, TryHeadersMut, TryInnerIpv4, TryIpv4, TryIpv4Mut};
-    use net::ip::NextHeader;
-    use net::packet::test_utils::{
-        build_test_icmp4_destination_unreachable_packet, build_test_ipv4_packet,
-        build_test_ipv4_packet_with_transport,
-    };
-    use net::packet::{DoneReason, Packet, VpcDiscriminant};
-    use net::tcp::TcpPort;
-    use net::udp::UdpPort;
-    use net::vxlan::Vni;
-    use pipeline::NetworkFunction;
-    use std::net::Ipv4Addr;
-    use std::str::FromStr;
-    use tracing_test::traced_test;
+use crate::StatelessNat;
+use crate::stateless::setup::build_nat_configuration;
+use crate::stateless::setup::tables::{NatTables, PerVniTable};
 
-    fn addr_v4(addr: &str) -> Ipv4Addr {
-        Ipv4Addr::from_str(addr).expect("Failed to create IPv4 address")
-    }
+use lpm::prefix::{PortRange, PrefixWithOptionalPorts};
+use net::buffer::PacketBufferMut;
+use net::eth::mac::Mac;
+use net::headers::{TryHeaders, TryHeadersMut, TryInnerIpv4, TryIpv4, TryIpv4Mut};
+use net::ip::NextHeader;
+use net::packet::test_utils::{
+    build_test_icmp4_destination_unreachable_packet, build_test_ipv4_packet,
+    build_test_ipv4_packet_with_transport,
+};
+use net::packet::{DoneReason, Packet, VpcDiscriminant};
+use net::tcp::TcpPort;
+use net::udp::UdpPort;
+use net::vxlan::Vni;
+use pipeline::NetworkFunction;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+use tracing_test::traced_test;
 
-    fn vni(vni: u32) -> Vni {
-        Vni::new_checked(vni).expect("Failed to create VNI")
-    }
+fn addr_v4(addr: &str) -> Ipv4Addr {
+    Ipv4Addr::from_str(addr).expect("Failed to create IPv4 address")
+}
 
-    fn get_src_ip_v4<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Ipv4Addr {
+fn vni(vni: u32) -> Vni {
+    Vni::new_checked(vni).expect("Failed to create VNI")
+}
+
+fn get_src_ip_v4<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Ipv4Addr {
+    packet
+        .headers()
+        .try_ipv4()
+        .expect("Failed to get IPv4 header")
+        .source()
+        .inner()
+}
+
+fn get_dst_ip_v4<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Ipv4Addr {
+    packet
+        .headers()
+        .try_ipv4()
+        .expect("Failed to get IPv4 header")
+        .destination()
+}
+
+fn get_src_port<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> u16 {
+    packet
+        .tcp_source_port()
+        .map(TcpPort::as_u16)
+        .or_else(|| packet.udp_source_port().map(UdpPort::as_u16))
+        .expect("Failed to get source port")
+}
+
+fn get_dst_port<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> u16 {
+    packet
+        .tcp_destination_port()
+        .map(TcpPort::as_u16)
+        .or_else(|| packet.udp_destination_port().map(UdpPort::as_u16))
+        .expect("Failed to get destination port")
+}
+
+fn set_addresses_v4<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    src_addr: Ipv4Addr,
+    dst_addr: Ipv4Addr,
+) -> &Packet<Buf> {
+    let hdr = packet
+        .headers_mut()
+        .try_ipv4_mut()
+        .expect("Failed to get IPv4 header");
+    hdr.set_source(src_addr.try_into().expect("Invalid Unicast IPv4 address"));
+    hdr.set_destination(dst_addr);
+    packet
+}
+
+fn set_ports<Buf: PacketBufferMut>(packet: &mut Packet<Buf>, src_port: u16, dst_port: u16) {
+    if packet.is_tcp() {
         packet
-            .headers()
-            .try_ipv4()
-            .expect("Failed to get IPv4 header")
-            .source()
-            .inner()
-    }
-
-    fn get_dst_ip_v4<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Ipv4Addr {
-        packet
-            .headers()
-            .try_ipv4()
-            .expect("Failed to get IPv4 header")
-            .destination()
-    }
-
-    fn get_src_port<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> u16 {
-        packet
-            .tcp_source_port()
-            .map(TcpPort::as_u16)
-            .or_else(|| packet.udp_source_port().map(UdpPort::as_u16))
-            .expect("Failed to get source port")
-    }
-
-    fn get_dst_port<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> u16 {
-        packet
-            .tcp_destination_port()
-            .map(TcpPort::as_u16)
-            .or_else(|| packet.udp_destination_port().map(UdpPort::as_u16))
-            .expect("Failed to get destination port")
-    }
-
-    fn set_addresses_v4<Buf: PacketBufferMut>(
-        packet: &mut Packet<Buf>,
-        src_addr: Ipv4Addr,
-        dst_addr: Ipv4Addr,
-    ) -> &Packet<Buf> {
-        let hdr = packet
-            .headers_mut()
-            .try_ipv4_mut()
-            .expect("Failed to get IPv4 header");
-        hdr.set_source(src_addr.try_into().expect("Invalid Unicast IPv4 address"));
-        hdr.set_destination(dst_addr);
-        packet
-    }
-
-    fn set_ports<Buf: PacketBufferMut>(packet: &mut Packet<Buf>, src_port: u16, dst_port: u16) {
-        if packet.is_tcp() {
-            packet
-                .set_tcp_source_port(TcpPort::new_checked(src_port).unwrap())
-                .unwrap();
-            packet
-                .set_tcp_destination_port(TcpPort::new_checked(dst_port).unwrap())
-                .unwrap();
-        } else if packet.is_udp() {
-            packet
-                .set_udp_source_port(UdpPort::new_checked(src_port).unwrap())
-                .unwrap();
-            packet
-                .set_udp_destination_port(UdpPort::new_checked(dst_port).unwrap())
-                .unwrap();
-        } else {
-            panic!("Packet is not TCP or UDP");
-        }
-    }
-
-    // Address translation
-
-    fn build_context() -> NatTables {
-        // Build VpcExpose objects
-        //
-        //     expose:
-        //       - ips:
-        //         - cidr: 1.1.0.0/16
-        //         - cidr: 1.2.0.0/16 # <- 1.2.3.4 will match here
-        //         - not: 1.1.5.0/24  # to account for when computing the offset
-        //         - not: 1.1.3.0/24  # to account for when computing the offset
-        //         - not: 1.1.1.0/24  # to account for when computing the offset
-        //         - not: 1.2.2.0/24  # to account for when computing the offset
-        //         as:
-        //         - cidr: 2.2.0.0/16
-        //         - cidr: 2.1.0.0/16 # <- corresp. target range, initially
-        //                            # (prefixes in BTreeSet are sorted)
-        //                            # offset for 2.1.255.4, before applying exlusions
-        //                            # final offset is for 2.2.0.4 after accounting for the one
-        //                            # relevant exclusion prefix
-        //         - not: 2.1.8.0/24  # to account for when fetching the address in range
-        //         - not: 2.2.10.0/24
-        //         - not: 2.2.1.0/24  # ignored, offset too low
-        //         - not: 2.2.2.0/24  # ignored, offset too low
-        //       - ips:
-        //         - cidr: 3.0.0.0/16
-        //         as:
-        //         - cidr: 4.0.0.0/16
-        let expose1 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .not("1.1.5.0/24".into())
-            .not("1.1.3.0/24".into())
-            .not("1.1.1.0/24".into())
-            .ip("1.2.0.0/16".into())
-            .not("1.2.2.0/24".into())
-            .as_range("2.2.0.0/16".into())
-            .unwrap()
-            .not_as("2.1.8.0/24".into())
-            .unwrap()
-            .not_as("2.2.10.0/24".into())
-            .unwrap()
-            .not_as("2.2.1.0/24".into())
-            .unwrap()
-            .not_as("2.2.2.0/24".into())
-            .unwrap()
-            .as_range("2.1.0.0/16".into())
+            .set_tcp_source_port(TcpPort::new_checked(src_port).unwrap())
             .unwrap();
-        let expose2 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("3.0.0.0/16".into())
-            .as_range("4.0.0.0/16".into())
+        packet
+            .set_tcp_destination_port(TcpPort::new_checked(dst_port).unwrap())
             .unwrap();
-
-        let manifest1 = VpcManifest {
-            name: "VPC-1".into(),
-            exposes: vec![expose1, expose2],
-        };
-
-        //     expose:
-        //       - ips:
-        //         - cidr: 8.0.0.0/17
-        //         - cidr: 9.0.0.0/17
-        //         - not: 8.0.0.0/24
-        //         as:
-        //         - cidr: 3.0.0.0/16
-        //         - not: 3.0.1.0/24
-        //       - ips:
-        //         - cidr: 10.0.0.0/16 # <- corresponding target range
-        //         - not: 10.0.1.0/24  # to account for when fetching the address in range
-        //         - not: 10.0.2.0/24  # to account for when fetching the address in range
-        //         as:
-        //         - cidr: 5.5.0.0/17
-        //         - cidr: 5.6.0.0/17  # <- 5.6.7.8 will match here
-        //         - not: 5.6.0.0/24   # to account for when computing the offset
-        //         - not: 5.6.8.0/24
-        let expose3 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("8.0.0.0/17".into())
-            .not("8.0.0.0/24".into())
-            .ip("9.0.0.0/17".into())
-            .as_range("3.0.0.0/16".into())
-            .unwrap()
-            .not_as("3.0.1.0/24".into())
+    } else if packet.is_udp() {
+        packet
+            .set_udp_source_port(UdpPort::new_checked(src_port).unwrap())
             .unwrap();
-        let expose4 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("10.0.0.0/16".into())
-            .not("10.0.1.0/24".into())
-            .not("10.0.2.0/24".into())
-            .as_range("5.5.0.0/17".into())
-            .unwrap()
-            .as_range("5.6.0.0/17".into())
-            .unwrap()
-            .not_as("5.6.0.0/24".into())
-            .unwrap()
-            .not_as("5.6.8.0/24".into())
+        packet
+            .set_udp_destination_port(UdpPort::new_checked(dst_port).unwrap())
             .unwrap();
-
-        let manifest2 = VpcManifest {
-            name: "VPC-2".into(),
-            exposes: vec![expose3, expose4],
-        };
-
-        let peering1 = Peering {
-            name: "test_peering1".into(),
-            local: manifest1.clone(),
-            remote: manifest2.clone(),
-            remote_id: "12345".try_into().expect("Failed to create VPC ID"),
-            gwgroup: None,
-        };
-        let peering2 = Peering {
-            name: "test_peering2".into(),
-            local: manifest2,
-            remote: manifest1,
-            remote_id: "67890".try_into().expect("Failed to create VPC ID"),
-            gwgroup: None,
-        };
-
-        // This code is extremely convoluted
-        let mut vpctable = VpcTable::new();
-
-        // vpc-1
-        let vni1 = Vni::new_checked(100).unwrap();
-        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1.as_u32()).unwrap();
-        vpc1.peerings.push(peering1.clone());
-        vpctable.add(vpc1).unwrap();
-
-        // vpc-2
-        let vni2 = Vni::new_checked(200).unwrap();
-        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2.as_u32()).unwrap();
-        vpc2.peerings.push(peering2.clone());
-        vpctable.add(vpc2).unwrap();
-
-        let mut nat_table = NatTables::new();
-
-        let mut vni_table1 = PerVniTable::new();
-        vni_table1
-            .add_peering(&peering1, vni2)
-            .expect("Failed to build NAT tables");
-
-        let mut vni_table2 = PerVniTable::new();
-        vni_table2
-            .add_peering(&peering2, vni1)
-            .expect("Failed to build NAT tables");
-
-        nat_table.add_table(vni_table1, vni1);
-        nat_table.add_table(vni_table2, vni2);
-
-        nat_table
+    } else {
+        panic!("Packet is not TCP or UDP");
     }
+}
 
-    #[test]
-    fn test_dst_nat_stateless_44() {
-        const TARGET_SRC_IP: Ipv4Addr = Ipv4Addr::new(2, 2, 0, 4);
-        const TARGET_DST_IP: Ipv4Addr = Ipv4Addr::new(10, 0, 136, 8);
+// Address translation
 
-        let nat_tables = build_context();
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables);
-
-        let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
-        let mut packet_reply = packet.clone();
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
-        packet_reply.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
-        packet_reply.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateless_nat(true);
-        packet_reply.meta_mut().set_overlay(true);
-        packet_reply.meta_mut().set_stateless_nat(true);
-
-        let orig_src_ip = get_src_ip_v4(&packet);
-        let orig_dst_ip = get_dst_ip_v4(&packet);
-
-        // Check request. We expect:
-        //
-        // {orig_src_ip, orig_dst_ip} -> {orig_src_ip, TARGET_DST_IP}
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        assert_eq!(packets_out.len(), 1);
-        assert_eq!(packets_out[0].get_done(), None);
-
-        let hdr_out = &packets_out[0]
-            .try_ipv4()
-            .expect("Failed to get IPv4 header");
-        println!("L3 header: {hdr_out:?}");
-        assert_eq!(hdr_out.source().inner(), TARGET_SRC_IP);
-        assert_eq!(hdr_out.destination(), TARGET_DST_IP);
-
-        // Check that reply gets reverse source NAT. We expect:
-        //
-        // {TARGET_DST_IP, orig_src_ip} -> {orig_dst_ip, orig_src_ip}
-        set_addresses_v4(&mut packet_reply, TARGET_DST_IP, TARGET_SRC_IP);
-
-        let packets_out_reply: Vec<_> = nat.process(vec![packet_reply].into_iter()).collect();
-        assert_eq!(packets_out_reply.len(), 1);
-        assert_eq!(packets_out_reply[0].get_done(), None);
-
-        let hdr_out_reply = &packets_out_reply[0]
-            .try_ipv4()
-            .expect("Failed to get IPv4 header");
-        println!("L3 header: {hdr_out_reply:?}");
-        assert_eq!(hdr_out_reply.source().inner(), orig_dst_ip);
-        assert_eq!(hdr_out_reply.destination(), orig_src_ip);
-    }
-
-    #[test]
-    fn test_nat_icmp_error_msg_stateless_44() {
-        let nat_tables = build_context();
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables);
-
-        // Imaginary request was:
-        // (1.1.0.1 -> 5.5.0.1) translated as (2.1.0.1 -> 10.0.0.1)
-        //
-        // Reply (this packet):
-        // - Destination unreachable contains inner packet with (2.1.0.1 -> 10.0.0.1)
-        // - Outer IP header: (10.0.0.1 -> 2.1.0.1) should be translated as (5.5.0.1 -> 1.1.0.1)
-        // - Inner IP header should be translated back to (1.1.0.1 -> 5.5.0.1)
-
-        let mut packet = build_test_icmp4_destination_unreachable_packet(
-            addr_v4("10.0.0.1"),
-            addr_v4("2.1.0.1"),
-            addr_v4("2.1.0.1"),
-            addr_v4("10.0.0.1"),
-            NextHeader::TCP,
-            1234,
-            5678,
-        )
+fn build_context() -> NatTables {
+    // Build VpcExpose objects
+    //
+    //     expose:
+    //       - ips:
+    //         - cidr: 1.1.0.0/16
+    //         - cidr: 1.2.0.0/16 # <- 1.2.3.4 will match here
+    //         - not: 1.1.5.0/24  # to account for when computing the offset
+    //         - not: 1.1.3.0/24  # to account for when computing the offset
+    //         - not: 1.1.1.0/24  # to account for when computing the offset
+    //         - not: 1.2.2.0/24  # to account for when computing the offset
+    //         as:
+    //         - cidr: 2.2.0.0/16
+    //         - cidr: 2.1.0.0/16 # <- corresp. target range, initially
+    //                            # (prefixes in BTreeSet are sorted)
+    //                            # offset for 2.1.255.4, before applying exclusions
+    //                            # final offset is for 2.2.0.4 after accounting for the one
+    //                            # relevant exclusion prefix
+    //         - not: 2.1.8.0/24  # to account for when fetching the address in range
+    //         - not: 2.2.10.0/24
+    //         - not: 2.2.1.0/24  # ignored, offset too low
+    //         - not: 2.2.2.0/24  # ignored, offset too low
+    //       - ips:
+    //         - cidr: 3.0.0.0/16
+    //         as:
+    //         - cidr: 4.0.0.0/16
+    let expose1 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .not("1.1.5.0/24".into())
+        .not("1.1.3.0/24".into())
+        .not("1.1.1.0/24".into())
+        .ip("1.2.0.0/16".into())
+        .not("1.2.2.0/24".into())
+        .as_range("2.2.0.0/16".into())
+        .unwrap()
+        .not_as("2.1.8.0/24".into())
+        .unwrap()
+        .not_as("2.2.10.0/24".into())
+        .unwrap()
+        .not_as("2.2.1.0/24".into())
+        .unwrap()
+        .not_as("2.2.2.0/24".into())
+        .unwrap()
+        .as_range("2.1.0.0/16".into())
+        .unwrap();
+    let expose2 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("3.0.0.0/16".into())
+        .as_range("4.0.0.0/16".into())
         .unwrap();
 
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateless_nat(true);
+    let manifest1 = VpcManifest {
+        name: "VPC-1".into(),
+        exposes: vec![expose1, expose2],
+    };
 
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        assert_eq!(packets_out.len(), 1);
-        assert_eq!(packets_out[0].get_done(), None);
+    //     expose:
+    //       - ips:
+    //         - cidr: 8.0.0.0/17
+    //         - cidr: 9.0.0.0/17
+    //         - not: 8.0.0.0/24
+    //         as:
+    //         - cidr: 3.0.0.0/16
+    //         - not: 3.0.1.0/24
+    //       - ips:
+    //         - cidr: 10.0.0.0/16 # <- corresponding target range
+    //         - not: 10.0.1.0/24  # to account for when fetching the address in range
+    //         - not: 10.0.2.0/24  # to account for when fetching the address in range
+    //         as:
+    //         - cidr: 5.5.0.0/17
+    //         - cidr: 5.6.0.0/17  # <- 5.6.7.8 will match here
+    //         - not: 5.6.0.0/24   # to account for when computing the offset
+    //         - not: 5.6.8.0/24
+    let expose3 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("8.0.0.0/17".into())
+        .not("8.0.0.0/24".into())
+        .ip("9.0.0.0/17".into())
+        .as_range("3.0.0.0/16".into())
+        .unwrap()
+        .not_as("3.0.1.0/24".into())
+        .unwrap();
+    let expose4 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("10.0.0.0/16".into())
+        .not("10.0.1.0/24".into())
+        .not("10.0.2.0/24".into())
+        .as_range("5.5.0.0/17".into())
+        .unwrap()
+        .as_range("5.6.0.0/17".into())
+        .unwrap()
+        .not_as("5.6.0.0/24".into())
+        .unwrap()
+        .not_as("5.6.8.0/24".into())
+        .unwrap();
 
-        let outer_ip = packets_out[0].try_ipv4().unwrap();
-        assert_eq!(outer_ip.source().inner(), addr_v4("5.5.0.1"));
-        assert_eq!(outer_ip.destination(), addr_v4("1.1.0.1"));
-        let inner_ip = packets_out[0].try_inner_ipv4().unwrap();
-        assert_eq!(inner_ip.source().inner(), addr_v4("1.1.0.1"));
-        assert_eq!(inner_ip.destination(), addr_v4("5.5.0.1"));
+    let manifest2 = VpcManifest {
+        name: "VPC-2".into(),
+        exposes: vec![expose3, expose4],
+    };
+
+    let peering1 = Peering {
+        name: "test_peering1".into(),
+        local: manifest1.clone(),
+        remote: manifest2.clone(),
+        remote_id: "12345".try_into().expect("Failed to create VPC ID"),
+        gwgroup: None,
+    };
+    let peering2 = Peering {
+        name: "test_peering2".into(),
+        local: manifest2,
+        remote: manifest1,
+        remote_id: "67890".try_into().expect("Failed to create VPC ID"),
+        gwgroup: None,
+    };
+
+    // This code is extremely convoluted
+    let mut vpctable = VpcTable::new();
+
+    // vpc-1
+    let vni1 = Vni::new_checked(100).unwrap();
+    let mut vpc1 = Vpc::new("VPC-1", "67890", vni1.as_u32()).unwrap();
+    vpc1.peerings.push(peering1.clone());
+    vpctable.add(vpc1).unwrap();
+
+    // vpc-2
+    let vni2 = Vni::new_checked(200).unwrap();
+    let mut vpc2 = Vpc::new("VPC-2", "12345", vni2.as_u32()).unwrap();
+    vpc2.peerings.push(peering2.clone());
+    vpctable.add(vpc2).unwrap();
+
+    let mut nat_table = NatTables::new();
+
+    let mut vni_table1 = PerVniTable::new();
+    vni_table1
+        .add_peering(&peering1, vni2)
+        .expect("Failed to build NAT tables");
+
+    let mut vni_table2 = PerVniTable::new();
+    vni_table2
+        .add_peering(&peering2, vni1)
+        .expect("Failed to build NAT tables");
+
+    nat_table.add_table(vni_table1, vni1);
+    nat_table.add_table(vni_table2, vni2);
+
+    nat_table
+}
+
+#[test]
+fn test_dst_nat_stateless_44() {
+    const TARGET_SRC_IP: Ipv4Addr = Ipv4Addr::new(2, 2, 0, 4);
+    const TARGET_DST_IP: Ipv4Addr = Ipv4Addr::new(10, 0, 136, 8);
+
+    let nat_tables = build_context();
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables);
+
+    let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
+    let mut packet_reply = packet.clone();
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
+    packet_reply.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
+    packet_reply.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateless_nat(true);
+    packet_reply.meta_mut().set_overlay(true);
+    packet_reply.meta_mut().set_stateless_nat(true);
+
+    let orig_src_ip = get_src_ip_v4(&packet);
+    let orig_dst_ip = get_dst_ip_v4(&packet);
+
+    // Check request. We expect:
+    //
+    // {orig_src_ip, orig_dst_ip} -> {orig_src_ip, TARGET_DST_IP}
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    assert_eq!(packets_out.len(), 1);
+    assert_eq!(packets_out[0].get_done(), None);
+
+    let hdr_out = &packets_out[0]
+        .try_ipv4()
+        .expect("Failed to get IPv4 header");
+    println!("L3 header: {hdr_out:?}");
+    assert_eq!(hdr_out.source().inner(), TARGET_SRC_IP);
+    assert_eq!(hdr_out.destination(), TARGET_DST_IP);
+
+    // Check that reply gets reverse source NAT. We expect:
+    //
+    // {TARGET_DST_IP, orig_src_ip} -> {orig_dst_ip, orig_src_ip}
+    set_addresses_v4(&mut packet_reply, TARGET_DST_IP, TARGET_SRC_IP);
+
+    let packets_out_reply: Vec<_> = nat.process(vec![packet_reply].into_iter()).collect();
+    assert_eq!(packets_out_reply.len(), 1);
+    assert_eq!(packets_out_reply[0].get_done(), None);
+
+    let hdr_out_reply = &packets_out_reply[0]
+        .try_ipv4()
+        .expect("Failed to get IPv4 header");
+    println!("L3 header: {hdr_out_reply:?}");
+    assert_eq!(hdr_out_reply.source().inner(), orig_dst_ip);
+    assert_eq!(hdr_out_reply.destination(), orig_src_ip);
+}
+
+#[test]
+fn test_nat_icmp_error_msg_stateless_44() {
+    let nat_tables = build_context();
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables);
+
+    // Imaginary request was:
+    // (1.1.0.1 -> 5.5.0.1) translated as (2.1.0.1 -> 10.0.0.1)
+    //
+    // Reply (this packet):
+    // - Destination unreachable contains inner packet with (2.1.0.1 -> 10.0.0.1)
+    // - Outer IP header: (10.0.0.1 -> 2.1.0.1) should be translated as (5.5.0.1 -> 1.1.0.1)
+    // - Inner IP header should be translated back to (1.1.0.1 -> 5.5.0.1)
+
+    let mut packet = build_test_icmp4_destination_unreachable_packet(
+        addr_v4("10.0.0.1"),
+        addr_v4("2.1.0.1"),
+        addr_v4("2.1.0.1"),
+        addr_v4("10.0.0.1"),
+        NextHeader::TCP,
+        1234,
+        5678,
+    )
+    .unwrap();
+
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(vni(200)));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(vni(100)));
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateless_nat(true);
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    assert_eq!(packets_out.len(), 1);
+    assert_eq!(packets_out[0].get_done(), None);
+
+    let outer_ip = packets_out[0].try_ipv4().unwrap();
+    assert_eq!(outer_ip.source().inner(), addr_v4("5.5.0.1"));
+    assert_eq!(outer_ip.destination(), addr_v4("1.1.0.1"));
+    let inner_ip = packets_out[0].try_inner_ipv4().unwrap();
+    assert_eq!(inner_ip.source().inner(), addr_v4("1.1.0.1"));
+    assert_eq!(inner_ip.destination(), addr_v4("5.5.0.1"));
+}
+
+#[allow(clippy::too_many_lines)]
+fn build_sample_config() -> GwConfig {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    #[allow(clippy::too_many_lines)]
-    fn build_sample_config() -> GwConfig {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-4", "DDDDD", 400).expect("Failed to add VPC"));
 
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).expect("Failed to add VPC"));
-        let _ = vpc_table.add(Vpc::new("VPC-4", "DDDDD", 400).expect("Failed to add VPC"));
+    // VPC1 --------- VPC 2
+    //  |    \           |
+    //  |      \         |
+    //  |        \       |
+    //  |          \     |
+    //  |            \   |
+    // VPC3 --------- VPC 4
 
-        // VPC1 --------- VPC 2
-        //  |    \           |
-        //  |      \         |
-        //  |        \       |
-        //  |          \     |
-        //  |            \   |
-        // VPC3 --------- VPC 4
+    // VPC1 <-> VPC2
+    let expose121 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("10.12.0.0/16".into())
+        .unwrap();
+    let expose122 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.2.0.0/16".into())
+        .as_range("10.98.128.0/17".into())
+        .unwrap()
+        .as_range("10.99.0.0/17".into())
+        .unwrap();
+    let expose123 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.3.0.0/24".into())
+        .as_range("10.100.0.0/24".into())
+        .unwrap();
+    let expose211 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.2.2.0/24".into())
+        .as_range("10.201.201.0/24".into())
+        .unwrap();
+    let expose212 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.2.3.0/24".into())
+        .as_range("10.201.202.0/24".into())
+        .unwrap();
+    let expose213 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("2.0.0.0/24".into())
+        .as_range("10.201.203.0/24".into())
+        .unwrap();
+    let expose214 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("2.0.1.0/28".into())
+        .as_range("10.201.204.192/28".into())
+        .unwrap();
 
-        // VPC1 <-> VPC2
-        let expose121 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("10.12.0.0/16".into())
-            .unwrap();
-        let expose122 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.2.0.0/16".into())
-            .as_range("10.98.128.0/17".into())
-            .unwrap()
-            .as_range("10.99.0.0/17".into())
-            .unwrap();
-        let expose123 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.3.0.0/24".into())
-            .as_range("10.100.0.0/24".into())
-            .unwrap();
-        let expose211 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.2.2.0/24".into())
-            .as_range("10.201.201.0/24".into())
-            .unwrap();
-        let expose212 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.2.3.0/24".into())
-            .as_range("10.201.202.0/24".into())
-            .unwrap();
-        let expose213 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("2.0.0.0/24".into())
-            .as_range("10.201.203.0/24".into())
-            .unwrap();
-        let expose214 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("2.0.1.0/28".into())
-            .as_range("10.201.204.192/28".into())
-            .unwrap();
+    // VPC1 <-> VPC3
+    let expose131 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("3.3.0.0/16".into())
+        .unwrap();
+    let expose132 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.2.0.0/16".into())
+        .as_range("3.1.0.0/16".into())
+        .unwrap()
+        .not_as("3.1.128.0/17".into())
+        .unwrap()
+        .as_range("3.2.0.0/17".into())
+        .unwrap();
+    let expose311 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("192.168.128.0/24".into())
+        .as_range("3.3.3.0/24".into())
+        .unwrap();
 
-        // VPC1 <-> VPC3
-        let expose131 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("3.3.0.0/16".into())
-            .unwrap();
-        let expose132 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.2.0.0/16".into())
-            .as_range("3.1.0.0/16".into())
-            .unwrap()
-            .not_as("3.1.128.0/17".into())
-            .unwrap()
-            .as_range("3.2.0.0/17".into())
-            .unwrap();
-        let expose311 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("192.168.128.0/24".into())
-            .as_range("3.3.3.0/24".into())
-            .unwrap();
+    // VPC1 <-> VPC4
+    let expose141 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("4.4.0.0/16".into())
+        .unwrap();
+    let expose411 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("4.5.0.0/16".into())
+        .unwrap();
 
-        // VPC1 <-> VPC4
-        let expose141 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("4.4.0.0/16".into())
-            .unwrap();
-        let expose411 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("1.1.0.0/16".into())
-            .as_range("4.5.0.0/16".into())
-            .unwrap();
+    // VPC2 <-> VPC4
+    let expose241 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("2.4.0.0/16".into())
+        .not("2.4.1.0/24".into())
+        .as_range("44.0.0.0/16".into())
+        .unwrap()
+        .not_as("44.0.200.0/24".into())
+        .unwrap();
+    let expose421 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("4.4.0.0/16".into())
+        .not("4.4.128.0/18".into())
+        .as_range("44.4.0.0/16".into())
+        .unwrap()
+        .not_as("44.4.64.0/18".into())
+        .unwrap();
 
-        // VPC2 <-> VPC4
-        let expose241 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("2.4.0.0/16".into())
-            .not("2.4.1.0/24".into())
-            .as_range("44.0.0.0/16".into())
-            .unwrap()
-            .not_as("44.0.200.0/24".into())
-            .unwrap();
-        let expose421 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("4.4.0.0/16".into())
-            .not("4.4.128.0/18".into())
-            .as_range("44.4.0.0/16".into())
-            .unwrap()
-            .not_as("44.4.64.0/18".into())
-            .unwrap();
+    // VPC3 <-> VPC4
+    let expose341 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip("192.168.100.0/24".into())
+        .as_range("34.34.34.0/24".into())
+        .unwrap();
+    let expose431 = VpcExpose::empty().ip("4.4.0.0/24".into());
 
-        // VPC3 <-> VPC4
-        let expose341 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("192.168.100.0/24".into())
-            .as_range("34.34.34.0/24".into())
-            .unwrap();
-        let expose431 = VpcExpose::empty().ip("4.4.0.0/24".into());
+    // VPC1 <-> VPC2
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest12, expose121);
+    add_expose(&mut manifest12, expose122);
+    add_expose(&mut manifest12, expose123);
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest21, expose211);
+    add_expose(&mut manifest21, expose212);
+    add_expose(&mut manifest21, expose213);
+    add_expose(&mut manifest21, expose214);
 
-        // VPC1 <-> VPC2
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest12, expose121);
-        add_expose(&mut manifest12, expose122);
-        add_expose(&mut manifest12, expose123);
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest21, expose211);
-        add_expose(&mut manifest21, expose212);
-        add_expose(&mut manifest21, expose213);
-        add_expose(&mut manifest21, expose214);
+    // VPC1 <-> VPC3
+    let mut manifest13 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest13, expose131);
+    add_expose(&mut manifest13, expose132);
+    let mut manifest31 = VpcManifest::new("VPC-3");
+    add_expose(&mut manifest31, expose311);
 
-        // VPC1 <-> VPC3
-        let mut manifest13 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest13, expose131);
-        add_expose(&mut manifest13, expose132);
-        let mut manifest31 = VpcManifest::new("VPC-3");
-        add_expose(&mut manifest31, expose311);
+    // VPC1 <-> VPC4
+    let mut manifest14 = VpcManifest::new("VPC-1");
+    add_expose(&mut manifest14, expose141);
+    let mut manifest41 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest41, expose411);
 
-        // VPC1 <-> VPC4
-        let mut manifest14 = VpcManifest::new("VPC-1");
-        add_expose(&mut manifest14, expose141);
-        let mut manifest41 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest41, expose411);
+    // VPC2 <-> VPC4
+    let mut manifest24 = VpcManifest::new("VPC-2");
+    add_expose(&mut manifest24, expose241);
+    let mut manifest42 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest42, expose421);
 
-        // VPC2 <-> VPC4
-        let mut manifest24 = VpcManifest::new("VPC-2");
-        add_expose(&mut manifest24, expose241);
-        let mut manifest42 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest42, expose421);
+    // VPC3 <-> VPC4
+    let mut manifest34 = VpcManifest::new("VPC-3");
+    add_expose(&mut manifest34, expose341);
+    let mut manifest43 = VpcManifest::new("VPC-4");
+    add_expose(&mut manifest43, expose431);
 
-        // VPC3 <-> VPC4
-        let mut manifest34 = VpcManifest::new("VPC-3");
-        add_expose(&mut manifest34, expose341);
-        let mut manifest43 = VpcManifest::new("VPC-4");
-        add_expose(&mut manifest43, expose431);
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
+    let peering31 = VpcPeering::with_default_group("VPC-3--VPC-1", manifest31, manifest13);
+    let peering14 = VpcPeering::with_default_group("VPC-1--VPC-4", manifest14, manifest41);
+    let peering24 = VpcPeering::with_default_group("VPC-2--VPC-4", manifest24, manifest42);
+    let peering34 = VpcPeering::with_default_group("VPC-3--VPC-4", manifest34, manifest43);
 
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-        let peering31 = VpcPeering::with_default_group("VPC-3--VPC-1", manifest31, manifest13);
-        let peering14 = VpcPeering::with_default_group("VPC-1--VPC-4", manifest14, manifest41);
-        let peering24 = VpcPeering::with_default_group("VPC-2--VPC-4", manifest24, manifest42);
-        let peering34 = VpcPeering::with_default_group("VPC-3--VPC-4", manifest34, manifest43);
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
+    peering_table.add(peering31).expect("Failed to add peering");
+    peering_table.add(peering14).expect("Failed to add peering");
+    peering_table.add(peering24).expect("Failed to add peering");
+    peering_table.add(peering34).expect("Failed to add peering");
 
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
-        peering_table.add(peering31).expect("Failed to add peering");
-        peering_table.add(peering14).expect("Failed to add peering");
-        peering_table.add(peering24).expect("Failed to add peering");
-        peering_table.add(peering34).expect("Failed to add peering");
+    let overlay = Overlay::new(vpc_table, peering_table);
 
-        let overlay = Overlay::new(vpc_table, peering_table);
+    build_gwconfig_from_overlay(overlay)
+}
 
-        build_gwconfig_from_overlay(overlay)
+// Use the provided overlay with some default configuration to build a valid GwConfig. This
+// configuration is not really relevant to our tests, we just want a valid GwConfig object to
+// work with.
+pub(crate) fn build_gwconfig_from_overlay(overlay: Overlay) -> GwConfig {
+    let device_config = DeviceConfig::new();
+
+    let vtep = InterfaceConfig::new(
+        "vtep",
+        InterfaceType::Vtep(IfVtepConfig {
+            mac: Some(Mac::from([0xca, 0xfe, 0xba, 0xbe, 0x00, 0x01])),
+            local: Ipv4Addr::from_str("127.0.0.1").expect("Failed to create local address"),
+            ttl: None,
+            vni: None,
+        }),
+        false,
+    );
+    let mut vrf_config = VrfConfig::new("default", None, true);
+    vrf_config.add_interface_config(vtep);
+    let bgp = BgpConfig::new(1);
+    vrf_config.set_bgp(bgp);
+    let underlay = Underlay {
+        vrf: vrf_config,
+        vtep: None,
+    };
+
+    let mut group_table = GwGroupTable::new();
+    group_table.add_group(GwGroup::new("default")).unwrap();
+
+    let mut external_builder = ExternalConfigBuilder::default();
+    external_builder.gwname("test-gw".to_string());
+    external_builder.genid(1);
+    external_builder.device(device_config);
+    external_builder.underlay(underlay);
+    external_builder.overlay(overlay);
+    external_builder.gwgroups(group_table);
+    external_builder.communities(PriorityCommunityTable::new());
+    let external_config = external_builder
+        .build()
+        .expect("Failed to build external config");
+
+    GwConfig::new(external_config)
+}
+
+fn check_packet(
+    nat: &mut StatelessNat,
+    src_vni: Vni,
+    dst_vni: Vni,
+    orig_src_ip: Ipv4Addr,
+    orig_dst_ip: Ipv4Addr,
+) -> (Ipv4Addr, Ipv4Addr, Option<DoneReason>) {
+    let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateless_nat(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+    set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let hdr_out = packets_out[0]
+        .try_ipv4()
+        .expect("Failed to get IPv4 header");
+    let done_reason = packets_out[0].get_done();
+
+    (hdr_out.source().inner(), hdr_out.destination(), done_reason)
+}
+
+#[test]
+#[traced_test]
+#[allow(clippy::too_many_lines)]
+fn test_full_config() {
+    let mut config = build_sample_config();
+    config.validate().expect("Failed to validate config");
+
+    let nat_tables = build_nat_configuration(&config.external.overlay.vpc_table).unwrap();
+    println!("Nat tables: {:#?}", &nat_tables);
+
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables.clone());
+
+    // No NAT
+    let (orig_src, orig_dst) = (addr_v4("8.8.8.8"), addr_v4("9.9.9.9"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
+    assert_eq!(output_src, orig_src);
+    assert_eq!(output_dst, orig_dst);
+    assert_eq!(done_reason, None);
+
+    // expose121 <-> expose211
+    let (orig_src, orig_dst) = (addr_v4("1.1.2.3"), addr_v4("10.201.201.18"));
+    let (target_src, target_dst) = (addr_v4("10.12.2.3"), addr_v4("1.2.2.18"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose122 <-> expose211
+    let (orig_src, orig_dst) = (addr_v4("1.2.129.3"), addr_v4("10.201.201.22"));
+    let (target_src, target_dst) = (addr_v4("10.99.1.3"), addr_v4("1.2.2.22"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose123 <-> expose214
+    let (orig_src, orig_dst) = (addr_v4("1.3.0.7"), addr_v4("10.201.204.193"));
+    let (target_src, target_dst) = (addr_v4("10.100.0.7"), addr_v4("2.0.1.1"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose131 <-> expose311 (reusing expose121 private IPs)
+    let (orig_src, orig_dst) = (addr_v4("1.1.3.3"), addr_v4("3.3.3.3"));
+    let (target_src, target_dst) = (addr_v4("3.3.3.3"), addr_v4("192.168.128.3"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(300), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(300), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose132 <-> expose311
+    let (orig_src, orig_dst) = (addr_v4("1.2.130.1"), addr_v4("3.3.3.3"));
+    let (target_src, target_dst) = (addr_v4("3.2.2.1"), addr_v4("192.168.128.3"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(300), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(300), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose141 <-> expose411
+    let (orig_src, orig_dst) = (addr_v4("1.1.1.1"), addr_v4("4.5.1.1"));
+    let (target_src, target_dst) = (addr_v4("4.4.1.1"), addr_v4("1.1.1.1"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(100), vni(400), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(400), vni(100), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose241 <-> expose421 (first/last addresses of ranges)
+    let (orig_src, orig_dst) = (addr_v4("2.4.255.255"), addr_v4("44.4.0.0"));
+    let (target_src, target_dst) = (addr_v4("44.0.255.255"), addr_v4("4.4.0.0"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(200), vni(400), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(400), vni(200), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose241 <-> expose421 (playing with not/not_as)
+    let (orig_src, orig_dst) = (addr_v4("2.4.2.1"), addr_v4("44.4.136.2"));
+    let (target_src, target_dst) = (addr_v4("44.0.1.1"), addr_v4("4.4.72.2"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(200), vni(400), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(400), vni(200), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+
+    // expose341 <-> expose431 (one-side NAT)
+    let (orig_src, orig_dst) = (addr_v4("192.168.100.34"), addr_v4("4.4.0.43"));
+    let (target_src, target_dst) = (addr_v4("34.34.34.34"), addr_v4("4.4.0.43"));
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(300), vni(400), orig_src, orig_dst);
+    assert_eq!(output_src, target_src);
+    assert_eq!(output_dst, target_dst);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src, output_dst, done_reason) =
+        check_packet(&mut nat, vni(400), vni(300), target_dst, target_src);
+    assert_eq!(output_src, orig_dst);
+    assert_eq!(output_dst, orig_src);
+    assert_eq!(done_reason, None);
+}
+
+// Address + port translation
+
+fn build_gwconfig_from_exposes(
+    exposes_left: Vec<VpcExpose>,
+    exposes_right: Vec<VpcExpose>,
+) -> GwConfig {
+    fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
+        manifest.add_expose(expose);
     }
 
-    // Use the provided overlay with some default configuration to build a valid GwConfig. This
-    // configuration is not really relevant to our tests, we just want a valid GwConfig object to
-    // work with.
-    pub(crate) fn build_gwconfig_from_overlay(overlay: Overlay) -> GwConfig {
-        let device_config = DeviceConfig::new();
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "VPC01", 100).unwrap());
+    let _ = vpc_table.add(Vpc::new("VPC-2", "VPC02", 200).unwrap());
 
-        let vtep = InterfaceConfig::new(
-            "vtep",
-            InterfaceType::Vtep(IfVtepConfig {
-                mac: Some(Mac::from([0xca, 0xfe, 0xba, 0xbe, 0x00, 0x01])),
-                local: Ipv4Addr::from_str("127.0.0.1").expect("Failed to create local address"),
-                ttl: None,
-                vni: None,
-            }),
-            false,
+    let mut manifest12 = VpcManifest::new("VPC-1");
+    for expose in exposes_left {
+        add_expose(&mut manifest12, expose);
+    }
+    let mut manifest21 = VpcManifest::new("VPC-2");
+    for expose in exposes_right {
+        add_expose(&mut manifest21, expose);
+    }
+
+    let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
+
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering12).expect("Failed to add peering");
+
+    let overlay = Overlay::new(vpc_table, peering_table);
+
+    let mut gw_config = build_gwconfig_from_overlay(overlay);
+    let validation = gw_config.validate();
+    assert!(
+        validation.is_ok(),
+        "GwConfig validation failed: {validation:?}"
+    );
+
+    gw_config
+}
+
+fn check_packet_with_ports(
+    nat: &mut StatelessNat,
+    src_vni: Vni,
+    dst_vni: Vni,
+    orig_src_ip: Ipv4Addr,
+    orig_src_port: u16,
+    orig_dst_ip: Ipv4Addr,
+    orig_dst_port: u16,
+) -> (Ipv4Addr, u16, Ipv4Addr, u16, Option<DoneReason>) {
+    let mut packet = build_test_ipv4_packet_with_transport(u8::MAX, Some(NextHeader::TCP)).unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_stateless_nat(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+    set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
+    set_ports(&mut packet, orig_src_port, orig_dst_port);
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let pkt_out = &packets_out[0];
+
+    (
+        get_src_ip_v4(pkt_out),
+        get_src_port(pkt_out),
+        get_dst_ip_v4(pkt_out),
+        get_dst_port(pkt_out),
+        pkt_out.get_done(),
+    )
+}
+
+#[test]
+#[traced_test]
+fn test_config_with_port_ranges_basic() {
+    let expose1 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.0.0/16".into(),
+            Some(PortRange::new(4001, 5000).unwrap()),
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.0/16".into(),
+            Some(PortRange::new(8001, 9000).unwrap()),
+        ))
+        .unwrap();
+    let expose2 = VpcExpose::empty().ip(PrefixWithOptionalPorts::new(
+        "10.2.0.0/16".into(),
+        Some(PortRange::new(1, 5).unwrap()),
+    ));
+
+    let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
+    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables);
+
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.2.3"), 4024, addr_v4("10.2.2.18"), 1);
+    let (target_src_addr, target_src_port) = (addr_v4("10.1.2.3"), 8024);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
         );
-        let mut vrf_config = VrfConfig::new("default", None, true);
-        vrf_config.add_interface_config(vtep);
-        let bgp = BgpConfig::new(1);
-        vrf_config.set_bgp(bgp);
-        let underlay = Underlay {
-            vrf: vrf_config,
-            vtep: None,
-        };
-
-        let mut group_table = GwGroupTable::new();
-        group_table.add_group(GwGroup::new("default")).unwrap();
-
-        let mut external_builder = ExternalConfigBuilder::default();
-        external_builder.gwname("test-gw".to_string());
-        external_builder.genid(1);
-        external_builder.device(device_config);
-        external_builder.underlay(underlay);
-        external_builder.overlay(overlay);
-        external_builder.gwgroups(group_table);
-        external_builder.communities(PriorityCommunityTable::new());
-        let external_config = external_builder
-            .build()
-            .expect("Failed to build external config");
-
-        GwConfig::new(external_config)
-    }
-
-    fn check_packet(
-        nat: &mut StatelessNat,
-        src_vni: Vni,
-        dst_vni: Vni,
-        orig_src_ip: Ipv4Addr,
-        orig_dst_ip: Ipv4Addr,
-    ) -> (Ipv4Addr, Ipv4Addr, Option<DoneReason>) {
-        let mut packet = build_test_ipv4_packet(u8::MAX).unwrap();
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateless_nat(true);
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
-        set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
-
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        let hdr_out = packets_out[0]
-            .try_ipv4()
-            .expect("Failed to get IPv4 header");
-        let done_reason = packets_out[0].get_done();
-
-        (hdr_out.source().inner(), hdr_out.destination(), done_reason)
-    }
-
-    #[test]
-    #[traced_test]
-    #[allow(clippy::too_many_lines)]
-    fn test_full_config() {
-        let mut config = build_sample_config();
-        config.validate().expect("Failed to validate config");
-
-        let nat_tables = build_nat_configuration(&config.external.overlay.vpc_table).unwrap();
-        println!("Nat tables: {:#?}", &nat_tables);
-
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables.clone());
-
-        // No NAT
-        let (orig_src, orig_dst) = (addr_v4("8.8.8.8"), addr_v4("9.9.9.9"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
-        assert_eq!(output_src, orig_src);
-        assert_eq!(output_dst, orig_dst);
-        assert_eq!(done_reason, None);
-
-        // expose121 <-> expose211
-        let (orig_src, orig_dst) = (addr_v4("1.1.2.3"), addr_v4("10.201.201.18"));
-        let (target_src, target_dst) = (addr_v4("10.12.2.3"), addr_v4("1.2.2.18"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose122 <-> expose211
-        let (orig_src, orig_dst) = (addr_v4("1.2.129.3"), addr_v4("10.201.201.22"));
-        let (target_src, target_dst) = (addr_v4("10.99.1.3"), addr_v4("1.2.2.22"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose123 <-> expose214
-        let (orig_src, orig_dst) = (addr_v4("1.3.0.7"), addr_v4("10.201.204.193"));
-        let (target_src, target_dst) = (addr_v4("10.100.0.7"), addr_v4("2.0.1.1"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(200), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(200), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose131 <-> expose311 (reusing expose121 private IPs)
-        let (orig_src, orig_dst) = (addr_v4("1.1.3.3"), addr_v4("3.3.3.3"));
-        let (target_src, target_dst) = (addr_v4("3.3.3.3"), addr_v4("192.168.128.3"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(300), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(300), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose132 <-> expose311
-        let (orig_src, orig_dst) = (addr_v4("1.2.130.1"), addr_v4("3.3.3.3"));
-        let (target_src, target_dst) = (addr_v4("3.2.2.1"), addr_v4("192.168.128.3"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(300), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(300), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose141 <-> expose411
-        let (orig_src, orig_dst) = (addr_v4("1.1.1.1"), addr_v4("4.5.1.1"));
-        let (target_src, target_dst) = (addr_v4("4.4.1.1"), addr_v4("1.1.1.1"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(100), vni(400), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(400), vni(100), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose241 <-> expose421 (first/last addresses of ranges)
-        let (orig_src, orig_dst) = (addr_v4("2.4.255.255"), addr_v4("44.4.0.0"));
-        let (target_src, target_dst) = (addr_v4("44.0.255.255"), addr_v4("4.4.0.0"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(200), vni(400), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(400), vni(200), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose241 <-> expose421 (playing with not/not_as)
-        let (orig_src, orig_dst) = (addr_v4("2.4.2.1"), addr_v4("44.4.136.2"));
-        let (target_src, target_dst) = (addr_v4("44.0.1.1"), addr_v4("4.4.72.2"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(200), vni(400), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(400), vni(200), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-
-        // expose341 <-> expose431 (one-side NAT)
-        let (orig_src, orig_dst) = (addr_v4("192.168.100.34"), addr_v4("4.4.0.43"));
-        let (target_src, target_dst) = (addr_v4("34.34.34.34"), addr_v4("4.4.0.43"));
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(300), vni(400), orig_src, orig_dst);
-        assert_eq!(output_src, target_src);
-        assert_eq!(output_dst, target_dst);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src, output_dst, done_reason) =
-            check_packet(&mut nat, vni(400), vni(300), target_dst, target_src);
-        assert_eq!(output_src, orig_dst);
-        assert_eq!(output_dst, orig_src);
-        assert_eq!(done_reason, None);
-    }
-
-    // Address + port translation
-
-    fn build_gwconfig_from_exposes(
-        exposes_left: Vec<VpcExpose>,
-        exposes_right: Vec<VpcExpose>,
-    ) -> GwConfig {
-        fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
-            manifest.add_expose(expose);
-        }
-
-        let mut vpc_table = VpcTable::new();
-        let _ = vpc_table.add(Vpc::new("VPC-1", "VPC01", 100).unwrap());
-        let _ = vpc_table.add(Vpc::new("VPC-2", "VPC02", 200).unwrap());
-
-        let mut manifest12 = VpcManifest::new("VPC-1");
-        for expose in exposes_left {
-            add_expose(&mut manifest12, expose);
-        }
-        let mut manifest21 = VpcManifest::new("VPC-2");
-        for expose in exposes_right {
-            add_expose(&mut manifest21, expose);
-        }
-
-        let peering12 = VpcPeering::with_default_group("VPC-1--VPC-2", manifest12, manifest21);
-
-        let mut peering_table = VpcPeeringTable::new();
-        peering_table.add(peering12).expect("Failed to add peering");
-
-        let overlay = Overlay::new(vpc_table, peering_table);
-
-        let mut gw_config = build_gwconfig_from_overlay(overlay);
-        let validation = gw_config.validate();
-        assert!(
-            validation.is_ok(),
-            "GwConfig validation failed: {validation:?}"
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, orig_dst_addr);
+    assert_eq!(output_dst_port, orig_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
         );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
+}
 
-        gw_config
-    }
-
-    fn check_packet_with_ports(
-        nat: &mut StatelessNat,
-        src_vni: Vni,
-        dst_vni: Vni,
-        orig_src_ip: Ipv4Addr,
-        orig_src_port: u16,
-        orig_dst_ip: Ipv4Addr,
-        orig_dst_port: u16,
-    ) -> (Ipv4Addr, u16, Ipv4Addr, u16, Option<DoneReason>) {
-        let mut packet =
-            build_test_ipv4_packet_with_transport(u8::MAX, Some(NextHeader::TCP)).unwrap();
-        packet.meta_mut().set_overlay(true);
-        packet.meta_mut().set_stateless_nat(true);
-        packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
-        packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
-        set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
-        set_ports(&mut packet, orig_src_port, orig_dst_port);
-
-        let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
-        let pkt_out = &packets_out[0];
-
-        (
-            get_src_ip_v4(pkt_out),
-            get_src_port(pkt_out),
-            get_dst_ip_v4(pkt_out),
-            get_dst_port(pkt_out),
-            pkt_out.get_done(),
-        )
-    }
-
-    #[test]
-    #[traced_test]
-    fn test_config_with_port_ranges_basic() {
-        let expose1 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "1.1.0.0/16".into(),
-                Some(PortRange::new(4001, 5000).unwrap()),
-            ))
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.0.0/16".into(),
-                Some(PortRange::new(8001, 9000).unwrap()),
-            ))
-            .unwrap();
-        let expose2 = VpcExpose::empty().ip(PrefixWithOptionalPorts::new(
-            "10.2.0.0/16".into(),
-            Some(PortRange::new(1, 5).unwrap()),
-        ));
-
-        let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
-        let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables);
-
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.2.3"), 4024, addr_v4("10.2.2.18"), 1);
-        let (target_src_addr, target_src_port) = (addr_v4("10.1.2.3"), 8024);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, orig_dst_addr);
-        assert_eq!(output_dst_port, orig_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
-    }
-
-    #[test]
-    #[traced_test]
-    #[allow(clippy::too_many_lines)]
-    fn test_config_with_port_ranges_complex() {
-        let expose1 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "1.1.1.0/24".into(),
-                Some(PortRange::new(4001, 5000).unwrap()), // 256 IPs, 1000 ports
-            ))
-            .not(PrefixWithOptionalPorts::new(
-                "1.1.1.64/26".into(),
-                Some(PortRange::new(4001, 5000).unwrap()), // 64 IPs, 1000 ports (exclusion)
-            ))
-            .not(PrefixWithOptionalPorts::new(
-                "1.1.1.128/25".into(),
-                Some(PortRange::new(4501, 5000).unwrap()), // 128 IPs, 500 ports (exclusion)
-            ))
-            .ip(PrefixWithOptionalPorts::new(
-                "1.1.2.0/25".into(),
-                Some(PortRange::new(4001, 5000).unwrap()), // 128 IPs, 1000 ports
-            ))
-            .ip(PrefixWithOptionalPorts::new(
-                "1.1.3.0/25".into(),
-                Some(PortRange::new(5001, 5500).unwrap()), // 128 IPs, 500 ports
-            ))
-            // Total: (256 * 1000 + 128 * 1000 + 128 * 500) - (64 * 1000 + 128 * 500)
-            //     = 320,000 ip/port combinations
-            //
-            // End of exposed prefixes, beginning of translated prefixes
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.0.0/30".into(),
-                Some(PortRange::new(2001, 2300).unwrap()), // 4 IPs, 300 ports
-            ))
-            .unwrap()
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.0.128/25".into(),
-                Some(PortRange::new(2001, 3000).unwrap()), // 128 IPs, 1000 ports
-            ))
-            .unwrap()
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.1.0/25".into(),
-                Some(PortRange::new(2501, 3000).unwrap()), // 128 IPs, 500 ports
-            ))
-            .unwrap()
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.1.128/25".into(),
-                Some(PortRange::new(3001, 4000).unwrap()), // 128 IPs, 1000 ports
-            ))
-            .unwrap()
-            .not_as(PrefixWithOptionalPorts::new(
-                "10.1.1.128/25".into(),
-                Some(PortRange::new(3456, 3755).unwrap()), // 128 IPs, 300 ports (exclusion)
-            ))
-            .unwrap()
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.2.3/32".into(),
-                Some(PortRange::new(1, 37200).unwrap()), // 1 IP, 37200 ports
-            ))
-            .unwrap();
-        // Total: (4 * 300 + 128 * 1000 + 128 * 500 + 128 * 1000 + 1 * 37200) - (128 * 300)
+#[test]
+#[traced_test]
+#[allow(clippy::too_many_lines)]
+fn test_config_with_port_ranges_complex() {
+    let expose1 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.1.0/24".into(),
+            Some(PortRange::new(4001, 5000).unwrap()), // 256 IPs, 1000 ports
+        ))
+        .not(PrefixWithOptionalPorts::new(
+            "1.1.1.64/26".into(),
+            Some(PortRange::new(4001, 5000).unwrap()), // 64 IPs, 1000 ports (exclusion)
+        ))
+        .not(PrefixWithOptionalPorts::new(
+            "1.1.1.128/25".into(),
+            Some(PortRange::new(4501, 5000).unwrap()), // 128 IPs, 500 ports (exclusion)
+        ))
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.2.0/25".into(),
+            Some(PortRange::new(4001, 5000).unwrap()), // 128 IPs, 1000 ports
+        ))
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.3.0/25".into(),
+            Some(PortRange::new(5001, 5500).unwrap()), // 128 IPs, 500 ports
+        ))
+        // Total: (256 * 1000 + 128 * 1000 + 128 * 500) - (64 * 1000 + 128 * 500)
         //     = 320,000 ip/port combinations
+        //
+        // End of exposed prefixes, beginning of translated prefixes
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.0/30".into(),
+            Some(PortRange::new(2001, 2300).unwrap()), // 4 IPs, 300 ports
+        ))
+        .unwrap()
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.128/25".into(),
+            Some(PortRange::new(2001, 3000).unwrap()), // 128 IPs, 1000 ports
+        ))
+        .unwrap()
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.1.0/25".into(),
+            Some(PortRange::new(2501, 3000).unwrap()), // 128 IPs, 500 ports
+        ))
+        .unwrap()
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.1.128/25".into(),
+            Some(PortRange::new(3001, 4000).unwrap()), // 128 IPs, 1000 ports
+        ))
+        .unwrap()
+        .not_as(PrefixWithOptionalPorts::new(
+            "10.1.1.128/25".into(),
+            Some(PortRange::new(3456, 3755).unwrap()), // 128 IPs, 300 ports (exclusion)
+        ))
+        .unwrap()
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.2.3/32".into(),
+            Some(PortRange::new(1, 37200).unwrap()), // 1 IP, 37200 ports
+        ))
+        .unwrap();
+    // Total: (4 * 300 + 128 * 1000 + 128 * 500 + 128 * 1000 + 1 * 37200) - (128 * 300)
+    //     = 320,000 ip/port combinations
 
-        let expose2 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "2.1.0.1/32".into(),
-                Some(PortRange::new(0, 65535).unwrap()), // 1 IP, 65536 ports
-            ))
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.2.0.0/30".into(),
-                Some(PortRange::new(1, 16384).unwrap()), // 4 IPs, 16384 ports
-            ))
-            .unwrap();
+    let expose2 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "2.1.0.1/32".into(),
+            Some(PortRange::new(0, 65535).unwrap()), // 1 IP, 65536 ports
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.2.0.0/30".into(),
+            Some(PortRange::new(1, 16384).unwrap()), // 4 IPs, 16384 ports
+        ))
+        .unwrap();
 
-        // First address/port (assuming ordered ranges)
+    // First address/port (assuming ordered ranges)
 
-        let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
-        let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables);
+    let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
+    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables);
 
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.1.0"), 4001, addr_v4("10.2.0.0"), 2);
-        // (actually second port for destination NAT because 0 is problematic)
-        let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-            (addr_v4("10.1.0.0"), 2001, addr_v4("2.1.0.1"), 1);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, target_dst_addr);
-        assert_eq!(output_dst_port, target_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.1.0"), 4001, addr_v4("10.2.0.0"), 2);
+    // (actually second port for destination NAT because 0 is problematic)
+    let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
+        (addr_v4("10.1.0.0"), 2001, addr_v4("2.1.0.1"), 1);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, target_dst_addr);
+    assert_eq!(output_dst_port, target_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
 
-        // Last address/port (assuming ordered ranges)
+    // Last address/port (assuming ordered ranges)
 
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.3.127"), 5500, addr_v4("10.2.0.3"), 16384);
-        let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-            (addr_v4("10.1.2.3"), 37200, addr_v4("2.1.0.1"), 65535);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, target_dst_addr);
-        assert_eq!(output_dst_port, target_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.3.127"), 5500, addr_v4("10.2.0.3"), 16384);
+    let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
+        (addr_v4("10.1.2.3"), 37200, addr_v4("2.1.0.1"), 65535);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, target_dst_addr);
+    assert_eq!(output_dst_port, target_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
 
-        // Something in the middle
+    // Something in the middle
 
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.1.255"), 4500, addr_v4("10.2.0.1"), 16384);
-        let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-            (addr_v4("10.1.0.254"), 2800, addr_v4("2.1.0.1"), 32767);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, target_dst_addr);
-        assert_eq!(output_dst_port, target_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.1.255"), 4500, addr_v4("10.2.0.1"), 16384);
+    let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
+        (addr_v4("10.1.0.254"), 2800, addr_v4("2.1.0.1"), 32767);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, target_dst_addr);
+    assert_eq!(output_dst_port, target_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
 
-        // Same, moving one port forward in the list
+    // Same, moving one port forward in the list
 
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.2.0"), 4001, addr_v4("10.2.0.2"), 1);
-        let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-            (addr_v4("10.1.0.254"), 2801, addr_v4("2.1.0.1"), 32768);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, target_dst_addr);
-        assert_eq!(output_dst_port, target_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
-    }
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.2.0"), 4001, addr_v4("10.2.0.2"), 1);
+    let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
+        (addr_v4("10.1.0.254"), 2801, addr_v4("2.1.0.1"), 32768);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, target_dst_addr);
+    assert_eq!(output_dst_port, target_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
+}
 
-    #[test]
-    #[traced_test]
-    fn test_config_with_port_ranges_with_default() {
-        let expose1 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "1.1.0.0/16".into(),
-                Some(PortRange::new(4001, 5000).unwrap()),
-            ))
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.1.0.0/16".into(),
-                Some(PortRange::new(8001, 9000).unwrap()),
-            ))
-            .unwrap();
-        let expose2 = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "1.2.0.0/16".into(),
-                Some(PortRange::new(2001, 3000).unwrap()),
-            ))
-            .as_range(PrefixWithOptionalPorts::new(
-                "10.2.0.0/16".into(),
-                Some(PortRange::new(6001, 7000).unwrap()),
-            ))
-            .unwrap();
-        let expose3 = VpcExpose::empty().set_default();
+#[test]
+#[traced_test]
+fn test_config_with_port_ranges_with_default() {
+    let expose1 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.0.0/16".into(),
+            Some(PortRange::new(4001, 5000).unwrap()),
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.0/16".into(),
+            Some(PortRange::new(8001, 9000).unwrap()),
+        ))
+        .unwrap();
+    let expose2 = VpcExpose::empty()
+        .make_stateless_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.2.0.0/16".into(),
+            Some(PortRange::new(2001, 3000).unwrap()),
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.2.0.0/16".into(),
+            Some(PortRange::new(6001, 7000).unwrap()),
+        ))
+        .unwrap();
+    let expose3 = VpcExpose::empty().set_default();
 
-        let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2, expose3]);
-        let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
-        let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
-        tablesw.update_nat_tables(nat_tables);
+    let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2, expose3]);
+    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
+    tablesw.update_nat_tables(nat_tables);
 
-        // Using the expose with a prefix
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.2.3"), 4024, addr_v4("10.2.2.18"), 7000);
-        let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-            (addr_v4("10.1.2.3"), 8024, addr_v4("1.2.2.18"), 3000);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, target_dst_addr);
-        assert_eq!(output_dst_port, target_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
+    // Using the expose with a prefix
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.2.3"), 4024, addr_v4("10.2.2.18"), 7000);
+    let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
+        (addr_v4("10.1.2.3"), 8024, addr_v4("1.2.2.18"), 3000);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, target_dst_addr);
+    assert_eq!(output_dst_port, target_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
 
-        // Using the default expose
-        let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-            (addr_v4("1.1.2.3"), 4024, addr_v4("123.123.123.123"), 7000);
-        let (target_src_addr, target_src_port) = (addr_v4("10.1.2.3"), 8024);
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(100),
-                vni(200),
-                orig_src_addr,
-                orig_src_port,
-                orig_dst_addr,
-                orig_dst_port,
-            );
-        assert_eq!(output_src_addr, target_src_addr);
-        assert_eq!(output_src_port, target_src_port);
-        assert_eq!(output_dst_addr, orig_dst_addr);
-        assert_eq!(output_dst_port, orig_dst_port);
-        assert_eq!(done_reason, None);
-        // Reverse path
-        let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
-            check_packet_with_ports(
-                &mut nat,
-                vni(200),
-                vni(100),
-                output_dst_addr,
-                output_dst_port,
-                output_src_addr,
-                output_src_port,
-            );
-        assert_eq!(output_src_addr, orig_dst_addr);
-        assert_eq!(output_src_port, orig_dst_port);
-        assert_eq!(output_dst_addr, orig_src_addr);
-        assert_eq!(output_dst_port, orig_src_port);
-        assert_eq!(done_reason, None);
-    }
+    // Using the default expose
+    let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
+        (addr_v4("1.1.2.3"), 4024, addr_v4("123.123.123.123"), 7000);
+    let (target_src_addr, target_src_port) = (addr_v4("10.1.2.3"), 8024);
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(100),
+            vni(200),
+            orig_src_addr,
+            orig_src_port,
+            orig_dst_addr,
+            orig_dst_port,
+        );
+    assert_eq!(output_src_addr, target_src_addr);
+    assert_eq!(output_src_port, target_src_port);
+    assert_eq!(output_dst_addr, orig_dst_addr);
+    assert_eq!(output_dst_port, orig_dst_port);
+    assert_eq!(done_reason, None);
+    // Reverse path
+    let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
+        check_packet_with_ports(
+            &mut nat,
+            vni(200),
+            vni(100),
+            output_dst_addr,
+            output_dst_port,
+            output_src_addr,
+            output_src_port,
+        );
+    assert_eq!(output_src_addr, orig_dst_addr);
+    assert_eq!(output_src_port, orig_dst_port);
+    assert_eq!(output_dst_addr, orig_src_addr);
+    assert_eq!(output_dst_port, orig_src_port);
+    assert_eq!(done_reason, None);
 }


### PR DESCRIPTION
The whole files are already test submodules, no need to embed the tests into some yet more deeply-nested "tests" submodules.

Note: There's no other change in the commit apart from automatic re-formatting (and a comment clean-up); this commit is best reviewed with the option for ignoring whitespace changes, "-w" in git.

Moved out of #1419 because it doesn't really belong in there, and it's a pain to rebase every time we edit NAT tests.
