### PR TITLE
Remove some "allow(unused)" in nat

### DIFF
--- a/nat/src/portfw/portfwtable/portrange.rs
+++ b/nat/src/portfw/portfwtable/portrange.rs
@@ -3,8 +3,6 @@
 
 //! Object to represent port ranges for port-forwarding and methods
 
-#![allow(unused)] // Temporary
-
 use super::PortFwTableError;
 use std::fmt::Display;
 use std::num::NonZero;

--- a/nat/src/stateful/apalloc/alloc.rs
+++ b/nat/src/stateful/apalloc/alloc.rs
@@ -9,10 +9,6 @@
 //!
 //! See also the architecture diagram at the top of mod.rs.
 
-// We plan to re-use unused functions soon as part of the work to conserve valid flows across
-// configuration changes.
-#![allow(dead_code)]
-
 use super::{NatIpWithBitmap, port_alloc};
 use crate::port::NatPort;
 use crate::ranges::IpRange;

--- a/nat/src/stateful/apalloc/port_alloc.rs
+++ b/nat/src/stateful/apalloc/port_alloc.rs
@@ -8,10 +8,6 @@
 //!
 //! See also the architecture diagram at the top of mod.rs.
 
-// We plan to re-use unused functions soon as part of the work to conserve valid flows across
-// configuration changes.
-#![allow(dead_code)]
-
 use super::NatIpWithBitmap;
 use super::alloc::AllocatedIp;
 use crate::port::NatPort;


### PR DESCRIPTION
Remove some unnecessary `#[allow(unused)]` and `#[allow(dead_code)]` in the `nat` crate.

Follow-up to #1414.