### PR TITLE
Add stage for pipeline packet stats collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "dyn-iter",
  "linkme",
  "ordermap",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bolero",
  "bytecheck",
+ "dataplane-common",
  "dataplane-concurrency",
  "dataplane-id",
  "derive_builder",

--- a/cli/bin/cmdtree_dp.rs
+++ b/cli/bin/cmdtree_dp.rs
@@ -286,6 +286,14 @@ fn cmd_show_config_summary() -> Node {
     root
 }
 
+fn cmd_show_packet_stats() -> Node {
+    let mut root = Node::new("packet");
+    root += Node::new("stats")
+        .desc("Show packet stats")
+        .action(CliAction::ShowPacketStats);
+    root
+}
+
 fn cmd_show_tech() -> Node {
     Node::new("tech")
         .desc("Dump dataplanes state")
@@ -306,6 +314,7 @@ fn cmd_show() -> Node {
     root += cmd_show_flow_filter();
     root += cmd_show_gateway();
     root += cmd_show_config_summary();
+    root += cmd_show_packet_stats();
     root += cmd_show_tech();
     root
 }

--- a/cli/src/cliproto.rs
+++ b/cli/src/cliproto.rs
@@ -327,6 +327,9 @@ pub enum CliAction {
     // NF: flow filter
     ShowFlowFilter,
 
+    // NF: Packet stats
+    ShowPacketStats,
+
     // internal config
     ShowConfigInternal,
 

--- a/dataplane/src/packet_processor/ipforward.rs
+++ b/dataplane/src/packet_processor/ipforward.rs
@@ -162,7 +162,7 @@ impl IpForwarder {
             }
             Some(Err(bad)) => {
                 debug!("The decapsulated packet is malformed!: {bad:#?}");
-                packet.done(DoneReason::Malformed);
+                packet.done(DoneReason::VxlanDecapFailure);
             }
             None => {
                 /* send to kernel, among other options */
@@ -229,26 +229,26 @@ impl IpForwarder {
 
         let Some(src_mac) = &vtep.get_mac() else {
             error!("{nfi}: VxLAN encap FAILED: VTEP has no mac associated!");
-            packet.done(DoneReason::InternalFailure);
+            packet.done(DoneReason::VxlanEncapFailure);
             return;
         };
         let Some(dst_mac) = &vxlan.dmac else {
             error!("{nfi}: VxLAN encap FAILED: unknown dst rmac!");
-            packet.done(DoneReason::InternalFailure);
+            packet.done(DoneReason::VxlanEncapFailure);
             return;
         };
 
         // set current packet src mac (inner)
         if let Err(e) = packet.set_eth_source(*src_mac) {
             error!("{nfi}: VxLAN encap FAILED: can't set src mac '{src_mac}': {e}");
-            packet.done(DoneReason::InternalFailure);
+            packet.done(DoneReason::VxlanEncapFailure);
             return;
         }
 
         // set current packet dst mac (inner)
         if let Err(e) = packet.set_eth_destination(*dst_mac) {
             error!("{nfi}: VxLAN encap FAILED: can't set dst mac '{dst_mac}': {e}");
-            packet.done(DoneReason::InternalFailure);
+            packet.done(DoneReason::VxlanEncapFailure);
             return;
         }
 
@@ -267,7 +267,7 @@ impl IpForwarder {
         match Self::build_vxlan_headers(vxlan, vtep) {
             Err(e) => {
                 warn!("{nfi}: Failed to build VxLAN headers: {e}");
-                packet.done(DoneReason::InternalFailure);
+                packet.done(DoneReason::VxlanEncapFailure);
             }
             Ok(vxlan_headers) => match packet.vxlan_encap(&vxlan_headers) {
                 Ok(()) => {
@@ -282,7 +282,7 @@ impl IpForwarder {
                 }
                 Err(e) => {
                     error!("{nfi}: Failed to ENCAPSULATE packet with VxLAN: {e}");
-                    packet.done(DoneReason::InternalFailure);
+                    packet.done(DoneReason::VxlanEncapFailure);
                 }
             },
         }

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -19,9 +19,10 @@ use nat::portfw::{PortForwarder, PortFwTableWriter};
 use nat::stateful::NatAllocatorWriter;
 use nat::stateless::NatTablesWriter;
 use nat::{IcmpErrorHandler, StatefulNat, StatelessNat};
+use net::packet::PacketStats;
 
 use net::buffer::PacketBufferMut;
-use pipeline::sample_nfs::PacketDumper;
+use pipeline::sample_nfs::{PacketDumper, PacketStatsNF};
 use pipeline::{DynPipeline, PipelineData};
 
 use routing::{CliSources, Router, RouterError, RouterParams};
@@ -68,6 +69,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     let portfw_w = PortFwTableWriter::new();
     let portfw_factory = portfw_w.reader().factory();
     let pdata = Arc::from(PipelineData::new(0));
+    let pkt_stats = Arc::from(PacketStats::new());
 
     // collect readers and the like for cli
     let cli_sources = CliSources {
@@ -76,6 +78,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         portfw_table: Some(Box::new(portfw_w.reader().inner())),
         nat_tables: Some(Box::new(nattabler_factory.handle().inner())),
         masquerade_state: Some(Box::new(natallocator_factory.handle().inner())),
+        pkt_stats: Some(Box::new(pkt_stats.clone())),
     };
 
     // create router
@@ -108,6 +111,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
             portfw_factory.handle(),
             flow_table.clone(),
         );
+        let pkt_stats_nf = PacketStatsNF::new(pkt_stats.clone());
 
         // Build the pipeline for a router. The composition of the pipeline (in stages) is currently
         // hard-coded. Flow expiration is handled by per-flow tokio timers; no ExpirationsNF needed.
@@ -124,6 +128,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
             .add_stage(iprouter2)
             .add_stage(stage_egress)
             .add_stage(pktdump)
+            .add_stage(pkt_stats_nf)
             .add_stage(stats_stage)
     };
 

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -84,7 +84,7 @@ impl PortForwarder {
             && (!tcp.syn() || tcp.ack())
         {
             debug!("Dropping TCP segment: it has no SYN (or ack) and we have no state for it");
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             return None;
         }
         let Some(dst_port) = transport.dst_port() else {
@@ -146,7 +146,7 @@ impl PortForwarder {
 
         // check if the packet can be port forwarded at all
         let Some((key, dst_ip, dst_port)) = Self::can_be_port_forwarded(packet) else {
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             let reason = packet.get_done().unwrap_or_else(|| unreachable!());
             debug!("{nfi}: packet cannot be port-forwarded. Dropping it (reason:{reason})");
             return;
@@ -155,7 +155,7 @@ impl PortForwarder {
         // lookup the port-forwarding rule, using the given key, that contains the destination port
         let Some(entry) = pfwtable.lookup_matching_rule(key, dst_ip.inner(), dst_port) else {
             debug!("{nfi}: no rule found for port-forwarding key {key}. Dropping packet.");
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::NatNotPortForwarded);
             return;
         };
 
@@ -163,7 +163,7 @@ impl PortForwarder {
         let Some((new_dst_ip, new_dst_port)) = entry.map_address_port(dst_ip.inner(), dst_port)
         else {
             debug!("{nfi}: Unable to build usable address and port"); // FIXME:
-            packet.done(DoneReason::Filtered);
+            packet.done(DoneReason::InternalFailure);
             return;
         };
 
@@ -319,7 +319,7 @@ impl PortForwarder {
                 debug!("Packet hit Active flow referring to STALE port-forwarding rule.");
                 let Some(entry) = Self::get_rule_from_pkt(packet, pfwtable, &state) else {
                     debug!("Packet should no longer be forwarded. Will drop and invalidate state");
-                    packet.done(DoneReason::Filtered);
+                    packet.done(DoneReason::NatNotPortForwarded);
                     invalidate_flow_state(packet);
                     return;
                 };

--- a/nat/src/portfw/test.rs
+++ b/nat/src/portfw/test.rs
@@ -265,7 +265,7 @@ mod nf_test {
         let tcp = packet.try_tcp_mut().unwrap();
         tcp.set_syn(false);
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered));
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
 
         // process a packet in reverse direction: no flow info should have been found
         let packet = tcp_packet_reverse_reply();
@@ -525,8 +525,7 @@ mod nf_test {
 
         let packet = tcp_packet_to_port_forward();
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered));
-        //        assert!(get_pfw_flow_status(&output).is_none());
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
 
         println!("{flow_table}");
 
@@ -535,7 +534,7 @@ mod nf_test {
 
         let packet = tcp_packet_to_port_forward();
         let output = process_packet(&mut pipeline, packet);
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered)); // should be filtered
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded));
         assert_eq!(get_flow_status(&output), None); // expiration NF should have removed the flow
         assert!(get_pfw_flow_status(&output).is_none());
         println!("{flow_table}");
@@ -814,7 +813,7 @@ mod nf_test {
         );
         let rule_referenced = get_pfw_flow_state_rule(&output);
         assert!(rule_referenced.is_none()); // flow did not get a new reference to a rule
-        assert_eq!(output.get_done(), Some(DoneReason::Filtered)); // packet was dropped
+        assert_eq!(output.get_done(), Some(DoneReason::NatNotPortForwarded)); // packet was dropped
 
         println!("{flow_table}");
     }

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -474,7 +474,7 @@ fn translate_error(error: &StatefulNatError) -> DoneReason {
 
         StatefulNatError::BadTransportHeader
         | StatefulNatError::AllocationFailure(AllocatorError::UnsupportedProtocol(_)) => {
-            DoneReason::UnsupportedTransport
+            DoneReason::NatUnsupportedProto
         }
 
         StatefulNatError::TupleParseError | StatefulNatError::InvalidPort(_) => {

--- a/nat/src/stateless/mod.rs
+++ b/nat/src/stateless/mod.rs
@@ -362,7 +362,7 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
         StatelessNatError::NoIpHeader
         | StatelessNatError::IcmpErrorMsg(IcmpErrorMsgError::BadIpHeader) => DoneReason::NotIp,
 
-        StatelessNatError::UnsupportedTranslation => DoneReason::UnsupportedTransport,
+        StatelessNatError::UnsupportedTranslation => DoneReason::NatUnsupportedProto,
 
         StatelessNatError::MissingTable(_) => DoneReason::Unroutable,
 
@@ -379,7 +379,7 @@ fn translate_error(error: &StatelessNatError) -> DoneReason {
 
         StatelessNatError::IcmpErrorMsg(
             IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_),
-        ) => DoneReason::Filtered,
+        ) => DoneReason::InvalidChecksum,
     }
 }
 

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -22,6 +22,7 @@ arrayvec = { workspace = true, features = ["serde", "std"] }
 bitflags = { workspace = true }
 bolero = { workspace = true, features = ["std"], optional = true }
 bytecheck = { workspace = true }
+common = { workspace = true }
 concurrency = { workspace = true }
 derive_builder = { workspace = true, features = ["alloc"] }
 downcast-rs = { workspace = true, features = ["sync"] }

--- a/net/src/packet/display.rs
+++ b/net/src/packet/display.rs
@@ -16,7 +16,7 @@ use crate::vlan::Vlan;
 use crate::buffer::PacketBufferMut;
 use crate::checksum::Checksum;
 #[allow(deprecated)]
-use crate::packet::{BridgeDomain, DoneReason, InvalidPacket, Packet, PacketMeta};
+use crate::packet::{BridgeDomain, InvalidPacket, Packet, PacketMeta};
 use std::fmt::{Display, Formatter};
 
 impl Display for Eth {
@@ -226,12 +226,6 @@ impl Display for Headers {
 }
 
 /* ============= METADATA =============== */
-impl Display for DoneReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // using Debug at the moment since the enum may soon change
-        write!(f, "{self:?}")
-    }
-}
 
 fn fmt_opt<T: Display>(
     f: &mut Formatter<'_>,

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -92,12 +92,14 @@ pub enum DoneReason {
     MacNotForUs,          /* frame is not broadcast nor for us */
     InvalidDstMac,        /* dropped the packet since it had to have an invalid destination mac */
     MissingEtherType,     /* couldn't determine ethertype to use */
-    Filtered,             /* The packet was administratively filtered */
     NotIp,                /* could not get IP header or packet is not IP */
     RouteFailure,         /* missing routing information */
     RouteDrop,            /* routing explicitly requests pkts to be dropped */
     HopLimitExceeded,     /* TTL / Hop count was exceeded */
     MissL2resolution,     /* adjacency failure: we don't know mac of some ip next-hop */
+    VxlanDecapFailure,    /* Failed to decap a Vxlan packet */
+    VxlanEncapFailure,    /* Failed to encap a packet in vxlan */
+    Filtered,             /* The packet was administratively filtered */
     NatOutOfResources,    /* can't do NAT due to lack of resources */
     NatUnsupportedProto,  /* unsupported transport protocol for NATing */
     NatFailure,           /* It was not possible to NAT the packet */

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -14,7 +14,7 @@ use concurrency::sync::Arc;
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;
-use strum_macros::EnumCount;
+use strum_macros::{EnumCount, FromRepr};
 use tracing::error;
 
 /// Every VRF is univocally identified with a numerical VRF id
@@ -79,7 +79,7 @@ impl Display for VpcDiscriminant {
 
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumCount)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumCount, FromRepr)]
 pub enum DoneReason {
     InternalFailure,      /* catch-all for internal issues */
     InterfaceUnknown,     /* the interface cannot be found */
@@ -109,15 +109,6 @@ pub enum DoneReason {
     InternalDrop,         /* the packet was dropped internally due to a queue being full */
     Local,                /* the packet has to be locally consumed by kernel */
     Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
-}
-
-impl From<u8> for DoneReason {
-    fn from(value: u8) -> Self {
-        #[allow(unsafe_code)]
-        unsafe {
-            std::mem::transmute(value)
-        }
-    }
 }
 
 bitflags! {

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -76,6 +76,7 @@ impl Display for VpcDiscriminant {
     }
 }
 
+#[repr(u8)]
 #[allow(unused)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DoneReason {
@@ -106,6 +107,15 @@ pub enum DoneReason {
     InternalDrop,         /* the packet was dropped internally due to a queue being full */
     InvalidChecksum,      /* the validation of a checksum for this packet failed */
     IcmpErrorIncomplete,  /* the packet is an ICMP error but it does not contain data it should */
+}
+
+impl From<u8> for DoneReason {
+    fn from(value: u8) -> Self {
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute(value)
+        }
+    }
 }
 
 bitflags! {

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -12,7 +12,6 @@ use crate::vxlan::Vni;
 use bitflags::bitflags;
 use concurrency::sync::Arc;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::net::IpAddr;
 use tracing::error;
@@ -254,65 +253,5 @@ impl Drop for PacketMeta {
         if self.done.is_none() && self.is_initialized() {
             error!("Attempted to drop packet with unspecified verdict!");
         }
-    }
-}
-
-#[derive(Default, Debug)]
-#[allow(unused)]
-pub struct PacketDropStats {
-    pub name: String,
-    reasons: HashMap<DoneReason, u64>,
-    //Fredi: Todo: replace by ahash or use a small vec indexed by the DropReason value
-}
-
-impl PacketDropStats {
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_owned(),
-            reasons: HashMap::default(),
-        }
-    }
-    #[allow(dead_code)]
-    pub fn incr(&mut self, reason: DoneReason, value: u64) {
-        self.reasons
-            .entry(reason)
-            .and_modify(|counter| *counter += value)
-            .or_insert(value);
-    }
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn get_stat(&self, reason: DoneReason) -> Option<u64> {
-        self.reasons.get(&reason).copied()
-    }
-    #[allow(dead_code)]
-    #[must_use]
-    pub fn get_stats(&self) -> &HashMap<DoneReason, u64> {
-        &self.reasons
-    }
-}
-
-#[cfg(test)]
-pub mod test {
-    use super::DoneReason;
-    use super::PacketDropStats;
-
-    #[test]
-    fn test_packet_drop_stats() {
-        let mut stats = PacketDropStats::new("Stats:pipeline-FOO-stage-BAR");
-        stats.incr(DoneReason::InterfaceAdmDown, 10);
-        stats.incr(DoneReason::InterfaceAdmDown, 1);
-        stats.incr(DoneReason::RouteFailure, 9);
-        stats.incr(DoneReason::Unroutable, 13);
-
-        // look up some particular stats
-        assert_eq!(stats.get_stat(DoneReason::InterfaceAdmDown), Some(11));
-        assert_eq!(stats.get_stat(DoneReason::Unroutable), Some(13));
-        assert_eq!(stats.get_stat(DoneReason::InterfaceUnsupported), None);
-
-        // access the whole stats map
-        let read = stats.get_stats();
-        assert_eq!(read.get(&DoneReason::InterfaceAdmDown), Some(11).as_ref());
     }
 }

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -14,6 +14,7 @@ use concurrency::sync::Arc;
 use serde::Serialize;
 use std::fmt::Display;
 use std::net::IpAddr;
