### PR TITLE
ci: Fix Dependabot's cooldown configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - "automated"
       - "dependencies"


### PR DESCRIPTION
From GitHub's documentation (and from our own CI failures), package ecosystem "GitHub Actions" does not support SemVer-related attributes:

    The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
    The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
    The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.

Remove them, keep the "default-days" parameter.

Link: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown
