### PR TITLE
feat(logging): Add configurable rate limit for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,6 +1676,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-throttle",
 ]
 
 [[package]]
@@ -5834,6 +5835,18 @@ checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-throttle"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4e430251f5ca8f86ea941286923dc2e91be7ca95fec777d75ee8ae1c493f64"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ tracing = { version = "0.1.44", default-features = false, features = [] }
 tracing-error = { version = "0.2.1", default-features = false, features = [] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = [] }
 tracing-test = { version = "0.2.6", default-features = false, features = [] }
+tracing-throttle = { version = "0.4.2", default-features = false, features = [] }
 ureq = { version = "3.3.0", default-features = false, features = [] }
 url = { version = "2.5.8", default-features = false, features = [] }
 uuid = { version = "1.23.1", default-features = false, features = [] }

--- a/args/src/lib.rs
+++ b/args/src/lib.rs
@@ -84,6 +84,23 @@ pub struct InterfaceArg {
     pub port: Option<PortArg>,
 }
 
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    serde::Serialize,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Archive,
+    CheckBytes,
+)]
+#[rkyv(attr(derive(PartialEq, Eq, Debug)))]
+pub struct TracingRateLimit {
+    pub burst: u32,
+    pub replenish_per_second: u32,
+}
+
 impl FromStr for PortArg {
     type Err = String;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
@@ -128,6 +145,34 @@ impl FromStr for InterfaceArg {
                 port: None,
             })
         }
+    }
+}
+
+impl FromStr for TracingRateLimit {
+    type Err = String;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (burst, replenish_per_second) = input
+            .split_once(':')
+            .ok_or("Bad syntax: missing :".to_string())?;
+
+        let burst = burst
+            .parse::<u32>()
+            .map_err(|e| format!("Bad burst value: {e}"))?;
+        let replenish_per_second = replenish_per_second
+            .parse::<u32>()
+            .map_err(|e| format!("Bad replenish-per-second value: {e}"))?;
+
+        if burst == 0 {
+            return Err("Burst must be greater than 0".to_string());
+        }
+        if replenish_per_second == 0 {
+            return Err("Replenish-per-second must be greater than 0".to_string());
+        }
+
+        Ok(Self {
+            burst,
+            replenish_per_second,
+        })
     }
 }
 
@@ -463,6 +508,8 @@ pub struct TracingConfigSection {
     pub show: TracingShowSection,
     /// Tracing configuration string (e.g., "default=info,nat=debug")
     pub config: Option<String>, // TODO: stronger typing on this config?
+    /// Optional rate limit for lower-severity tracing output
+    pub rate_limit: Option<TracingRateLimit>,
 }
 
 /// Display option for trace metadata elements.
@@ -1146,6 +1193,7 @@ impl TryFrom<CmdArgs> for LaunchConfiguration {
                     },
                 },
                 config: value.tracing.clone(),
+                rate_limit: value.tracing_rate_limit.clone(),
             },
             metrics: MetricsConfigSection {
                 address: value.metrics_address(),
@@ -1266,6 +1314,16 @@ E.g. default=error,all=info,nat=debug will set the default target to error, and 
     )]
     tracing: Option<String>,
 
+    #[arg(
+        long,
+        value_name = "BURST:REPLENISH_PER_SECOND",
+        value_parser=TracingRateLimit::from_str,
+        help = "Optional rate limit for lower-severity tracing output. Syntax: BURST:REPLENISH_PER_SECOND.
+Example: --tracing-rate-limit 50:5 allows bursts up to 50 repeated messages and replenishes 5 messages per second.
+If omitted, tracing output is not rate-limited."
+    )]
+    tracing_rate_limit: Option<TracingRateLimit>,
+
     #[arg(long, help = "Set the name of this gateway")]
     name: Option<String>,
 
