### PR TITLE
fix: fix user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY --link --chown=0:0 ./target/${PROFILE}/cli /bin/cli
 
 WORKDIR /
 # this is a privileged container, we really do want to run as root
-USER root # nosem
+USER 0
 ENTRYPOINT ["/bin/dataplane"]


### PR DESCRIPTION
Counter the fact that root may not appear in /etc/passwd or the latter not be present.