+use strum_macros::EnumCount;
 use tracing::error;
 
 /// Every VRF is univocally identified with a numerical VRF id
@@ -78,35 +79,36 @@ impl Display for VpcDiscriminant {
 
 #[repr(u8)]
 #[allow(unused)]
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, EnumCount)]
 pub enum DoneReason {
     InternalFailure,      /* catch-all for internal issues */
-    NotEthernet,          /* could not get eth header */
-    NotIp,                /* could not get IP header - maybe it's not ip */
-    UnsupportedTransport, /* unsupported transport layer */
-    MacNotForUs,          /* frame is not broadcast nor for us */
+    InterfaceUnknown,     /* the interface cannot be found */
     InterfaceDetached,    /* interface has not been attached to any VRF */
     InterfaceAdmDown,     /* interface is admin down */
     InterfaceOperDown,    /* interface is oper down : no link */
-    InterfaceUnknown,     /* the interface cannot be found */
     InterfaceUnsupported, /* the operation is not supported on the interface */
-    NatOutOfResources,    /* can't do NAT due to lack of resources */
+    NotEthernet,          /* could not get eth header */
+    Unhandled,            /* there exists no support to handle this type of packet */
+    MacNotForUs,          /* frame is not broadcast nor for us */
+    InvalidDstMac,        /* dropped the packet since it had to have an invalid destination mac */
+    MissingEtherType,     /* couldn't determine ethertype to use */
+    Filtered,             /* The packet was administratively filtered */
+    NotIp,                /* could not get IP header or packet is not IP */
     RouteFailure,         /* missing routing information */
     RouteDrop,            /* routing explicitly requests pkts to be dropped */
     HopLimitExceeded,     /* TTL / Hop count was exceeded */
-    Filtered,             /* The packet was administratively filtered */
-    Unhandled,            /* there exists no support to handle this type of packet */
     MissL2resolution,     /* adjacency failure: we don't know mac of some ip next-hop */
-    InvalidDstMac,        /* dropped the packet since it had to have an invalid destination mac */
-    Malformed,            /* the packet does not conform / is malformed */
-    MissingEtherType,     /* can't determine ethertype to use */
-    Unroutable,           /* we don't have state to forward the packet */
+    NatOutOfResources,    /* can't do NAT due to lack of resources */
+    NatUnsupportedProto,  /* unsupported transport protocol for NATing */
     NatFailure,           /* It was not possible to NAT the packet */
-    Local,                /* the packet has to be locally consumed by kernel */
-    Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
-    InternalDrop,         /* the packet was dropped internally due to a queue being full */
+    NatNotPortForwarded,  /* Packet was sent to port forwarder and it rejected it */
+    Malformed,            /* the packet does not conform / is malformed */
+    Unroutable,           /* we don't have state to forward the packet */
     InvalidChecksum,      /* the validation of a checksum for this packet failed */
     IcmpErrorIncomplete,  /* the packet is an ICMP error but it does not contain data it should */
+    InternalDrop,         /* the packet was dropped internally due to a queue being full */
+    Local,                /* the packet has to be locally consumed by kernel */
+    Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
 }
 
 impl From<u8> for DoneReason {

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -8,6 +8,9 @@
 mod display;
 mod hash;
 mod meta;
+mod stats;
+
+pub use stats::PacketStats;
 
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -9,6 +9,7 @@ mod display;
 mod hash;
 mod meta;
 mod stats;
+mod stats_display;
 
 pub use stats::PacketStats;
 

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -4,8 +4,6 @@
 //! Module to compute packet processing counters
 
 use super::meta::DoneReason;
-use common::cliprovider::{CliDataProvider, Heading};
-use std::fmt::Display;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use strum::EnumCount;
@@ -35,71 +33,6 @@ impl PacketStats {
                 count.load(Ordering::Relaxed),
             )
         })
