### PR TITLE
NAT: Reject TCP/UDP port 0 at validation

### DIFF
--- a/config/src/external/overlay/validation_tests.rs
+++ b/config/src/external/overlay/validation_tests.rs
@@ -167,7 +167,6 @@ mod test {
 
     // Port 0 in port range should be rejected
     #[test]
-    #[ignore = "TODO: validation for port 0 not yet implemented"]
     fn test_port_zero_rejected() {
         let expose = VpcExpose::empty().ip(prefix_with_ports("10.0.0.0/24", 0, 80));
         assert!(expose.validate().is_err());

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -414,6 +414,21 @@ impl VpcExpose {
             self.as_range_or_empty(),
             self.not_as_or_empty(),
         ];
+
+        // Port 0 is not allowed in the exposed ranges. We do not check the excluded ranges here,
+        // as they are only used to remove prefixes/ports from the effective configuration.
+        for prefixes in [&self.ips, self.as_range_or_empty()] {
+            for prefix_with_ports in prefixes {
+                if let Some(ports) = prefix_with_ports.ports()
+                    && ports.start() == 0
+                {
+                    return Err(ConfigError::Forbidden(
+                        "Port 0 is not allowed in expose prefix port ranges",
+                    ));
+                }
+            }
+        }
+
         for prefixes in prefix_sets {
             if prefixes.iter().any(|p| {
                 if let Some(is_ipv4) = is_ipv4_opt {

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -970,8 +970,12 @@ fn test_config_with_port_ranges_complex() {
         .make_stateless_nat()
         .unwrap()
         .ip(PrefixWithOptionalPorts::new(
+            "2.1.0.0/32".into(),
+            Some(PortRange::new(1, 32768).unwrap()), // 1 IP, 32768 ports
+        ))
+        .ip(PrefixWithOptionalPorts::new(
             "2.1.0.1/32".into(),
-            Some(PortRange::new(0, 65535).unwrap()), // 1 IP, 65536 ports
+            Some(PortRange::new(1, 32768).unwrap()), // 1 IP, 32768 ports
         ))
         .as_range(PrefixWithOptionalPorts::new(
             "10.2.0.0/30".into(),
@@ -987,10 +991,9 @@ fn test_config_with_port_ranges_complex() {
     tablesw.update_nat_tables(nat_tables);
 
     let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
-        (addr_v4("1.1.1.0"), 4001, addr_v4("10.2.0.0"), 2);
-    // (actually second port for destination NAT because 0 is problematic)
+        (addr_v4("1.1.1.0"), 4001, addr_v4("10.2.0.0"), 1);
     let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-        (addr_v4("10.1.0.0"), 2001, addr_v4("2.1.0.1"), 1);
+        (addr_v4("10.1.0.0"), 2001, addr_v4("2.1.0.0"), 1);
     let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
         check_packet_with_ports(
             &mut nat,
@@ -1028,7 +1031,7 @@ fn test_config_with_port_ranges_complex() {
     let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
         (addr_v4("1.1.3.127"), 5500, addr_v4("10.2.0.3"), 16384);
     let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-        (addr_v4("10.1.2.3"), 37200, addr_v4("2.1.0.1"), 65535);
+        (addr_v4("10.1.2.3"), 37200, addr_v4("2.1.0.1"), 32768);
     let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
         check_packet_with_ports(
             &mut nat,
@@ -1066,7 +1069,7 @@ fn test_config_with_port_ranges_complex() {
     let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
         (addr_v4("1.1.1.255"), 4500, addr_v4("10.2.0.1"), 16384);
     let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-        (addr_v4("10.1.0.254"), 2800, addr_v4("2.1.0.1"), 32767);
+        (addr_v4("10.1.0.254"), 2800, addr_v4("2.1.0.0"), 32768);
     let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
         check_packet_with_ports(
             &mut nat,
@@ -1104,7 +1107,7 @@ fn test_config_with_port_ranges_complex() {
     let (orig_src_addr, orig_src_port, orig_dst_addr, orig_dst_port) =
         (addr_v4("1.1.2.0"), 4001, addr_v4("10.2.0.2"), 1);
     let (target_src_addr, target_src_port, target_dst_addr, target_dst_port) =
-        (addr_v4("10.1.0.254"), 2801, addr_v4("2.1.0.1"), 32768);
+        (addr_v4("10.1.0.254"), 2801, addr_v4("2.1.0.1"), 1);
     let (output_src_addr, output_src_port, output_dst_addr, output_dst_port, done_reason) =
         check_packet_with_ports(
             &mut nat,


### PR DESCRIPTION
Don't allow port `0` within `VpcExpose` `ips` ranges