### PR TITLE
Pr/fredi/masquerade timeouts

### DIFF
--- a/flow-entry/src/flow_table/mod.rs
+++ b/flow-entry/src/flow_table/mod.rs
@@ -11,5 +11,14 @@ pub use table::{FlowTable, FlowTableReadGuard};
 pub use net::flows::atomic_instant::AtomicInstant;
 pub use net::flows::flow_info::*;
 
-use tracectl::trace_target;
+use tracectl::{custom_target_named, trace_target};
 trace_target!("flow-table", LevelFilter::INFO, &["pipeline"]);
+
+// create a target for logs in net/flows on its behalf since the net crate cannot link linkme
+// due to the wasm constraint
+custom_target_named!(
+    "dataplane_net::flows::flow_info",
+    "flows",
+    LevelFilter::INFO,
+    &["flow-table"]
+);

--- a/nat/src/common/mod.rs
+++ b/nat/src/common/mod.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use std::fmt::Display;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NatAction {
+    DstNat,
+    SrcNat,
+}
+impl Display for NatAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NatAction::DstNat => write!(f, "dnat"),
+            NatAction::SrcNat => write!(f, "snat"),
+        }
+    }
+}

--- a/nat/src/common/mod.rs
+++ b/nat/src/common/mod.rs
@@ -1,11 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use std::fmt::Display;
+//! Types common to port-forwarding and masquerading.
+//! While common to both NAT flavors, their use is not dictated here
+//! but individually by each NAT flavor implementation.
 