@@ -1361,6 +1419,11 @@ impl CmdArgs {
     #[must_use]
     pub fn tracing(&self) -> Option<&String> {
         self.tracing.as_ref()
+    }
+
+    #[must_use]
+    pub fn tracing_rate_limit(&self) -> Option<&TracingRateLimit> {
+        self.tracing_rate_limit.as_ref()
     }
 
     /// Get the number of worker threads for the kernel driver.
@@ -1478,6 +1541,7 @@ mod tests {
     use hardware::pci::function::Function;
     use net::interface::InterfaceName;
 
+    use super::TracingRateLimit;
     use crate::{InterfaceArg, PortArg};
     use std::str::FromStr;
 
@@ -1519,5 +1583,30 @@ mod tests {
 
         // bad discriminant
         assert!(InterfaceArg::from_str("GbEth1.9000=foo@0000:02:01.7").is_err());
+    }
+    #[test]
+    fn tracing_rate_limit_parses_valid_values() {
+        let rate_limit = TracingRateLimit::from_str("10:20").unwrap();
+        assert_eq!(rate_limit.burst, 10);
+        assert_eq!(rate_limit.replenish_per_second, 20);
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_missing_separator() {
+        let err = TracingRateLimit::from_str("10").unwrap_err();
+        assert_eq!(err, "Bad syntax: missing :");
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_non_numeric_values() {
+        let err = TracingRateLimit::from_str("abc:20").unwrap_err();
+        assert!(err.starts_with("Bad burst value:"));
+        let err = TracingRateLimit::from_str("10:def").unwrap_err();
+        assert!(err.starts_with("Bad replenish-per-second value:"));
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_zero_values() {
+        let err = TracingRateLimit::from_str("0:20").unwrap_err();
+        assert_eq!(err, "Burst must be greater than 0");
+        let err = TracingRateLimit::from_str("10:0").unwrap_err();
+        assert_eq!(err, "Replenish-per-second must be greater than 0");
     }
 }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -21,7 +21,9 @@ use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::PyroscopeAgentBuilder;
 
 use routing::{BmpServerParams, RouterParamsBuilder};
-use tracectl::{custom_target, get_trace_ctl, trace_target};
+use tracectl::{
+    TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
+};
 
 use tracing::{error, info, level_filters::LevelFilter};
 
@@ -50,15 +52,24 @@ fn init_name(args: &CmdArgs) -> Result<String, String> {
         Ok(name.to_string())
     }
 }
-fn init_logging(gwname: &str) {
+fn init_logging(args: &CmdArgs, gwname: &str) {
+    TracingControl::init_with_rate_limit(args.tracing_rate_limit().map(|rate_limit| {
+        TracingRateLimitConfig {
+            burst: rate_limit.burst,
+            replenish_per_second: rate_limit.replenish_per_second,
+        }
+    }));
+
     let tctl = get_trace_ctl();
     info!(
         " ━━━━━━ Starting dataplane for gateway '{gwname}' (Version = {}) ━━━━━━",
         option_env!("VERSION").unwrap_or("dev").to_string()
     );
 
-    tctl.set_default_level(LevelFilter::DEBUG)
-        .expect("Setting default loglevel failed");
+    if args.tracing().is_none() {
+        tctl.set_default_level(LevelFilter::DEBUG)
+            .expect("Setting default loglevel failed");
+    }
 }
 
 fn process_tracing_cmds(args: &CmdArgs) {
@@ -131,7 +142,7 @@ fn main() {
             std::process::exit(1);
         }
     };
-    init_logging(&gwname);
+    init_logging(&args, &gwname);
 
     let (bmp_server_params, bmp_client_opts) = parse_bmp_params(&args);
 

--- a/tracectl/Cargo.toml
+++ b/tracectl/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-error = { workspace = true, features = ["traced-error"] }
 tracing-subscriber = { workspace = true, features = ["registry", "std", "env-filter", "fmt"] }
+tracing-throttle = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/tracectl/src/control.rs
+++ b/tracectl/src/control.rs
@@ -5,17 +5,31 @@
 
 use ordermap::OrderMap;
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock, Mutex};
-use std::{collections::HashSet, sync::MutexGuard};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::{collections::HashSet, sync::MutexGuard, time::Duration};
 use thiserror::Error;
 #[allow(unused)]
-use tracing::{debug, error, info, warn};
-use tracing_subscriber::{EnvFilter, Registry, filter::LevelFilter, prelude::*, reload};
+use tracing::{Level, Subscriber, debug, error, info, warn};
+use tracing_subscriber::{
+    EnvFilter, Registry,
+    filter::{FilterExt, LevelFilter, filter_fn},
+    layer::{Filter, Layer},
+    prelude::*,
+    registry::LookupSpan,
+    reload,
+};
+use tracing_throttle::{Policy, TracingRateLimitLayer};
 
 use crate::display::TargetCfgDbByTag;
 use crate::targets::{TRACING_TAG_ALL, TRACING_TARGETS};
 use crate::trace_target;
 trace_target!("tracectl", LevelFilter::INFO, &[]);
+
+#[derive(Copy, Clone, Debug)]
+pub struct TracingRateLimitConfig {
+    pub burst: u32,
+    pub replenish_per_second: u32,
+}
 
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum TraceCtlError {
@@ -278,32 +292,128 @@ impl TargetCfgDb {
     }
 }
 
+type BoxedTracingLayer<S> = Box<dyn Layer<S> + Send + Sync>;
+
+type ReloadLayer = reload::Layer<EnvFilter, Registry>;
+
 pub struct TracingControl {
     db: Arc<Mutex<TargetCfgDb>>,
     reload_filter: Arc<reload::Handle<EnvFilter, Registry>>,
 }
 impl TracingControl {
-    fn new() -> Self {
-        let db = TargetCfgDb::new();
-        let (filter, reload_filter) = reload::Layer::new(db.env_filter());
-
-        // formatting layer
-        let fmt_layer = tracing_subscriber::fmt::layer()
+    fn fmt_layer<S>() -> impl Layer<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::layer()
             .with_line_number(true)
             .with_target(true)
             .with_thread_ids(false)
             .with_thread_names(true)
-            .with_level(true);
+            .with_level(true)
+    }
 
-        // we should not be initializing the subscriber here, but that's fine atm
+    // To get rid of spaghetti filters in the layers, we split the fmt layer into two:
+    // one for unthrottled levels and one for throttled levels.
+
+    // `DEBUG` level remains unthrottled if we assume that it is the most verbose level
+    // that users would want to enable while digging into particular issues.
+    fn unthrottled_level_filter<S>() -> impl Filter<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        filter_fn(|meta| matches!(*meta.level(), Level::DEBUG))
+    }
+
+    fn throttled_level_filter<S>() -> impl Filter<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        filter_fn(|meta| {
+            matches!(
+                *meta.level(),
+                Level::INFO | Level::TRACE | Level::ERROR | Level::WARN
+            )
+        })
+    }
+
+    fn unthrottled_fmt_layer<S>() -> BoxedTracingLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+    {
+        Self::fmt_layer()
+            .with_filter(Self::unthrottled_level_filter())
+            .boxed()
+    }
+
+    fn throttled_fmt_layer<S>(
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> BoxedTracingLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+    {
+        if let Some(rate_limit) = Self::build_rate_limit_layer(rate_limit_config) {
+            Self::fmt_layer()
+                .with_filter(Self::throttled_level_filter().and(rate_limit))
+                .boxed()
+        } else {
+            Self::fmt_layer()
+                .with_filter(Self::throttled_level_filter())
+                .boxed()
+        }
+    }
+
+    fn build_rate_limit_layer(
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> Option<TracingRateLimitLayer> {
+        let rate_limit_config = rate_limit_config?;
+
+        let policy = match Policy::token_bucket(
+            f64::from(rate_limit_config.burst),
+            f64::from(rate_limit_config.replenish_per_second),
+        ) {
+            Ok(policy) => policy,
+            Err(e) => {
+                eprintln!(
+                    "Failed to create tracing throttle policy: {e}; falling back to unthrottled logging"
+                );
+                return None;
+            }
+        };
+
+        match TracingRateLimitLayer::builder()
+            .with_policy(policy)
+            .with_summary_interval(Duration::from_secs(30))
+            .build()
+        {
+            Ok(rate_limit) => Some(rate_limit),
+            Err(e) => {
+                eprintln!(
+                    "Failed to create tracing throttle layer: {e}; falling back to unthrottled logging"
+                );
+                None
+            }
+        }
+    }
+
+    fn init_subscriber(filter: ReloadLayer, rate_limit_config: Option<TracingRateLimitConfig>) {
         if let Err(e) = tracing_subscriber::registry()
             .with(filter)
-            .with(fmt_layer)
+            .with(Self::unthrottled_fmt_layer())
+            .with(Self::throttled_fmt_layer(rate_limit_config))
             .with(tracing_error::ErrorLayer::default())
             .try_init()
         {
             eprintln!("Failed to set global tracing subscriber: {e} !!");
         }
+    }
+
+    fn new(rate_limit_config: Option<TracingRateLimitConfig>) -> Self {
+        let db = TargetCfgDb::new();
+        let (filter, reload_filter) = reload::Layer::new(db.env_filter());
+
+        Self::init_subscriber(filter, rate_limit_config);
+
         if let Err(e) = color_eyre::install() {
             eprintln!("Failed to initialize color_eyre:\n{e}");
         }
@@ -339,17 +449,35 @@ impl TracingControl {
 }
 
 /// Get a reference to a static [`TracingControl`], initializing it if needed
-static TRACING_CTL: LazyLock<TracingControl> = LazyLock::new(TracingControl::new);
+static TRACING_CTL: OnceLock<TracingControl> = OnceLock::new();
 #[must_use]
 pub fn get_trace_ctl() -> &'static TracingControl {
-    #[allow(clippy::explicit_auto_deref)] // needed by mechanics of lazy lock
-    &*TRACING_CTL
+    TRACING_CTL.get_or_init(|| TracingControl::new(None))
 }
 
 // public methods for TracingControl
 impl TracingControl {
+    fn init_once(
+        tracing_ctl: &OnceLock<TracingControl>,
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> bool {
+        let mut initialized = false;
+        let _ = tracing_ctl.get_or_init(|| {
+            initialized = true;
+            TracingControl::new(rate_limit_config)
+        });
+        initialized
+    }
+
     pub fn init() {
         let _ = get_trace_ctl();
+    }
+    pub fn init_with_rate_limit(rate_limit_config: Option<TracingRateLimitConfig>) {
+        let has_rate_limit_config = rate_limit_config.is_some();
+        let initialized = Self::init_once(&TRACING_CTL, rate_limit_config);
+        if has_rate_limit_config && !initialized {
+            warn!("TracingControl already initialized; ignoring provided rate-limit config");
+        }
     }
     fn set_tag_level(&self, tag: &str, level: LevelFilter) -> Result<(), TraceCtlError> {
         let mut db = self.lock()?;
@@ -485,6 +613,7 @@ mod tests {
     use crate::targets::TRACING_TARGETS;
     use crate::{LevelFilter, custom_target, trace_target};
     use serial_test::serial;
+    use std::sync::OnceLock;
     use tracing::Level;
     use tracing::event_enabled;
     #[allow(unused)]
@@ -522,6 +651,25 @@ mod tests {
             tctl.get_default_level().unwrap()
         );
         println!("{:#?}", tctl.db.lock().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_rate_limit() {
+        let tracing_ctl = OnceLock::new();
+        let rate_limit_config = Some(crate::control::TracingRateLimitConfig {
+            burst: 10,
+            replenish_per_second: 1,
+        });
+
+        assert!(TracingControl::init_once(&tracing_ctl, rate_limit_config));
+        assert!(tracing_ctl.get().is_some());
+        assert_eq!(
+            tracing_ctl.get().unwrap().get_default_level().unwrap(),
+            crate::control::DEFAULT_DEFAULT_LOGLEVEL
+        );
+
+        assert!(!TracingControl::init_once(&tracing_ctl, rate_limit_config));
     }
 
     #[test]

--- a/tracectl/src/lib.rs
+++ b/tracectl/src/lib.rs
@@ -13,5 +13,5 @@ pub mod targets;
 // re-exports
 pub use control::DEFAULT_DEFAULT_LOGLEVEL;
 pub use control::get_trace_ctl;
-pub use control::{TraceCtlError, TracingControl};
+pub use control::{TraceCtlError, TracingControl, TracingRateLimitConfig};
 pub use tracing_subscriber::filter::LevelFilter;


### PR DESCRIPTION
Introduce --tracing-rate-limit BURST:REPLENISH_PER_SECOND. if omitted, logging is unchanged and no throttling is applied. Initialize tracing explicitly from main() so CLI-provided throttle settings are applied before startup logs.