-    }
-}
-
-impl Display for DoneReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InternalFailure => write!(f, "Internal failure"),
-
-            Self::InterfaceDetached => write!(f, "Interface: detached"),
-            Self::InterfaceAdmDown => write!(f, "Interface: admin down"),
-            Self::InterfaceOperDown => write!(f, "Interface: oper down"),
-            Self::InterfaceUnknown => write!(f, "Interface: unknown"),
-            Self::InterfaceUnsupported => write!(f, "Interface: unsupported"),
-
-            Self::NotEthernet => write!(f, "Not Ethernet"),
-            Self::Unhandled => write!(f, "Unhandled"),
-            Self::MacNotForUs => write!(f, "Frame not for us"),
-            Self::MissingEtherType => write!(f, "Missing ether type"),
-            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
-
-            Self::NotIp => write!(f, "IP:  packet is not IP"),
-            Self::RouteFailure => write!(f, "IP:  missing routing info"),
-            Self::RouteDrop => write!(f, "IP:  route drop"),
-            Self::HopLimitExceeded => write!(f, "IP:  TTL exceeded"),
-            Self::MissL2resolution => write!(f, "IP:  L2 resolution failure"),
-
-            Self::Filtered => write!(f, "Filtered"),
-
-            Self::NatOutOfResources => write!(f, "NAT: out of resources"),
-            Self::NatFailure => write!(f, "NAT: failure"),
-            Self::NatUnsupportedProto => write!(f, "NAT: Unsupported protocol"),
-            Self::NatNotPortForwarded => write!(f, "NAT: not port-forwarded"),
-
-            Self::Malformed => write!(f, "Malformed packet"),
-            Self::Unroutable => write!(f, "Unroutable"),
-            Self::InvalidChecksum => write!(f, "Invalid checksum"),
-            Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
-
-            Self::InternalDrop => write!(f, "Internal drop"),
-            Self::Local => write!(f, "Locally delivered"),
-            Self::Delivered => write!(f, "Delivered"),
-        }
-    }
-}
-
-macro_rules! PKT_STATS {
-    () => {
-        "    {:<30} {}"
-    };
-}
-
-impl Display for PacketStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Heading("Packet stats").fmt(f)?;
-        writeln!(f, PKT_STATS!(), "Packet result", "count")?;
-        for (reason, count) in self.snapshot() {
-            writeln!(f, PKT_STATS!(), reason.to_string(), count)?;
-        }
-        Ok(())
-    }
-}
-
-impl CliDataProvider for PacketStats {
-    fn provide(&self) -> String {
-        self.to_string()
     }
 }
 

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -8,6 +8,7 @@ use common::cliprovider::{CliDataProvider, Heading};
 use std::fmt::Display;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use strum::EnumCount;
 
 /// A tiny table of packet counts per `DoneReason`
 pub struct PacketStats {
@@ -15,20 +16,15 @@ pub struct PacketStats {
 }
 impl PacketStats {
     #[must_use]
+    #[allow(clippy::new_without_default)]
     /// Build an instance of `PacketStats`
     pub fn new() -> Self {
         Self {
-            counts: (DoneReason::InternalFailure as u8..=DoneReason::IcmpErrorIncomplete as u8)
-                .map(|_| AtomicU64::new(0))
-                .collect(),
+            counts: (0..DoneReason::COUNT).map(|_| AtomicU64::new(0)).collect(),
         }
     }
     /// Increment the count for a given `DoneReason`
     pub fn incr(&self, done_reason: DoneReason) {
-        debug_assert_eq!(
-            self.counts.len(),
-            DoneReason::IcmpErrorIncomplete as usize + 1
-        );
         self.counts[done_reason as usize].fetch_add(1, Ordering::Relaxed);
     }
     /// Provide a snapshot of the `PacketStats`
@@ -46,39 +42,47 @@ impl Display for DoneReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InternalFailure => write!(f, "Internal failure"),
-            Self::NotEthernet => write!(f, "Non-Ethernet"),
-            Self::NotIp => write!(f, "Non-IP"),
-            Self::UnsupportedTransport => write!(f, "Unsupported transport"),
-            Self::MacNotForUs => write!(f, "Frame not for us"),
-            Self::InterfaceDetached => write!(f, "Detached interface"),
-            Self::InterfaceAdmDown => write!(f, "Interface admin down"),
-            Self::InterfaceOperDown => write!(f, "Interface oper down"),
-            Self::InterfaceUnknown => write!(f, "Unknown interface"),
-            Self::InterfaceUnsupported => write!(f, "Interface unsupported"),
-            Self::NatOutOfResources => write!(f, "NAT out of resources"),
-            Self::RouteFailure => write!(f, "Route failure"),
-            Self::RouteDrop => write!(f, "Route drop"),
-            Self::HopLimitExceeded => write!(f, "TTL exceeded"),
-            Self::Filtered => write!(f, "Filtered"),
+
+            Self::InterfaceDetached => write!(f, "Interface: detached"),
+            Self::InterfaceAdmDown => write!(f, "Interface: admin down"),
+            Self::InterfaceOperDown => write!(f, "Interface: oper down"),
+            Self::InterfaceUnknown => write!(f, "Interface: unknown"),
+            Self::InterfaceUnsupported => write!(f, "Interface: unsupported"),
+
+            Self::NotEthernet => write!(f, "Not Ethernet"),
             Self::Unhandled => write!(f, "Unhandled"),
-            Self::MissL2resolution => write!(f, "L2 resolution failure"),
-            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
-            Self::Malformed => write!(f, "Malformed packet"),
+            Self::MacNotForUs => write!(f, "Frame not for us"),
             Self::MissingEtherType => write!(f, "Missing ether type"),
+            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+
+            Self::NotIp => write!(f, "IP:  packet is not IP"),
+            Self::RouteFailure => write!(f, "IP:  missing routing info"),
+            Self::RouteDrop => write!(f, "IP:  route drop"),
+            Self::HopLimitExceeded => write!(f, "IP:  TTL exceeded"),
+            Self::MissL2resolution => write!(f, "IP:  L2 resolution failure"),
+
+            Self::Filtered => write!(f, "Filtered"),
+
+            Self::NatOutOfResources => write!(f, "NAT: out of resources"),
+            Self::NatFailure => write!(f, "NAT: failure"),
+            Self::NatUnsupportedProto => write!(f, "NAT: Unsupported protocol"),
+            Self::NatNotPortForwarded => write!(f, "NAT: not port-forwarded"),
+
+            Self::Malformed => write!(f, "Malformed packet"),
             Self::Unroutable => write!(f, "Unroutable"),
-            Self::NatFailure => write!(f, "NAT failure"),
-            Self::Local => write!(f, "Locally delivered"),
-            Self::Delivered => write!(f, "Delivered"),
-            Self::InternalDrop => write!(f, "Internal drop"),
             Self::InvalidChecksum => write!(f, "Invalid checksum"),
             Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+
+            Self::InternalDrop => write!(f, "Internal drop"),
+            Self::Local => write!(f, "Locally delivered"),
+            Self::Delivered => write!(f, "Delivered"),
         }
     }
 }
 
 macro_rules! PKT_STATS {
     () => {
-        "    {:<22} {:>10}"
+        "    {:<30} {}"
     };
 }
 
