### PR TITLE
Dependencies update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa514b7c2d4cb8ac9d54925c91900d21fdda508877694661858744211c11c69c"
 dependencies = [
  "futures-lite",
- "libc 0.2.184",
+ "libc 0.2.185",
  "tokio",
 ]
 
@@ -77,7 +77,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -365,7 +365,7 @@ checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "miniz_oxide",
  "object 0.37.3",
  "rustc-demangle",
@@ -504,7 +504,7 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if",
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ dependencies = [
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
 ]
 
@@ -705,7 +705,7 @@ checksum = "4a6e71767585f51c2a33fed6d67147ec0343725fc3c03bf4b89fe67fede56aa5"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -747,13 +747,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
- "libc 0.2.184",
+ "libc 0.2.185",
  "shlex",
 ]
 
@@ -814,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
- "libc 0.2.184",
+ "libc 0.2.185",
  "libloading",
 ]
 
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -955,16 +955,16 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "command-fds"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f849b92c694fe237ecd8fafd1ba0df7ae0d45c1df6daeb7f68ed4220d51640bd"
+checksum = "1b60b5124979fccd9addd89d8b97a1d6eebb4950694520c75ddd722535ea443f"
 dependencies = [
- "nix 0.30.1",
+ "nix 0.31.2",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -1017,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -1059,7 +1059,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -1098,7 +1098,7 @@ dependencies = [
  "document-features",
  "filedescriptor",
  "futures-core",
- "libc 0.2.184",
+ "libc 0.2.185",
  "mio",
  "parking_lot",
  "rustix",
@@ -1946,7 +1946,7 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc 0.2.184",
+ "libc 0.2.185",
  "objc2",
 ]
 
@@ -1967,7 +1967,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "once_cell",
  "winapi",
 ]
@@ -2131,8 +2131,8 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "libc 0.2.184",
- "windows-sys 0.52.0",
+ "libc 0.2.185",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "thiserror 1.0.69",
  "winapi",
 ]
@@ -2246,7 +2246,7 @@ checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
  "cc",
  "lazy_static",
- "libc 0.2.184",
+ "libc 0.2.185",
  "winapi",
 ]
 
@@ -2466,7 +2466,7 @@ checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "rustversion",
  "windows-link",
@@ -2490,7 +2490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "wasi",
 ]
 
@@ -2501,7 +2501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "r-efi 5.3.0",
  "wasip2",
 ]
@@ -2513,7 +2513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
@@ -2639,7 +2639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "windows-link",
 ]
 
@@ -2710,7 +2710,7 @@ dependencies = [
  "derive_more",
  "errno",
  "hwlocality-sys",
- "libc 0.2.184",
+ "libc 0.2.185",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
@@ -2722,7 +2722,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a83c43a772c1f774b806deb44891c2a9578eb33cec48aad513482e0da3d4d4"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "pkg-config",
  "windows-sys 0.61.2",
 ]
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
  "hyper",
@@ -2785,7 +2785,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2818,7 +2817,7 @@ dependencies = [
  "http-body",
  "hyper",
  "ipnet",
- "libc 0.2.184",
+ "libc 0.2.185",
  "percent-encoding",
  "pin-project-lite",
  "socket2",
@@ -3028,7 +3027,7 @@ dependencies = [
  "bitflags 2.11.0",
  "futures-core",
  "inotify-sys",
- "libc 0.2.184",
+ "libc 0.2.185",
  "tokio",
 ]
 
@@ -3038,7 +3037,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -3071,7 +3070,7 @@ checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
 dependencies = [
  "doctest-file",
  "futures-core",
- "libc 0.2.184",
+ "libc 0.2.185",
  "recvmsg",
  "tokio",
  "widestring",
@@ -3164,14 +3163,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3387,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libc"
@@ -3438,7 +3437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -3579,7 +3578,7 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -3588,7 +3587,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -3641,7 +3640,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -3713,7 +3712,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "wasi",
  "windows-sys 0.61.2",
@@ -3813,7 +3812,7 @@ dependencies = [
  "dispatch2",
  "dlopen2",
  "ipnet",
- "libc 0.2.184",
+ "libc 0.2.185",
  "mac-addr",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
@@ -3920,7 +3919,7 @@ version = "0.25.1"
 source = "git+https://github.com/githedgehog/netlink-packet-route.git?branch=pr%2Fdaniel-noland%2Fswing4#09b8ffdf9b4e9bbc8780a3efb4ec3494ee7ee3fd"
 dependencies = [
  "bitflags 2.11.0",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "netlink-packet-core",
 ]
@@ -3932,7 +3931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
  "bitflags 2.11.0",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "netlink-packet-core",
 ]
@@ -3970,7 +3969,7 @@ checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
  "futures-util",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "tokio",
 ]
@@ -3992,7 +3991,7 @@ checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -4004,7 +4003,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -4016,7 +4015,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "libc 0.2.184",
+ "libc 0.2.185",
  "memoffset",
 ]
 
@@ -4029,7 +4028,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -4041,7 +4040,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "libc 0.2.184",
+ "libc 0.2.185",
  "memoffset",
 ]
 
@@ -4105,7 +4104,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -4126,7 +4125,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "dispatch2",
- "libc 0.2.184",
+ "libc 0.2.185",
  "objc2",
 ]
 