+use std::fmt::Display;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+
+/// A type to represent a NAT action
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NatAction {
+    /// Nat destination address and ports
     DstNat,
+    /// Nat source address and ports
     SrcNat,
 }
 impl Display for NatAction {
@@ -14,5 +23,83 @@ impl Display for NatAction {
             NatAction::DstNat => write!(f, "dnat"),
             NatAction::SrcNat => write!(f, "snat"),
         }
+    }
+}
+
+/// The status of a flow from the perspective of port forwarding or masquerading.
+/// This status is shared between a pair of related flows. How these status change
+/// is determined by their users and not prescribed here.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NatFlowStatus {
+    OneWay = 0,
+    TwoWay = 1,
+    Established = 2,
+    Reset = 3,
+    CClosing = 4,
+    SClosing = 5,
+    CHalfClose = 6,
+    SHalfClose = 7,
+    LastAck = 8,
+    Closed = 9,
+}
+
+impl From<u8> for NatFlowStatus {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => NatFlowStatus::OneWay,
+            1 => NatFlowStatus::TwoWay,
+            2 => NatFlowStatus::Established,
+            3 => NatFlowStatus::Reset,
+            4 => NatFlowStatus::CClosing,
+            5 => NatFlowStatus::SClosing,
+            6 => NatFlowStatus::CHalfClose,
+            7 => NatFlowStatus::SHalfClose,
+            8 => NatFlowStatus::LastAck,
+            9 => NatFlowStatus::Closed,
+            _ => unreachable!(),
+        }
+    }
+}
+impl From<NatFlowStatus> for u8 {
+    fn from(value: NatFlowStatus) -> Self {
+        value as u8
+    }
+}
+
+impl Display for NatFlowStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NatFlowStatus::OneWay => write!(f, "oneway"),
+            NatFlowStatus::TwoWay => write!(f, "twoway"),
+            NatFlowStatus::Established => write!(f, "established"),
+            NatFlowStatus::Reset => write!(f, "reset"),
+            NatFlowStatus::CClosing => write!(f, "client-closing"),
+            NatFlowStatus::SClosing => write!(f, "server-closing"),
+            NatFlowStatus::CHalfClose => write!(f, "client-half-close"),
+            NatFlowStatus::SHalfClose => write!(f, "server-half-close"),
+            NatFlowStatus::LastAck => write!(f, "last-ack"),
+            NatFlowStatus::Closed => write!(f, "closed"),
+        }
+    }
+}
+
+/// A thread-safe, shareable and mutable wrapper of `NatFlowStatus`
+#[derive(Debug, Clone)]
+pub struct AtomicNatFlowStatus(Arc<AtomicU8>);
+impl AtomicNatFlowStatus {
+    #[must_use]
+    pub fn new() -> Self {
+        AtomicNatFlowStatus(Arc::new(AtomicU8::new(NatFlowStatus::OneWay.into())))
+    }
+
+    #[must_use]
+    pub fn load(&self) -> NatFlowStatus {
+        self.0.load(std::sync::atomic::Ordering::Relaxed).into()
+    }
+
+    pub fn store(&self, status: NatFlowStatus) {
+        self.0
+            .store(status.into(), std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -21,6 +21,7 @@
 //! - The total number of available (not excluded) private addresses used in an "Expose" object must
 //!   be equal to the total number of publicly exposed addresses in this object.
 
+mod common;
 mod icmp_handler;
 mod port;
 pub mod portfw;

--- a/nat/src/lib.rs
+++ b/nat/src/lib.rs
@@ -35,7 +35,7 @@ pub use stateful::StatefulNat;
 pub use stateless::StatelessNat;
 use std::net::IpAddr;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 struct NatTranslationData {
     src_addr: Option<IpAddr>,
     dst_addr: Option<IpAddr>,

--- a/nat/src/port.rs
+++ b/nat/src/port.rs
@@ -27,8 +27,8 @@ pub enum NatPort {
 impl std::fmt::Display for NatPort {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NatPort::Port(port) => write!(f, "{} (port)", port.get()),
-            NatPort::Identifier(id) => write!(f, "{id} (id)"),
+            NatPort::Port(port) => write!(f, "port:{}", port.get()),
+            NatPort::Identifier(id) => write!(f, "id:{id}"),
         }
     }
 }

--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -18,9 +18,9 @@ use std::sync::{Arc, Weak};
 
 use flow_entry::flow_table::FlowInfo;
 
-use crate::common::NatAction;
+use crate::common::{AtomicNatFlowStatus, NatAction, NatFlowStatus};
 use crate::portfw::PortFwEntry;
-use crate::portfw::protocol::{AtomicNatFlowStatus, NatFlowStatus, next_flow_status};
+use crate::portfw::protocol::next_flow_status;
 
 #[allow(unused)]
 use tracing::{debug, error, warn};

--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -18,17 +18,12 @@ use std::sync::{Arc, Weak};
 
 use flow_entry::flow_table::FlowInfo;
 
+use crate::common::NatAction;
 use crate::portfw::PortFwEntry;
 use crate::portfw::protocol::{AtomicPortFwFlowStatus, PortFwFlowStatus, next_flow_status};
 
 #[allow(unused)]
 use tracing::{debug, error, warn};
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum NatAction {
-    DstNat,
-    SrcNat,
-}
 
 #[derive(Debug, Clone)]
 pub struct PortFwState {
@@ -84,15 +79,6 @@ impl PortFwState {
     #[must_use]
     pub fn rule(&self) -> &Weak<PortFwEntry> {
         &self.rule
-    }
-}
-
-impl Display for NatAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NatAction::DstNat => write!(f, "dnat"),
-            NatAction::SrcNat => write!(f, "snat"),
-        }
     }
 }
 

--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -20,7 +20,7 @@ use flow_entry::flow_table::FlowInfo;
 
 use crate::common::NatAction;
 use crate::portfw::PortFwEntry;
-use crate::portfw::protocol::{AtomicPortFwFlowStatus, PortFwFlowStatus, next_flow_status};
+use crate::portfw::protocol::{AtomicNatFlowStatus, NatFlowStatus, next_flow_status};
 
 #[allow(unused)]
 use tracing::{debug, error, warn};
@@ -28,7 +28,7 @@ use tracing::{debug, error, warn};
 #[derive(Debug, Clone)]
 pub struct PortFwState {
     pub(crate) action: NatAction,
-    pub(crate) status: AtomicPortFwFlowStatus,
+    pub(crate) status: AtomicNatFlowStatus,
     use_ip: UnicastIpAddr,
     use_port: NonZero<u16>,
     pub(crate) rule: Weak<PortFwEntry>,
@@ -39,7 +39,7 @@ impl PortFwState {
         use_ip: UnicastIpAddr,
         use_port: NonZero<u16>,
         rule: Weak<PortFwEntry>,
-        status: AtomicPortFwFlowStatus,
+        status: AtomicNatFlowStatus,
     ) -> Self {
         Self {
             action: NatAction::SrcNat,
@@ -54,7 +54,7 @@ impl PortFwState {
         use_ip: UnicastIpAddr,
         use_port: NonZero<u16>,
         rule: Weak<PortFwEntry>,
-        status: AtomicPortFwFlowStatus,
+        status: AtomicNatFlowStatus,
     ) -> Self {
         Self {
             action: NatAction::DstNat,
@@ -129,9 +129,9 @@ pub(crate) fn setup_forward_flow(
     entry: &Arc<PortFwEntry>,
     new_dst_ip: UnicastIpAddr,
     new_dst_port: NonZero<u16>,
-) -> AtomicPortFwFlowStatus {
+) -> AtomicNatFlowStatus {
     // build port forwarding state for the forward flow
-    let status = AtomicPortFwFlowStatus::new();
+    let status = AtomicNatFlowStatus::new();
     let port_fw_state = PortFwState::new_dnat(
         new_dst_ip,
         new_dst_port,
@@ -156,7 +156,7 @@ pub(crate) fn setup_reverse_flow(
     entry: &Arc<PortFwEntry>,
     dst_ip: UnicastIpAddr,
     dst_port: NonZero<u16>,
-    status: AtomicPortFwFlowStatus,
+    status: AtomicNatFlowStatus,
 ) {
     // build port forwarding state for the REVERSE flow
     let port_fw_state = PortFwState::new_snat(dst_ip, dst_port, Arc::downgrade(entry), status);
@@ -231,8 +231,8 @@ pub(crate) fn refresh_port_fw_entry<Buf: PacketBufferMut>(
     // compute new timeout for the flow. In case of TCP, if the connection was reset or closed,
     // invalidate the flows in both directions. In either case, the packet is let through.
     let extend_by = match new_status {
-        PortFwFlowStatus::Established => entry.estab_timeout(),
-        PortFwFlowStatus::Closed | PortFwFlowStatus::Reset => return packet.invalidate_flows(),
+        NatFlowStatus::Established => entry.estab_timeout(),
+        NatFlowStatus::Closed | NatFlowStatus::Reset => return packet.invalidate_flows(),
         _ => entry.init_timeout(),
     };
 
@@ -245,7 +245,7 @@ pub(crate) fn refresh_port_fw_entry<Buf: PacketBufferMut>(
         }
 
         // .. except if we transition to established, as that is a sound indication of legit traffic
-        if new_status == PortFwFlowStatus::Established && new_status != current_status {
+        if new_status == NatFlowStatus::Established && new_status != current_status {
             flow.related
                 .as_ref()
                 .and_then(Weak::upgrade)

--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -25,14 +25,14 @@ use crate::portfw::protocol::{AtomicPortFwFlowStatus, PortFwFlowStatus, next_flo
 use tracing::{debug, error, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PortFwAction {
+pub enum NatAction {
     DstNat,
     SrcNat,
 }
 
 #[derive(Debug, Clone)]
 pub struct PortFwState {
-    pub(crate) action: PortFwAction,
+    pub(crate) action: NatAction,
     pub(crate) status: AtomicPortFwFlowStatus,
     use_ip: UnicastIpAddr,
     use_port: NonZero<u16>,
@@ -47,7 +47,7 @@ impl PortFwState {
         status: AtomicPortFwFlowStatus,
     ) -> Self {
         Self {
-            action: PortFwAction::SrcNat,
+            action: NatAction::SrcNat,
             status,
             use_ip,
             use_port,
@@ -62,7 +62,7 @@ impl PortFwState {
         status: AtomicPortFwFlowStatus,
     ) -> Self {
         Self {
-            action: PortFwAction::DstNat,
+            action: NatAction::DstNat,
             status,
             use_ip,
             use_port,
@@ -70,7 +70,7 @@ impl PortFwState {
         }
     }
     #[must_use]
-    pub fn action(&self) -> PortFwAction {
+    pub fn action(&self) -> NatAction {
         self.action
     }
     #[must_use]
@@ -87,11 +87,11 @@ impl PortFwState {
     }
 }
 
-impl Display for PortFwAction {
+impl Display for NatAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PortFwAction::DstNat => write!(f, "dnat"),
-            PortFwAction::SrcNat => write!(f, "snat"),
+            NatAction::DstNat => write!(f, "dnat"),
+            NatAction::SrcNat => write!(f, "snat"),
         }
     }
 }
@@ -99,8 +99,8 @@ impl Display for PortFwAction {
 impl Display for PortFwState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let dir = match self.action {
-            PortFwAction::DstNat => "to",
-            PortFwAction::SrcNat => "from",
+            NatAction::DstNat => "to",
+            NatAction::SrcNat => "from",
         };
         write!(f, "\n        {}", self.action)?;
         writeln!(f, " {dir} ip:{} port:{}", self.use_ip, self.use_port)?;

--- a/nat/src/portfw/icmp_handling.rs
+++ b/nat/src/portfw/icmp_handling.rs
@@ -44,17 +44,17 @@ use crate::portfw::packet::nat_packet;
 use crate::{NatPort, NatTranslationData};
 
 use super::flow_state::PortFwState;
-use crate::portfw::flow_state::PortFwAction;
+use crate::portfw::flow_state::NatAction;
 
 use tracing::debug;
 
 // Build `NatTranslationData` from `PortFwState` to translate the packet embedded in the ICMP error
 fn as_nat_translation(pfw_state: &PortFwState) -> NatTranslationData {
     match pfw_state.action {
-        PortFwAction::SrcNat => NatTranslationData::default()
+        NatAction::SrcNat => NatTranslationData::default()
             .dst_addr(pfw_state.use_ip().inner())
             .dst_port(NatPort::Port(pfw_state.use_port())),
-        PortFwAction::DstNat => NatTranslationData::default()
+        NatAction::DstNat => NatTranslationData::default()
             .src_addr(pfw_state.use_ip().inner())
             .src_port(NatPort::Port(pfw_state.use_port())),
     }

--- a/nat/src/portfw/icmp_handling.rs
+++ b/nat/src/portfw/icmp_handling.rs
@@ -39,12 +39,11 @@ use net::flows::ExtractRef;
 use net::flows::FlowInfo;
 use net::packet::{DoneReason, Packet};
 
-use crate::icmp_handler::icmp_error_msg::nat_translate_icmp_inner;
-use crate::portfw::packet::nat_packet;
-use crate::{NatPort, NatTranslationData};
-
 use super::flow_state::PortFwState;
+use super::packet::nat_packet;
 use crate::common::NatAction;
+use crate::icmp_handler::icmp_error_msg::nat_translate_icmp_inner;
+use crate::{NatPort, NatTranslationData};
 
 use tracing::debug;
 
@@ -101,8 +100,8 @@ pub(crate) fn handle_icmp_error_port_forwarding<Buf: PacketBufferMut>(
     }
 
     // NAT the ICMP packet according to the port-fw state of the reverse flow of the offending packet
-    if !nat_packet(packet, pfw_state) {
-        debug!("Failed to NAT ICMP error packet: {packet}");
+    if let Err(e) = nat_packet(packet, pfw_state) {
+        debug!("Failed to NAT ICMP error packet:{e}, packet=\n{packet}");
         packet.done(DoneReason::InternalFailure);
         return;
     }

--- a/nat/src/portfw/icmp_handling.rs
+++ b/nat/src/portfw/icmp_handling.rs
@@ -44,7 +44,7 @@ use crate::portfw::packet::nat_packet;
 use crate::{NatPort, NatTranslationData};
 
 use super::flow_state::PortFwState;
-use crate::portfw::flow_state::NatAction;
+use crate::common::NatAction;
 
 use tracing::debug;
 

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -16,7 +16,7 @@ use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::portfw::flow_state::PortFwAction;
+use crate::portfw::flow_state::NatAction;
 use crate::portfw::flow_state::build_portfw_flow_keys;
 use crate::portfw::flow_state::get_packet_port_fw_state;
 use crate::portfw::flow_state::refresh_port_fw_entry;
@@ -301,10 +301,8 @@ impl PortForwarder {
 
         // find compatible rule depending on the path this packet lives, forward or reverse
         let entry = match state.action() {
-            PortFwAction::DstNat => {
-                Self::get_rule_from_pkt_fw_path(packet, dst_vpcd, state, pfwtable)
-            }
-            PortFwAction::SrcNat => {
+            NatAction::DstNat => Self::get_rule_from_pkt_fw_path(packet, dst_vpcd, state, pfwtable),
+            NatAction::SrcNat => {
                 Self::get_rule_from_pkt_rev_path(packet, dst_vpcd, state, pfwtable)
             }
         };

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -129,7 +129,8 @@ impl PortForwarder {
             .unwrap_or_else(|| unreachable!());
 
         // translate destination according to the rule. If this fails, no state will be created
-        if !nat_packet(packet, pfw_state) {
+        if let Err(e) = nat_packet(packet, pfw_state) {
+            debug!("Failed to port-forward packet (initial):{e}");
             packet.done(DoneReason::InternalFailure);
             return;
         }
@@ -356,8 +357,8 @@ impl PortForwarder {
             };
 
             // nat the packet
-            if !nat_packet(packet, &state) {
-                error!("Failed to nat port-forwarded packet");
+            if let Err(e) = nat_packet(packet, &state) {
+                error!("Failed to port-forward packet:{e}");
                 packet.done(DoneReason::InternalFailure);
                 return;
             }

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -16,7 +16,7 @@ use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::portfw::flow_state::NatAction;
+use crate::common::NatAction;
 use crate::portfw::flow_state::build_portfw_flow_keys;
 use crate::portfw::flow_state::get_packet_port_fw_state;
 use crate::portfw::flow_state::refresh_port_fw_entry;

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -7,7 +7,7 @@ use crate::portfw::{PortFwEntry, PortFwKey, PortFwState, PortFwTable, PortFwTabl
 use flow_entry::flow_table::table::{FlowTable, FlowTableError};
 
 use net::buffer::PacketBufferMut;
-use net::flows::{ExtractMut, FlowInfo};
+use net::flows::{ExtractMut, ExtractRef, FlowInfo};
 use net::headers::{TryIp, TryTcp, TryTransport};
 use net::ip::{NextHeader, UnicastIpAddr};
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
@@ -22,7 +22,7 @@ use crate::portfw::flow_state::get_packet_port_fw_state;
 use crate::portfw::flow_state::refresh_port_fw_entry;
 use crate::portfw::flow_state::setup_forward_flow;
 use crate::portfw::flow_state::setup_reverse_flow;
-use crate::portfw::packet::{dnat_packet, nat_packet};
+use crate::portfw::packet::nat_packet;
 
 #[allow(unused)]
 use tracing::{debug, error, trace, warn};
@@ -121,8 +121,15 @@ impl PortForwarder {
         let status = setup_forward_flow(&fw_key, &fw_flow, entry, new_dst_ip, new_dst_port);
         setup_reverse_flow(&rev_key, &rev_flow, entry, dst_ip, dst_port, status);
 
-        // translate destination according to the rule matched. If this fails, no state will be created
-        if !dnat_packet(packet, new_dst_ip.inner(), new_dst_port) {
+        // get the state we just created for the FORWARD direction
+        let locked = fw_flow.locked.read().unwrap();
+        let pfw_state = locked
+            .port_fw_state
+            .extract_ref::<PortFwState>()
+            .unwrap_or_else(|| unreachable!());
+
+        // translate destination according to the rule. If this fails, no state will be created
+        if !nat_packet(packet, pfw_state) {
             packet.done(DoneReason::InternalFailure);
             return;
         }

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -14,7 +14,7 @@ use std::num::NonZero;
 use tracing::error;
 
 use crate::portfw::PortFwState;
-use crate::portfw::flow_state::PortFwAction;
+use crate::portfw::flow_state::NatAction;
 
 #[inline]
 #[must_use]
@@ -100,8 +100,8 @@ pub(crate) fn nat_packet<Buf: PacketBufferMut>(
     state: &PortFwState,
 ) -> bool {
     match state.action() {
-        PortFwAction::DstNat => dnat_packet(packet, state.use_ip().inner(), state.use_port()),
-        PortFwAction::SrcNat => snat_packet(packet, state.use_ip(), state.use_port()),
+        NatAction::DstNat => dnat_packet(packet, state.use_ip().inner(), state.use_port()),
+        NatAction::SrcNat => snat_packet(packet, state.use_ip(), state.use_port()),
     }
 }
 

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -58,7 +58,7 @@ fn snat_packet<Buf: PacketBufferMut>(
 #[inline]
 #[must_use]
 /// Perform dst-nat/pat for a packet. Returns true if the packet could be source-natted and false otherwise
-pub(crate) fn dnat_packet<Buf: PacketBufferMut>(
+fn dnat_packet<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     new_dst_ip: IpAddr,
     new_dst_port: NonZero<u16>,

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -13,8 +13,8 @@ use std::net::IpAddr;
 use std::num::NonZero;
 use tracing::error;
 
+use crate::common::NatAction;
 use crate::portfw::PortFwState;
-use crate::portfw::flow_state::NatAction;
 
 #[inline]
 #[must_use]

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -6,189 +6,137 @@
 //! with UDP/TCP payloads.
 
 use net::buffer::PacketBufferMut;
-use net::headers::{TryIpMut, TryTransportMut};
-use net::ip::UnicastIpAddr;
+use net::headers::Net;
+use net::headers::{NetError, Transport, TransportError, TryHeadersMut};
+use net::ip::{NextHeader, UnicastIpAddr};
 use net::packet::Packet;
 use std::net::IpAddr;
 use std::num::NonZero;
-use tracing::error;
 
 use crate::common::NatAction;
 use crate::portfw::PortFwState;
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum NatPacketError {
+    #[error("Failed to update ip header")]
+    UpdateNet(#[from] NetError),
+    #[error("Failed to update transport header")]
+    UpdateTransport(#[from] TransportError),
+    #[error("Failed to NAT packet: unsupported traffic")]
+    UnsupportedTraffic,
+}
+
 #[inline]
-#[must_use]
-/// Perform source-nat/pat for a packet. Returns true if the packet could be source-natted and false otherwise
+fn is_port_forwardable(net: &Net) -> bool {
+    matches!(net.next_header(), NextHeader::UDP | NextHeader::TCP)
+}
+
+#[inline]
+fn is_icmp(net: &Net) -> bool {
+    match net {
+        Net::Ipv4(ipv4) => ipv4.next_header() == NextHeader::ICMP,
+        Net::Ipv6(ipv6) => ipv6.next_header() == NextHeader::ICMP6,
+    }
+}
+
+#[inline]
+/// Perform source-nat/pat for a packet
 fn snat_packet<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     new_src_ip: UnicastIpAddr,
     new_src_port: NonZero<u16>,
-) -> bool {
+) -> Result<bool, NatPacketError> {
     let mut modified = false;
-    let Some(ip) = packet.try_ip_mut() else {
-        error!("Failed to access IP header");
-        return false;
-    };
-    if ip.src_addr() != new_src_ip.inner() {
-        if let Err(e) = ip.try_set_source(new_src_ip) {
-            error!("Failed to set src ip address to {new_src_ip}: {e}");
-            return false;
-        }
-        modified = true;
-    }
-    let Some(tport) = packet.try_transport_mut() else {
-        error!("Failed to access transport header");
-        return false;
-    };
-    if let Some(p) = tport.src_port()
-        && p != new_src_port
+    match packet
+        .headers_mut()
+        .pat_mut()
+        .eth()
+        .net()
+        .transport()
+        .done()
     {
-        if let Err(e) = tport.try_set_source(new_src_port) {
-            error!("Failed to set src transport port to {new_src_port}: {e}");
-            return false;
+        // traffic can be port forwarded: it's Ip + UDP/TCP
+        Some((_, ip, tp)) if is_port_forwardable(ip) => {
+            if ip.src_addr() != new_src_ip.inner() {
+                ip.try_set_source(new_src_ip)?;
+                modified = true;
+            }
+            if let Some(p) = tp.src_port()
+                && p != new_src_port
+            {
+                tp.try_set_source(new_src_port)?;
+                modified = true;
+            }
         }
-        modified = true;
+        // needed for ICMP error handling
+        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(ip) => {
+            if ip.src_addr() != new_src_ip.inner() {
+                ip.try_set_source(new_src_ip)?;
+                modified = true;
+            }
+        }
+        _ => {
+            return Err(NatPacketError::UnsupportedTraffic);
+        }
     }
     if modified {
         packet.meta_mut().set_checksum_refresh(true);
     }
-    true
+    Ok(modified)
 }
 
 #[inline]
-#[must_use]
-/// Perform dst-nat/pat for a packet. Returns true if the packet could be source-natted and false otherwise
+/// Perform dst-nat/pat for a packet
 fn dnat_packet<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     new_dst_ip: IpAddr,
     new_dst_port: NonZero<u16>,
-) -> bool {
+) -> Result<bool, NatPacketError> {
     let mut modified = false;
-    let Some(ip) = packet.try_ip_mut() else {
-        error!("Failed to access IP header");
-        return false;
-    };
-    if ip.dst_addr() != new_dst_ip {
-        if let Err(e) = ip.try_set_destination(new_dst_ip) {
-            error!("failed to set destination ip address to {new_dst_ip}: {e}");
-            return false;
-        }
-        modified = true;
-    }
-    let Some(tport) = packet.try_transport_mut() else {
-        error!("Failed to access transport header");
-        return false;
-    };
-    if let Some(p) = tport.dst_port()
-        && p != new_dst_port
+    match packet
+        .headers_mut()
+        .pat_mut()
+        .eth()
+        .net()
+        .transport()
+        .done()
     {
-        if let Err(e) = tport.try_set_destination(new_dst_port) {
-            error!("Failed to set destination port: {e}");
-            return false;
+        Some((_, ip, tp)) if is_port_forwardable(ip) => {
+            if ip.dst_addr() != new_dst_ip {
+                ip.try_set_destination(new_dst_ip)?;
+                modified = true;
+            }
+            if let Some(p) = tp.dst_port()
+                && p != new_dst_port
+            {
+                tp.try_set_destination(new_dst_port)?;
+                modified = true;
+            }
         }
-        modified = true;
+        // needed for ICMP error handling
+        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(ip) => {
+            if ip.dst_addr() != new_dst_ip {
+                ip.try_set_destination(new_dst_ip)?;
+                modified = true;
+            }
+        }
+        _ => {
+            return Err(NatPacketError::UnsupportedTraffic);
+        }
     }
     if modified {
         packet.meta_mut().set_checksum_refresh(true);
     }
-    true
+    Ok(modified)
 }
 
 /// Perform src or dst nat for a packet, depending on the action indicated in state
-pub(crate) fn nat_packet<Buf: PacketBufferMut>(
+pub fn nat_packet<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     state: &PortFwState,
-) -> bool {
+) -> Result<bool, NatPacketError> {
     match state.action() {
         NatAction::DstNat => dnat_packet(packet, state.use_ip().inner(), state.use_port()),
         NatAction::SrcNat => snat_packet(packet, state.use_ip(), state.use_port()),
     }
-}
-
-use net::headers::Net;
-use net::headers::{TryIp, TryIpv4Mut, TryIpv6Mut, TryTcp, TryTcpMut};
-use net::tcp::Tcp;
-
-/// Build a TCP RST from a packet. This method is unfinished, unpolished and NOT currently in use.
-/// Error handling has to be significantly re-worked, and I am adding it here only for future reference.
-/// The idea is to send a RST back to the source of the packet.
-/// We reverse all fields. However, for the RST to be valid, we need to ACK the last seqn sent by the sender,
-/// do not include any options, use a window of 0... see rfc 5961.
-/// This function is ugly because we don't have yet the ability to generically allocate buffers,
-/// (only `TestBuffers`). So, we attempt to build the packet from the one we receive.
-#[allow(unused)]
-pub(crate) fn tcp_reset<Buf: PacketBufferMut>(packet: &mut Packet<Buf>) -> Result<(), ()> {
-    if !packet.is_tcp() {
-        return Err(());
-    }
-
-    // get all the info we need to build our packet
-    let src_vpcd = packet.meta().src_vpcd;
-    let dst_vpcd = packet.meta().dst_vpcd;
-    let src_mac = packet.eth_source().unwrap_or_else(|| unreachable!());
-    let dst_mac = packet.eth_destination().unwrap_or_else(|| unreachable!());
-    let src_ip = packet.ip_source().unwrap_or_else(|| unreachable!());
-    let dst_ip = packet.ip_destination().unwrap_or_else(|| unreachable!());
-    let src_port = packet.tcp_source_port().unwrap_or_else(|| unreachable!());
-    let dst_port = packet
-        .tcp_destination_port()
-        .unwrap_or_else(|| unreachable!());
-
-    let tcp = packet.try_tcp().unwrap_or_else(|| unreachable!());
-    let ackn = tcp.ack_number();
-    let seqn = tcp.sequence_number();
-    let tcp_data_offset = u16::from(tcp.data_offset() * 4); // how much tcp header + options occupy in quad-words
-
-    // == Build of new packet ==/
-
-    // reset the metadata
-    packet.meta_reset();
-
-    // set vpc discriminants
-    packet.meta_mut().src_vpcd = dst_vpcd;
-    packet.meta_mut().dst_vpcd = src_vpcd;
-
-    // Eth header
-    packet.set_eth_source(dst_mac).map_err(|_| ())?;
-    packet.set_eth_destination(src_mac).map_err(|_| ())?;
-
-    // Ip source and dest
-    packet.set_ip_destination(src_ip).map_err(|_| ())?;
-    packet
-        .set_ip_source(dst_ip.try_into().map_err(|_| ())?)
-        .map_err(|_| ())?;
-
-    // compute length of tcp payload. We need this to know how much we need to ack in TCP
-    let data_len = match packet.try_ip().unwrap_or_else(|| unreachable!()) {
-        #[allow(clippy::cast_possible_truncation)]
-        // ipv4.header_len() should probably not return usize
-        Net::Ipv4(ipv4) => ipv4.total_len() - (ipv4.header_len() as u16) - tcp_data_offset,
-        Net::Ipv6(_ipv6) => todo!(),
-    };
-
-    // IP adjustments
-    if let Some(ipv4) = packet.try_ipv4_mut() {
-        ipv4.set_ttl(64);
-        ipv4.set_payload_len(Tcp::MIN_LENGTH.into())
-            .map_err(|_| ())?;
-    } else if let Some(ipv6) = packet.try_ipv6_mut() {
-        ipv6.set_hop_limit(64);
-        ipv6.set_payload_length(Tcp::MIN_LENGTH.into());
-    } else {
-        unreachable!()
-    }
-
-    // build TCP header without options and RST|ACK flags, with the proper ack number and seq number
-    let tcp = packet.try_tcp_mut().unwrap_or_else(|| unreachable!());
-    *tcp = Tcp::new(dst_port, src_port);
-    tcp.set_ack(true);
-    tcp.set_rst(true);
-    tcp.set_ack_number(seqn + u32::from(data_len));
-    tcp.set_sequence_number(ackn);
-    tcp.set_window_size(0);
-
-    // we need to recompute the checksum
-    packet.meta_mut().set_checksum_refresh(true);
-
-    Ok(())
 }

--- a/nat/src/portfw/protocol.rs
+++ b/nat/src/portfw/protocol.rs
@@ -1,76 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-//! Types to represent the status of a communication in a port-forwarding context
-//! These types do not aim to represent a real state machine for any protocol.
-//! The status here modelled is aimed at determining how much the lifetime of a flow
-//! entry should be extended, or if it could be removed.
+//! Functions to represent tiny state machines for flows in the context
+//! of port forwarding. These models are very simple and aim at helping to
+//! determine how much the lifetime of flows should be extended based on
+//! the activity. This module is only for port-forwarding.
 
 use net::buffer::PacketBufferMut;
 use net::headers::TryTcp;
 use net::packet::Packet;
 use net::tcp::Tcp;
-use std::fmt::Display;
-use std::sync::Arc;
-use std::sync::atomic::AtomicU8;
 
 use super::PortFwState;
-use crate::common::NatAction;
-
-#[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum NatFlowStatus {
-    OneWay = 0,
-    TwoWay = 1,
-    Established = 2,
-    Reset = 3,
-    CClosing = 4,
-    SClosing = 5,
-    CHalfClose = 6,
-    SHalfClose = 7,
-    LastAck = 8,
-    Closed = 9,
-}
-
-impl From<u8> for NatFlowStatus {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => NatFlowStatus::OneWay,
-            1 => NatFlowStatus::TwoWay,
-            2 => NatFlowStatus::Established,
-            3 => NatFlowStatus::Reset,
-            4 => NatFlowStatus::CClosing,
-            5 => NatFlowStatus::SClosing,
-            6 => NatFlowStatus::CHalfClose,
-            7 => NatFlowStatus::SHalfClose,
-            8 => NatFlowStatus::LastAck,
-            9 => NatFlowStatus::Closed,
-            _ => unreachable!(),
-        }
-    }
-}
-impl From<NatFlowStatus> for u8 {
-    fn from(value: NatFlowStatus) -> Self {
-        value as u8
-    }
-}
-
-impl Display for NatFlowStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NatFlowStatus::OneWay => write!(f, "oneway"),
-            NatFlowStatus::TwoWay => write!(f, "twoway"),
-            NatFlowStatus::Established => write!(f, "established"),
-            NatFlowStatus::Reset => write!(f, "reset"),
-            NatFlowStatus::CClosing => write!(f, "client-closing"),
-            NatFlowStatus::SClosing => write!(f, "server-closing"),
-            NatFlowStatus::CHalfClose => write!(f, "client-half-close"),
-            NatFlowStatus::SHalfClose => write!(f, "server-half-close"),
-            NatFlowStatus::LastAck => write!(f, "last-ack"),
-            NatFlowStatus::Closed => write!(f, "closed"),
-        }
-    }
-}
+use crate::common::{NatAction, NatFlowStatus};
 
 fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> NatFlowStatus {
     let status = pfw_state.status.load();
@@ -112,7 +54,7 @@ fn next_flow_status_non_tcp(pfw_state: &PortFwState) -> NatFlowStatus {
     }
 }
 
-/// Compute the next `PortFwFlowStatus` of a flow, given the current, the received packet and
+/// Compute the next `NatFlowStatus` of a flow, given the current, the received packet and
 /// the direction, which is implicit in the `PortFwAction`:
 ///     `DstNat` is the forward path and
 ///     `SrcNat` the reverse path.
@@ -124,24 +66,5 @@ pub(crate) fn next_flow_status<Buf: PacketBufferMut>(
         next_flow_status_tcp(pfw_state, tcp)
     } else {
         next_flow_status_non_tcp(pfw_state)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct AtomicNatFlowStatus(Arc<AtomicU8>);
-impl AtomicNatFlowStatus {
-    #[must_use]
-    pub fn new() -> Self {
-        AtomicNatFlowStatus(Arc::new(AtomicU8::new(NatFlowStatus::OneWay.into())))
-    }
-
-    #[must_use]
-    pub fn load(&self) -> NatFlowStatus {
-        self.0.load(std::sync::atomic::Ordering::Relaxed).into()
-    }
-
-    pub fn store(&self, status: NatFlowStatus) {
-        self.0
-            .store(status.into(), std::sync::atomic::Ordering::Relaxed);
     }
 }

--- a/nat/src/portfw/protocol.rs
+++ b/nat/src/portfw/protocol.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 
 use super::PortFwState;
-use super::flow_state::PortFwAction;
+use super::flow_state::NatAction;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -75,7 +75,7 @@ impl Display for PortFwFlowStatus {
 fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> PortFwFlowStatus {
     let status = pfw_state.status.load();
     match pfw_state.action {
-        PortFwAction::DstNat => match status {
+        NatAction::DstNat => match status {
             PortFwFlowStatus::TwoWay if !tcp.syn() && tcp.ack() => PortFwFlowStatus::Established,
             PortFwFlowStatus::Established if tcp.fin() => PortFwFlowStatus::CClosing,
             PortFwFlowStatus::SClosing if !tcp.fin() && tcp.ack() => PortFwFlowStatus::SHalfClose,
@@ -85,7 +85,7 @@ fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> PortFwFlowStatus 
             _other if tcp.rst() => PortFwFlowStatus::Reset,
             other => other,
         },
-        PortFwAction::SrcNat => match status {
+        NatAction::SrcNat => match status {
             PortFwFlowStatus::OneWay if tcp.syn() && tcp.ack() => PortFwFlowStatus::TwoWay,
             PortFwFlowStatus::Established if tcp.fin() => PortFwFlowStatus::SClosing,
             PortFwFlowStatus::CClosing if !tcp.fin() && tcp.ack() => PortFwFlowStatus::CHalfClose,
@@ -101,11 +101,11 @@ fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> PortFwFlowStatus 
 fn next_flow_status_non_tcp(pfw_state: &PortFwState) -> PortFwFlowStatus {
     let status = pfw_state.status.load();
     match pfw_state.action {
-        PortFwAction::DstNat => match status {
+        NatAction::DstNat => match status {
             PortFwFlowStatus::TwoWay => PortFwFlowStatus::Established,
             other => other,
         },
-        PortFwAction::SrcNat => match status {
+        NatAction::SrcNat => match status {
             PortFwFlowStatus::OneWay => PortFwFlowStatus::TwoWay,
             other => other,
         },

--- a/nat/src/portfw/protocol.rs
+++ b/nat/src/portfw/protocol.rs
@@ -19,7 +19,7 @@ use crate::common::NatAction;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PortFwFlowStatus {
+pub enum NatFlowStatus {
     OneWay = 0,
     TwoWay = 1,
     Established = 2,
@@ -32,81 +32,81 @@ pub enum PortFwFlowStatus {
     Closed = 9,
 }
 
-impl From<u8> for PortFwFlowStatus {
+impl From<u8> for NatFlowStatus {
     fn from(value: u8) -> Self {
         match value {
-            0 => PortFwFlowStatus::OneWay,
-            1 => PortFwFlowStatus::TwoWay,
-            2 => PortFwFlowStatus::Established,
-            3 => PortFwFlowStatus::Reset,
-            4 => PortFwFlowStatus::CClosing,
-            5 => PortFwFlowStatus::SClosing,
-            6 => PortFwFlowStatus::CHalfClose,
-            7 => PortFwFlowStatus::SHalfClose,
-            8 => PortFwFlowStatus::LastAck,
-            9 => PortFwFlowStatus::Closed,
+            0 => NatFlowStatus::OneWay,
+            1 => NatFlowStatus::TwoWay,
+            2 => NatFlowStatus::Established,
+            3 => NatFlowStatus::Reset,
+            4 => NatFlowStatus::CClosing,
+            5 => NatFlowStatus::SClosing,
+            6 => NatFlowStatus::CHalfClose,
+            7 => NatFlowStatus::SHalfClose,
+            8 => NatFlowStatus::LastAck,
+            9 => NatFlowStatus::Closed,
             _ => unreachable!(),
         }
     }
 }
-impl From<PortFwFlowStatus> for u8 {
-    fn from(value: PortFwFlowStatus) -> Self {
+impl From<NatFlowStatus> for u8 {
+    fn from(value: NatFlowStatus) -> Self {
         value as u8
     }
 }
 
-impl Display for PortFwFlowStatus {
+impl Display for NatFlowStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PortFwFlowStatus::OneWay => write!(f, "oneway"),
-            PortFwFlowStatus::TwoWay => write!(f, "twoway"),
-            PortFwFlowStatus::Established => write!(f, "established"),
-            PortFwFlowStatus::Reset => write!(f, "reset"),
-            PortFwFlowStatus::CClosing => write!(f, "client-closing"),
-            PortFwFlowStatus::SClosing => write!(f, "server-closing"),
-            PortFwFlowStatus::CHalfClose => write!(f, "client-half-close"),
-            PortFwFlowStatus::SHalfClose => write!(f, "server-half-close"),
-            PortFwFlowStatus::LastAck => write!(f, "last-ack"),
-            PortFwFlowStatus::Closed => write!(f, "closed"),
+            NatFlowStatus::OneWay => write!(f, "oneway"),
+            NatFlowStatus::TwoWay => write!(f, "twoway"),
+            NatFlowStatus::Established => write!(f, "established"),
+            NatFlowStatus::Reset => write!(f, "reset"),
+            NatFlowStatus::CClosing => write!(f, "client-closing"),
+            NatFlowStatus::SClosing => write!(f, "server-closing"),
+            NatFlowStatus::CHalfClose => write!(f, "client-half-close"),
+            NatFlowStatus::SHalfClose => write!(f, "server-half-close"),
+            NatFlowStatus::LastAck => write!(f, "last-ack"),
+            NatFlowStatus::Closed => write!(f, "closed"),
         }
     }
 }
 
-fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> PortFwFlowStatus {
+fn next_flow_status_tcp(pfw_state: &PortFwState, tcp: &Tcp) -> NatFlowStatus {
     let status = pfw_state.status.load();
     match pfw_state.action {
         NatAction::DstNat => match status {
-            PortFwFlowStatus::TwoWay if !tcp.syn() && tcp.ack() => PortFwFlowStatus::Established,
-            PortFwFlowStatus::Established if tcp.fin() => PortFwFlowStatus::CClosing,
-            PortFwFlowStatus::SClosing if !tcp.fin() && tcp.ack() => PortFwFlowStatus::SHalfClose,
-            PortFwFlowStatus::SClosing if tcp.fin() && tcp.ack() => PortFwFlowStatus::LastAck,
-            PortFwFlowStatus::SHalfClose if tcp.fin() => PortFwFlowStatus::LastAck,
-            PortFwFlowStatus::LastAck if tcp.ack() => PortFwFlowStatus::Closed,
-            _other if tcp.rst() => PortFwFlowStatus::Reset,
+            NatFlowStatus::TwoWay if !tcp.syn() && tcp.ack() => NatFlowStatus::Established,
+            NatFlowStatus::Established if tcp.fin() => NatFlowStatus::CClosing,
+            NatFlowStatus::SClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::SHalfClose,
+            NatFlowStatus::SClosing if tcp.fin() && tcp.ack() => NatFlowStatus::LastAck,
+            NatFlowStatus::SHalfClose if tcp.fin() => NatFlowStatus::LastAck,
+            NatFlowStatus::LastAck if tcp.ack() => NatFlowStatus::Closed,
+            _other if tcp.rst() => NatFlowStatus::Reset,
             other => other,
         },
         NatAction::SrcNat => match status {
-            PortFwFlowStatus::OneWay if tcp.syn() && tcp.ack() => PortFwFlowStatus::TwoWay,
-            PortFwFlowStatus::Established if tcp.fin() => PortFwFlowStatus::SClosing,
-            PortFwFlowStatus::CClosing if !tcp.fin() && tcp.ack() => PortFwFlowStatus::CHalfClose,
-            PortFwFlowStatus::CClosing if tcp.fin() && tcp.ack() => PortFwFlowStatus::LastAck,
-            PortFwFlowStatus::CClosing if !tcp.fin() && tcp.ack() => PortFwFlowStatus::CHalfClose,
-            PortFwFlowStatus::CHalfClose if tcp.fin() => PortFwFlowStatus::LastAck,
-            PortFwFlowStatus::LastAck if tcp.ack() => PortFwFlowStatus::Closed,
-            _other if tcp.rst() => PortFwFlowStatus::Reset,
+            NatFlowStatus::OneWay if tcp.syn() && tcp.ack() => NatFlowStatus::TwoWay,
+            NatFlowStatus::Established if tcp.fin() => NatFlowStatus::SClosing,
+            NatFlowStatus::CClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::CHalfClose,
+            NatFlowStatus::CClosing if tcp.fin() && tcp.ack() => NatFlowStatus::LastAck,
+            NatFlowStatus::CClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::CHalfClose,
+            NatFlowStatus::CHalfClose if tcp.fin() => NatFlowStatus::LastAck,
+            NatFlowStatus::LastAck if tcp.ack() => NatFlowStatus::Closed,
+            _other if tcp.rst() => NatFlowStatus::Reset,
             other => other,
         },
     }
 }
-fn next_flow_status_non_tcp(pfw_state: &PortFwState) -> PortFwFlowStatus {
+fn next_flow_status_non_tcp(pfw_state: &PortFwState) -> NatFlowStatus {
     let status = pfw_state.status.load();
     match pfw_state.action {
         NatAction::DstNat => match status {
-            PortFwFlowStatus::TwoWay => PortFwFlowStatus::Established,
+            NatFlowStatus::TwoWay => NatFlowStatus::Established,
             other => other,
         },
         NatAction::SrcNat => match status {
-            PortFwFlowStatus::OneWay => PortFwFlowStatus::TwoWay,
+            NatFlowStatus::OneWay => NatFlowStatus::TwoWay,
             other => other,
         },
     }
@@ -119,7 +119,7 @@ fn next_flow_status_non_tcp(pfw_state: &PortFwState) -> PortFwFlowStatus {
 pub(crate) fn next_flow_status<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     pfw_state: &PortFwState,
-) -> PortFwFlowStatus {
+) -> NatFlowStatus {
     if let Some(tcp) = packet.try_tcp() {
         next_flow_status_tcp(pfw_state, tcp)
     } else {
@@ -128,19 +128,19 @@ pub(crate) fn next_flow_status<Buf: PacketBufferMut>(
 }
 
 #[derive(Debug, Clone)]
-pub struct AtomicPortFwFlowStatus(Arc<AtomicU8>);
-impl AtomicPortFwFlowStatus {
+pub struct AtomicNatFlowStatus(Arc<AtomicU8>);
+impl AtomicNatFlowStatus {
     #[must_use]
     pub fn new() -> Self {
-        AtomicPortFwFlowStatus(Arc::new(AtomicU8::new(PortFwFlowStatus::OneWay.into())))
+        AtomicNatFlowStatus(Arc::new(AtomicU8::new(NatFlowStatus::OneWay.into())))
     }
 
     #[must_use]
-    pub fn load(&self) -> PortFwFlowStatus {
+    pub fn load(&self) -> NatFlowStatus {
         self.0.load(std::sync::atomic::Ordering::Relaxed).into()
     }
 
-    pub fn store(&self, status: PortFwFlowStatus) {
+    pub fn store(&self, status: NatFlowStatus) {
         self.0
             .store(status.into(), std::sync::atomic::Ordering::Relaxed);
     }

--- a/nat/src/portfw/protocol.rs
+++ b/nat/src/portfw/protocol.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 
 use super::PortFwState;
-use super::flow_state::NatAction;
+use crate::common::NatAction;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/nat/src/portfw/test.rs
+++ b/nat/src/portfw/test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod nf_test {
-    use crate::portfw::protocol::NatFlowStatus;
+    use crate::common::NatFlowStatus;
     use crate::portfw::{PortForwarder, PortFwEntry, PortFwKey, PortFwState, PortFwTableWriter};
 
     use flow_entry::flow_table::{FlowLookup, FlowTable};

--- a/nat/src/portfw/test.rs
+++ b/nat/src/portfw/test.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 mod nf_test {
-    use crate::portfw::protocol::PortFwFlowStatus;
+    use crate::portfw::protocol::NatFlowStatus;
     use crate::portfw::{PortForwarder, PortFwEntry, PortFwKey, PortFwState, PortFwTableWriter};
 
     use flow_entry::flow_table::{FlowLookup, FlowTable};
@@ -30,7 +30,7 @@ mod nf_test {
             .map(|flow_info| flow_info.status())
     }
 
-    fn get_pfw_flow_status(packet: &Packet<TestBuffer>) -> Option<PortFwFlowStatus> {
+    fn get_pfw_flow_status(packet: &Packet<TestBuffer>) -> Option<NatFlowStatus> {
         packet
             .meta()
             .flow_info
@@ -224,7 +224,7 @@ mod nf_test {
         assert_eq!(output.udp_source_port().unwrap().as_u16(), 3053);
         assert_eq!(output.udp_destination_port().unwrap().as_u16(), 9876);
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::TwoWay));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::TwoWay));
 
         let flow_info = output.meta().flow_info.as_ref().unwrap();
         assert_eq!(flow_info.status(), FlowStatus::Active);
@@ -286,7 +286,7 @@ mod nf_test {
         let output = process_packet(pipeline, reply);
         assert!(output.meta().flow_info.is_some());
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::TwoWay));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::TwoWay));
 
         // process TCP ACK packet in forward direction
         let mut packet = tcp_packet_to_port_forward();
@@ -296,7 +296,7 @@ mod nf_test {
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::Established)
+            Some(NatFlowStatus::Established)
         );
     }
 
@@ -329,10 +329,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::SClosing)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::SClosing));
 
         // process TCP FIN ACK packet in forward direction
         let mut packet = tcp_packet_to_port_forward();
@@ -340,10 +337,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(!output.is_done());
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::LastAck)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::LastAck));
 
         // process TCP ACK in reverse direction: flow entry should be found. State should become Closed
         let mut packet = tcp_packet_reverse_reply();
@@ -351,7 +345,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
         assert!(get_flow_status(&output) != Some(FlowStatus::Active)); // it may be None if the nf expiration removes it
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::Closed));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::Closed));
         println!("{flow_table}");
         assert_eq!(flow_table.len().unwrap(), 2);
     }
@@ -372,20 +366,14 @@ mod nf_test {
         packet.try_tcp_mut().unwrap().set_fin(true);
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::CClosing)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::CClosing));
 
         // process TCP FIN ACK packet in reverse direction
         let mut packet = tcp_packet_reverse_reply();
         packet.try_tcp_mut().unwrap().set_ack(true).set_fin(true);
         let output = process_packet(&mut pipeline, packet);
         assert!(!output.is_done());
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::LastAck)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::LastAck));
 
         // process TCP ACK in forward direction: flow entry should be found. State should become Closed
         let mut packet = tcp_packet_reverse_reply();
@@ -393,7 +381,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
         assert!(get_flow_status(&output) != Some(FlowStatus::Active)); // may be cancelled or none
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::Closed));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::Closed));
         println!("{flow_table}");
         assert_eq!(flow_table.len().unwrap(), 2);
     }
@@ -414,10 +402,7 @@ mod nf_test {
         packet.try_tcp_mut().unwrap().set_fin(true);
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::CClosing)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::CClosing));
 
         // process TCP ACK packet in reverse direction. We assume this ACKs the FIN
         let mut packet = tcp_packet_reverse_reply();
@@ -426,7 +411,7 @@ mod nf_test {
         assert!(!output.is_done());
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::CHalfClose)
+            Some(NatFlowStatus::CHalfClose)
         );
 
         // process TCP FIN in reverse direction: flow entry should be found. State should become LastAck
@@ -434,10 +419,7 @@ mod nf_test {
         packet.try_tcp_mut().unwrap().set_fin(true);
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
-        assert_eq!(
-            get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::LastAck)
-        );
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::LastAck));
 
         // process TCP ACK in forward direction: flow entry should be found. State should become Closed
         let mut packet = tcp_packet_to_port_forward();
@@ -445,7 +427,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
         assert!(get_flow_status(&output) != Some(FlowStatus::Active)); // may be cancelled or none
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::Closed));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::Closed));
         println!("{flow_table}");
         assert_eq!(flow_table.len().unwrap(), 2);
     }
@@ -471,7 +453,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::Established)
+            Some(NatFlowStatus::Established)
         );
 
         // process TCP RST packet in forward direction.
@@ -480,7 +462,7 @@ mod nf_test {
         let output = process_packet(&mut pipeline, packet);
         assert!(!output.is_done());
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Cancelled));
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::Reset));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::Reset));
 
         // the flow table still contains the two flows, although they are unusable
         assert_eq!(flow_table.len(), Some(2));
@@ -506,7 +488,7 @@ mod nf_test {
         packet.try_tcp_mut().unwrap().set_syn(true).set_ack(true);
         let output = process_packet(&mut pipeline, packet);
         assert!(output.meta().flow_info.is_some());
-        assert_eq!(get_pfw_flow_status(&output), Some(PortFwFlowStatus::TwoWay));
+        assert_eq!(get_pfw_flow_status(&output), Some(NatFlowStatus::TwoWay));
 
         // process TCP ACK packet in forward direction
         let mut packet = tcp_packet_to_port_forward();
@@ -515,7 +497,7 @@ mod nf_test {
         assert!(!output.is_done());
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::Established)
+            Some(NatFlowStatus::Established)
         );
 
         // build the same table without the TCP port-forwarding rule
@@ -749,7 +731,7 @@ mod nf_test {
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Active));
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::Established)
+            Some(NatFlowStatus::Established)
         );
         let rule_referenced = get_pfw_flow_state_rule(&output);
         assert_eq!(rule_referenced.as_ref().unwrap().as_ref(), &entry);
@@ -809,7 +791,7 @@ mod nf_test {
         assert_eq!(get_flow_status(&output), Some(FlowStatus::Cancelled)); // flow should be cancelled
         assert_eq!(
             get_pfw_flow_status(&output),
-            Some(PortFwFlowStatus::Established) // this remains established. That's fine.
+            Some(NatFlowStatus::Established) // this remains established. That's fine.
         );
         let rule_referenced = get_pfw_flow_state_rule(&output);
         assert!(rule_referenced.is_none()); // flow did not get a new reference to a rule

--- a/nat/src/stateful/flows.rs
+++ b/nat/src/stateful/flows.rs
@@ -2,8 +2,9 @@
 // Copyright Open Network Fabric Authors
 
 use crate::NatPort;
+use crate::common::NatAction;
 use crate::stateful::apalloc::NatAllocator;
-use crate::stateful::state::{MasqueradeAction, MasqueradeState};
+use crate::stateful::state::MasqueradeState;
 
 use config::GenId;
 use flow_entry::flow_table::{FlowTable, FlowTableReadGuard};
@@ -76,7 +77,7 @@ fn re_reserve_ip_and_port(
             let nat_state = nat_state
                 .extract_mut::<MasqueradeState>()
                 .unwrap_or_else(|| unreachable!());
-            debug_assert!(matches!(nat_state.action(), MasqueradeAction::SrcNat));
+            debug_assert!(matches!(nat_state.action(), NatAction::SrcNat));
             nat_state.set_allocation(alloc);
             debug!("Successfully associated ip {ip} port/Id {port_u16} to flow {flow_key}");
             Ok(())

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod icmp_handling;
 mod natip;
 mod nf;
 mod packet;
+mod protocol;
 mod state;
 mod test;
 

--- a/nat/src/stateful/mod.rs
+++ b/nat/src/stateful/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod flows;
 pub(crate) mod icmp_handling;
 mod natip;
 mod nf;
+mod packet;
 mod state;
 mod test;
 

--- a/nat/src/stateful/nf.rs
+++ b/nat/src/stateful/nf.rs
@@ -4,12 +4,14 @@
 //! Masquerade NF
 
 use crate::NatPort;
+use crate::common::NatFlowStatus;
 use crate::stateful::NatAllocatorWriter;
 use crate::stateful::allocation::{AllocationResult, AllocatorError};
 use crate::stateful::allocator_writer::NatAllocatorReader;
 use crate::stateful::apalloc::Allocation;
 use crate::stateful::flows::check_masquerading_flow;
 use crate::stateful::packet::{NatPacketError, NatTranslate, masquerade};
+use crate::stateful::protocol::next_flow_status;
 use crate::stateful::state::MasqueradeState;
 use concurrency::sync::Arc;
 use flow_entry::flow_table::table::{FlowTable, FlowTableError};
@@ -22,13 +24,10 @@ use net::{FlowKey, IpProtoKey};
 use pipeline::{NetworkFunction, PipelineData};
 use std::fmt::Debug;
 use std::net::IpAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[allow(unused)]
 use tracing::{debug, error, warn};
-
-#[cfg(test)]
-use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
 enum StatefulNatError {
@@ -69,6 +68,10 @@ pub struct StatefulNat {
 }
 
 impl StatefulNat {
+    // Internal flow timeouts for masquerading
+    pub const MASQUERADE_ONEWAY_TIMEOUT: Duration = Duration::from_secs(5);
+    pub const MASQUERADE_TWOWAY_TIMEOUT: Duration = Duration::from_secs(3);
+
     /// Creates a new [`StatefulNat`] processor from provided parameters.
     #[must_use]
     pub fn new(name: &str, flow_table: Arc<FlowTable>, allocator: NatAllocatorReader) -> Self {
@@ -117,16 +120,54 @@ impl StatefulNat {
         packet.meta().dst_vpcd
     }
 
-    // Look up for a session for a packet, based on attached flow key.
-    // On success, update session timeout.
-    fn get_masquerade_state<Buf: PacketBufferMut>(
-        packet: &mut Packet<Buf>,
-    ) -> Option<NatTranslate> {
-        let flow_info = packet.meta_mut().flow_info.as_mut()?;
+    /// Update the `FlowStatus` of a masqueraded flow with a packet, depending on the direction of the
+    /// communication and the protocol, and returns how much the timeout of a flow should be extended.
+    fn refresh_masquerade_state<Buf: PacketBufferMut>(
+        packet: &Packet<Buf>,
+        flow_info: &FlowInfo,
+        state: &MasqueradeState,
+    ) -> Option<Duration> {
+        let key = flow_info.flowkey();
+        let current = state.status.load();
+        let new_status = next_flow_status(packet, state.action(), current);
+        if new_status != current {
+            debug!("Status of flow {key} changed: {current} -> {new_status}");
+            state.status.store(new_status);
+        }
+        match new_status {
+            NatFlowStatus::TwoWay => Some(Self::MASQUERADE_TWOWAY_TIMEOUT),
+            NatFlowStatus::Established => Some(state.idle_timeout()),
+            NatFlowStatus::Closed | NatFlowStatus::Reset => {
+                flow_info.invalidate_pair();
+                None
+            }
+            _ => {
+                warn!("Observed unexpected flow status {new_status}");
+                None
+            }
+        }
+    }
+
+    // Get the flow info referred to by the packet and, if found, check its masquerade state.
+    // Refresh the flow status and update the flow or invalidate it
+    fn get_masquerade_state<Buf: PacketBufferMut>(packet: &Packet<Buf>) -> Option<NatTranslate> {
+        let flow_info = packet.meta().flow_info.as_ref()?;
+        if !flow_info.is_active() {
+            debug!("Hit INACTIVE flow: {}", flow_info.logfmt());
+            return None;
+        }
+        debug!("Hit ACTIVE flow: {}", flow_info.logfmt());
         let value = flow_info.locked.read().unwrap();
-        let state = value.nat_state.as_ref()?.extract_ref::<MasqueradeState>()?;
-        flow_info.reset_expiry(state.idle_timeout()).ok()?; // FIXME
-        Some(state.as_translate())
+        let Some(state) = value.nat_state.as_ref()?.extract_ref::<MasqueradeState>() else {
+            debug!("Unable to access masquerade state");
+            return None;
+        };
+        let xlate = state.as_translate();
+        if let Some(extend_by) = Self::refresh_masquerade_state(packet, flow_info, state) {
+            let _ = flow_info.reset_expiry_unchecked(extend_by); // error purposely ignored
+        }
+        debug!("Will translate packet with {xlate}");
+        Some(xlate)
     }
 
     // Look up for a session by passing the parameters that make up a flow key.
@@ -206,7 +247,7 @@ impl StatefulNat {
             MasqueradeState::new_pair(alloc.allocation, src_ip, src_port, idle_timeout);
 
         // build a flow pair from the keys (without NAT state)
-        let expires_at = Instant::now() + idle_timeout;
+        let expires_at = Instant::now() + Self::MASQUERADE_ONEWAY_TIMEOUT;
         let (forward, reverse) = FlowInfo::related_pair(expires_at, *flow_key, reverse_key);
 
         // set up their NAT state
@@ -339,6 +380,7 @@ impl StatefulNat {
             .ok_or(StatefulNatError::Bug("Unexpected masquerade state miss"))?
             .as_translate();
 
+        // translate the packet
         if let Err(e) = masquerade(packet, &translate) {
             installed.invalidate_pair();
             return Err(e.into());
@@ -364,7 +406,6 @@ impl StatefulNat {
                     allocator.as_ref(),
                 );
                 if installed.is_active() {
-                    // translate the packet
                     Ok(())
                 } else {
                     // we invalidated the flow. Signal that packet should be dropped

--- a/nat/src/stateful/nf.rs
+++ b/nat/src/stateful/nf.rs
@@ -3,19 +3,20 @@
 
 //! Masquerade NF
 
+use crate::NatPort;
 use crate::stateful::NatAllocatorWriter;
 use crate::stateful::allocation::{AllocationResult, AllocatorError};
 use crate::stateful::allocator_writer::NatAllocatorReader;
 use crate::stateful::apalloc::Allocation;
 use crate::stateful::flows::check_masquerading_flow;
+use crate::stateful::packet::{NatPacketError, NatTranslate, masquerade};
 use crate::stateful::state::MasqueradeState;
-use crate::{NatPort, NatTranslationData};
 use concurrency::sync::Arc;
 use flow_entry::flow_table::table::{FlowTable, FlowTableError};
 use net::buffer::PacketBufferMut;
 use net::flow_key::{IcmpProtoKey, Uni};
 use net::flows::{ExtractRef, FlowInfo};
-use net::headers::{Transport, TryIp, TryIpMut, TryTransportMut};
+use net::headers::TryIp;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use net::{FlowKey, IpProtoKey};
 use pipeline::{NetworkFunction, PipelineData};
@@ -29,12 +30,10 @@ use tracing::{debug, error, warn};
 #[cfg(test)]
 use std::time::Duration;
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 enum StatefulNatError {
     #[error("Unexpected failure: {0}")]
     Bug(&'static str),
-    #[error("failure to get IP header")]
-    BadIpHeader,
     #[error("failure to get transport header")]
     BadTransportHeader,
     #[error("failure to build flow key")]
@@ -43,10 +42,6 @@ enum StatefulNatError {
     NoAllocator,
     #[error("allocation failed: {0}")]
     AllocationFailure(AllocatorError),
-    #[error("invalid IP version")]
-    InvalidIpVersion,
-    #[error("IP address {0} is not unicast")]
-    NotUnicast(IpAddr),
     #[error("invalid port {0}")]
     InvalidPort(u16),
     #[error("unexpected IP protocol key variant")]
@@ -59,6 +54,8 @@ enum StatefulNatError {
     IcmpError,
     #[error("dropped the packet, reason: {0}")]
     IntendedDrop(&'static str),
+    #[error("Failed to NAT packet: {0}")]
+    NatError(#[from] NatPacketError),
 }
 
 /// A stateful NAT processor, implementing the [`NetworkFunction`] trait. [`StatefulNat`] processes
@@ -122,14 +119,14 @@ impl StatefulNat {
 
     // Look up for a session for a packet, based on attached flow key.
     // On success, update session timeout.
-    fn lookup_session<Buf: PacketBufferMut>(
+    fn get_masquerade_state<Buf: PacketBufferMut>(
         packet: &mut Packet<Buf>,
-    ) -> Option<NatTranslationData> {
+    ) -> Option<NatTranslate> {
         let flow_info = packet.meta_mut().flow_info.as_mut()?;
         let value = flow_info.locked.read().unwrap();
         let state = value.nat_state.as_ref()?.extract_ref::<MasqueradeState>()?;
-        flow_info.reset_expiry(state.idle_timeout()).ok()?;
-        Some(state.translation_data())
+        flow_info.reset_expiry(state.idle_timeout()).ok()?; // FIXME
+        Some(state.as_translate())
     }
 
     // Look up for a session by passing the parameters that make up a flow key.
@@ -143,12 +140,12 @@ impl StatefulNat {
         src_ip: IpAddr,
         dst_ip: IpAddr,
         proto_key_info: IpProtoKey,
-    ) -> Option<(NatTranslationData, Duration)> {
+    ) -> Option<(NatTranslate, Duration)> {
         let flow_key = FlowKey::uni(src_vpcd, src_ip, dst_ip, proto_key_info);
         let flow_info = self.flow_table.lookup(&flow_key)?;
         let value = flow_info.locked.read().unwrap();
         let state = value.nat_state.as_ref()?.extract_ref::<MasqueradeState>()?;
-        Some((state.translation_data(), state.idle_timeout()))
+        Some((state.as_translate(), state.idle_timeout()))
     }
 
     fn setup_flow_nat_state(
@@ -242,102 +239,6 @@ impl StatefulNat {
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps)]
-    fn translate<Buf: PacketBufferMut>(
-        nfi: &String,
-        packet: &mut Packet<Buf>,
-        translate: &NatTranslationData,
-    ) -> Result<(), StatefulNatError> {
-        debug_assert!(translate.src_port.is_none() || translate.src_addr.is_some());
-        debug_assert!(translate.dst_port.is_none() || translate.dst_addr.is_some());
-
-        // translate ip fields
-        let net = packet.try_ip_mut().ok_or(StatefulNatError::BadIpHeader)?;
-        let (src_ip, dst_ip) = (net.src_addr(), net.dst_addr());
-
-        if let Some(target_src_ip) = translate.src_addr {
-            net.try_set_source(
-                target_src_ip
-                    .try_into()
-                    .map_err(|_| StatefulNatError::NotUnicast(target_src_ip))?,
-            )
-            .map_err(|_| StatefulNatError::InvalidIpVersion)?;
-        }
-        if let Some(target_dst_ip) = translate.dst_addr {
-            net.try_set_destination(target_dst_ip)
-                .map_err(|_| StatefulNatError::InvalidIpVersion)?;
-        }
-        let (new_src_ip, new_dst_ip) = (net.src_addr(), net.dst_addr());
-
-        // translate transport fields
-        let transport = packet
-            .try_transport_mut()
-            .ok_or(StatefulNatError::BadTransportHeader)?;
-        let (src_port, dst_port) = (transport.src_port(), transport.dst_port());
-        let id = transport.identifier();
-
-        match transport {
-            Transport::Tcp(_) | Transport::Udp(_) => {
-                if let Some(target_src_port) = translate.src_port {
-                    transport
-                        .try_set_source(
-                            target_src_port.try_into().map_err(|_| {
-                                StatefulNatError::InvalidPort(target_src_port.as_u16())
-                            })?,
-                        )
-                        .map_err(|_| StatefulNatError::BadTransportHeader)?;
-                }
-                if let Some(target_dst_port) = translate.dst_port {
-                    let new_dst_port = target_dst_port.as_u16();
-                    transport
-                        .try_set_destination(
-                            new_dst_port.try_into().map_err(|_| {
-                                StatefulNatError::InvalidPort(target_dst_port.as_u16())
-                            })?,
-                        )
-                        .map_err(|_| StatefulNatError::BadTransportHeader)?;
-                }
-            }
-            Transport::Icmp4(_) | Transport::Icmp6(_) => {
-                if let Some(old_identifier) = transport.identifier() {
-                    //FIXME(Quentin): set identifier independently of ports
-                    let new_identifier = if let Some(target_src_port) = translate.src_port {
-                        target_src_port.as_u16()
-                    } else if let Some(target_dst_port) = translate.dst_port {
-                        target_dst_port.as_u16()
-                    } else {
-                        old_identifier
-                    };
-                    transport
-                        .try_set_identifier(new_identifier)
-                        .map_err(|_| StatefulNatError::BadTransportHeader)?;
-                }
-            }
-        }
-
-        if id.is_some() {
-            let new_id = transport.identifier();
-            debug!(
-                "{nfi}: translated src={src_ip} dst={dst_ip} id:{id:?} -> src={new_src_ip} dst={new_dst_ip} id:{new_id:?}"
-            );
-        } else {
-            let (new_src_port, new_dst_port) = (transport.src_port(), transport.dst_port());
-            debug!(
-                "{nfi}: translated src={src_ip}:{src_port:?} dst={dst_ip}:{dst_port:?} -> src={new_src_ip}:{new_src_port:?} dst={new_dst_ip}:{new_dst_port:?}"
-            );
-        }
-        Ok(())
-    }
-
-    fn get_translation_data(src_alloc: &Allocation) -> NatTranslationData {
-        NatTranslationData {
-            src_addr: Some(src_alloc.ip()),
-            dst_addr: None,
-            src_port: Some(src_alloc.port()),
-            dst_port: None,
-        }
-    }
-
     fn new_reverse_session(
         flow_key: &FlowKey,
         alloc: &AllocationResult<Allocation>,
@@ -393,12 +294,10 @@ impl StatefulNat {
     ) -> Result<(), StatefulNatError> {
         let nfi = self.name();
 
-        // Hot path: if we have a session, directly translate the address.
-        // We don't check here if the flow is valid or not. That's done when the
-        // configuration is applied.
-        if let Some(translate) = Self::lookup_session(packet) {
+        // Hot path: if we have a session with masquerade state, translate the packet
+        if let Some(translate) = Self::get_masquerade_state(packet) {
             debug!("{nfi}: Found session, translating packet");
-            return Self::translate(self.name(), packet, &translate);
+            return Ok(masquerade(packet, &translate)?);
         }
 
         // If no allocator has been configured, drop the packet
@@ -421,10 +320,6 @@ impl StatefulNat {
 
         debug!("{nfi}: Allocated: {alloc}");
 
-        // translate the packet. If this fails, no flow will be created
-        let translation_data = Self::get_translation_data(&alloc.allocation);
-        Self::translate(self.name(), packet, &translation_data)?;
-
         // create flow pair
         self.create_flow_pair(packet, &flow_key, alloc)?;
 
@@ -433,6 +328,21 @@ impl StatefulNat {
             .flow_table
             .lookup(&flow_key)
             .ok_or(StatefulNatError::Bug("Unexpected flow lookup failure"))?;
+
+        // check that the masquerade state is readable
+        let translate = installed
+            .locked
+            .read()
+            .unwrap()
+            .nat_state
+            .extract_ref::<MasqueradeState>()
+            .ok_or(StatefulNatError::Bug("Unexpected masquerade state miss"))?
+            .as_translate();
+
+        if let Err(e) = masquerade(packet, &translate) {
+            installed.invalidate_pair();
+            return Err(e.into());
+        }
 
         // .. and check whether the allocation we made and stored in the flows is still fine
         // with the current allocator. This counters for the potential race where we got a port
@@ -454,6 +364,7 @@ impl StatefulNat {
                     allocator.as_ref(),
                 );
                 if installed.is_active() {
+                    // translate the packet
                     Ok(())
                 } else {
                     // we invalidated the flow. Signal that packet should be dropped
@@ -507,8 +418,6 @@ impl StatefulNat {
 
 fn translate_error(error: &StatefulNatError) -> DoneReason {
     match error {
-        StatefulNatError::BadIpHeader => DoneReason::NotIp,
-
         StatefulNatError::BadTransportHeader
         | StatefulNatError::AllocationFailure(AllocatorError::UnsupportedProtocol(_)) => {
             DoneReason::NatUnsupportedProto
@@ -523,17 +432,16 @@ fn translate_error(error: &StatefulNatError) -> DoneReason {
 
         StatefulNatError::NoAllocator
         | StatefulNatError::UnexpectedKeyVariant
-        | StatefulNatError::NotUnicast(_)
         | StatefulNatError::IcmpUnsupportedCategory
         | StatefulNatError::IcmpError
         | StatefulNatError::AllocationFailure(
             AllocatorError::PortAllocationFailed(_)
             | AllocatorError::MissingDiscriminant
             | AllocatorError::UnsupportedDiscriminant,
-        ) => DoneReason::NatFailure,
+        )
+        | StatefulNatError::NatError(_) => DoneReason::NatFailure,
 
-        StatefulNatError::InvalidIpVersion
-        | StatefulNatError::AllocationFailure(AllocatorError::InternalIssue(_)) => {
+        StatefulNatError::AllocationFailure(AllocatorError::InternalIssue(_)) => {
             DoneReason::InternalFailure
         }
 

--- a/nat/src/stateful/nf.rs
+++ b/nat/src/stateful/nf.rs
@@ -166,7 +166,6 @@ impl StatefulNat {
         if let Some(extend_by) = Self::refresh_masquerade_state(packet, flow_info, state) {
             let _ = flow_info.reset_expiry_unchecked(extend_by); // error purposely ignored
         }
-        debug!("Will translate packet with {xlate}");
         Some(xlate)
     }
 
@@ -337,13 +336,11 @@ impl StatefulNat {
 
         // Hot path: if we have a session with masquerade state, translate the packet
         if let Some(translate) = Self::get_masquerade_state(packet) {
-            debug!("{nfi}: Found session, translating packet");
             return Ok(masquerade(packet, &translate)?);
         }
 
         // If no allocator has been configured, drop the packet
         let Some(allocator) = self.allocator.get() else {
-            debug!("{nfi}: Can't masquerade packet: no NAT allocator present");
             return Err(StatefulNatError::NoAllocator);
         };
 
@@ -452,7 +449,6 @@ impl StatefulNat {
         } else {
             packet.meta_mut().set_checksum_refresh(true);
             packet.meta_mut().natted(true);
-            debug!("Packet was MASQUERADED");
         }
     }
 }

--- a/nat/src/stateful/packet.rs
+++ b/nat/src/stateful/packet.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Packet mangling routines specific to masquerade
+
+#![allow(unused)] // TEMPORARY
+
+use crate::NatPort;
+use crate::common::NatAction;
+use crate::stateful::state::MasqueradeState;
+use net::buffer::PacketBufferMut;
+use net::headers::Net;
+use net::headers::{NetError, Transport, TransportError, TryHeadersMut};
+use net::icmp4::Icmp4Error;
+use net::icmp6::Icmp6Error;
+use net::ip::UnicastIpAddr;
+use net::packet::Packet;
+use std::net::IpAddr;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum NatPacketError {
+    #[error("Failed to update ip header")]
+    UpdateNet(#[from] NetError),
+    #[error("Failed to update transport header")]
+    UpdateTransport(#[from] TransportError),
+    #[error("Failed to update ICMPv4 header")]
+    UpdateIcmpv4(#[from] Icmp4Error),
+    #[error("Failed to update ICMPv6 header")]
+    UpdateIcmpv6(#[from] Icmp6Error),
+    #[error("Failed to NAT packet: unsupported traffic")]
+    UnsupportedTraffic,
+}
+
+fn snat<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    new_src_ip: UnicastIpAddr,
+    natport: NatPort,
+) -> Result<bool, NatPacketError> {
+    let mut modified = false;
+    match packet
+        .headers_mut()
+        .pat_mut()
+        .eth()
+        .net()
+        .transport()
+        .done()
+    {
+        Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
+            if ip.src_addr() != new_src_ip.inner() {
+                ip.try_set_source(new_src_ip)?;
+                modified = true;
+            }
+            if let NatPort::Port(port) = natport {
+                tp.try_set_source(port)?;
+                modified = true;
+            }
+        }
+        Some((_, Net::Ipv6(_), Transport::Icmp4(_)) | (_, Net::Ipv4(_), Transport::Icmp6(_))) => {
+            return Err(NatPacketError::UnsupportedTraffic);
+        }
+        Some((_, ip, Transport::Icmp4(icmp))) => {
+            if ip.src_addr() != new_src_ip.inner() {
+                ip.try_set_source(new_src_ip)?;
+                modified = true;
+            }
+            if let NatPort::Identifier(id) = natport
+                && let Some(current) = icmp.identifier()
+                && current != id
+            {
+                icmp.try_set_identifier(id)?;
+                modified = true;
+            }
+        }
+        Some((_, ip, Transport::Icmp6(icmp))) => {
+            if ip.src_addr() != new_src_ip.inner() {
+                ip.try_set_source(new_src_ip)?;
+                modified = true;
+            }
+            if let NatPort::Identifier(id) = natport
+                && let Some(current) = icmp.identifier()
+                && current != id
+            {
+                icmp.try_set_identifier(id)?;
+                modified = true;
+            }
+        }
+        _ => return Err(NatPacketError::UnsupportedTraffic),
+    }
+    if modified {
+        packet.meta_mut().set_checksum_refresh(true);
+    }
+    Ok(modified)
+}
+
+fn dnat<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    new_dst_ip: IpAddr,
+    natport: NatPort,
+) -> Result<bool, NatPacketError> {
+    let mut modified = false;
+
+    match packet
+        .headers_mut()
+        .pat_mut()
+        .eth()
+        .net()
+        .transport()
+        .done()
+    {
+        Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
+            if ip.dst_addr() != new_dst_ip {
+                ip.try_set_destination(new_dst_ip)?;
+                modified = true;
+            }
+            if let NatPort::Port(port) = natport {
+                tp.try_set_destination(port)?;
+                modified = true;
+            }
+        }
+        Some((_, Net::Ipv6(_), Transport::Icmp4(_)) | (_, Net::Ipv4(_), Transport::Icmp6(_))) => {
+            return Err(NatPacketError::UnsupportedTraffic);
+        }
+
+        Some((_, ip, Transport::Icmp4(icmp))) => {
+            if ip.src_addr() != new_dst_ip {
+                ip.try_set_destination(new_dst_ip)?;
+                modified = true;
+            }
+            if let NatPort::Identifier(id) = natport
+                && let Some(current) = icmp.identifier()
+                && current != id
+            {
+                icmp.try_set_identifier(id)?;
+                modified = true;
+            }
+        }
+        Some((_, ip, Transport::Icmp6(icmp))) => {
+            if ip.src_addr() != new_dst_ip {
+                ip.try_set_destination(new_dst_ip)?;
+                modified = true;
+            }
+            if let NatPort::Identifier(id) = natport
+                && let Some(current) = icmp.identifier()
+                && current != id
+            {
+                icmp.try_set_identifier(id)?;
+                modified = true;
+            }
+        }
+        _ => return Err(NatPacketError::UnsupportedTraffic),
+    }
+
+    if modified {
+        packet.meta_mut().set_checksum_refresh(true);
+    }
+    Ok(modified)
+}
+
+#[derive(Debug)]
+pub(super) struct NatTranslate {
+    pub action: NatAction,
+    pub use_ip: IpAddr,
+    pub nat_port: NatPort,
+}
+
+pub(super) fn masquerade<Buf: PacketBufferMut>(
+    packet: &mut Packet<Buf>,
+    xlate: &NatTranslate,
+) -> Result<bool, NatPacketError> {
+    match xlate.action {
+        NatAction::SrcNat => snat(packet, xlate.use_ip.try_into().unwrap(), xlate.nat_port), // FIXME
+        NatAction::DstNat => dnat(packet, xlate.use_ip, xlate.nat_port),
+    }
+}

--- a/nat/src/stateful/packet.rs
+++ b/nat/src/stateful/packet.rs
@@ -176,7 +176,7 @@ pub(super) fn masquerade<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     xlate: &NatTranslate,
 ) -> Result<(), NatPacketError> {
-    debug!("Natting packet using {xlate}");
+    debug!("Natting packet using {xlate} (masquerading flow)");
     match xlate.action {
         NatAction::SrcNat => snat(packet, xlate.use_ip.try_into().unwrap(), xlate.nat_port), // FIXME
         NatAction::DstNat => dnat(packet, xlate.use_ip, xlate.nat_port),

--- a/nat/src/stateful/packet.rs
+++ b/nat/src/stateful/packet.rs
@@ -3,11 +3,8 @@
 
 //! Packet mangling routines specific to masquerade
 
-#![allow(unused)] // TEMPORARY
-
 use crate::NatPort;
 use crate::common::NatAction;
-use crate::stateful::state::MasqueradeState;
 use net::buffer::PacketBufferMut;
 use net::headers::Net;
 use net::headers::{NetError, Transport, TransportError, TryHeadersMut};
@@ -16,6 +13,8 @@ use net::icmp6::Icmp6Error;
 use net::ip::UnicastIpAddr;
 use net::packet::Packet;
 use std::net::IpAddr;
+
+use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum NatPacketError {
@@ -35,7 +34,7 @@ fn snat<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     new_src_ip: UnicastIpAddr,
     natport: NatPort,
-) -> Result<bool, NatPacketError> {
+) -> Result<(), NatPacketError> {
     let mut modified = false;
     match packet
         .headers_mut()
@@ -89,14 +88,14 @@ fn snat<Buf: PacketBufferMut>(
     if modified {
         packet.meta_mut().set_checksum_refresh(true);
     }
-    Ok(modified)
+    Ok(())
 }
 
 fn dnat<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     new_dst_ip: IpAddr,
     natport: NatPort,
-) -> Result<bool, NatPacketError> {
+) -> Result<(), NatPacketError> {
     let mut modified = false;
 
     match packet
@@ -153,20 +152,31 @@ fn dnat<Buf: PacketBufferMut>(
     if modified {
         packet.meta_mut().set_checksum_refresh(true);
     }
-    Ok(modified)
+    Ok(())
 }
 
 #[derive(Debug)]
-pub(super) struct NatTranslate {
+pub(crate) struct NatTranslate {
     pub action: NatAction,
     pub use_ip: IpAddr,
     pub nat_port: NatPort,
 }
 
+impl std::fmt::Display for NatTranslate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "action: {} with {}:{}",
+            self.action, self.use_ip, self.nat_port
+        )
+    }
+}
+
 pub(super) fn masquerade<Buf: PacketBufferMut>(
     packet: &mut Packet<Buf>,
     xlate: &NatTranslate,
-) -> Result<bool, NatPacketError> {
+) -> Result<(), NatPacketError> {
+    debug!("Natting packet using {xlate}");
     match xlate.action {
         NatAction::SrcNat => snat(packet, xlate.use_ip.try_into().unwrap(), xlate.nat_port), // FIXME
         NatAction::DstNat => dnat(packet, xlate.use_ip, xlate.nat_port),

--- a/nat/src/stateful/protocol.rs
+++ b/nat/src/stateful/protocol.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Functions to represent tiny state machines for flows in the context
+//! of masquerading. We currently use these to know how much to extend the lifetime of flows
+//! for port conservation.
+
+use crate::common::{NatAction, NatFlowStatus};
+use net::buffer::PacketBufferMut;
+use net::headers::{TryIp, TryTcp};
+use net::ip::NextHeader;
+use net::packet::Packet;
+use net::tcp::Tcp;
+
+fn next_flow_status_udp<Buf: PacketBufferMut>(
+    _packet: &Packet<Buf>,
+    action: NatAction,
+    status: NatFlowStatus,
+) -> NatFlowStatus {
+    match action {
+        NatAction::SrcNat => match status {
+            NatFlowStatus::TwoWay => NatFlowStatus::Established,
+            _ => status,
+        },
+        NatAction::DstNat => match status {
+            NatFlowStatus::OneWay => NatFlowStatus::TwoWay,
+            _ => status,
+        },
+    }
+}
+fn next_flow_status_icmp(action: NatAction, status: NatFlowStatus) -> NatFlowStatus {
+    match action {
+        NatAction::SrcNat => match status {
+            _ => status,
+        },
+        NatAction::DstNat => match status {
+            NatFlowStatus::OneWay => NatFlowStatus::TwoWay,
+            _ => status,
+        },
+    }
+}
+
+fn next_flow_status_tcp(action: NatAction, status: NatFlowStatus, tcp: &Tcp) -> NatFlowStatus {
+    match action {
+        NatAction::SrcNat => match status {
+            NatFlowStatus::TwoWay if !tcp.syn() && tcp.ack() => NatFlowStatus::Established,
+            NatFlowStatus::Established if tcp.fin() => NatFlowStatus::CClosing,
+            NatFlowStatus::SClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::SHalfClose,
+            NatFlowStatus::SClosing if tcp.fin() && tcp.ack() => NatFlowStatus::LastAck,
+            NatFlowStatus::SHalfClose if tcp.fin() => NatFlowStatus::LastAck,
+            NatFlowStatus::LastAck if tcp.ack() => NatFlowStatus::Closed,
+            _other if tcp.rst() => NatFlowStatus::Reset,
+            other => other,
+        },
+        NatAction::DstNat => match status {
+            NatFlowStatus::OneWay if tcp.syn() && tcp.ack() => NatFlowStatus::TwoWay,
+            NatFlowStatus::Established if tcp.fin() => NatFlowStatus::SClosing,
+            NatFlowStatus::CClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::CHalfClose,
+            NatFlowStatus::CClosing if tcp.fin() && tcp.ack() => NatFlowStatus::LastAck,
+            NatFlowStatus::CClosing if !tcp.fin() && tcp.ack() => NatFlowStatus::CHalfClose,
+            NatFlowStatus::CHalfClose if tcp.fin() => NatFlowStatus::LastAck,
+            NatFlowStatus::LastAck if tcp.ack() => NatFlowStatus::Closed,
+            _other if tcp.rst() => NatFlowStatus::Reset,
+            other => other,
+        },
+    }
+}
+
+// Compute the next `NatFlowStatus` of a flow, given the current, the received packet and
+// the direction
+pub(crate) fn next_flow_status<Buf: PacketBufferMut>(
+    packet: &Packet<Buf>,
+    action: NatAction,     // action of the flow hit
+    status: NatFlowStatus, // current status
+) -> NatFlowStatus {
+    let proto = packet
+        .try_ip()
+        .unwrap_or_else(|| unreachable!()) // packet without IP hdr should not make it here
+        .next_header();
+
+    // match on next-header, instead of relying on headers, as those may not be present w/ fragmentation
+    match proto {
+        NextHeader::UDP => next_flow_status_udp(packet, action, status),
+        NextHeader::ICMP | NextHeader::ICMP6 => next_flow_status_icmp(action, status),
+        NextHeader::TCP => {
+            if let Some(tcp) = packet.try_tcp() {
+                next_flow_status_tcp(action, status, tcp)
+            } else {
+                status
+            }
+        }
+        _ => status,
+    }
+}

--- a/nat/src/stateful/protocol.rs
+++ b/nat/src/stateful/protocol.rs
@@ -7,16 +7,37 @@
 
 use crate::common::{NatAction, NatFlowStatus};
 use net::buffer::PacketBufferMut;
-use net::headers::{TryIp, TryTcp};
+use net::headers::{TryHeaders, TryIp, TryTcp};
+
 use net::ip::NextHeader;
 use net::packet::Packet;
 use net::tcp::Tcp;
 
-fn next_flow_status_udp<Buf: PacketBufferMut>(
-    _packet: &Packet<Buf>,
-    action: NatAction,
-    status: NatFlowStatus,
-) -> NatFlowStatus {
+impl NatFlowStatus {
+    fn udp_status_patch_dnat<Buf: PacketBufferMut>(self, packet: &Packet<Buf>) -> NatFlowStatus {
+        match packet.headers().pat().eth().net().udp().done() {
+            Some((_, _, udp)) => match udp.source().as_u16() {
+                53 | 853 | 8853 => NatFlowStatus::Closed, // DNS|DNS-over-quic|nextdns
+                _ => self,
+            },
+            _ => self,
+        }
+    }
+
+    // Refine the status of a UDP flow based on the application
+    fn udp_status_patch<Buf: PacketBufferMut>(
+        self,
+        packet: &Packet<Buf>,
+        action: NatAction,
+    ) -> NatFlowStatus {
+        match action {
+            NatAction::SrcNat => self,
+            NatAction::DstNat => self.udp_status_patch_dnat(packet),
+        }
+    }
+}
+
+fn next_flow_status_udp(action: NatAction, status: NatFlowStatus) -> NatFlowStatus {
     match action {
         NatAction::SrcNat => match status {
             NatFlowStatus::TwoWay => NatFlowStatus::Established,
@@ -28,6 +49,8 @@ fn next_flow_status_udp<Buf: PacketBufferMut>(
         },
     }
 }
+
+#[allow(clippy::match_single_binding)]
 fn next_flow_status_icmp(action: NatAction, status: NatFlowStatus) -> NatFlowStatus {
     match action {
         NatAction::SrcNat => match status {
@@ -80,7 +103,7 @@ pub(crate) fn next_flow_status<Buf: PacketBufferMut>(
 
     // match on next-header, instead of relying on headers, as those may not be present w/ fragmentation
     match proto {
-        NextHeader::UDP => next_flow_status_udp(packet, action, status),
+        NextHeader::UDP => next_flow_status_udp(action, status).udp_status_patch(packet, action),
         NextHeader::ICMP | NextHeader::ICMP6 => next_flow_status_icmp(action, status),
         NextHeader::TCP => {
             if let Some(tcp) = packet.try_tcp() {

--- a/nat/src/stateful/state.rs
+++ b/nat/src/stateful/state.rs
@@ -3,7 +3,7 @@
 
 use super::apalloc::Allocation;
 use super::packet::NatTranslate;
-use crate::common::NatAction;
+use crate::common::{AtomicNatFlowStatus, NatAction};
 use crate::{NatPort, NatTranslationData};
 use std::fmt::Display;
 use std::net::IpAddr;
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 #[derive(Debug)]
 pub struct MasqueradeState {
+    pub(crate) status: AtomicNatFlowStatus,
     action: NatAction,
     use_ip: IpAddr,
     use_port: NatPort,
@@ -20,9 +21,10 @@ pub struct MasqueradeState {
 
 impl MasqueradeState {
     #[must_use]
-    fn snat(allocation: Allocation, idle_timeout: Duration) -> Self {
+    fn snat(allocation: Allocation, idle_timeout: Duration, status: AtomicNatFlowStatus) -> Self {
         Self {
             action: NatAction::SrcNat,
+            status,
             use_ip: allocation.ip(),
             use_port: allocation.port(),
             allocation: Some(allocation),
@@ -31,9 +33,15 @@ impl MasqueradeState {
     }
 
     #[must_use]
-    fn dnat(use_ip: IpAddr, use_port: NatPort, idle_timeout: Duration) -> Self {
+    fn dnat(
+        use_ip: IpAddr,
+        use_port: NatPort,
+        idle_timeout: Duration,
+        status: AtomicNatFlowStatus,
+    ) -> Self {
         Self {
             action: NatAction::DstNat,
+            status,
             use_ip,
             use_port,
             allocation: None,
@@ -57,8 +65,9 @@ impl MasqueradeState {
         src_port: NatPort,
         idle_timeout: Duration,
     ) -> (Self, Self) {
-        let snat = Self::snat(alloc, idle_timeout);
-        let dnat = Self::dnat(src_ip, src_port, idle_timeout);
+        let status = AtomicNatFlowStatus::new();
+        let snat = Self::snat(alloc, idle_timeout, status.clone());
+        let dnat = Self::dnat(src_ip, src_port, idle_timeout, status);
         (snat, dnat)
     }
 
@@ -97,12 +106,13 @@ impl Display for MasqueradeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            " {} ip: {} port|Id: {} timeout: {} {}",
+            " {} ip: {} port|Id: {} timeout: {} {} flow-status: {}",
             self.action,
             self.use_ip,
             self.use_port,
             self.idle_timeout.as_secs(),
-            self.allocation.as_ref().map_or("", |_| "(allocated)")
+            self.allocation.as_ref().map_or("", |_| "(allocated)"),
+            self.status.load()
         )
     }
 }

--- a/nat/src/stateful/state.rs
+++ b/nat/src/stateful/state.rs
@@ -2,6 +2,7 @@
 // Copyright Open Network Fabric Authors
 
 use super::apalloc::Allocation;
+use super::packet::NatTranslate;
 use crate::common::NatAction;
 use crate::{NatPort, NatTranslationData};
 use std::fmt::Display;
@@ -18,6 +19,7 @@ pub struct MasqueradeState {
 }
 
 impl MasqueradeState {
+    #[must_use]
     fn snat(allocation: Allocation, idle_timeout: Duration) -> Self {
         Self {
             action: NatAction::SrcNat,
@@ -28,6 +30,7 @@ impl MasqueradeState {
         }
     }
 
+    #[must_use]
     fn dnat(use_ip: IpAddr, use_port: NatPort, idle_timeout: Duration) -> Self {
         Self {
             action: NatAction::DstNat,
@@ -38,6 +41,16 @@ impl MasqueradeState {
         }
     }
 
+    #[must_use]
+    pub(crate) fn as_translate(&self) -> NatTranslate {
+        NatTranslate {
+            action: self.action,
+            use_ip: self.use_ip,
+            nat_port: self.use_port,
+        }
+    }
+
+    #[must_use]
     pub(crate) fn new_pair(
         alloc: Allocation,
         src_ip: IpAddr,
@@ -49,27 +62,19 @@ impl MasqueradeState {
         (snat, dnat)
     }
 
+    #[must_use]
     pub(crate) fn idle_timeout(&self) -> Duration {
         self.idle_timeout
     }
 
+    #[must_use]
     pub(crate) fn allocation(&self) -> Option<&Allocation> {
         self.allocation.as_ref()
     }
 
+    #[must_use]
     pub(crate) fn action(&self) -> NatAction {
         self.action
-    }
-
-    pub(crate) fn translation_data(&self) -> NatTranslationData {
-        match self.action {
-            NatAction::SrcNat => {
-                NatTranslationData::new(Some(self.use_ip), None, Some(self.use_port), None)
-            }
-            NatAction::DstNat => {
-                NatTranslationData::new(None, Some(self.use_ip), None, Some(self.use_port))
-            }
-        }
     }
 
     pub(crate) fn reverse_translation_data(&self) -> NatTranslationData {

--- a/nat/src/stateful/state.rs
+++ b/nat/src/stateful/state.rs
@@ -2,20 +2,15 @@
 // Copyright Open Network Fabric Authors
 
 use super::apalloc::Allocation;
+use crate::common::NatAction;
 use crate::{NatPort, NatTranslationData};
 use std::fmt::Display;
 use std::net::IpAddr;
 use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum MasqueradeAction {
-    DstNat,
-    SrcNat,
-}
-
 #[derive(Debug)]
 pub struct MasqueradeState {
-    action: MasqueradeAction,
+    action: NatAction,
     use_ip: IpAddr,
     use_port: NatPort,
     idle_timeout: Duration,
@@ -25,7 +20,7 @@ pub struct MasqueradeState {
 impl MasqueradeState {
     fn snat(allocation: Allocation, idle_timeout: Duration) -> Self {
         Self {
-            action: MasqueradeAction::SrcNat,
+            action: NatAction::SrcNat,
             use_ip: allocation.ip(),
             use_port: allocation.port(),
             allocation: Some(allocation),
@@ -35,7 +30,7 @@ impl MasqueradeState {
 
     fn dnat(use_ip: IpAddr, use_port: NatPort, idle_timeout: Duration) -> Self {
         Self {
-            action: MasqueradeAction::DstNat,
+            action: NatAction::DstNat,
             use_ip,
             use_port,
             allocation: None,
@@ -62,16 +57,16 @@ impl MasqueradeState {
         self.allocation.as_ref()
     }
 
-    pub(crate) fn action(&self) -> MasqueradeAction {
+    pub(crate) fn action(&self) -> NatAction {
         self.action
     }
 
     pub(crate) fn translation_data(&self) -> NatTranslationData {
         match self.action {
-            MasqueradeAction::SrcNat => {
+            NatAction::SrcNat => {
                 NatTranslationData::new(Some(self.use_ip), None, Some(self.use_port), None)
             }
-            MasqueradeAction::DstNat => {
+            NatAction::DstNat => {
                 NatTranslationData::new(None, Some(self.use_ip), None, Some(self.use_port))
             }
         }
@@ -79,10 +74,10 @@ impl MasqueradeState {
 
     pub(crate) fn reverse_translation_data(&self) -> NatTranslationData {
         match self.action {
-            MasqueradeAction::SrcNat => {
+            NatAction::SrcNat => {
                 NatTranslationData::new(None, Some(self.use_ip), None, Some(self.use_port))
             }
-            MasqueradeAction::DstNat => {
+            NatAction::DstNat => {
                 NatTranslationData::new(Some(self.use_ip), None, Some(self.use_port), None)
             }
         }
@@ -90,15 +85,6 @@ impl MasqueradeState {
 
     pub(crate) fn set_allocation(&mut self, allocation: Allocation) {
         self.allocation = Some(allocation);
-    }
-}
-
-impl Display for MasqueradeAction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SrcNat => write!(f, "src-nat"),
-            Self::DstNat => write!(f, "dst-nat"),
-        }
     }
 }
 

--- a/nat/src/stateful/state.rs
+++ b/nat/src/stateful/state.rs
@@ -106,12 +106,12 @@ impl Display for MasqueradeState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            " {} ip: {} port|Id: {} timeout: {} {} flow-status: {}",
+            " {} ip:{} {} {} timeout: {} flow-status: {}",
             self.action,
             self.use_ip,
             self.use_port,
-            self.idle_timeout.as_secs(),
             self.allocation.as_ref().map_or("", |_| "(allocated)"),
+            self.idle_timeout.as_secs(),
             self.status.load()
         )
     }

--- a/net/src/flows/display.rs
+++ b/net/src/flows/display.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 impl Display for FlowKeyData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(vpcd) = self.src_vpcd() {
-            write!(f, "from: {vpcd},")?;
+            write!(f, "from {vpcd},")?;
         }
         let ports = self.ports();
         let proto = self.proto();
@@ -112,7 +112,7 @@ impl Display for FlowInfoOneLiner<'_> {
         if let Ok(info) = flow_info.locked.read() {
             write!(
                 f,
-                "{key} info:{} related:{r} genid:{genid}",
+                "{key} {} related:{r} genid:{genid}",
                 FlowInfoLockedOneLiner(&info)
             )
         } else {

--- a/net/src/flows/flow_info.rs
+++ b/net/src/flows/flow_info.rs
@@ -386,8 +386,6 @@ impl FlowInfo {
             debug!("Invalidating flow {}...", self.logfmt());
             self.update_status(FlowStatus::Cancelled);
             self.token.cancel();
-        } else {
-            debug!("Flow {} was not active", self.logfmt());
         }
     }
 

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -633,17 +633,6 @@ impl Hash for FlowKey {
 }
 
 /// Wrapper to specify unidirectional `FlowKey` creation
-///
-/// Example:
-/// ```
-/// # use dataplane_net::FlowKey;
-/// # use dataplane_net::flow_key::{Uni};
-/// # use dataplane_net::ip::NextHeader;
-/// # use dataplane_net::packet::test_utils::build_test_ipv4_packet_with_transport;
-/// # let packet = build_test_ipv4_packet_with_transport(100, Some(NextHeader::TCP)).unwrap();
-/// let flow_key = FlowKey::try_from(Uni(&packet));
-/// # assert!(flow_key.is_ok());
-/// ```
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct Uni<T>(pub T);

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -1083,11 +1083,11 @@ impl<T> AbstractHeadersMut for T where
 }
 
 pub trait TryHeaders {
-    fn headers(&self) -> &impl AbstractHeaders;
+    fn headers(&self) -> &Headers;
 }
 
 pub trait TryHeadersMut {
-    fn headers_mut(&mut self) -> &mut impl AbstractHeadersMut;
+    fn headers_mut(&mut self) -> &mut Headers;
 }
 
 // ---------------------------------------------------------------------------

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -24,9 +24,8 @@ use crate::eth::Eth;
 use crate::eth::EthError;
 use crate::flows::{FlowInfo, FlowStatus};
 use crate::headers::{
-    AbstractEmbeddedHeaders, AbstractEmbeddedHeadersMut, AbstractHeaders, AbstractHeadersMut,
-    Headers, Net, Transport, TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryHeaders, TryHeadersMut,
-    TryIpMut, TryVxlan,
+    AbstractEmbeddedHeaders, AbstractEmbeddedHeadersMut, Headers, Net, Transport,
+    TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryHeaders, TryHeadersMut, TryIpMut, TryVxlan,
 };
 use crate::ip::{dscp::Dscp, ecn::Ecn};
 use crate::parse::{DeParse, Parse, ParseError};
@@ -339,13 +338,13 @@ impl<Buf: PacketBufferMut> Packet<Buf> {
 }
 
 impl<Buf: PacketBufferMut> TryHeaders for Packet<Buf> {
-    fn headers(&self) -> &impl AbstractHeaders {
+    fn headers(&self) -> &Headers {
         &self.headers
     }
 }
 
 impl<Buf: PacketBufferMut> TryHeadersMut for Packet<Buf> {
-    fn headers_mut(&mut self) -> &mut impl AbstractHeadersMut {
+    fn headers_mut(&mut self) -> &mut Headers {
         &mut self.headers
     }
 }

--- a/tracectl/src/targets.rs
+++ b/tracectl/src/targets.rs
@@ -81,6 +81,20 @@ macro_rules! custom_target {
 }
 
 #[macro_export]
+macro_rules! custom_target_named {
+    ($target:expr, $name:expr, $level:expr, $tags:expr) => {
+        const _: () = {
+            #[allow(unused)]
+            use $crate::trace_target_deps;
+            trace_target_deps!();
+
+            #[distributed_slice(TRACING_TARGETS)]
+            static TRACE_TGT: STarget = STarget::new($target, $name, $level, $tags, true);
+        };
+    };
+}
+
+#[macro_export]
 macro_rules! terror {
     ($target:expr, $($args:tt)*) => {
         tracing::error!(target: $target, $($args)*)


### PR DESCRIPTION
* further cleanup stateful implementation
* unify some types with port forwarding implementation
* rewrite utils with new packet header matching support
* add flowstatus + state machine for masqueraded flows
* set timeouts for masqueraded flows accordingly.
* The behavior is
    * configured timeout is ignored for ICMP. The timeout is set internally
    * UDP traffic: configured timeout is only applied until traffic gets to "established" state (2-way communication + 1 packet).
    * In the case of DNS (udp 53), the flow is closed (and flows cancelled) on the response.
    * TCP: user timeout ignored until flow becomes established.

Fixes: https://github.com/githedgehog/internal/issues/364

NOTE: this targets https://github.com/githedgehog/dataplane/pull/1499