@@ -94,7 +98,7 @@ impl Display for PacketStats {
 }
 
 impl CliDataProvider for PacketStats {
-    fn provide(&self, _what: Option<common::cliprovider::CliData>) -> String {
+    fn provide(&self) -> String {
         self.to_string()
     }
 }

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Module to compute packet processing counters
+
+use super::meta::DoneReason;
+use common::cliprovider::{CliDataProvider, Heading};
+use std::fmt::Display;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// A tiny table of packet counts per `DoneReason`
+pub struct PacketStats {
+    counts: Vec<AtomicU64>,
+}
+impl PacketStats {
+    #[must_use]
+    /// Build an instance of `PacketStats`
+    pub fn new() -> Self {
+        Self {
+            counts: (DoneReason::InternalFailure as u8..=DoneReason::IcmpErrorIncomplete as u8)
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+        }
+    }
+    /// Increment the count for a given `DoneReason`
+    pub fn incr(&self, done_reason: DoneReason) {
+        debug_assert_eq!(
+            self.counts.len(),
+            DoneReason::IcmpErrorIncomplete as usize + 1
+        );
+        self.counts[done_reason as usize].fetch_add(1, Ordering::Relaxed);
+    }
+    /// Provide a snapshot of the `PacketStats`
+    pub fn snapshot(&self) -> impl Iterator<Item = (DoneReason, u64)> {
+        self.counts.iter().enumerate().map(|(reason, count)| {
+            (
+                DoneReason::from(u8::try_from(reason).unwrap_or_else(|_| unreachable!())),
+                count.load(Ordering::Relaxed),
+            )
+        })
+    }
+}
+
+impl Display for DoneReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InternalFailure => write!(f, "Internal failure"),
+            Self::NotEthernet => write!(f, "Non-Ethernet"),
+            Self::NotIp => write!(f, "Non-IP"),
+            Self::UnsupportedTransport => write!(f, "Unsupported transport"),
+            Self::MacNotForUs => write!(f, "Frame not for us"),
+            Self::InterfaceDetached => write!(f, "Detached interface"),
+            Self::InterfaceAdmDown => write!(f, "Interface admin down"),
+            Self::InterfaceOperDown => write!(f, "Interface oper down"),
+            Self::InterfaceUnknown => write!(f, "Unknown interface"),
+            Self::InterfaceUnsupported => write!(f, "Interface unsupported"),
+            Self::NatOutOfResources => write!(f, "NAT out of resources"),
+            Self::RouteFailure => write!(f, "Route failure"),
+            Self::RouteDrop => write!(f, "Route drop"),
+            Self::HopLimitExceeded => write!(f, "TTL exceeded"),
+            Self::Filtered => write!(f, "Filtered"),
+            Self::Unhandled => write!(f, "Unhandled"),
+            Self::MissL2resolution => write!(f, "L2 resolution failure"),
+            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+            Self::Malformed => write!(f, "Malformed packet"),
+            Self::MissingEtherType => write!(f, "Missing ether type"),
+            Self::Unroutable => write!(f, "Unroutable"),
+            Self::NatFailure => write!(f, "NAT failure"),
+            Self::Local => write!(f, "Locally delivered"),
+            Self::Delivered => write!(f, "Delivered"),
+            Self::InternalDrop => write!(f, "Internal drop"),
+            Self::InvalidChecksum => write!(f, "Invalid checksum"),
+            Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+        }
+    }
+}
+
+macro_rules! PKT_STATS {
+    () => {
+        "    {:<22} {:>10}"
+    };
+}
+
+impl Display for PacketStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading("Packet stats").fmt(f)?;
+        writeln!(f, PKT_STATS!(), "Packet result", "count")?;
+        for (reason, count) in self.snapshot() {
+            writeln!(f, PKT_STATS!(), reason.to_string(), count)?;
+        }
+        Ok(())
+    }
+}
+
+impl CliDataProvider for PacketStats {
+    fn provide(&self, _what: Option<common::cliprovider::CliData>) -> String {
+        self.to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::packet::DoneReason;
+    use crate::packet::stats::PacketStats;
+
+    #[test]
+    fn test_packet_stats_display() {
+        let stats = PacketStats::new();
+        stats.incr(DoneReason::Delivered);
+        stats.incr(DoneReason::InvalidChecksum);
+        stats.incr(DoneReason::NatFailure);
+        println!("{stats}");
+    }
+}

--- a/net/src/packet/stats.rs
+++ b/net/src/packet/stats.rs
@@ -4,13 +4,24 @@
 //! Module to compute packet processing counters
 
 use super::meta::DoneReason;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use strum::EnumCount;
 
-/// A tiny table of packet counts per `DoneReason`
+/// A 64-byte aligned atomic u64
+#[repr(align(64))]
+pub struct AlignedCounter(AtomicU64);
+impl AlignedCounter {
+    pub fn fetch_add(&self, val: u64) {
+        self.0.fetch_add(val, Ordering::Relaxed);
+    }
+    pub fn load(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// A tiny table of packet counters per `DoneReason`. This will be shared by multiple threads
 pub struct PacketStats {
-    counts: Vec<AtomicU64>,
+    counters: [AlignedCounter; DoneReason::COUNT],
 }
 impl PacketStats {
     #[must_use]
@@ -18,35 +29,68 @@ impl PacketStats {
     /// Build an instance of `PacketStats`
     pub fn new() -> Self {
         Self {
-            counts: (0..DoneReason::COUNT).map(|_| AtomicU64::new(0)).collect(),
+            counters: std::array::from_fn(|_| AlignedCounter(AtomicU64::new(0))),
         }
     }
+
     /// Increment the count for a given `DoneReason`
-    pub fn incr(&self, done_reason: DoneReason) {
-        self.counts[done_reason as usize].fetch_add(1, Ordering::Relaxed);
+    pub fn incr(&self, done_reason: DoneReason, val: u64) {
+        self.counters[done_reason as usize].fetch_add(val);
     }
-    /// Provide a snapshot of the `PacketStats`
-    pub fn snapshot(&self) -> impl Iterator<Item = (DoneReason, u64)> {
-        self.counts.iter().enumerate().map(|(reason, count)| {
-            (
-                DoneReason::from(u8::try_from(reason).unwrap_or_else(|_| unreachable!())),
-                count.load(Ordering::Relaxed),
-            )
-        })
+
+    /// Increment counts from an array
+    pub fn incr_batch(&self, counts: &[u64; DoneReason::COUNT]) {
+        for (reason, count) in counts.iter().enumerate().filter(|(_, count)| **count != 0) {
+            self.counters[reason].fetch_add(*count);
+        }
+    }
+
+    /// Get the count for a given `DoneReason`
+    #[must_use]
+    pub fn get(&self, reason: DoneReason) -> u64 {
+        self.counters[reason as usize].load()
+    }
+
+    /// Provide a snapshot of a `PacketStats`
+    pub fn snapshot(&self) -> [u64; DoneReason::COUNT] {
+        let mut snapshot: [u64; DoneReason::COUNT] = [0u64; _];
+        for (index, counter) in self.counters.iter().enumerate() {
+            snapshot[index] = counter.load();
+        }
+        snapshot
     }
 }
 
 #[cfg(test)]
 mod test {
+    use strum::EnumCount;
+
     use crate::packet::DoneReason;
     use crate::packet::stats::PacketStats;
 
     #[test]
     fn test_packet_stats_display() {
         let stats = PacketStats::new();
-        stats.incr(DoneReason::Delivered);
-        stats.incr(DoneReason::InvalidChecksum);
-        stats.incr(DoneReason::NatFailure);
+        stats.incr(DoneReason::Delivered, 100_000);
+        stats.incr(DoneReason::InvalidChecksum, 999);
+        stats.incr(DoneReason::NatFailure, 129);
         println!("{stats}");
+    }
+
+    #[test]
+    fn test_packet_stats_batch_update() {
+        let stats = PacketStats::new();
+        let mut counts: [u64; DoneReason::COUNT] = [0; _];
+        counts[DoneReason::Delivered as usize] = 100_000;
+        counts[DoneReason::InvalidChecksum as usize] = 13;
+        counts[DoneReason::NatFailure as usize] = 987;
+
+        stats.incr_batch(&counts);
+
+        println!("{stats}");
+
+        assert_eq!(stats.get(DoneReason::Delivered), 100_000);
+        assert_eq!(stats.get(DoneReason::InvalidChecksum), 13);
+        assert_eq!(stats.get(DoneReason::NatFailure), 987);
     }
 }

--- a/net/src/packet/stats_display.rs
+++ b/net/src/packet/stats_display.rs
@@ -20,17 +20,19 @@ impl Display for DoneReason {
             Self::InterfaceUnknown => f.pad("Interface: unknown"),
             Self::InterfaceUnsupported => f.pad("Interface: unsupported"),
 
-            Self::NotEthernet => f.pad("Not Ethernet"),
-            Self::Unhandled => f.pad("Unhandled"),
-            Self::MacNotForUs => f.pad("Frame not for us"),
-            Self::MissingEtherType => f.pad("Missing ether type"),
-            Self::InvalidDstMac => f.pad("Invalid dst MAC"),
+            Self::NotEthernet => f.pad("Eth: Not Ethernet"),
+            Self::Unhandled => f.pad("Eth: Unhandled"),
+            Self::MacNotForUs => f.pad("Eth: not for us"),
+            Self::MissingEtherType => f.pad("Eth: Missing ethernet type"),
+            Self::InvalidDstMac => f.pad("Eth: Invalid dst MAC"),
 
             Self::NotIp => f.pad("IP:  packet is not IP"),
             Self::RouteFailure => f.pad("IP:  missing routing info"),
             Self::RouteDrop => f.pad("IP:  route drop"),
             Self::HopLimitExceeded => f.pad("IP:  TTL exceeded"),
             Self::MissL2resolution => f.pad("IP:  L2 resolution failure"),
+            Self::VxlanEncapFailure => f.pad("VxLAN: encap failure"),
+            Self::VxlanDecapFailure => f.pad("VxLAN: decap failure"),
 
             Self::Filtered => f.pad("Filtered"),
 
@@ -42,7 +44,7 @@ impl Display for DoneReason {
             Self::Malformed => f.pad("Malformed packet"),
             Self::Unroutable => f.pad("Unroutable"),
             Self::InvalidChecksum => f.pad("Invalid checksum"),
-            Self::IcmpErrorIncomplete => f.pad("Incomplete ICMP error"),
+            Self::IcmpErrorIncomplete => f.pad("Incomplete ICMP error message"),
 
             Self::InternalDrop => f.pad("Internal drop"),
             Self::Local => f.pad("Locally delivered"),

--- a/net/src/packet/stats_display.rs
+++ b/net/src/packet/stats_display.rs
@@ -12,41 +12,41 @@ use super::stats::PacketStats;
 impl Display for DoneReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InternalFailure => write!(f, "Internal failure"),
+            Self::InternalFailure => f.pad("Internal failure"),
 
-            Self::InterfaceDetached => write!(f, "Interface: detached"),
-            Self::InterfaceAdmDown => write!(f, "Interface: admin down"),
-            Self::InterfaceOperDown => write!(f, "Interface: oper down"),
-            Self::InterfaceUnknown => write!(f, "Interface: unknown"),
-            Self::InterfaceUnsupported => write!(f, "Interface: unsupported"),
+            Self::InterfaceDetached => f.pad("Interface: detached"),
+            Self::InterfaceAdmDown => f.pad("Interface: admin down"),
+            Self::InterfaceOperDown => f.pad("Interface: oper down"),
+            Self::InterfaceUnknown => f.pad("Interface: unknown"),
+            Self::InterfaceUnsupported => f.pad("Interface: unsupported"),
 
-            Self::NotEthernet => write!(f, "Not Ethernet"),
-            Self::Unhandled => write!(f, "Unhandled"),
-            Self::MacNotForUs => write!(f, "Frame not for us"),
-            Self::MissingEtherType => write!(f, "Missing ether type"),
-            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+            Self::NotEthernet => f.pad("Not Ethernet"),
+            Self::Unhandled => f.pad("Unhandled"),
+            Self::MacNotForUs => f.pad("Frame not for us"),
+            Self::MissingEtherType => f.pad("Missing ether type"),
+            Self::InvalidDstMac => f.pad("Invalid dst MAC"),
 
-            Self::NotIp => write!(f, "IP:  packet is not IP"),
-            Self::RouteFailure => write!(f, "IP:  missing routing info"),
-            Self::RouteDrop => write!(f, "IP:  route drop"),
-            Self::HopLimitExceeded => write!(f, "IP:  TTL exceeded"),
-            Self::MissL2resolution => write!(f, "IP:  L2 resolution failure"),
+            Self::NotIp => f.pad("IP:  packet is not IP"),
+            Self::RouteFailure => f.pad("IP:  missing routing info"),
+            Self::RouteDrop => f.pad("IP:  route drop"),
+            Self::HopLimitExceeded => f.pad("IP:  TTL exceeded"),
+            Self::MissL2resolution => f.pad("IP:  L2 resolution failure"),
 
-            Self::Filtered => write!(f, "Filtered"),
+            Self::Filtered => f.pad("Filtered"),
 
-            Self::NatOutOfResources => write!(f, "NAT: out of resources"),
-            Self::NatFailure => write!(f, "NAT: failure"),
-            Self::NatUnsupportedProto => write!(f, "NAT: Unsupported protocol"),
-            Self::NatNotPortForwarded => write!(f, "NAT: not port-forwarded"),
+            Self::NatOutOfResources => f.pad("NAT: out of resources"),
+            Self::NatFailure => f.pad("NAT: failure"),
+            Self::NatUnsupportedProto => f.pad("NAT: Unsupported protocol"),
+            Self::NatNotPortForwarded => f.pad("NAT: not port-forwarded"),
 
-            Self::Malformed => write!(f, "Malformed packet"),
-            Self::Unroutable => write!(f, "Unroutable"),
-            Self::InvalidChecksum => write!(f, "Invalid checksum"),
-            Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+            Self::Malformed => f.pad("Malformed packet"),
+            Self::Unroutable => f.pad("Unroutable"),
+            Self::InvalidChecksum => f.pad("Invalid checksum"),
+            Self::IcmpErrorIncomplete => f.pad("Incomplete ICMP error"),
 
-            Self::InternalDrop => write!(f, "Internal drop"),
-            Self::Local => write!(f, "Locally delivered"),
-            Self::Delivered => write!(f, "Delivered"),
+            Self::InternalDrop => f.pad("Internal drop"),
+            Self::Local => f.pad("Locally delivered"),
+            Self::Delivered => f.pad("Delivered"),
         }
     }
 }
@@ -62,8 +62,10 @@ impl Display for PacketStats {
         Heading("Packet stats").fmt(f)?;
         writeln!(f, PKT_STATS!(), "Packet result", "count")?;
         for (index, counter) in self.snapshot().iter().enumerate() {
-            let reason = index; //FIXME
-            writeln!(f, PKT_STATS!(), reason, counter)?;
+            let reason_u8 = u8::try_from(index).unwrap_or_else(|_| unreachable!());
+            if let Some(reason) = DoneReason::from_repr(reason_u8) {
+                writeln!(f, PKT_STATS!(), reason, counter)?;
+            }
         }
         Ok(())
     }

--- a/net/src/packet/stats_display.rs
+++ b/net/src/packet/stats_display.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Display of `PacketStats`
+
+use common::cliprovider::{CliDataProvider, Heading};
+use std::fmt::Display;
+
+use super::meta::DoneReason;
+use super::stats::PacketStats;
+
+impl Display for DoneReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InternalFailure => write!(f, "Internal failure"),
+
+            Self::InterfaceDetached => write!(f, "Interface: detached"),
+            Self::InterfaceAdmDown => write!(f, "Interface: admin down"),
+            Self::InterfaceOperDown => write!(f, "Interface: oper down"),
+            Self::InterfaceUnknown => write!(f, "Interface: unknown"),
+            Self::InterfaceUnsupported => write!(f, "Interface: unsupported"),
+
+            Self::NotEthernet => write!(f, "Not Ethernet"),
+            Self::Unhandled => write!(f, "Unhandled"),
+            Self::MacNotForUs => write!(f, "Frame not for us"),
+            Self::MissingEtherType => write!(f, "Missing ether type"),
+            Self::InvalidDstMac => write!(f, "Invalid dst MAC"),
+
+            Self::NotIp => write!(f, "IP:  packet is not IP"),
+            Self::RouteFailure => write!(f, "IP:  missing routing info"),
+            Self::RouteDrop => write!(f, "IP:  route drop"),
+            Self::HopLimitExceeded => write!(f, "IP:  TTL exceeded"),
+            Self::MissL2resolution => write!(f, "IP:  L2 resolution failure"),
+
+            Self::Filtered => write!(f, "Filtered"),
+
+            Self::NatOutOfResources => write!(f, "NAT: out of resources"),
+            Self::NatFailure => write!(f, "NAT: failure"),
+            Self::NatUnsupportedProto => write!(f, "NAT: Unsupported protocol"),
+            Self::NatNotPortForwarded => write!(f, "NAT: not port-forwarded"),
+
+            Self::Malformed => write!(f, "Malformed packet"),
+            Self::Unroutable => write!(f, "Unroutable"),
+            Self::InvalidChecksum => write!(f, "Invalid checksum"),
+            Self::IcmpErrorIncomplete => write!(f, "Incomplete ICMP error"),
+
+            Self::InternalDrop => write!(f, "Internal drop"),
+            Self::Local => write!(f, "Locally delivered"),
+            Self::Delivered => write!(f, "Delivered"),
+        }
+    }
+}
+
+macro_rules! PKT_STATS {
+    () => {
+        "    {:<30} {}"
+    };
+}
+
+impl Display for PacketStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading("Packet stats").fmt(f)?;
+        writeln!(f, PKT_STATS!(), "Packet result", "count")?;
+        for (reason, counter) in self.snapshot() {
+            writeln!(f, PKT_STATS!(), reason, counter)?;
+        }
+        Ok(())
+    }
+}
+
+impl CliDataProvider for PacketStats {
+    fn provide(&self) -> String {
+        self.to_string()
+    }
+}

--- a/net/src/packet/stats_display.rs
+++ b/net/src/packet/stats_display.rs
@@ -61,7 +61,8 @@ impl Display for PacketStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Heading("Packet stats").fmt(f)?;
         writeln!(f, PKT_STATS!(), "Packet result", "count")?;
-        for (reason, counter) in self.snapshot() {
+        for (index, counter) in self.snapshot().iter().enumerate() {
+            let reason = index; //FIXME
             writeln!(f, PKT_STATS!(), reason, counter)?;
         }
         Ok(())

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -12,6 +12,7 @@ id = { workspace = true }
 linkme = { workspace = true }
 net = { workspace = true, features = ["test_buffer"] }
 ordermap = { workspace = true, features = ["std"] }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tracectl = { workspace = true }
 tracing = { workspace = true }

--- a/pipeline/src/sample_nfs.rs
+++ b/pipeline/src/sample_nfs.rs
@@ -8,12 +8,13 @@ use net::eth::mac::{DestinationMac, Mac};
 use net::headers::TryIcmp4;
 use net::headers::TryUdp;
 use net::headers::{TryEthMut, TryHeaders, TryIpv4Mut, TryIpv6Mut};
-use net::packet::{Packet, PacketStats};
+use net::packet::{DoneReason, Packet, PacketStats};
 use net::vxlan::Vxlan;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use strum::EnumCount;
 use tracectl::custom_target;
 use tracectl::tdebug;
 use tracing::{debug, trace};
@@ -238,10 +239,36 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for PacketStatsNF {
         &'a mut self,
         input: Input,
     ) -> impl Iterator<Item = Packet<Buf>> + 'a {
-        input.inspect(|packet| {
-            if let Some(reason) = packet.get_done() {
-                self.pkt_stats.incr(reason);
-            }
-        })
+        PacketStatsIter {
+            inner: input,
+            counts: [0u64; DoneReason::COUNT],
+            pkt_stats: &self.pkt_stats,
+        }
+    }
+}
+
+struct PacketStatsIter<'a, Buf: PacketBufferMut, I: Iterator<Item = Packet<Buf>>> {
+    inner: I,
+    counts: [u64; DoneReason::COUNT],
+    pkt_stats: &'a PacketStats,
+}
+
+impl<Buf: PacketBufferMut, I: Iterator<Item = Packet<Buf>>> Iterator
+    for PacketStatsIter<'_, Buf, I>
+{
+    type Item = Packet<Buf>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let packet = self.inner.next()?;
+        if let Some(reason) = packet.get_done() {
+            self.counts[reason as usize] += 1;
+        }
+        Some(packet)
+    }
+}
+
+impl<Buf: PacketBufferMut, I: Iterator<Item = Packet<Buf>>> Drop for PacketStatsIter<'_, Buf, I> {
+    fn drop(&mut self) {
+        self.pkt_stats.incr_batch(&self.counts);
     }
 }