@@ -4155,7 +4154,7 @@ checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "libc 0.2.184",
+ "libc 0.2.185",
  "objc2",
  "objc2-core-foundation",
  "objc2-security",
@@ -4260,7 +4259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "redox_syscall",
  "smallvec",
  "windows-link",
@@ -4443,9 +4442,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
@@ -4486,7 +4485,7 @@ dependencies = [
  "downcast-rs 1.2.1",
  "filedescriptor",
  "lazy_static",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "nix 0.28.0",
  "serial2",
@@ -4522,7 +4521,7 @@ dependencies = [
  "cfg-if",
  "findshlibs",
  "framehop",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "memmap2 0.5.10",
  "nix 0.26.4",
@@ -4691,7 +4690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eebd4bcbf45db75f67d2ba20ea0207bd111d2029c07a7db3229289173d4387"
 dependencies = [
  "lazy_static",
- "libc 0.2.184",
+ "libc 0.2.185",
  "libflate",
  "log",
  "names",
@@ -4711,7 +4710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
- "libc 0.2.184",
+ "libc 0.2.185",
  "once_cell",
  "raw-cpuid",
  "wasi",
@@ -4780,16 +4779,16 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5086,7 +5085,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.17",
- "libc 0.2.184",
+ "libc 0.2.185",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5199,16 +5198,16 @@ checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
- "libc 0.2.184",
+ "libc 0.2.185",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5251,9 +5250,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5276,7 +5275,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "clipboard-win",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "memchr",
  "nix 0.31.2",
@@ -5391,7 +5390,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.184",
+ "libc 0.2.185",
  "security-framework-sys",
 ]
 
@@ -5402,7 +5401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -5558,7 +5557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66ab7ee258c6456796c6098e1b53a5baa1a5e0637347de59ddb44ee8e20be6e"
 dependencies = [
  "cfg-if",
- "libc 0.2.184",
+ "libc 0.2.185",
  "winapi",
 ]
 
@@ -5629,7 +5628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 dependencies = [
  "lazy_static",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -5679,7 +5678,7 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "signal-hook-registry",
 ]
 
@@ -5689,7 +5688,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "mio",
  "signal-hook",
 ]
@@ -5701,7 +5700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -5799,7 +5798,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "windows-sys 0.61.2",
 ]
 
@@ -5901,9 +5900,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.3"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ca086c1eb5c7ee74b151ba83c6487d5d33f8c08ad991b86f3f58f6629e68d5"
+checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
 dependencies = [
  "debugid",
  "memmap2 0.9.10",
@@ -5913,9 +5912,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.3"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa911a28a62823aaf2cc2e074212492a3ee69d0d926cc8f5b12b4a108ff5c0c"
+checksum = "595bddd9d363c2ef6fc9fb33b98416ff209c5aae8bdca89a7dbbf2ef5e0ecc45"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -5980,7 +5979,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6011,7 +6010,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]
@@ -6029,7 +6028,7 @@ dependencies = [
  "fixedbitset",
  "hex",
  "lazy_static",
- "libc 0.2.184",
+ "libc 0.2.185",
  "log",
  "memmem",
  "nix 0.29.0",
@@ -6123,7 +6122,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "libc 0.2.184",
+ "libc 0.2.185",
  "num-conv",
  "num_threads",
  "powerfmt",
@@ -6180,7 +6179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
- "libc 0.2.184",
+ "libc 0.2.185",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
@@ -6258,7 +6257,7 @@ checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
 dependencies = [
  "bytes",
  "futures",
- "libc 0.2.184",
+ "libc 0.2.185",
  "tokio",
  "vsock",
 ]
@@ -6627,7 +6626,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
  "nix 0.31.2",
 ]
 
@@ -6702,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6715,9 +6714,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6725,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6735,9 +6734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6748,9 +6747,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6791,9 +6790,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6877,7 +6876,7 @@ version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "libc 0.2.184",
+ "libc 0.2.185",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ rapidhash = { version = "4.4.1", default-features = false, features = [] }
 rkyv = { version = "0.8.15", default-features = false, features = [] }
 roaring = { version = "0.11.3", default-features = false, features = [] }
 rtnetlink = { git = "https://github.com/githedgehog/rtnetlink.git", branch = "hh/tc-actions3", default-features = false, features = [] }
-rustls = { version = "0.23.37", default-features = false, features = [] }
+rustls = { version = "0.23.38", default-features = false, features = [] }
 rustyline = { version = "18.0.0", default-features = false, features = [] }
 schemars = { version = "1", default-features = false, features = [] }
 serde = { version = "1.0.228", default-features = false, features = [] }


### PR DESCRIPTION
```
name     old req compatible latest  new req
====     ======= ========== ======  =======
rand     0.10.0  0.10.1     0.10.1  0.10.1
rustls   0.23.37 0.23.38    0.23.38 0.23.38
tokio    1.51.0  1.51.1     1.51.1  1.51.1
```

Manual bump. The automatic workflow [failed](https://github.com/githedgehog/dataplane/actions/runs/24325609975/job/71020200811) because it also tried to upgrade ordermap from 1.1.0 to 1.2.0; this would pull indexmap 2.14.0, which is incompatible with skim 4.0.0 (pulled via rustyline), which pins indexmap to version 2.13.0.

In this PR, we leave the ordermap bump out. There is an open, recent Dependabot PR to bump the indexmap dependency in skim, so the hope is that the conflict will naturally solve itself soon.
