### PR TITLE
fix(frr): make /etc a real directory (runc 1.4.x path-escape fix)   

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -704,6 +704,24 @@ let
 
   };
 
+  # runc 1.4.x (shipped in k3s >=1.35.3, containerd >=2.2) resolves rootfs
+  # paths with openat2(RESOLVE_BENEATH) as part of the CVE-2025-31133 /
+  # -52565 / -52881 container-escape mitigations. That resolver refuses to
+  # follow any absolute symlink during rootfs setup, so /etc being a single
+  # store-path symlink (the shape buildEnv produces when only one package
+  # contributes to /etc) is rejected with
+  #   "openat etc/passwd: path escapes from parent"
+  # when runc reads /etc/passwd for user resolution. Materialize /etc as a
+  # real directory so the resolver stays beneath the rootfs.
+  materializeEtc = ''
+    if [ -L etc ]; then
+      target=$(readlink etc)
+      rm etc
+      mkdir etc
+      cp -a "$target"/. etc/
+    fi
+  '';
+
   containers.frr.dataplane = pkgs.dockerTools.buildLayeredImage {
     name = "ghcr.io/githedgehog/dataplane/frr";
     inherit tag;
@@ -728,6 +746,8 @@ let
         tini
       ];
     };
+
+    extraCommands = materializeEtc;
 
     fakeRootCommands = ''
       #!${pkgs.bash}/bin/bash
@@ -775,6 +795,9 @@ let
         tini
       ];
     };
+
+    extraCommands = materializeEtc;
+
     fakeRootCommands = ''
       #!${pkgs.bash}/bin/bash
       set -euxo pipefail


### PR DESCRIPTION
Materialize `/etc` in the FRR container images as a real directory instead of an absolute Nix-store symlink, so runc 1.4.x's `openat2(RESOLVE_BENEATH)` rootfs resolver accepts them.                                              
   
Unblocks the k3s 1.35.3 bump in [fabricator#1671](https://github.com/githedgehog/fabricator/pull/1671). That bump ships runc 1.4.x (CVE-2025-31133 / CVE-2025-52565 / CVE-2025-52881 container-escape mitigations), whose path resolver refuses to follow any absolute symlink during rootfs setup. The FRR image's `/etc -> /nix/store/…-frr-config-0/etc` trips it, and `init-frr` fails with `openat etc/passwd: path escapes from parent`, so the gateway never reaches Ready.