--- a/pipeline/src/sample_nfs.rs
+++ b/pipeline/src/sample_nfs.rs
@@ -8,7 +8,7 @@ use net::eth::mac::{DestinationMac, Mac};
 use net::headers::TryIcmp4;
 use net::headers::TryUdp;
 use net::headers::{TryEthMut, TryHeaders, TryIpv4Mut, TryIpv6Mut};
-use net::packet::Packet;
+use net::packet::{Packet, PacketStats};
 use net::vxlan::Vxlan;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -218,5 +218,30 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Passthrough {
         input: Input,
     ) -> impl Iterator<Item = Packet<Buf>> + 'a {
         input
+    }
+}
+
+/// Network function that collects packet stats
+pub struct PacketStatsNF {
+    pkt_stats: Arc<PacketStats>,
+}
+impl PacketStatsNF {
+    #[must_use]
+    /// Create a `PacketStatsNF`
+    pub fn new(pkt_stats: Arc<PacketStats>) -> Self {
+        Self { pkt_stats }
+    }
+}
+
+impl<Buf: PacketBufferMut> NetworkFunction<Buf> for PacketStatsNF {
+    fn process<'a, Input: Iterator<Item = Packet<Buf>> + 'a>(
+        &'a mut self,
+        input: Input,
+    ) -> impl Iterator<Item = Packet<Buf>> + 'a {
+        input.inspect(|packet| {
+            if let Some(reason) = packet.get_done() {
+                self.pkt_stats.incr(reason);
+            }
+        })
     }
 }

