### PR TITLE
fix(frr): make /etc a real directory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -717,7 +717,15 @@ let
     inherit tag;
     contents = pkgs.buildEnv {
       name = "dataplane-frr-env";
-      pathsToLink = [ "/" ];
+      pathsToLink = [
+        "/bin"
+        "/etc"
+        "/lib"
+        "/libexec"
+        "/share"
+        "/usr"
+        "/var"
+      ];
       paths = with pkgs; [
         bash
         coreutils
@@ -746,6 +754,9 @@ let
       mkdir -p /var
       ln -s /run /var/run
       chown -R frr:frr /var/run/frr
+      rm /etc/passwd /etc/group
+      cp ${pkgs.fancy.frr-config}/etc/passwd /etc/passwd
+      cp ${pkgs.fancy.frr-config}/etc/group /etc/group
     '';
 
     enableFakechroot = true;
@@ -763,7 +774,13 @@ let
     contents = pkgs.buildEnv {
       name = "dataplane-frr-host-env";
       pathsToLink = [
-        "/"
+        "/bin"
+        "/etc"
+        "/lib"
+        "/libexec"
+        "/share"
+        "/usr"
+        "/var"
       ];
       paths = with pkgs; [
         bash
@@ -792,6 +809,9 @@ let
       mkdir -p /var
       ln -s /run /var/run
       chown -R frr:frr /var/run/frr
+      rm /etc/passwd /etc/group
+      cp ${pkgs.fancy.frr-config}/etc/passwd /etc/passwd
+      cp ${pkgs.fancy.frr-config}/etc/group /etc/group
     '';
 
     enableFakechroot = true;


### PR DESCRIPTION
This addresses a runc 1.4.x path-escape fix.  To quote Pau:

> Unblocks the k3s 1.35.3 bump in fabricator#1671. That bump ships runc 1.4.x (CVE-2025-31133 / CVE-2025-52565 /
CVE-2025-52881 container-escape mitigations), whose path resolver refuses to follow any absolute symlink during rootfs setup. The FRR image's /etc -> /nix/store/…-frr-config-0/etc trips it, and init-frr fails with openat etc/passwd: path escapes from parent, so the gateway never reaches Ready.

The fix is to properly materialize the path in the nix image build rather than letting it be a symlink to the nix store.