--- a/routing/src/cli/handler.rs
+++ b/routing/src/cli/handler.rs
@@ -524,6 +524,7 @@ fn do_handle_cli_request(
         CliAction::ShowPortForwarding => show_provider(request, sources.portfw_table.as_deref()),
         CliAction::ShowStaticNat => show_provider(request, sources.nat_tables.as_deref()),
         CliAction::ShowMasquerading => show_provider(request, sources.masquerade_state.as_deref()),
+        CliAction::ShowPacketStats => show_provider(request, sources.pkt_stats.as_deref()),
         _ => Err(CliError::NotSupported("Not implemented yet".to_string()))?,
     };
     Ok(response)

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -87,6 +87,7 @@ pub struct CliSources {
     pub portfw_table: Option<Box<dyn CliDataProvider + Send>>,
     pub nat_tables: Option<Box<dyn CliDataProvider + Send>>,
     pub masquerade_state: Option<Box<dyn CliDataProvider + Send>>,
+    pub pkt_stats: Option<Box<dyn CliDataProvider + Send>>,
 }
 
 impl Display for RouterParams {


### PR DESCRIPTION
* I recovered this which was never finished
* Collects the "done reason" for all packets going through the pipeline, which can help in troubleshooting.
* Sample:

```
dataplane(✔)# show packet stats
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Packet stats ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    Packet result                  count
    Internal failure               0
    Interface: unknown             19
    Interface: detached            0
    Interface: admin down          0
    Interface: oper down           0
    Interface: unsupported         0
    Not Ethernet                   0
    Unhandled                      2
    Frame not for us               220
    Invalid dst MAC                0
    Missing ether type             0
    Filtered                       0
    IP:  packet is not IP          2
    IP:  missing routing info      0
    IP:  route drop                0
    IP:  TTL exceeded              0
    IP:  L2 resolution failure     0
    NAT: out of resources          0
    NAT: Unsupported protocol      0
    NAT: failure                   0
    NAT: not port-forwarded        0
    Malformed packet               0
    Unroutable                     0
    Invalid checksum               0
    Incomplete ICMP error          0
    Internal drop                  0
    Locally delivered              204
    Delivered                      3128
``` 