### PR TITLE
Validated types for expose, manifest, peering, VPC, etc.

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -5,6 +5,11 @@ license.workspace = true
 publish.workspace = true
 version.workspace = true
 
+[features]
+# Expose the unsafe `fake_*_for_tests` constructors that mint validated wrappers without running
+# real validation. Intended for use from other crates' test code only.
+testing = []
+
 [dependencies]
 # internal
 common = { workspace = true }

--- a/config/src/display.rs
+++ b/config/src/display.rs
@@ -8,14 +8,15 @@
 use std::fmt::Display;
 
 use crate::GwConfigMeta;
-use crate::external::overlay::Overlay;
-use crate::external::overlay::vpc::Vpc;
-use crate::external::overlay::vpc::{Peering, VpcId, VpcTable};
+use crate::external::overlay::vpc::{
+    Peering, ValidatedPeering, ValidatedVpc, ValidatedVpcTable, Vpc, VpcId, VpcTable,
+};
 use crate::external::overlay::vpcpeering::{
-    VpcExpose, VpcExposeNatConfig, VpcExposePortForwarding, VpcExposeStatefulNat,
-    VpcExposeStatelessNat,
+    ValidatedExpose, ValidatedManifest, VpcExpose, VpcExposeNatConfig, VpcExposePortForwarding,
+    VpcExposeStatefulNat, VpcExposeStatelessNat,
 };
 use crate::external::overlay::vpcpeering::{VpcManifest, VpcPeering, VpcPeeringTable};
+use crate::external::overlay::{Overlay, ValidatedOverlay};
 use chrono::{DateTime, Utc};
 
 use common::cliprovider::Heading;
@@ -95,6 +96,32 @@ impl Display for VpcExpose {
     }
 }
 
+impl Display for ValidatedExpose {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut carriage = false;
+        if self.is_default() {
+            write!(f, "{SEP} prefixes: default")?;
+        }
+        if !self.ips().is_empty() {
+            write!(f, "{SEP} prefixes:")?;
+            self.ips().iter().for_each(|x| {
+                let _ = write!(f, " {x}");
+            });
+        }
+
+        writeln!(f)?;
+
+        if let Some(nat) = self.nat() {
+            write!(f, "{SEP}       as:")?;
+            self.as_range_or_empty().iter().for_each(|pfx| {
+                let _ = write!(f, " {pfx} proto: {:?} NAT:{}", nat.proto, nat.config);
+            });
+            carriage = true;
+        }
+        if carriage { writeln!(f) } else { Ok(()) }
+    }
+}
+
 // Vpc manifest is common to VpcPeering and Peering
 fn fmt_local_manifest(f: &mut std::fmt::Formatter<'_>, manifest: &VpcManifest) -> std::fmt::Result {
     writeln!(f, "     local:")?;
@@ -130,6 +157,45 @@ impl Display for Peering {
         fmt_local_manifest(f, &self.local)?;
         writeln!(f)?;
         fmt_remote_manifest(f, &self.remote, &self.remote_id)?;
+        writeln!(f)
+    }
+}
+
+// Vpc manifest is common to VpcPeering and Peering
+fn fmt_local_validated_manifest(
+    f: &mut std::fmt::Formatter<'_>,
+    manifest: &ValidatedManifest,
+) -> std::fmt::Result {
+    writeln!(f, "     local:")?;
+    for e in manifest.valexp() {
+        e.fmt(f)?;
+    }
+    Ok(())
+}
+fn fmt_remote_validated_manifest(
+    f: &mut std::fmt::Formatter<'_>,
+    manifest: &ValidatedManifest,
+    remote_id: &VpcId,
+) -> std::fmt::Result {
+    writeln!(
+        f,
+        "     remote VPC is {} (id:{}):",
+        manifest.name(),
+        remote_id
+    )?;
+    for e in manifest.valexp() {
+        e.fmt(f)?;
+    }
+    Ok(())
+}
+
+impl Display for ValidatedPeering {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "  ■ {}:", self.name())?;
+        writeln!(f, "   gwgroup: {}", self.gwgroup().map_or("none", |v| v))?;
+        fmt_local_validated_manifest(f, self.local())?;
+        writeln!(f)?;
+        fmt_remote_validated_manifest(f, self.remote(), self.remote_id())?;
         writeln!(f)
     }
 }
@@ -220,8 +286,83 @@ impl Display for VpcSummary<'_> {
     }
 }
 
+pub struct ValidatedVpcDetailed<'a>(pub &'a ValidatedVpc);
+impl Display for ValidatedVpcDetailed<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vpc = self.0;
+        Heading(format!(
+            "Peerings of VPC:{} Id:{} vni :{} ({})",
+            vpc.name(),
+            vpc.id(),
+            vpc.vni(),
+            vpc.peerings().len()
+        ))
+        .fmt(f)?;
+        for peering in vpc.peerings() {
+            peering.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct ValidatedVpcSummary<'a>(&'a ValidatedVpc);
+impl Display for ValidatedVpcSummary<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vpc = self.0;
+
+        // VPC that has no peerings
+        if vpc.peerings().is_empty() {
+            writeln!(
+                f,
+                "{}",
+                format_args!(VPC_TBL_FMT!(), &vpc.name(), vpc.id(), vpc.vni(), "", "", "")
+            )?;
+        } else {
+            // VPC that has peerings
+            for (num, peering) in vpc.peerings().iter().enumerate() {
+                let (name, id, vni, num_peers) = if num == 0 {
+                    (
+                        vpc.name(),
+                        vpc.id().to_string(),
+                        vpc.vni().to_string(),
+                        vpc.peerings().len().to_string(),
+                    )
+                } else {
+                    ("", "".to_string(), "".to_string(), "".to_string())
+                };
+                writeln!(
+                    f,
+                    "{}",
+                    format_args!(
+                        VPC_TBL_FMT!(),
+                        name,
+                        id,
+                        vni,
+                        num_peers,
+                        peering.remote().name(),
+                        peering.name()
+                    )
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
 pub struct VpcTableSummary<'a>(&'a VpcTable);
 impl Display for VpcTableSummary<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading(format!("VPCs ({})", self.0.len())).fmt(f)?;
+        fmt_vpc_table_heading(f)?;
+        for vpc in self.0.values() {
+            vpc.as_summary().fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct ValidatedVpcTableSummary<'a>(&'a ValidatedVpcTable);
+impl Display for ValidatedVpcTableSummary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Heading(format!("VPCs ({})", self.0.len())).fmt(f)?;
         fmt_vpc_table_heading(f)?;
@@ -242,6 +383,16 @@ impl Display for VpcTablePeerings<'_> {
     }
 }
 
+pub struct ValidatedVpcTablePeerings<'a>(&'a ValidatedVpcTable);
+impl Display for ValidatedVpcTablePeerings<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for vpc in self.0.values() {
+            vpc.as_detailed().fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
 impl VpcTable {
     #[must_use]
     pub fn as_summary(&self) -> VpcTableSummary<'_> {
@@ -253,6 +404,17 @@ impl VpcTable {
     }
 }
 
+impl ValidatedVpcTable {
+    #[must_use]
+    pub fn as_summary(&self) -> ValidatedVpcTableSummary<'_> {
+        ValidatedVpcTableSummary(self)
+    }
+    #[must_use]
+    pub fn as_peerings(&self) -> ValidatedVpcTablePeerings<'_> {
+        ValidatedVpcTablePeerings(self)
+    }
+}
+
 impl Vpc {
     #[must_use]
     pub fn as_summary(&self) -> VpcSummary<'_> {
@@ -261,6 +423,17 @@ impl Vpc {
     #[must_use]
     pub fn as_detailed(&self) -> VpcDetailed<'_> {
         VpcDetailed(self)
+    }
+}
+
+impl ValidatedVpc {
+    #[must_use]
+    pub fn as_summary(&self) -> ValidatedVpcSummary<'_> {
+        ValidatedVpcSummary(self)
+    }
+    #[must_use]
+    pub fn as_detailed(&self) -> ValidatedVpcDetailed<'_> {
+        ValidatedVpcDetailed(self)
     }
 }
 
@@ -300,6 +473,13 @@ impl Display for Overlay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.vpc_table.as_summary().fmt(f)?;
         self.peering_table.fmt(f)
+    }
+}
+
+impl Display for ValidatedOverlay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.vpc_table().as_summary().fmt(f)?;
+        self.peering_table().fmt(f)
     }
 }
 

--- a/config/src/external/mod.rs
+++ b/config/src/external/mod.rs
@@ -128,6 +128,34 @@ impl ExternalConfig {
             flow_table_capacity: self.flow_table_capacity,
         })
     }
+
+    /// FOR TESTS ONLY. Fake validation for the external config.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the underlay validation fails.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_validated_external_for_tests(self) -> ValidatedExternalConfig {
+        #[allow(clippy::unwrap_used)]
+        let validated_underlay = self.underlay.validate().unwrap();
+        let fake_valid_overlay = unsafe { self.overlay.fake_validated_overlay_for_tests() };
+        ValidatedExternalConfig {
+            gwname: self.gwname,
+            genid: self.genid,
+            device: self.device,
+            underlay: validated_underlay,
+            overlay: fake_valid_overlay,
+            gwgroups: self.gwgroups,
+            communities: self.communities,
+            flow_table_capacity: self.flow_table_capacity,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -143,6 +171,20 @@ pub struct ValidatedExternalConfig {
 }
 
 impl ValidatedExternalConfig {
+    #[must_use]
+    pub(crate) fn blank() -> Self {
+        Self {
+            gwname: String::new(),
+            genid: ExternalConfig::BLANK_GENID,
+            device: DeviceConfig::new(),
+            underlay: Underlay::default(),
+            overlay: ValidatedOverlay::blank(),
+            gwgroups: GwGroupTable::new(),
+            communities: PriorityCommunityTable::new(),
+            flow_table_capacity: None,
+        }
+    }
+
     #[must_use]
     pub fn gwname(&self) -> &str {
         &self.gwname

--- a/config/src/external/mod.rs
+++ b/config/src/external/mod.rs
@@ -15,8 +15,8 @@ use crate::{ConfigError, ConfigResult};
 use communities::PriorityCommunityTable;
 use derive_builder::Builder;
 use gwgroup::GwGroupTable;
-use overlay::Overlay;
 use overlay::vpc::Peering;
+use overlay::{Overlay, ValidatedOverlay};
 use tracing::debug;
 use underlay::Underlay;
 
@@ -118,5 +118,57 @@ impl ExternalConfig {
         debug!("Community table mappings:\n{}", self.communities);
         debug!("Gateway-groups are:\n{}", self.gwgroups);
         Ok(())
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct ValidatedExternalConfig(ExternalConfig);
+
+impl ValidatedExternalConfig {
+    #[must_use]
+    pub fn gwname(&self) -> &str {
+        &self.0.gwname
+    }
+
+    #[must_use]
+    pub fn genid(&self) -> GenId {
+        self.0.genid
+    }
+
+    #[must_use]
+    pub fn device(&self) -> &DeviceConfig {
+        &self.0.device
+    }
+
+    #[must_use]
+    pub fn underlay(&self) -> &Underlay {
+        &self.0.underlay
+    }
+
+    #[must_use]
+    pub fn overlay(&self) -> &ValidatedOverlay {
+        // SAFETY: ValidatedOverlay is #[repr(transparent)] over Overlay. A
+        // ValidatedExternalConfig is only obtained through `GwConfig::validate`, which validates
+        // the overlay.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(&raw const self.0.overlay).cast::<ValidatedOverlay>()
+        }
+    }
+
+    #[must_use]
+    pub fn gwgroups(&self) -> &GwGroupTable {
+        &self.0.gwgroups
+    }
+
+    #[must_use]
+    pub fn communities(&self) -> &PriorityCommunityTable {
+        &self.0.communities
+    }
+
+    #[must_use]
+    pub fn flow_table_capacity(&self) -> Option<&NonZero<usize>> {
+        self.0.flow_table_capacity.as_ref()
     }
 }

--- a/config/src/external/mod.rs
+++ b/config/src/external/mod.rs
@@ -103,72 +103,83 @@ impl ExternalConfig {
     /// # Errors
     ///
     /// Returns a [`ConfigError`] if validation fails.
-    pub fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&self) -> Result<ValidatedExternalConfig, ConfigError> {
         self.device.validate()?;
-        self.underlay.validate()?;
-        self.overlay.validate()?;
+        let validated_underlay = self.underlay.validate()?;
+        let validated_overlay = self.overlay.validate()?;
         self.validate_peering_gw_groups()?;
 
         // if there are vpcs configured, there MUST be a vtep configured
-        if !self.overlay.vpc_table.is_empty() && self.underlay.vtep.is_none() {
+        if !validated_overlay.vpc_table().is_empty() && validated_underlay.vtep.is_none() {
             return Err(ConfigError::MissingParameter(
                 "Vtep interface configuration",
             ));
         }
         debug!("Community table mappings:\n{}", self.communities);
         debug!("Gateway-groups are:\n{}", self.gwgroups);
-        Ok(())
+        Ok(ValidatedExternalConfig {
+            gwname: self.gwname.clone(),
+            genid: self.genid,
+            device: self.device.clone(),
+            underlay: validated_underlay,
+            overlay: validated_overlay,
+            gwgroups: self.gwgroups.clone(),
+            communities: self.communities.clone(),
+            flow_table_capacity: self.flow_table_capacity,
+        })
     }
 }
 
-#[repr(transparent)]
 #[derive(Debug)]
-pub struct ValidatedExternalConfig(ExternalConfig);
+pub struct ValidatedExternalConfig {
+    gwname: String,                              /* name of gateway */
+    genid: GenId,                                /* configuration generation id (version) */
+    device: DeviceConfig,                        /* goes as-is into the internal config */
+    underlay: Underlay,                          /* goes as-is into the internal config */
+    overlay: ValidatedOverlay, /* VPCs and peerings -- get highly developed in internal config */
+    gwgroups: GwGroupTable,    /* gateway group table */
+    communities: PriorityCommunityTable, /* priority-to-community table */
+    flow_table_capacity: Option<NonZero<usize>>, /* optional hard cap of flow table */
+}
 
 impl ValidatedExternalConfig {
     #[must_use]
     pub fn gwname(&self) -> &str {
-        &self.0.gwname
+        &self.gwname
     }
 
     #[must_use]
     pub fn genid(&self) -> GenId {
-        self.0.genid
+        self.genid
     }
 
     #[must_use]
     pub fn device(&self) -> &DeviceConfig {
-        &self.0.device
+        &self.device
     }
 
     #[must_use]
     pub fn underlay(&self) -> &Underlay {
-        &self.0.underlay
+        &self.underlay
     }
 
     #[must_use]
     pub fn overlay(&self) -> &ValidatedOverlay {
-        // SAFETY: ValidatedOverlay is #[repr(transparent)] over Overlay. A
-        // ValidatedExternalConfig is only obtained through `GwConfig::validate`, which validates
-        // the overlay.
-        #[allow(unsafe_code)]
-        unsafe {
-            &*(&raw const self.0.overlay).cast::<ValidatedOverlay>()
-        }
+        &self.overlay
     }
 
     #[must_use]
     pub fn gwgroups(&self) -> &GwGroupTable {
-        &self.0.gwgroups
+        &self.gwgroups
     }
 
     #[must_use]
     pub fn communities(&self) -> &PriorityCommunityTable {
-        &self.0.communities
+        &self.communities
     }
 
     #[must_use]
     pub fn flow_table_capacity(&self) -> Option<&NonZero<usize>> {
-        self.0.flow_table_capacity.as_ref()
+        self.flow_table_capacity.as_ref()
     }
 }

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -61,42 +61,35 @@ impl Overlay {
         id_map
     }
 
-    /// Top most validation function for `Overlay` configuration
+    /// Validate the overlay configuration, returning a `ValidatedOverlay` if successful.
     ///
     /// # Errors
     ///
     /// Returns an error if the overlay configuration is invalid.
-    pub fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&self) -> Result<ValidatedOverlay, ConfigError> {
         debug!("Validating overlay configuration...");
 
         self.validate_peerings()?;
 
-        // collect peerings for every vpc.
-        self.collect_peerings();
+        // Collect peerings for every VPC and validate the table
+        let validated_vpc_table = self.collect_peerings().validate()?;
 
-        self.vpc_table.validate()?;
+        let validated_overlay = ValidatedOverlay {
+            vpc_table: validated_vpc_table,
+            peering_table: self.peering_table.clone(),
+        };
 
-        debug!("Overlay configuration is VALID:\n{self}");
-        Ok(())
-    }
-
-    /// Consume `self` and produce a [`ValidatedOverlay`] if it passes validation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the overlay configuration is invalid.
-    pub fn validated(mut self) -> Result<ValidatedOverlay, ConfigError> {
-        self.validate()?;
-        Ok(ValidatedOverlay(self))
+        debug!("Overlay configuration is VALID:\n{validated_overlay}");
+        Ok(validated_overlay)
     }
 
     /// Collect peerings from the peering table for every VPC.
     ///
     /// Should only be called in `validate`, or in tests.
-    pub(crate) fn collect_peerings(&mut self) {
+    pub(crate) fn collect_peerings(&self) -> VpcTable {
         let id_map = self.vpcid_map();
         self.vpc_table
-            .collect_peerings(&self.peering_table, &id_map);
+            .collect_peerings(&self.peering_table, &id_map)
     }
 
     /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
@@ -119,39 +112,34 @@ impl Overlay {
     #[cfg(feature = "testing")]
     #[allow(unsafe_code)]
     #[must_use]
-    pub unsafe fn fake_validated_overlay_for_tests(mut self) -> ValidatedOverlay {
-        unsafe {
-            self.fake_manifest_validation_for_tests();
+    pub unsafe fn fake_validated_overlay_for_tests(&self) -> ValidatedOverlay {
+        let vpc_table = self.collect_peerings();
+        let fake_valid_vpc_table = unsafe { vpc_table.fake_validated_vpc_table_for_tests() };
+        ValidatedOverlay {
+            vpc_table: fake_valid_vpc_table,
+            peering_table: self.peering_table.clone(),
         }
-        ValidatedOverlay(self)
     }
 }
 
-#[repr(transparent)]
 #[derive(Clone, Debug)]
-pub struct ValidatedOverlay(Overlay);
+pub struct ValidatedOverlay {
+    vpc_table: ValidatedVpcTable,
+    // Note: unlike the vpc_table, the peering_table is not changed to a `Validated*` new type. A
+    // VpcPeering is symmetric (no local/remote distinction), and per-side validation is performed
+    // only on the asymmetric Peering copies held by the VPCs, in the vpc_table. Since the peering
+    // table is not validated independently, it is exposed as-is.
+    peering_table: VpcPeeringTable,
+}
 
 impl ValidatedOverlay {
     #[must_use]
     pub fn vpc_table(&self) -> &ValidatedVpcTable {
-        // SAFETY: ValidatedVpcTable is #[repr(transparent)] over VpcTable. A ValidatedOverlay is
-        // only ever obtained from `Overlay::validated`, which validates the underlying table.
-        #[allow(unsafe_code)]
-        unsafe {
-            &*(&raw const self.0.vpc_table).cast::<ValidatedVpcTable>()
-        }
+        &self.vpc_table
     }
 
-    /// Return the peering table.
-    ///
-    /// Note: unlike the other fields exposed on [`ValidatedOverlay`], the peering table is not
-    /// wrapped in a `Validated*` newtype. A [`crate::external::overlay::vpcpeering::VpcPeering`]
-    /// is symmetric (no local/remote distinction), and per-side validation is performed only on
-    /// the asymmetric [`crate::external::overlay::vpc::Peering`] copies that
-    /// [`Overlay::collect_peerings`] places on each VPC. Validating the peering table itself
-    /// would not provide useful guarantees on top of that, so consumers see the raw type.
     #[must_use]
     pub fn peering_table(&self) -> &VpcPeeringTable {
-        &self.0.peering_table
+        &self.peering_table
     }
 }

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -107,14 +107,8 @@ impl Overlay {
     #[cfg(feature = "testing")]
     #[allow(unsafe_code)]
     pub(crate) unsafe fn fake_manifest_validation_for_tests(&mut self) {
-        for peering in self.peering_table.values_mut() {
-            for manifest in [&mut peering.left, &mut peering.right] {
-                unsafe {
-                    manifest.fake_expose_validation_for_tests();
-                }
-            }
-        }
-        self.collect_peerings();
+        // FIXME
+        todo!()
     }
 
     /// FOR TESTS ONLY. Fake validation for the overlay.

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -52,7 +52,7 @@ impl Overlay {
 
     /// Build a `VpcIdMap`. We have already checked that all VPC Ids are distinct
     #[must_use]
-    pub fn vpcid_map(&self) -> VpcIdMap {
+    pub(crate) fn vpcid_map(&self) -> VpcIdMap {
         let id_map: VpcIdMap = self
             .vpc_table
             .values()
@@ -93,7 +93,7 @@ impl Overlay {
     /// Collect peerings from the peering table for every VPC.
     ///
     /// Should only be called in `validate`, or in tests.
-    pub fn collect_peerings(&mut self) {
+    pub(crate) fn collect_peerings(&mut self) {
         let id_map = self.vpcid_map();
         self.vpc_table
             .collect_peerings(&self.peering_table, &id_map);

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -80,6 +80,16 @@ impl Overlay {
         Ok(())
     }
 
+    /// Consume `self` and produce a [`ValidatedOverlay`] if it passes validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the overlay configuration is invalid.
+    pub fn validated(mut self) -> Result<ValidatedOverlay, ConfigError> {
+        self.validate()?;
+        Ok(ValidatedOverlay(self))
+    }
+
     /// Collect peerings from the peering table for every VPC.
     ///
     /// Should only be called in `validate`, or in tests.

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -92,18 +92,6 @@ impl Overlay {
             .collect_peerings(&self.peering_table, &id_map)
     }
 
-    /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
-    ///
-    /// # Safety
-    ///
-    /// All bets are off. Do not use outside of tests.
-    #[cfg(feature = "testing")]
-    #[allow(unsafe_code)]
-    pub(crate) unsafe fn fake_manifest_validation_for_tests(&mut self) {
-        // FIXME
-        todo!()
-    }
-
     /// FOR TESTS ONLY. Fake validation for the overlay.
     ///
     /// # Safety
@@ -133,6 +121,14 @@ pub struct ValidatedOverlay {
 }
 
 impl ValidatedOverlay {
+    #[must_use]
+    pub(crate) fn blank() -> Self {
+        Self {
+            vpc_table: ValidatedVpcTable::blank(),
+            peering_table: VpcPeeringTable::default(),
+        }
+    }
+
     #[must_use]
     pub fn vpc_table(&self) -> &ValidatedVpcTable {
         &self.vpc_table

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -98,6 +98,39 @@ impl Overlay {
         self.vpc_table
             .collect_peerings(&self.peering_table, &id_map);
     }
+
+    /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    pub(crate) unsafe fn fake_manifest_validation_for_tests(&mut self) {
+        for peering in self.peering_table.values_mut() {
+            for manifest in [&mut peering.left, &mut peering.right] {
+                unsafe {
+                    manifest.fake_expose_validation_for_tests();
+                }
+            }
+        }
+        self.collect_peerings();
+    }
+
+    /// FOR TESTS ONLY. Fake validation for the overlay.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_validated_overlay_for_tests(mut self) -> ValidatedOverlay {
+        unsafe {
+            self.fake_manifest_validation_for_tests();
+        }
+        ValidatedOverlay(self)
+    }
 }
 
 #[repr(transparent)]

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -10,10 +10,8 @@ pub mod vpcpeering;
 
 use crate::{ConfigError, ConfigResult};
 use tracing::{debug, error};
-use vpc::VpcIdMap;
-use vpc::VpcTable;
-use vpcpeering::VpcManifest;
-use vpcpeering::VpcPeeringTable;
+use vpc::{ValidatedVpcTable, VpcIdMap, VpcTable};
+use vpcpeering::{VpcManifest, VpcPeeringTable};
 
 #[derive(Clone, Debug, Default)]
 pub struct Overlay {
@@ -89,5 +87,34 @@ impl Overlay {
         let id_map = self.vpcid_map();
         self.vpc_table
             .collect_peerings(&self.peering_table, &id_map);
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct ValidatedOverlay(Overlay);
+
+impl ValidatedOverlay {
+    #[must_use]
+    pub fn vpc_table(&self) -> &ValidatedVpcTable {
+        // SAFETY: ValidatedVpcTable is #[repr(transparent)] over VpcTable. A ValidatedOverlay is
+        // only ever obtained from `Overlay::validated`, which validates the underlying table.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(&raw const self.0.vpc_table).cast::<ValidatedVpcTable>()
+        }
+    }
+
+    /// Return the peering table.
+    ///
+    /// Note: unlike the other fields exposed on [`ValidatedOverlay`], the peering table is not
+    /// wrapped in a `Validated*` newtype. A [`crate::external::overlay::vpcpeering::VpcPeering`]
+    /// is symmetric (no local/remote distinction), and per-side validation is performed only on
+    /// the asymmetric [`crate::external::overlay::vpc::Peering`] copies that
+    /// [`Overlay::collect_peerings`] places on each VPC. Validating the peering table itself
+    /// would not provide useful guarantees on top of that, so consumers see the raw type.
+    #[must_use]
+    pub fn peering_table(&self) -> &VpcPeeringTable {
+        &self.0.peering_table
     }
 }

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -1255,7 +1255,7 @@ pub mod test {
 
     #[test]
     fn test_manifest_must_have_exposes() {
-        let mut manifest = VpcManifest::new("some-vpc");
+        let manifest = VpcManifest::new("some-vpc");
         assert!(
             manifest
                 .validate()

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -377,9 +377,9 @@ pub mod test {
         peering_table.add(peering).unwrap();
 
         // Build overlay object and validate it
-        let mut overlay = Overlay::new(vpc_table, peering_table);
+        let overlay = Overlay::new(vpc_table, peering_table);
         assert_eq!(
-            overlay.validate(),
+            overlay.validate().map(|_| ()),
             Err(ConfigError::IncompatibleNatModes("Peering-1".to_owned()))
         );
     }
@@ -425,10 +425,11 @@ pub mod test {
         peering_table.add(peering).unwrap();
 
         // Build overlay object and validate it
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::IncompatibleNatModes("Peering-1".to_owned()))
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(
+            overlay
+                .validate()
+                .is_err_and(|e| e == ConfigError::IncompatibleNatModes("Peering-1".to_owned()))
         );
     }
 
@@ -449,10 +450,11 @@ pub mod test {
         peering_table.add(peering).expect("Should succeed");
 
         /* build overlay object and validate it */
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::NoSuchVpc("VPC-2".to_owned()))
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(
+            overlay
+                .validate()
+                .is_err_and(|e| e == ConfigError::NoSuchVpc("VPC-2".to_owned()))
         );
     }
 
@@ -483,10 +485,11 @@ pub mod test {
         peering_table.add(peering2).expect("Should succeed");
 
         /* build overlay object and validate it */
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::DuplicateVpcPeerings(name1))
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(
+            overlay
+                .validate()
+                .is_err_and(|e| e == ConfigError::DuplicateVpcPeerings(name1))
         );
     }
 
@@ -511,8 +514,8 @@ pub mod test {
         println!("{peering_table}");
 
         /* build overlay object and validate it */
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(overlay.validate(), Ok(()));
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(overlay.validate().is_ok());
     }
 
     #[test]
@@ -1041,10 +1044,9 @@ pub mod test {
             ))
             .unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::OverlappingPrefixes(
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(overlay.validate().is_err_and(|e| e
+            == ConfigError::OverlappingPrefixes(
                 PrefixWithOptionalPorts::new(
                     "5.0.0.0/24".into(),
                     Some(PortRange::new(6001, 8000).unwrap())
@@ -1053,8 +1055,7 @@ pub mod test {
                     "5.0.0.0/25".into(),
                     Some(PortRange::new(5001, 7000).unwrap())
                 ),
-            )),
-        );
+            )));
     }
 
     #[test]
@@ -1105,7 +1106,7 @@ pub mod test {
             ))
             .unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
+        let overlay = Overlay::new(vpc_table, peering_table);
         assert!(overlay.validate().is_ok());
     }
 
@@ -1150,7 +1151,7 @@ pub mod test {
             ))
             .unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
+        let overlay = Overlay::new(vpc_table, peering_table);
         assert!(overlay.validate().is_ok());
     }
 
@@ -1195,13 +1196,10 @@ pub mod test {
             ))
             .unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::Forbidden(
-                "Multiple 'default' destinations exposed to VPC"
-            )),
-        );
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(overlay.validate().is_err_and(
+            |e| e == ConfigError::Forbidden("Multiple 'default' destinations exposed to VPC")
+        ));
     }
 
     #[test]
@@ -1244,13 +1242,10 @@ pub mod test {
             ))
             .unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        assert_eq!(
-            overlay.validate(),
-            Err(ConfigError::Forbidden(
-                "Manifest cannot have multiple default exposes",
-            )),
-        );
+        let overlay = Overlay::new(vpc_table, peering_table);
+        assert!(overlay.validate().is_err_and(
+            |e| e == ConfigError::Forbidden("Manifest cannot have multiple default exposes",)
+        ));
     }
 
     #[test]

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -115,13 +115,13 @@ pub mod test {
         // Empty ips but non-empty nots - Currently not supported
         /*
         let expose = VpcExpose::empty().not("10.0.1.0/24".into());
-        assert!(expose.validate().is_ok());
+        assert_eq!(expose.validate(), Ok(()));
         */
 
         // Empty as_range but non-empty not_as - Currently not supported
         /*
         let expose = VpcExpose::empty().not_as("2.0.1.0/24".into());
-        assert!(expose.validate().is_ok());
+        assert_eq!(expose.validate(), Ok(()));
         */
 
         let expose = VpcExpose::empty()
@@ -297,7 +297,7 @@ pub mod test {
         let mut manifest = VpcManifest::new("VPC-1");
         manifest.add_expose(expose1);
         manifest.add_expose(expose2);
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.clone().validate().is_ok());
 
         // Overlap between a manifest's exposes prefixes is not allowed
         let mut invalid_manifest = manifest.clone();
@@ -468,14 +468,14 @@ pub mod test {
         vpc_table.add(vpc2).expect("Should succeed");
 
         /* build peerings */
-        let mut peering1 = build_vpc_peering();
+        let peering1 = build_vpc_peering();
         let mut peering2 = build_vpc_peering();
         peering2.name = "Peering-2".to_owned();
 
         let name1 = peering1.name.clone();
 
-        assert_eq!(peering1.validate(), Ok(()));
-        assert_eq!(peering2.validate(), Ok(()));
+        assert!(peering1.clone().validate().is_ok());
+        assert!(peering2.clone().validate().is_ok());
 
         /* build peering table */
         let mut peering_table = VpcPeeringTable::new();
@@ -1248,7 +1248,7 @@ pub mod test {
         assert_eq!(
             overlay.validate(),
             Err(ConfigError::Forbidden(
-                "Multiple 'default' expose blocks for a same peering",
+                "Manifest cannot have multiple default exposes",
             )),
         );
     }

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -468,7 +468,7 @@ pub mod test {
         vpc_table.add(vpc2).expect("Should succeed");
 
         /* build peerings */
-        let peering1 = build_vpc_peering();
+        let mut peering1 = build_vpc_peering();
         let mut peering2 = build_vpc_peering();
         peering2.name = "Peering-2".to_owned();
 
@@ -1255,7 +1255,7 @@ pub mod test {
 
     #[test]
     fn test_manifest_must_have_exposes() {
-        let manifest = VpcManifest::new("some-vpc");
+        let mut manifest = VpcManifest::new("some-vpc");
         assert!(
             manifest
                 .validate()

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -110,18 +110,18 @@ pub mod test {
         );
 
         let expose = VpcExpose::empty().ip("10.0.0.0/16".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Empty ips but non-empty nots - Currently not supported
         /*
         let expose = VpcExpose::empty().not("10.0.1.0/24".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
         */
 
         // Empty as_range but non-empty not_as - Currently not supported
         /*
         let expose = VpcExpose::empty().not_as("2.0.1.0/24".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
         */
 
         let expose = VpcExpose::empty()
@@ -130,7 +130,7 @@ pub mod test {
             .ip("10.0.0.0/16".into())
             .as_range("2.0.0.0/16".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         let expose = VpcExpose::empty()
             .make_stateless_nat()
@@ -141,7 +141,7 @@ pub mod test {
             .unwrap()
             .not_as("2.0.0.0/24".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         let expose = VpcExpose::empty()
             .make_stateless_nat()
@@ -149,7 +149,7 @@ pub mod test {
             .ip("1::/64".into())
             .as_range("2::/64".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Out-of-range exclusion prefix
         let expose = VpcExpose::empty()
@@ -161,7 +161,7 @@ pub mod test {
             .unwrap()
             .not_as("2.0.1.0/24".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()
@@ -719,7 +719,7 @@ pub mod test {
             "10.0.0.0/16".into(),
             Some(PortRange::new(1, 65535).unwrap()),
         ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         let expose = VpcExpose::empty()
             .make_stateless_nat()
@@ -733,7 +733,7 @@ pub mod test {
                 Some(PortRange::new(8001, 9000).unwrap()),
             ))
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         let expose = VpcExpose::empty()
             .make_stateless_nat()
@@ -756,7 +756,7 @@ pub mod test {
                 Some(PortRange::new(8001, 8200).unwrap()),
             ))
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         let expose = VpcExpose::empty()
             .make_stateless_nat()
@@ -770,7 +770,7 @@ pub mod test {
                 Some(PortRange::new(8001, 9000).unwrap()),
             ))
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Overlapping prefix, but distinct port ranges
         let expose = VpcExpose::empty()
@@ -782,7 +782,7 @@ pub mod test {
                 "10.0.0.0/17".into(),
                 Some(PortRange::new(8001, 9500).unwrap()),
             ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Out-of-range exclusion prefix (IPs)
         let expose = VpcExpose::empty()
@@ -798,7 +798,7 @@ pub mod test {
                 "10.0.0.0/15".into(),
                 Some(PortRange::new(5001, 5500).unwrap()),
             ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Out-of-range exclusion prefix (port range)
         let expose = VpcExpose::empty()
@@ -810,7 +810,7 @@ pub mod test {
                 "10.0.0.0/24".into(),
                 Some(PortRange::new(7001, 8000).unwrap()),
             ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Out-of-range exclusion prefix (port range, albeit with overlap)
         let expose = VpcExpose::empty()
@@ -822,7 +822,7 @@ pub mod test {
                 "10.0.0.0/24".into(),
                 Some(PortRange::new(5001, 8000).unwrap()),
             ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Incorrect: mixed IP versions
         let expose = VpcExpose::empty()

--- a/config/src/external/overlay/validation_tests.rs
+++ b/config/src/external/overlay/validation_tests.rs
@@ -37,8 +37,8 @@ mod test {
         let mut peering_table = VpcPeeringTable::new();
         peering_table.add(peering).unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
-        overlay.validate()
+        let overlay = Overlay::new(vpc_table, peering_table);
+        overlay.validate().map(|_| ())
     }
 
     // Helper: build an Overlay from three VPCs and two peerings, then validate it
@@ -58,8 +58,8 @@ mod test {
         peering_table.add(peering1).unwrap();
         peering_table.add(peering2).unwrap();
 
-        let mut overlay: Overlay = Overlay::new(vpc_table, peering_table);
-        overlay.validate()
+        let overlay: Overlay = Overlay::new(vpc_table, peering_table);
+        overlay.validate().map(|_| ())
     }
 
     // ==================================================================================
@@ -1417,7 +1417,7 @@ mod test {
         peering_table.add(peering1).unwrap();
         peering_table.add(peering2).unwrap();
 
-        let mut overlay = Overlay::new(vpc_table, peering_table);
+        let overlay = Overlay::new(vpc_table, peering_table);
         let result = overlay.validate();
         assert!(
             matches!(result, Err(ConfigError::DuplicateVpcPeerings(_))),

--- a/config/src/external/overlay/validation_tests.rs
+++ b/config/src/external/overlay/validation_tests.rs
@@ -639,7 +639,7 @@ mod test {
         let mut manifest = VpcManifest::new("VPC-1");
         manifest.add_expose(VpcExpose::empty().ip("10.0.0.0/16".into()));
         manifest.add_expose(VpcExpose::empty().ip("10.1.0.0/16".into()));
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.validate().is_ok());
     }
 
     // Two no-NAT exposes with overlapping ips rejected
@@ -795,7 +795,7 @@ mod test {
                 .as_range("2.1.0.0/16".into())
                 .unwrap(),
         );
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.validate().is_ok());
     }
 
     // Two stateless NAT exposes with overlapping ips rejected
@@ -1088,7 +1088,7 @@ mod test {
                 .as_range(prefix_with_ports("2.0.0.1/32", 9090, 9090))
                 .unwrap(),
         );
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.validate().is_ok());
     }
 
     // Stateful + port forwarding overlap where stateful NAT contains port forwarding passes
@@ -1113,7 +1113,7 @@ mod test {
                 .as_range(prefix_with_ports("2.0.0.1/32", 8080, 8080))
                 .unwrap(),
         );
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.validate().is_ok());
     }
 
     // Stateful + port forwarding partial overlap passes
@@ -1138,7 +1138,7 @@ mod test {
                 .as_range(prefix_with_ports("3.0.0.0/24", 8080, 8080))
                 .unwrap(),
         );
-        assert_eq!(manifest.validate(), Ok(()));
+        assert!(manifest.validate().is_ok());
     }
 
     // ==================================================================================

--- a/config/src/external/overlay/validation_tests.rs
+++ b/config/src/external/overlay/validation_tests.rs
@@ -181,14 +181,14 @@ mod test {
     #[test]
     fn test_root_v4_in_ips_passes() {
         let expose = VpcExpose::empty().ip("0.0.0.0/0".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Root prefix ::/0 in ips is legal (IPv6 variant)
     #[test]
     fn test_root_v6_in_ips_passes() {
         let expose = VpcExpose::empty().ip("::/0".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Root prefix 0.0.0.0/0 in as_range is legal
@@ -200,7 +200,7 @@ mod test {
             .ip("10.0.0.0/8".into())
             .as_range("0.0.0.0/0".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Root prefix 0.0.0.0/0 in nots is rejected - not illegal per-se, but excludes all available
@@ -276,7 +276,7 @@ mod test {
         let expose = VpcExpose::empty()
             .ip("10.0.0.0/16".into())
             .ip("10.0.0.0/17".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Overlapping prefixes within as_range are allowed, should be merged internally
@@ -291,7 +291,7 @@ mod test {
             .unwrap()
             .as_range("10.0.0.0/17".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
         // TODO: Can we merge the two overlapping prefixes?
     }
 
@@ -303,7 +303,7 @@ mod test {
             .ip("10.0.0.0/8".into())
             .not("10.0.0.0/16".into())
             .not("10.0.0.0/17".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Overlapping prefixes within not_as are allowed, should be merged internally
@@ -320,7 +320,7 @@ mod test {
             .unwrap()
             .not_as("10.0.0.0/17".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Overlapping prefixes in ips with distinct port ranges passes
@@ -329,7 +329,7 @@ mod test {
         let expose = VpcExpose::empty()
             .ip(prefix_with_ports("10.0.0.0/24", 80, 80))
             .ip(prefix_with_ports("10.0.0.0/24", 443, 443));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Overlapping prefixes in ips with overlapping port ranges passes
@@ -338,7 +338,7 @@ mod test {
         let expose = VpcExpose::empty()
             .ip(prefix_with_ports("10.0.0.0/24", 80, 80))
             .ip(prefix_with_ports("10.0.0.0/24", 80, 80));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // --- Exclusion prefixes ---
@@ -349,7 +349,7 @@ mod test {
         let expose = VpcExpose::empty()
             .ip("10.0.0.0/16".into())
             .not("8.0.0.0/24".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Out-of-range exclusion prefix for as_range is legal (but we should warn about it)
@@ -363,7 +363,7 @@ mod test {
             .unwrap()
             .not_as("8.0.0.0/24".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Exclusion prefix for ips with partial overlap (not fully contained) is valid (but we should
@@ -382,7 +382,7 @@ mod test {
             .ip("20.0.0.0/16".into())
             .ip("10.0.0.0/16".into())
             .not("10.0.0.0/8".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Exclusion prefix for ips with partial overlap (not fully contained), when using port ranges,
@@ -399,7 +399,7 @@ mod test {
                 "10.0.0.0/16".into(),
                 Some(PortRange::new(1500, 2500).unwrap()),
             ));
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Exclusion prefix for as_range with partial overlap (not fully contained) is valid (but we
@@ -424,7 +424,7 @@ mod test {
             .unwrap()
             .not_as("10.0.0.0/8".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Exclusion prefix for as_range with partial overlap (not fully contained) is valid (but we
@@ -446,7 +446,7 @@ mod test {
                 Some(PortRange::new(1500, 2500).unwrap()),
             ))
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Excluding all prefixes in ips is rejected
@@ -611,7 +611,7 @@ mod test {
         let expose = VpcExpose::empty()
             .ip("10.0.0.0/16".into())
             .ip("10.1.0.0/16".into());
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // Valid expose with ips + as_range + nots + not_as passes
@@ -626,7 +626,7 @@ mod test {
             .unwrap()
             .not_as("2.0.1.0/24".into())
             .unwrap();
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
     }
 
     // ==================================================================================
@@ -1565,7 +1565,7 @@ mod test {
         // A default expose cannot have nat field set at all
         let expose = VpcExpose::empty().set_default();
         // Verify default alone is valid
-        assert_eq!(expose.validate(), Ok(()));
+        assert!(expose.validate().is_ok());
 
         // Default with NAT should fail
         let expose = VpcExpose::empty()

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -305,8 +305,9 @@ impl Vpc {
     pub unsafe fn fake_validated_vpc_for_tests(mut self) -> ValidatedVpc {
         for peering in &mut self.peerings {
             unsafe {
-                peering.local.fake_expose_validation_for_tests();
-                peering.remote.fake_expose_validation_for_tests();
+                // FIXME
+                //peering.local.fake_expose_validation_for_tests();
+                //peering.remote.fake_expose_validation_for_tests();
             }
         }
         ValidatedVpc(self)

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -294,12 +294,6 @@ impl Vpc {
         Ok(ValidatedVpc(self))
     }
 
-    /// Tell how many peerings this VPC has
-    #[must_use]
-    pub fn num_peerings(&self) -> usize {
-        self.peerings.len()
-    }
-
     /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
     ///
     /// # Safety
@@ -356,6 +350,12 @@ impl ValidatedVpc {
                 self.0.peerings.len(),
             )
         }
+    }
+
+    /// Tell how many peerings this VPC has
+    #[must_use]
+    pub fn num_peerings(&self) -> usize {
+        self.0.peerings.len()
     }
 
     /// Provide an iterator over all peerings that have either masquerade or port-forwarding
@@ -425,11 +425,6 @@ impl ValidatedVpc {
             }
         }
         Ok(())
-    }
-
-    #[must_use]
-    pub fn inner(&self) -> &Vpc {
-        &self.0
     }
 }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -503,7 +503,7 @@ impl VpcTable {
     }
 
     /// Collect peerings for all [`Vpc`]s in this [`VpcTable`]
-    pub fn collect_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
+    pub(crate) fn collect_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
         debug!("Collecting peerings for all VPCs..");
         self.values_mut()
             .for_each(|vpc| vpc.set_peerings(peering_table, idmap));

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -502,10 +502,56 @@ impl VpcTable {
     }
 
     /// Validate the [`VpcTable`]
-    pub fn validate(&mut self) -> ConfigResult {
+    pub(crate) fn validate(&mut self) -> ConfigResult {
         for vpc in self.values_mut() {
             vpc.validate()?;
         }
         Ok(())
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct ValidatedVpcTable(VpcTable);
+
+impl ValidatedVpcTable {
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.vpcs.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.vpcs.is_empty()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &ValidatedVpc> {
+        // SAFETY: ValidatedVpc is #[repr(transparent)] over Vpc, and a ValidatedVpcTable can only
+        // be obtained from a successful `VpcTable::validated`, which validates every Vpc.
+        #[allow(unsafe_code)]
+        self.0
+            .vpcs
+            .values()
+            .map(|vpc| unsafe { &*(&raw const *vpc).cast::<ValidatedVpc>() })
+    }
+
+    #[must_use]
+    pub fn get_vpc(&self, vpc_name: &str) -> Option<&ValidatedVpc> {
+        self.0.get_vpc(vpc_name).map(|vpc| {
+            // SAFETY: ValidatedVpc is `#[repr(transparent)]` over Vpc, and a `ValidatedVpcTable`
+            // can only be obtained from `VpcTable::validated`, which validates every Vpc.
+            #[allow(unsafe_code)]
+            unsafe {
+                &*(&raw const *vpc).cast::<ValidatedVpc>()
+            }
+        })
+    }
+
+    #[must_use]
+    pub fn get_remote_vni(&self, peering: &ValidatedPeering) -> Vni {
+        self.0
+            .get_vpc_by_vpcid(peering.remote_id())
+            .unwrap_or_else(|| unreachable!())
+            .vni
     }
 }

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -256,87 +256,27 @@ impl Vpc {
         Ok(())
     }
 
-    /// Check that prefixes exposed to a given VPC do not overlap. Exceptions:
-    ///
-    /// - overlap is allowed between a prefix and a default expose (it overlaps by design)
-    /// - overlap is allowed between prefixes from different exposes if both their exposes use
-    ///   stateful NAT (we can fall back to the flow table to disambiguate the destination VPC)
-    ///
-    /// Also check that at most one default expose is exposed to the VPC.
-    fn check_overlap_and_default(&self) -> ConfigResult {
-        let mut found_default = false;
-
-        // FIXME: Find a less expensive approach to find overlapping prefixes
-        for (i, current_peering) in self.peerings.iter().enumerate() {
-            // Check we don't have multiple default expose blocks in the peering
-            for expose in &current_peering.remote.valexp {
-                if expose.is_default() {
-                    if found_default {
-                        error!(
-                            "Multiple 'default' expose blocks for a same peering in VPC {}",
-                            self.name
-                        );
-                        return Err(ConfigError::Forbidden(
-                            "Multiple 'default' expose blocks for a same peering",
-                        ));
-                    }
-                    found_default = true;
-                }
-            }
-
-            // Check we don't have non-default, overlapping prefixes exposed to the VPC
-            for other_peering in &self.peerings[i + 1..] {
-                for current_expose in &current_peering.remote.valexp {
-                    for other_expose in &other_peering.remote.valexp {
-                        if current_expose.has_stateful_nat() && other_expose.has_stateful_nat() {
-                            // Overlap is allowed if both expose blocks use stateful NAT
-                            continue;
-                        }
-                        match (current_expose.is_default(), other_expose.is_default()) {
-                            (true, true) => {
-                                // We support at most one default destination exposed to any VPC
-                                error!(
-                                    "Multiple 'default' destinations exposed to VPC {}",
-                                    self.name
-                                );
-                                return Err(ConfigError::Forbidden(
-                                    "Multiple 'default' destinations exposed to VPC",
-                                ));
-                            }
-                            (true, false) | (false, true) => {
-                                // Overlap is allowed between a prefix and a default expose
-                                continue;
-                            }
-                            (false, false) => { /* keep processing */ }
-                        }
-                        for current_prefix in current_expose.public_ips() {
-                            for other_prefix in other_expose.public_ips() {
-                                if current_prefix.overlaps(other_prefix) {
-                                    error!(
-                                        "Prefixes exposed to VPC {} overlap: {} and {}",
-                                        self.name, current_prefix, other_prefix
-                                    );
-                                    return Err(ConfigError::OverlappingPrefixes(
-                                        *current_prefix,
-                                        *other_prefix,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
     /// Validate a [`Vpc`]
-    pub fn validate(&mut self) -> ConfigResult {
+    pub(crate) fn validate(&mut self) -> ConfigResult {
         debug!("Validating config for VPC {}...", self.name);
         self.check_peering_count()?;
         self.check_peerings()?;
-        self.check_overlap_and_default()?;
-        Ok(())
+
+        // SAFETY: `ValidatedVpc` is `#[repr(transparent)]` over `Vpc`, so the cast is
+        // layout-compatible. The only invariant `check_overlap_and_default` relies on is that
+        // every peering's `local`/`remote` manifest has its `valexp` populated -- which is
+        // exactly what `check_peerings` (via `Peering::validate` -> `VpcManifest::validate`)
+        // guarantees on the line above. We are not yet returning an `&ValidatedVpc` to the
+        // outside world; this view is purely internal so we can call the post-collapse overlap
+        // check that lives on the validated wrapper.
+        #[allow(unsafe_code)]
+        let validated_vpc = unsafe {
+            (&raw const *self)
+                .cast::<ValidatedVpc>()
+                .as_ref()
+                .unwrap_or_else(|| unreachable!())
+        };
+        validated_vpc.check_overlap_and_default()
     }
 
     /// Tell how many peerings this VPC has
@@ -363,6 +303,118 @@ impl Vpc {
                 .iter()
                 .any(|e| e.has_port_forwarding() || e.has_stateful_nat())
         })
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValidatedVpc(Vpc);
+
+impl ValidatedVpc {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    #[must_use]
+    pub fn id(&self) -> &VpcId {
+        &self.0.id
+    }
+
+    #[must_use]
+    pub fn vni(&self) -> Vni {
+        self.0.vni
+    }
+
+    #[must_use]
+    pub fn interfaces(&self) -> &InterfaceConfigTable {
+        &self.0.interfaces
+    }
+
+    #[must_use]
+    pub fn peerings(&self) -> &[ValidatedPeering] {
+        // SAFETY: ValidatedPeering is #[repr(transparent)] over Peering, so [Peering] and
+        // [ValidatedPeering] have identical layout. Every Peering in a ValidatedVpc has been
+        // validated (established by Vpc::validate, which calls Peering::validate on each element).
+        #[allow(unsafe_code)]
+        unsafe {
+            std::slice::from_raw_parts(
+                self.0.peerings.as_ptr().cast::<ValidatedPeering>(),
+                self.0.peerings.len(),
+            )
+        }
+    }
+
+    /// Provide an iterator over all peerings that have either masquerade or port-forwarding
+    /// exposes locally.
+    pub fn local_stateful_nat_peerings(&self) -> impl Iterator<Item = &ValidatedPeering> {
+        self.peerings().iter().filter(|p| {
+            p.local()
+                .valexp()
+                .iter()
+                .any(|e| e.has_port_forwarding() || e.has_stateful_nat())
+        })
+    }
+
+    /// Check that prefixes exposed to a given VPC do not overlap. Exceptions:
+    ///
+    /// - overlap is allowed between a prefix and a default expose (it overlaps by design)
+    /// - overlap is allowed between prefixes from different exposes if both their exposes use
+    ///   stateful NAT (we can fall back to the flow table to disambiguate the destination VPC)
+    fn check_overlap_and_default(&self) -> ConfigResult {
+        // FIXME: Find a less expensive approach to find overlapping prefixes
+        for (i, current_peering) in self.peerings().iter().enumerate() {
+            // Check we don't have non-default, overlapping prefixes exposed to the VPC
+            for other_peering in &self.peerings()[i + 1..] {
+                for current_expose in current_peering.remote().valexp() {
+                    for other_expose in other_peering.remote().valexp() {
+                        if current_expose.has_stateful_nat() && other_expose.has_stateful_nat() {
+                            // Overlap is allowed if both expose blocks use stateful NAT
+                            continue;
+                        }
+                        match (current_expose.is_default(), other_expose.is_default()) {
+                            (true, true) => {
+                                // We support at most one default destination exposed to any VPC
+                                error!(
+                                    "Multiple 'default' destinations exposed to VPC {}",
+                                    self.name()
+                                );
+                                return Err(ConfigError::Forbidden(
+                                    "Multiple 'default' destinations exposed to VPC",
+                                ));
+                            }
+                            (true, false) | (false, true) => {
+                                // Overlap is allowed between a prefix and a default expose
+                                continue;
+                            }
+                            (false, false) => { /* keep processing */ }
+                        }
+                        for current_prefix in current_expose.public_ips() {
+                            for other_prefix in other_expose.public_ips() {
+                                if current_prefix.overlaps(other_prefix) {
+                                    error!(
+                                        "Prefixes exposed to VPC {} overlap: {} and {}",
+                                        self.name(),
+                                        current_prefix,
+                                        other_prefix
+                                    );
+                                    return Err(ConfigError::OverlappingPrefixes(
+                                        *current_prefix,
+                                        *other_prefix,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn inner(&self) -> &Vpc {
+        &self.0
     }
 }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -34,7 +34,7 @@ pub struct Peering {
 }
 
 impl Peering {
-    fn validate(&self) -> ConfigResult {
+    fn validate(&mut self) -> ConfigResult {
         debug!(
             "Validating manifest of VPC {} in peering {}",
             self.local.name, self.name
@@ -207,9 +207,9 @@ impl Vpc {
     }
 
     /// Check the peerings that a VPC participates in
-    fn check_peerings(&self) -> ConfigResult {
+    fn check_peerings(&mut self) -> ConfigResult {
         debug!("Checking peerings of VPC {}...", self.name);
-        for peering in &self.peerings {
+        for peering in &mut self.peerings {
             peering.validate()?;
         }
         Ok(())
@@ -228,8 +228,8 @@ impl Vpc {
         // FIXME: Find a less expensive approach to find overlapping prefixes
         for (i, current_peering) in self.peerings.iter().enumerate() {
             // Check we don't have multiple default expose blocks in the peering
-            for expose in &current_peering.remote.exposes {
-                if expose.default {
+            for expose in &current_peering.remote.valexp {
+                if expose.is_default() {
                     if found_default {
                         error!(
                             "Multiple 'default' expose blocks for a same peering in VPC {}",
@@ -245,13 +245,13 @@ impl Vpc {
 
             // Check we don't have non-default, overlapping prefixes exposed to the VPC
             for other_peering in &self.peerings[i + 1..] {
-                for current_expose in &current_peering.remote.exposes {
-                    for other_expose in &other_peering.remote.exposes {
+                for current_expose in &current_peering.remote.valexp {
+                    for other_expose in &other_peering.remote.valexp {
                         if current_expose.has_stateful_nat() && other_expose.has_stateful_nat() {
                             // Overlap is allowed if both expose blocks use stateful NAT
                             continue;
                         }
-                        match (current_expose.default, other_expose.default) {
+                        match (current_expose.is_default(), other_expose.is_default()) {
                             (true, true) => {
                                 // We support at most one default destination exposed to any VPC
                                 error!(
@@ -290,7 +290,7 @@ impl Vpc {
     }
 
     /// Validate a [`Vpc`]
-    pub fn validate(&self) -> ConfigResult {
+    pub fn validate(&mut self) -> ConfigResult {
         debug!("Validating config for VPC {}...", self.name);
         self.check_peering_count()?;
         self.check_peerings()?;
@@ -409,8 +409,8 @@ impl VpcTable {
     }
 
     /// Validate the [`VpcTable`]
-    pub fn validate(&self) -> ConfigResult {
-        for vpc in self.values() {
+    pub fn validate(&mut self) -> ConfigResult {
+        for vpc in self.values_mut() {
             vpc.validate()?;
         }
         Ok(())

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -324,6 +324,24 @@ impl Vpc {
                 .any(|e| e.has_port_forwarding() || e.has_stateful_nat())
         })
     }
+
+    /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_validated_vpc_for_tests(mut self) -> ValidatedVpc {
+        for peering in &mut self.peerings {
+            unsafe {
+                peering.local.fake_expose_validation_for_tests();
+                peering.remote.fake_expose_validation_for_tests();
+            }
+        }
+        ValidatedVpc(self)
+    }
 }
 
 #[repr(transparent)]

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -58,6 +58,30 @@ impl Peering {
 
         Ok(valid_peering_candidate)
     }
+
+    /// FOR TESTS ONLY. Fake validation for a VPC peering.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_validated_peering_for_tests(&self) -> ValidatedPeering {
+        let (fake_local, fake_remote) = unsafe {
+            (
+                self.local.fake_valid_manifest_for_tests(),
+                self.remote.fake_valid_manifest_for_tests(),
+            )
+        };
+        ValidatedPeering {
+            name: self.name.clone(),
+            local: fake_local,
+            remote: fake_remote,
+            remote_id: self.remote_id.clone(),
+            gwgroup: self.gwgroup.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -242,46 +266,32 @@ impl Vpc {
         Ok(())
     }
 
-    /// Check the peerings that a VPC participates in
-    fn check_peerings(&mut self) -> ConfigResult {
-        debug!("Checking peerings of VPC {}...", self.name);
-        for peering in &mut self.peerings {
-            peering.validate()?;
-        }
-        Ok(())
-    }
-
-    /// Validate a [`Vpc`]
-    fn validate(&mut self) -> ConfigResult {
-        debug!("Validating config for VPC {}...", self.name);
-        self.check_peering_count()?;
-        self.check_peerings()?;
-
-        // SAFETY: `ValidatedVpc` is `#[repr(transparent)]` over `Vpc`, so the cast is
-        // layout-compatible. The only invariant `check_overlap_and_default` relies on is that
-        // every peering's `local`/`remote` manifest has its `valexp` populated -- which is
-        // exactly what `check_peerings` (via `Peering::validate` -> `VpcManifest::validate`)
-        // guarantees on the line above. We are not yet returning an `&ValidatedVpc` to the
-        // outside world; this view is purely internal so we can call the post-collapse overlap
-        // check that lives on the validated wrapper.
-        #[allow(unsafe_code)]
-        let validated_vpc = unsafe {
-            (&raw const *self)
-                .cast::<ValidatedVpc>()
-                .as_ref()
-                .unwrap_or_else(|| unreachable!())
-        };
-        validated_vpc.check_overlap_and_default()
-    }
-
-    /// Consume `self` and produce a [`ValidatedVpc`] if it passes validation.
+    /// Validate a [`Vpc`] and produce a [`ValidatedVpc`] if it passes validation.
     ///
     /// # Errors
     ///
     /// Returns an error if the VPC configuration is invalid.
-    pub fn validated(mut self) -> Result<ValidatedVpc, ConfigError> {
-        self.validate()?;
-        Ok(ValidatedVpc(self))
+    pub fn validate(&self) -> Result<ValidatedVpc, ConfigError> {
+        debug!("Validating config for VPC {}...", self.name);
+        self.check_peering_count()?;
+
+        debug!("Checking peerings of VPC {}...", self.name);
+        let validated_peerings: Vec<ValidatedPeering> = self
+            .peerings
+            .iter()
+            .map(Peering::validate)
+            .collect::<Result<_, _>>()?;
+
+        let valid_vpc_candidate = ValidatedVpc {
+            name: self.name.clone(),
+            id: self.id.clone(),
+            vni: self.vni,
+            interfaces: self.interfaces.clone(),
+            peerings: validated_peerings,
+        };
+
+        valid_vpc_candidate.check_overlap_and_default()?;
+        Ok(valid_vpc_candidate)
     }
 
     /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
@@ -292,61 +302,76 @@ impl Vpc {
     #[cfg(feature = "testing")]
     #[allow(unsafe_code)]
     #[must_use]
-    pub unsafe fn fake_validated_vpc_for_tests(mut self) -> ValidatedVpc {
-        for peering in &mut self.peerings {
-            unsafe {
-                // FIXME
-                //peering.local.fake_expose_validation_for_tests();
-                //peering.remote.fake_expose_validation_for_tests();
-            }
+    pub unsafe fn fake_validated_vpc_for_tests(&self) -> ValidatedVpc {
+        let fake_validated_peerings = self
+            .peerings
+            .iter()
+            .map(|peering| {
+                let (fake_local, fake_remote) = unsafe {
+                    (
+                        peering.local.fake_valid_manifest_for_tests(),
+                        peering.remote.fake_valid_manifest_for_tests(),
+                    )
+                };
+                ValidatedPeering {
+                    name: peering.name.clone(),
+                    local: fake_local,
+                    remote: fake_remote,
+                    remote_id: peering.remote_id.clone(),
+                    gwgroup: peering.gwgroup.clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        ValidatedVpc {
+            name: self.name.clone(),
+            id: self.id.clone(),
+            vni: self.vni,
+            interfaces: self.interfaces.clone(),
+            peerings: fake_validated_peerings,
         }
-        ValidatedVpc(self)
     }
 }
 
-#[repr(transparent)]
 #[derive(Clone, Debug, PartialEq)]
-pub struct ValidatedVpc(Vpc);
+pub struct ValidatedVpc {
+    name: String,                     /* name of vpc, used as key */
+    id: VpcId,                        /* internal Id, unique*/
+    vni: Vni,                         /* mandatory */
+    interfaces: InterfaceConfigTable, /* user-defined interfaces in this VPC */
+    peerings: Vec<ValidatedPeering>,  /* peerings of this VPC - NOT set via gRPC */
+}
 
 impl ValidatedVpc {
     #[must_use]
     pub fn name(&self) -> &str {
-        &self.0.name
+        &self.name
     }
 
     #[must_use]
     pub fn id(&self) -> &VpcId {
-        &self.0.id
+        &self.id
     }
 
     #[must_use]
     pub fn vni(&self) -> Vni {
-        self.0.vni
+        self.vni
     }
 
     #[must_use]
     pub fn interfaces(&self) -> &InterfaceConfigTable {
-        &self.0.interfaces
+        &self.interfaces
     }
 
     #[must_use]
     pub fn peerings(&self) -> &[ValidatedPeering] {
-        // SAFETY: ValidatedPeering is #[repr(transparent)] over Peering, so [Peering] and
-        // [ValidatedPeering] have identical layout. Every Peering in a ValidatedVpc has been
-        // validated (established by Vpc::validate, which calls Peering::validate on each element).
-        #[allow(unsafe_code)]
-        unsafe {
-            std::slice::from_raw_parts(
-                self.0.peerings.as_ptr().cast::<ValidatedPeering>(),
-                self.0.peerings.len(),
-            )
-        }
+        &self.peerings
     }
 
     /// Tell how many peerings this VPC has
     #[must_use]
     pub fn num_peerings(&self) -> usize {
-        self.0.peerings.len()
+        self.peerings.len()
     }
 
     /// Provide an iterator over all peerings that have either masquerade or port-forwarding

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -52,6 +52,16 @@ impl Peering {
         self.validate_nat_combinations()
     }
 
+    /// Consume `self` and produce a [`ValidatedPeering`] if it passes validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the peering configuration is invalid.
+    pub fn validated(mut self) -> Result<ValidatedPeering, ConfigError> {
+        self.validate()?;
+        Ok(ValidatedPeering(self))
+    }
+
     fn validate_nat_combinations(&self) -> ConfigResult {
         // If stateful NAT is set up on one side of the peering, we don't support NAT (stateless or
         // stateful) on the other side.
@@ -277,6 +287,16 @@ impl Vpc {
                 .unwrap_or_else(|| unreachable!())
         };
         validated_vpc.check_overlap_and_default()
+    }
+
+    /// Consume `self` and produce a [`ValidatedVpc`] if it passes validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the VPC configuration is invalid.
+    pub fn validated(mut self) -> Result<ValidatedVpc, ConfigError> {
+        self.validate()?;
+        Ok(ValidatedVpc(self))
     }
 
     /// Tell how many peerings this VPC has
@@ -507,6 +527,16 @@ impl VpcTable {
             vpc.validate()?;
         }
         Ok(())
+    }
+
+    /// Consume `self` and produce a [`ValidatedVpcTable`] if it passes validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table is invalid.
+    pub fn validated(mut self) -> Result<ValidatedVpcTable, ConfigError> {
+        self.validate()?;
+        Ok(ValidatedVpcTable(self))
     }
 }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -566,6 +566,14 @@ pub struct ValidatedVpcTable {
 
 impl ValidatedVpcTable {
     #[must_use]
+    pub fn blank() -> Self {
+        Self {
+            vpcs: BTreeMap::new(),
+            ids: BTreeMap::new(),
+        }
+    }
+
+    #[must_use]
     pub fn len(&self) -> usize {
         self.vpcs.len()
     }

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, warn};
 
 use crate::external::overlay::VpcManifest;
 use crate::external::overlay::VpcPeeringTable;
+use crate::external::overlay::vpcpeering::ValidatedManifest;
 use crate::external::overlay::vpcpeering::VpcExposeNatConfig;
 use crate::internal::interfaces::interface::{InterfaceConfig, InterfaceConfigTable};
 use crate::{ConfigError, ConfigResult};
@@ -40,10 +41,7 @@ impl Peering {
             self.local.name, self.name
         );
         self.local.validate()?;
-        if false {
-            // not needed will be validated when validating the remote vpc
-            self.remote.validate()?;
-        }
+        self.remote.validate()?;
 
         if self.local.default_expose().is_some() && self.remote.default_expose().is_some() {
             return Err(ConfigError::Forbidden(
@@ -108,6 +106,49 @@ impl Peering {
             return Err(ConfigError::IncompatibleNatModes(self.name.clone()));
         }
         Ok(())
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValidatedPeering(Peering);
+
+impl ValidatedPeering {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    #[must_use]
+    pub fn local(&self) -> &ValidatedManifest {
+        // SAFETY: ValidatedManifest is #[repr(transparent)] over VpcManifest.
+        // A ValidatedPeering is only ever obtained from `Peering::validated`,
+        // which validated the local manifest.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(&raw const self.0.local).cast::<ValidatedManifest>()
+        }
+    }
+
+    #[must_use]
+    pub fn remote(&self) -> &ValidatedManifest {
+        // SAFETY: ValidatedManifest is #[repr(transparent)] over VpcManifest.
+        // A ValidatedPeering is only ever obtained from `Peering::validated`,
+        // which validated the remote manifest.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(&raw const self.0.remote).cast::<ValidatedManifest>()
+        }
+    }
+
+    #[must_use]
+    pub fn remote_id(&self) -> &VpcId {
+        &self.0.remote_id
+    }
+
+    #[must_use]
+    pub fn gwgroup(&self) -> Option<&String> {
+        self.0.gwgroup.as_ref()
     }
 }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -489,14 +489,6 @@ impl VpcTable {
     pub fn get_vpc(&self, vpc_name: &str) -> Option<&Vpc> {
         self.vpcs.get(vpc_name)
     }
-    /// Get a [`Vpc`] by [`VpcId`]
-    #[must_use]
-    pub fn get_vpc_by_vpcid(&self, vpcid: &VpcId) -> Option<&Vpc> {
-        match self.ids.get(vpcid) {
-            Some(name) => self.vpcs.get(name),
-            None => None,
-        }
-    }
 
     /// Iterate over [`Vpc`]s in a [`VpcTable`]
     pub fn values(&self) -> impl Iterator<Item = &Vpc> {
@@ -514,72 +506,94 @@ impl VpcTable {
     }
 
     /// Collect peerings for all [`Vpc`]s in this [`VpcTable`]
-    pub(crate) fn collect_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
+    pub(crate) fn collect_peerings(
+        &self,
+        peering_table: &VpcPeeringTable,
+        idmap: &VpcIdMap,
+    ) -> VpcTable {
         debug!("Collecting peerings for all VPCs..");
-        self.values_mut()
+        let mut new_table = self.clone();
+        new_table
+            .values_mut()
             .for_each(|vpc| vpc.set_peerings(peering_table, idmap));
+        new_table
     }
 
-    /// Validate the [`VpcTable`]
-    pub fn validate(&mut self) -> ConfigResult {
-        for vpc in self.values_mut() {
-            vpc.validate()?;
-        }
-        Ok(())
-    }
-
-    /// Consume `self` and produce a [`ValidatedVpcTable`] if it passes validation.
+    /// Validate the [`VpcTable`] and produce a [`ValidatedVpcTable`] if it passes validation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the table is invalid.
-    pub fn validated(mut self) -> Result<ValidatedVpcTable, ConfigError> {
-        self.validate()?;
-        Ok(ValidatedVpcTable(self))
+    /// Returns an error if any [`Vpc`] fails validation.
+    pub fn validate(&self) -> Result<ValidatedVpcTable, ConfigError> {
+        let validated_vpcs = self
+            .vpcs
+            .iter()
+            .map(|(name, vpc)| vpc.validate().map(|vpc| (name.clone(), vpc)))
+            .collect::<Result<_, _>>()?;
+        Ok(ValidatedVpcTable {
+            vpcs: validated_vpcs,
+            ids: self.ids.clone(),
+        })
+    }
+
+    /// FOR TESTS ONLY. Fake validation for the VPC table.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub(crate) unsafe fn fake_validated_vpc_table_for_tests(&self) -> ValidatedVpcTable {
+        let fake_validated_vpcs = unsafe {
+            self.vpcs
+                .iter()
+                .map(|(name, vpc)| (name.clone(), vpc.fake_validated_vpc_for_tests()))
+                .collect()
+        };
+        ValidatedVpcTable {
+            vpcs: fake_validated_vpcs,
+            ids: self.ids.clone(),
+        }
     }
 }
 
-#[repr(transparent)]
 #[derive(Clone, Debug)]
-pub struct ValidatedVpcTable(VpcTable);
+pub struct ValidatedVpcTable {
+    vpcs: BTreeMap<String, ValidatedVpc>,
+    ids: BTreeMap<VpcId, String>, // name of vpc
+}
 
 impl ValidatedVpcTable {
     #[must_use]
     pub fn len(&self) -> usize {
-        self.0.vpcs.len()
+        self.vpcs.len()
     }
 
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.0.vpcs.is_empty()
+        self.vpcs.is_empty()
     }
 
     pub fn values(&self) -> impl Iterator<Item = &ValidatedVpc> {
-        // SAFETY: ValidatedVpc is #[repr(transparent)] over Vpc, and a ValidatedVpcTable can only
-        // be obtained from a successful `VpcTable::validated`, which validates every Vpc.
-        #[allow(unsafe_code)]
-        self.0
-            .vpcs
-            .values()
-            .map(|vpc| unsafe { &*(&raw const *vpc).cast::<ValidatedVpc>() })
+        self.vpcs.values()
     }
 
     #[must_use]
     pub fn get_vpc(&self, vpc_name: &str) -> Option<&ValidatedVpc> {
-        self.0.get_vpc(vpc_name).map(|vpc| {
-            // SAFETY: ValidatedVpc is `#[repr(transparent)]` over Vpc, and a `ValidatedVpcTable`
-            // can only be obtained from `VpcTable::validated`, which validates every Vpc.
-            #[allow(unsafe_code)]
-            unsafe {
-                &*(&raw const *vpc).cast::<ValidatedVpc>()
-            }
-        })
+        self.vpcs.get(vpc_name)
+    }
+
+    fn get_vpc_by_vpcid(&self, vpcid: &VpcId) -> Option<&ValidatedVpc> {
+        match self.ids.get(vpcid) {
+            Some(name) => self.vpcs.get(name),
+            None => None,
+        }
     }
 
     #[must_use]
     pub fn get_remote_vni(&self, peering: &ValidatedPeering) -> Vni {
-        self.0
-            .get_vpc_by_vpcid(peering.remote_id())
+        self.get_vpc_by_vpcid(peering.remote_id())
             .unwrap_or_else(|| unreachable!())
             .vni
     }

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -3,20 +3,20 @@
 
 //! Dataplane configuration model: vpc
 
-#![allow(unused)]
 #![allow(clippy::missing_errors_doc)]
 
 use lpm::prefix::IpRangeWithPorts;
 use net::vxlan::Vni;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+#[allow(unused)]
 use tracing::{debug, error, warn};
 
 use crate::external::overlay::VpcManifest;
 use crate::external::overlay::VpcPeeringTable;
 use crate::external::overlay::vpcpeering::ValidatedManifest;
 use crate::external::overlay::vpcpeering::VpcExposeNatConfig;
-use crate::internal::interfaces::interface::{InterfaceConfig, InterfaceConfigTable};
+use crate::internal::interfaces::interface::InterfaceConfigTable;
 use crate::{ConfigError, ConfigResult};
 
 #[cfg(doc)]
@@ -184,7 +184,7 @@ impl TryFrom<&str> for VpcId {
         let mut chars = value.chars().take(ID_LEN);
         // unwrap cannot fail here because we checked the length earlier
         Ok(VpcId::new(
-            [(); 5].map(|i| chars.next().unwrap_or_else(|| unreachable!())),
+            [(); 5].map(|()| chars.next().unwrap_or_else(|| unreachable!())),
         ))
     }
 }
@@ -212,13 +212,8 @@ impl Vpc {
         })
     }
 
-    /// Add an [`InterfaceConfig`] to this [`Vpc`]
-    pub fn add_interface_config(&mut self, if_cfg: InterfaceConfig) {
-        self.interfaces.add_interface_config(if_cfg);
-    }
-
     /// Collect all peerings from the [`VpcPeeringTable`] table this vpc participates in
-    pub fn set_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
+    fn set_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
         debug!("Collecting peerings for vpc '{}'...", self.name);
         self.peerings = peering_table
             .peerings_vpc(&self.name)
@@ -246,7 +241,7 @@ impl Vpc {
         // We use the VPC Ids to identify peer VPCs.
         let mut peers = BTreeSet::new();
         for peering in &self.peerings {
-            if (!peers.insert(peering.remote_id.clone())) {
+            if !peers.insert(peering.remote_id.clone()) {
                 error!(
                     "VPC {} peers more than once with peer {}",
                     self.name, peering.remote.name
@@ -267,7 +262,7 @@ impl Vpc {
     }
 
     /// Validate a [`Vpc`]
-    pub(crate) fn validate(&mut self) -> ConfigResult {
+    fn validate(&mut self) -> ConfigResult {
         debug!("Validating config for VPC {}...", self.name);
         self.check_peering_count()?;
         self.check_peerings()?;
@@ -303,26 +298,6 @@ impl Vpc {
     #[must_use]
     pub fn num_peerings(&self) -> usize {
         self.peerings.len()
-    }
-
-    /// Tell if the peerings of this VPC have host routes
-    #[must_use]
-    pub fn has_peers_with_host_prefixes(&self) -> bool {
-        self.peerings
-            .iter()
-            .filter(|peering| peering.remote.has_host_prefixes())
-            .count()
-            > 0
-    }
-
-    /// Provide an iterator over all peerings that have either masquerade or port-forwarding exposes locally
-    pub fn local_stateful_nat_peerings(&self) -> impl Iterator<Item = &Peering> {
-        self.peerings.iter().filter(|p| {
-            p.local
-                .exposes
-                .iter()
-                .any(|e| e.has_port_forwarding() || e.has_stateful_nat())
-        })
     }
 
     /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
@@ -399,6 +374,8 @@ impl ValidatedVpc {
     /// - overlap is allowed between a prefix and a default expose (it overlaps by design)
     /// - overlap is allowed between prefixes from different exposes if both their exposes use
     ///   stateful NAT (we can fall back to the flow table to disambiguate the destination VPC)
+    ///
+    /// Also check that at most one default expose is exposed to the VPC.
     fn check_overlap_and_default(&self) -> ConfigResult {
         // FIXME: Find a less expensive approach to find overlapping prefixes
         for (i, current_peering) in self.peerings().iter().enumerate() {
@@ -509,13 +486,6 @@ impl VpcTable {
             None => None,
         }
     }
-    /// Get the [`Vni`] of the remote [`Vpc`] for a given [`Peering`]
-    #[must_use]
-    pub fn get_remote_vni(&self, peering: &Peering) -> Vni {
-        self.get_vpc_by_vpcid(&peering.remote_id)
-            .unwrap_or_else(|| unreachable!())
-            .vni
-    }
 
     /// Iterate over [`Vpc`]s in a [`VpcTable`]
     pub fn values(&self) -> impl Iterator<Item = &Vpc> {
@@ -540,7 +510,7 @@ impl VpcTable {
     }
 
     /// Validate the [`VpcTable`]
-    pub(crate) fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&mut self) -> ConfigResult {
         for vpc in self.values_mut() {
             vpc.validate()?;
         }

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -35,13 +35,11 @@ pub struct Peering {
 }
 
 impl Peering {
-    fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&self) -> Result<ValidatedPeering, ConfigError> {
         debug!(
             "Validating manifest of VPC {} in peering {}",
             self.local.name, self.name
         );
-        self.local.validate()?;
-        self.remote.validate()?;
 
         if self.local.default_expose().is_some() && self.remote.default_expose().is_some() {
             return Err(ConfigError::Forbidden(
@@ -49,17 +47,52 @@ impl Peering {
             ));
         }
 
-        self.validate_nat_combinations()
+        let valid_peering_candidate = ValidatedPeering {
+            name: self.name.clone(),
+            local: self.local.validate()?,
+            remote: self.remote.validate()?,
+            remote_id: self.remote_id.clone(),
+            gwgroup: self.gwgroup.clone(),
+        };
+        valid_peering_candidate.validate_nat_combinations()?;
+
+        Ok(valid_peering_candidate)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValidatedPeering {
+    name: String,              /* name of peering */
+    local: ValidatedManifest,  /* local manifest */
+    remote: ValidatedManifest, /* remote manifest */
+    remote_id: VpcId,          /* Id of peer */
+    gwgroup: Option<String>,   /* gateway group serving this peering */
+}
+
+impl ValidatedPeering {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
-    /// Consume `self` and produce a [`ValidatedPeering`] if it passes validation.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the peering configuration is invalid.
-    pub fn validated(mut self) -> Result<ValidatedPeering, ConfigError> {
-        self.validate()?;
-        Ok(ValidatedPeering(self))
+    #[must_use]
+    pub fn local(&self) -> &ValidatedManifest {
+        &self.local
+    }
+
+    #[must_use]
+    pub fn remote(&self) -> &ValidatedManifest {
+        &self.remote
+    }
+
+    #[must_use]
+    pub fn remote_id(&self) -> &VpcId {
+        &self.remote_id
+    }
+
+    #[must_use]
+    pub fn gwgroup(&self) -> Option<&String> {
+        self.gwgroup.as_ref()
     }
 
     fn validate_nat_combinations(&self) -> ConfigResult {
@@ -68,7 +101,7 @@ impl Peering {
         let mut local_has_stateless_nat = false;
         let mut local_has_stateful_nat = false;
         let mut local_has_port_forwarding = false;
-        for expose in &self.local.exposes {
+        for expose in self.local.valexp() {
             match expose.nat_config() {
                 Some(VpcExposeNatConfig::Stateful { .. }) => {
                     local_has_stateful_nat = true;
@@ -105,7 +138,7 @@ impl Peering {
         // - port forwarding --- port forwarding
         // - port forwarding --- stateless NAT
 
-        for remote_expose in &self.remote.exposes {
+        for remote_expose in self.remote.valexp() {
             if !remote_expose.has_nat() {
                 continue;
             }
@@ -116,49 +149,6 @@ impl Peering {
             return Err(ConfigError::IncompatibleNatModes(self.name.clone()));
         }
         Ok(())
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Debug, PartialEq)]
-pub struct ValidatedPeering(Peering);
-
-impl ValidatedPeering {
-    #[must_use]
-    pub fn name(&self) -> &str {
-        &self.0.name
-    }
-
-    #[must_use]
-    pub fn local(&self) -> &ValidatedManifest {
-        // SAFETY: ValidatedManifest is #[repr(transparent)] over VpcManifest.
-        // A ValidatedPeering is only ever obtained from `Peering::validated`,
-        // which validated the local manifest.
-        #[allow(unsafe_code)]
-        unsafe {
-            &*(&raw const self.0.local).cast::<ValidatedManifest>()
-        }
-    }
-
-    #[must_use]
-    pub fn remote(&self) -> &ValidatedManifest {
-        // SAFETY: ValidatedManifest is #[repr(transparent)] over VpcManifest.
-        // A ValidatedPeering is only ever obtained from `Peering::validated`,
-        // which validated the remote manifest.
-        #[allow(unsafe_code)]
-        unsafe {
-            &*(&raw const self.0.remote).cast::<ValidatedManifest>()
-        }
-    }
-
-    #[must_use]
-    pub fn remote_id(&self) -> &VpcId {
-        &self.0.remote_id
-    }
-
-    #[must_use]
-    pub fn gwgroup(&self) -> Option<&String> {
-        self.0.gwgroup.as_ref()
     }
 }
 

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -671,6 +671,9 @@ impl ValidatedExpose {
 pub struct VpcManifest {
     pub name: String, /* key: name of vpc */
     pub exposes: Vec<VpcExpose>,
+    // Validated, exclusion-prefixes-free view of exposes. Populated by VpcManifest::validate.
+    // Never to be used in VpcManifest; only with wrapper ValidatedManifest
+    pub valexp: Vec<ValidatedExpose>,
 }
 impl VpcManifest {
     #[must_use]
@@ -698,11 +701,17 @@ impl VpcManifest {
     pub fn has_host_prefixes(&self) -> bool {
         self.exposes.iter().any(VpcExpose::has_host_prefixes)
     }
+
+    #[must_use]
+    pub fn raw_exposes(&self) -> &[VpcExpose] {
+        &self.exposes
+    }
+
     fn validate_expose_collisions(&self) -> ConfigResult {
         // Check that prefixes in each expose don't overlap with prefixes in other exposes
-        for (index, expose_left) in self.exposes.iter().enumerate() {
+        for (index, expose_left) in self.valexp.iter().enumerate() {
             // Loop over the remaining exposes in the list
-            for expose_right in self.exposes.iter().skip(index + 1) {
+            for expose_right in self.valexp.iter().skip(index + 1) {
                 #[allow(clippy::unnested_or_patterns)]
                 match (&expose_left.nat_config(), &expose_right.nat_config()) {
                     // Overlap allowed
@@ -775,13 +784,18 @@ impl VpcManifest {
     /// # Errors
     ///
     /// Returns an error if the manifest configuration is invalid.
-    pub fn validate(&self) -> ConfigResult {
+    pub(crate) fn validate(&mut self) -> ConfigResult {
         if self.name.is_empty() {
             return Err(ConfigError::MissingIdentifier("Manifest name"));
         }
         if self.exposes.is_empty() {
             return Err(ConfigError::NoExposes(self.name.clone()));
         }
+
+        // Reset any previously-populated `valexp` so a retry after partial validation does not
+        // accumulate duplicates.
+        self.valexp.clear();
+        self.valexp.reserve(self.exposes.len());
 
         let mut found_default = false;
         for expose in &self.exposes {
@@ -793,7 +807,7 @@ impl VpcManifest {
                 }
                 found_default = true;
             }
-            expose.validate()?;
+            self.valexp.push(expose.validate()?);
         }
         self.validate_expose_collisions()?;
         Ok(())
@@ -850,6 +864,66 @@ impl VpcManifest {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct ValidatedManifest(VpcManifest);
+
+impl ValidatedManifest {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    #[must_use]
+    pub fn valexp(&self) -> &[ValidatedExpose] {
+        &self.0.valexp
+    }
+
+    #[must_use]
+    pub fn default_expose(&self) -> Option<&ValidatedExpose> {
+        self.valexp().iter().find(|expose| expose.is_default())
+    }
+
+    fn filter_exposes<F>(&self, predicate: F) -> impl Iterator<Item = &ValidatedExpose>
+    where
+        F: FnMut(&&ValidatedExpose) -> bool,
+    {
+        self.valexp().iter().filter(predicate)
+    }
+
+    pub fn stateless_nat_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateless_nat())
+    }
+
+    pub fn stateful_nat_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_44())
+    }
+
+    pub fn stateful_nat_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_66())
+    }
+
+    pub fn no_stateful_nat_exposes_v4(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v4())
+    }
+
+    pub fn no_stateful_nat_exposes_v6(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v6())
+    }
+
+    pub fn port_forwarding_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding())
+    }
+
+    pub fn port_forwarding_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_44())
+    }
+
+    pub fn port_forwarding_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_66())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct VpcPeering {
     pub name: String,            /* name of peering (key in table) */
@@ -886,7 +960,7 @@ impl VpcPeering {
     /// # Errors
     ///
     /// Returns an error if the peering configuration is invalid.
-    pub fn validate(&self) -> ConfigResult {
+    pub fn validate(&mut self) -> ConfigResult {
         self.left.validate()?;
         self.right.validate()?;
         Ok(())

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -545,6 +545,18 @@ impl VpcExpose {
 
         Ok(collapsed_expose)
     }
+
+    /// FOR TESTS ONLY
+    #[cfg(feature = "testing")]
+    #[must_use]
+    #[allow(unsafe_code)]
+    unsafe fn fake_validated_expose(&self) -> ValidatedExpose {
+        ValidatedExpose {
+            default: self.default,
+            ips: self.ips.clone(),
+            nat: self.nat.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -872,6 +884,36 @@ impl VpcManifest {
     pub fn default_expose(&self) -> Option<&VpcExpose> {
         self.exposes.iter().find(|expose| expose.default)
     }
+
+    /// FOR TESTS ONLY. Fake validation for the manifest's expose blocks.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    pub unsafe fn fake_expose_validation_for_tests(&mut self) {
+        self.valexp.clear();
+        for expose in &self.exposes {
+            let fake_valid_expose = unsafe { expose.fake_validated_expose() };
+            self.valexp.push(fake_valid_expose);
+        }
+    }
+
+    /// FOR TESTS ONLY. Fake validation for the manifest.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_valid_manifest_for_tests(mut self) -> ValidatedManifest {
+        unsafe {
+            self.fake_expose_validation_for_tests();
+        }
+        ValidatedManifest(self)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1035,6 +1077,12 @@ impl VpcPeeringTable {
     pub fn values(&self) -> impl Iterator<Item = &VpcPeering> {
         self.0.values()
     }
+
+    /// Iterate over all [`VpcPeering`]s in a [`VpcPeeringTable`], with mutable access
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut VpcPeering> {
+        self.0.values_mut()
+    }
+
     /// Produce iterator of [`VpcPeering`]s that involve the vpc with the provided name
     pub fn peerings_vpc(&self, vpc: &str) -> impl Iterator<Item = &VpcPeering> {
         self.0

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -812,6 +812,16 @@ impl VpcManifest {
         self.validate_expose_collisions()?;
         Ok(())
     }
+
+    /// Consume `self` and produce a [`ValidatedManifest`] if it passes validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest configuration is invalid.
+    pub fn validated(mut self) -> Result<ValidatedManifest, ConfigError> {
+        self.validate()?;
+        Ok(ValidatedManifest(self))
+    }
     pub fn stateless_nat_exposes(&self) -> impl Iterator<Item = &VpcExpose> {
         self.exposes
             .iter()

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -604,9 +604,6 @@ impl ValidatedExpose {
 pub struct VpcManifest {
     pub name: String, /* key: name of vpc */
     pub(crate) exposes: Vec<VpcExpose>,
-    // Validated, exclusion-prefixes-free view of exposes. Populated by VpcManifest::validate.
-    // Never to be used in VpcManifest; only with wrapper ValidatedManifest
-    valexp: Vec<ValidatedExpose>,
 }
 impl VpcManifest {
     #[must_use]
@@ -636,6 +633,124 @@ impl VpcManifest {
 
     pub fn add_exposes(&mut self, exposes: impl IntoIterator<Item = VpcExpose>) {
         self.exposes.extend(exposes);
+    }
+
+    /// Validate the [`VpcManifest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the manifest configuration is invalid.
+    pub fn validate(&mut self) -> Result<ValidatedManifest, ConfigError> {
+        if self.name.is_empty() {
+            return Err(ConfigError::MissingIdentifier("Manifest name"));
+        }
+        if self.exposes.is_empty() {
+            return Err(ConfigError::NoExposes(self.name.clone()));
+        }
+        if self.exposes.iter().filter(|expose| expose.default).count() > 1 {
+            return Err(ConfigError::Forbidden(
+                "Manifest cannot have multiple default exposes",
+            ));
+        }
+
+        let mut valid_manifest_candidate = ValidatedManifest {
+            name: self.name.clone(),
+            valexp: Vec::new(),
+        };
+        for expose in &self.exposes {
+            valid_manifest_candidate.valexp.push(expose.validate()?);
+        }
+
+        valid_manifest_candidate.validate_expose_collisions()?;
+        Ok(valid_manifest_candidate)
+    }
+
+    #[must_use]
+    pub fn default_expose(&self) -> Option<&VpcExpose> {
+        self.exposes.iter().find(|expose| expose.default)
+    }
+
+    /// FOR TESTS ONLY. Fake validation for the manifest.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_valid_manifest_for_tests(&self) -> ValidatedManifest {
+        let mut fake_valid_manifest = ValidatedManifest {
+            name: self.name.clone(),
+            valexp: Vec::new(),
+        };
+        for expose in &self.exposes {
+            let fake_valid_expose = unsafe { expose.fake_validated_expose() };
+            fake_valid_manifest.valexp.push(fake_valid_expose);
+        }
+        fake_valid_manifest
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValidatedManifest {
+    name: String, /* key: name of vpc */
+    // Validated, exclusion-prefixes-free view of exposes.
+    valexp: Vec<ValidatedExpose>,
+}
+
+impl ValidatedManifest {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn valexp(&self) -> &[ValidatedExpose] {
+        &self.valexp
+    }
+
+    #[must_use]
+    pub fn default_expose(&self) -> Option<&ValidatedExpose> {
+        self.valexp().iter().find(|expose| expose.is_default())
+    }
+
+    fn filter_exposes<F>(&self, predicate: F) -> impl Iterator<Item = &ValidatedExpose>
+    where
+        F: FnMut(&&ValidatedExpose) -> bool,
+    {
+        self.valexp().iter().filter(predicate)
+    }
+
+    pub fn stateless_nat_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateless_nat())
+    }
+
+    pub fn stateful_nat_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_44())
+    }
+
+    pub fn stateful_nat_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_66())
+    }
+
+    pub fn no_stateful_nat_exposes_v4(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v4())
+    }
+
+    pub fn no_stateful_nat_exposes_v6(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v6())
+    }
+
+    pub fn port_forwarding_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding())
+    }
+
+    pub fn port_forwarding_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_44())
+    }
+
+    pub fn port_forwarding_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
+        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_66())
     }
 
     fn validate_expose_collisions(&self) -> ConfigResult {
@@ -703,145 +818,6 @@ impl VpcManifest {
             }
         }
         Ok(())
-    }
-
-    /// Validate the [`VpcManifest`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the manifest configuration is invalid.
-    pub(crate) fn validate(&mut self) -> ConfigResult {
-        if self.name.is_empty() {
-            return Err(ConfigError::MissingIdentifier("Manifest name"));
-        }
-        if self.exposes.is_empty() {
-            return Err(ConfigError::NoExposes(self.name.clone()));
-        }
-
-        // Reset any previously-populated `valexp` so a retry after partial validation does not
-        // accumulate duplicates.
-        self.valexp.clear();
-        self.valexp.reserve(self.exposes.len());
-
-        let mut found_default = false;
-        for expose in &self.exposes {
-            if expose.default {
-                if found_default {
-                    return Err(ConfigError::Forbidden(
-                        "Manifest cannot have multiple default exposes",
-                    ));
-                }
-                found_default = true;
-            }
-            self.valexp.push(expose.validate()?);
-        }
-        self.validate_expose_collisions()?;
-        Ok(())
-    }
-
-    /// Validate the manifest and return a validated version
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the manifest configuration is invalid.
-    pub fn validated(mut self) -> Result<ValidatedManifest, ConfigError> {
-        self.validate()?;
-        Ok(ValidatedManifest(self))
-    }
-
-    #[must_use]
-    pub fn default_expose(&self) -> Option<&VpcExpose> {
-        self.exposes.iter().find(|expose| expose.default)
-    }
-
-    /// FOR TESTS ONLY. Fake validation for the manifest's expose blocks.
-    ///
-    /// # Safety
-    ///
-    /// All bets are off. Do not use outside of tests.
-    #[cfg(feature = "testing")]
-    #[allow(unsafe_code)]
-    pub unsafe fn fake_expose_validation_for_tests(&mut self) {
-        self.valexp.clear();
-        for expose in &self.exposes {
-            let fake_valid_expose = unsafe { expose.fake_validated_expose() };
-            self.valexp.push(fake_valid_expose);
-        }
-    }
-
-    /// FOR TESTS ONLY. Fake validation for the manifest.
-    ///
-    /// # Safety
-    ///
-    /// All bets are off. Do not use outside of tests.
-    #[cfg(feature = "testing")]
-    #[allow(unsafe_code)]
-    #[must_use]
-    pub unsafe fn fake_valid_manifest_for_tests(mut self) -> ValidatedManifest {
-        unsafe {
-            self.fake_expose_validation_for_tests();
-        }
-        ValidatedManifest(self)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct ValidatedManifest(VpcManifest);
-
-impl ValidatedManifest {
-    #[must_use]
-    pub fn name(&self) -> &str {
-        &self.0.name
-    }
-
-    #[must_use]
-    pub fn valexp(&self) -> &[ValidatedExpose] {
-        &self.0.valexp
-    }
-
-    #[must_use]
-    pub fn default_expose(&self) -> Option<&ValidatedExpose> {
-        self.valexp().iter().find(|expose| expose.is_default())
-    }
-
-    fn filter_exposes<F>(&self, predicate: F) -> impl Iterator<Item = &ValidatedExpose>
-    where
-        F: FnMut(&&ValidatedExpose) -> bool,
-    {
-        self.valexp().iter().filter(predicate)
-    }
-
-    pub fn stateless_nat_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_stateless_nat())
-    }
-
-    pub fn stateful_nat_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_44())
-    }
-
-    pub fn stateful_nat_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_stateful_nat() && expose.is_66())
-    }
-
-    pub fn no_stateful_nat_exposes_v4(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v4())
-    }
-
-    pub fn no_stateful_nat_exposes_v6(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| !expose.has_stateful_nat() && expose.is_v6())
-    }
-
-    pub fn port_forwarding_exposes(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_port_forwarding())
-    }
-
-    pub fn port_forwarding_exposes_44(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_44())
-    }
-
-    pub fn port_forwarding_exposes_66(&self) -> impl Iterator<Item = &ValidatedExpose> {
-        self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_66())
     }
 }
 

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -226,25 +226,6 @@ impl VpcExpose {
         self.ips.iter().any(|p| p.prefix().is_host())
     }
 
-    /// The prefixes of an expose to be advertised to a remote peer
-    #[must_use]
-    pub fn adv_prefixes(&self) -> Vec<Prefix> {
-        if self.default {
-            // only V4 atm
-            vec![Prefix::root_v4()]
-        } else if let Some(nat) = self.nat.as_ref() {
-            nat.as_range
-                .iter()
-                .map(PrefixWithOptionalPorts::prefix)
-                .collect::<Vec<_>>()
-        } else {
-            self.ips
-                .iter()
-                .map(PrefixWithOptionalPorts::prefix)
-                .collect::<Vec<_>>()
-        }
-    }
-
     // If the as_range list is empty, then there's no NAT required for the expose, meaning that the
     // public IPs are those from the "ips" list. This method returns the current list of public IPs
     // for the VpcExpose.
@@ -518,6 +499,25 @@ impl ValidatedExpose {
         }
     }
 
+    /// The prefixes of an expose to be advertised to a remote peer
+    #[must_use]
+    pub fn adv_prefixes(&self) -> Vec<Prefix> {
+        if self.default {
+            // only V4 atm
+            vec![Prefix::root_v4()]
+        } else if let Some(nat) = self.nat.as_ref() {
+            nat.as_range
+                .iter()
+                .map(PrefixWithOptionalPorts::prefix)
+                .collect::<Vec<_>>()
+        } else {
+            self.ips
+                .iter()
+                .map(PrefixWithOptionalPorts::prefix)
+                .collect::<Vec<_>>()
+        }
+    }
+
     // This method returns true if the list of allowed prefixes is IPv4.
     #[must_use]
     pub fn is_v4(&self) -> bool {
@@ -636,11 +636,6 @@ impl VpcManifest {
 
     pub fn add_exposes(&mut self, exposes: impl IntoIterator<Item = VpcExpose>) {
         self.exposes.extend(exposes);
-    }
-
-    #[must_use]
-    pub fn raw_exposes(&self) -> &[VpcExpose] {
-        &self.exposes
     }
 
     fn validate_expose_collisions(&self) -> ConfigResult {

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -3,11 +3,10 @@
 
 //! Dataplane configuration model: vpc peering
 
-use crate::utils::{check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap};
-use lpm::prefix::{
-    IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts,
-    PrefixWithPortsSize, ppsize_zero,
+use crate::utils::{
+    check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, collapse_prefixes,
 };
+use lpm::prefix::{IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
 use std::collections::BTreeMap;
 use std::ops::Bound::{Excluded, Unbounded};
 use std::time::Duration;
@@ -383,7 +382,7 @@ impl VpcExpose {
     ///
     /// Returns an error if the expose configuration is invalid.
     #[allow(clippy::too_many_lines)]
-    pub fn validate(&self) -> ConfigResult {
+    pub fn validate(&self) -> Result<ValidatedExpose, ConfigError> {
         // Check default exposes and prefixes
         self.validate_default_expose()?;
 
@@ -473,57 +472,54 @@ impl VpcExpose {
             }
         }
 
-        #[allow(clippy::items_after_statements)]
-        fn prefixes_size(prefixes: &PrefixPortsSet) -> PrefixWithPortsSize {
-            prefixes
-                .iter()
-                .map(PrefixWithOptionalPorts::size)
-                .sum::<PrefixWithPortsSize>()
-        }
-        let zero_size = ppsize_zero();
+        // Apply exclusion prefixes
+        let mut clone = self.clone();
+        collapse_prefixes(&mut clone);
+        let collapsed_expose = ValidatedExpose {
+            default: clone.default,
+            ips: clone.ips,
+            nat: clone.nat,
+        };
 
         // Ensure we don't exclude all of the allowed prefixes
-        let ips_sizes = prefixes_size(&self.ips);
-        let nots_sizes = prefixes_size(&self.nots);
-        if ips_sizes > zero_size && ips_sizes <= nots_sizes {
+        if collapsed_expose.ips().is_empty() && !collapsed_expose.is_default() {
             return Err(ConfigError::ExcludedAllPrefixes(Box::new(self.clone())));
         }
-        let as_range_sizes = prefixes_size(self.as_range_or_empty());
-        let not_as_sizes = prefixes_size(self.not_as_or_empty());
+        if collapsed_expose.nat().is_some() && collapsed_expose.as_range_or_empty().is_empty() {
+            return Err(ConfigError::ExcludedAllPrefixes(Box::new(self.clone())));
+        }
 
-        if as_range_sizes > zero_size && as_range_sizes <= not_as_sizes {
-            return Err(ConfigError::ExcludedAllPrefixes(Box::new(self.clone())));
-        }
+        let ips_sizes = collapsed_expose.ips().total_prefixes_size();
+        let as_range_sizes = collapsed_expose.as_range_or_empty().total_prefixes_size();
 
         // For static NAT, ensure that, if the list of publicly-exposed addresses is not empty, then
         // we have the same number of addresses on each side.
         //
         // Note: We shouldn't have subtraction overflows because we check that exclusion prefixes
         // size was smaller than allowed prefixes size already.
-        if self.has_stateless_nat()
-            && as_range_sizes > zero_size
-            && ips_sizes - nots_sizes != as_range_sizes - not_as_sizes
-        {
+        if collapsed_expose.has_stateless_nat() && ips_sizes != as_range_sizes {
             return Err(ConfigError::MismatchedPrefixSizes(
-                ips_sizes - nots_sizes,
-                as_range_sizes - not_as_sizes,
+                ips_sizes,
+                as_range_sizes,
             ));
         }
 
         // For port forwarding, ensure that:
+        // - we have no exclusion prefixes (note: we could relax this constraint now that we
+        //   collapse exclusion prefixes early)
         // - we have a single prefix on each side (private and public addresses)
-        // - we do not use any exclusion prefixes
-        // - if the list of publicly-exposed addresses is not empty, then we have the same number of
-        //   addresses on each side
-        // - the list of associated port ranges also is on the same size on each side
-        if self.has_port_forwarding() {
-            if self.ips.len() != 1
-                || self.as_range_or_empty().len() != 1
-                || !self.nots.is_empty()
-                || !self.not_as_or_empty().is_empty()
+        // - we have the same number of addresses on each side
+        // - the list of associated port ranges also has the same size on each side
+        if collapsed_expose.has_port_forwarding() {
+            if !self.nots.is_empty() || !self.not_as_or_empty().is_empty() {
+                return Err(ConfigError::Forbidden(
+                    "Port forwarding does not support exclusion prefixes",
+                ));
+            }
+            if collapsed_expose.ips().len() != 1 || collapsed_expose.as_range_or_empty().len() != 1
             {
                 return Err(ConfigError::Forbidden(
-                    "Port forwarding requires a single prefix on each side, no exclusion prefix allowed",
+                    "Port forwarding requires a single prefix on each side",
                 ));
             }
             if ips_sizes != as_range_sizes {
@@ -535,16 +531,139 @@ impl VpcExpose {
         }
 
         // For stateful NAT, we don't support port ranges
-        if self.has_stateful_nat()
-            && (self.ips.iter().any(|p| p.ports().is_some())
-                || self.as_range_or_empty().iter().any(|p| p.ports().is_some()))
+        if collapsed_expose.has_stateful_nat()
+            && (collapsed_expose.ips().iter().any(|p| p.ports().is_some())
+                || collapsed_expose
+                    .as_range_or_empty()
+                    .iter()
+                    .any(|p| p.ports().is_some()))
         {
             return Err(ConfigError::Forbidden(
                 "Port ranges are not supported with stateful NAT",
             ));
         }
 
-        Ok(())
+        Ok(collapsed_expose)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ValidatedExpose {
+    default: bool,
+    ips: PrefixPortsSet,
+    nat: Option<VpcExposeNat>,
+}
+
+impl ValidatedExpose {
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        self.default
+    }
+
+    #[must_use]
+    pub fn ips(&self) -> &PrefixPortsSet {
+        &self.ips
+    }
+
+    #[must_use]
+    pub fn as_range_or_empty(&self) -> &PrefixPortsSet {
+        self.nat.as_ref().map_or(empty_set(), |nat| &nat.as_range)
+    }
+
+    // If the as_range list is empty, then there's no NAT required for the expose, meaning that the
+    // public IPs are those from the "ips" list. This method returns the current list of public IPs
+    // for the VpcExpose.
+    #[must_use]
+    pub fn public_ips(&self) -> &PrefixPortsSet {
+        let Some(nat) = self.nat.as_ref() else {
+            return &self.ips;
+        };
+        if nat.as_range.is_empty() {
+            &self.ips
+        } else {
+            &nat.as_range
+        }
+    }
+
+    // This method returns true if the list of allowed prefixes is IPv4.
+    #[must_use]
+    pub fn is_v4(&self) -> bool {
+        self.ips.first().is_some_and(|p| p.prefix().is_ipv4())
+    }
+
+    // This method returns true if the list of allowed prefixes is IPv6.
+    #[must_use]
+    pub fn is_v6(&self) -> bool {
+        self.ips.first().is_some_and(|p| p.prefix().is_ipv6())
+    }
+
+    // This method returns true if both allowed and translated prefixes are IPv4.
+    #[must_use]
+    pub fn is_44(&self) -> bool {
+        matches!(
+            (
+                self.ips.first().map(PrefixWithOptionalPorts::prefix),
+                self.as_range_or_empty()
+                    .first()
+                    .map(PrefixWithOptionalPorts::prefix)
+            ),
+            (Some(Prefix::IPV4(_)), Some(Prefix::IPV4(_)))
+        )
+    }
+
+    // This method returns true if both allowed and translated prefixes are IPv6.
+    #[must_use]
+    pub fn is_66(&self) -> bool {
+        matches!(
+            (
+                self.ips.first().map(PrefixWithOptionalPorts::prefix),
+                self.as_range_or_empty()
+                    .first()
+                    .map(PrefixWithOptionalPorts::prefix)
+            ),
+            (Some(Prefix::IPV6(_)), Some(Prefix::IPV6(_)))
+        )
+    }
+
+    #[must_use]
+    pub fn has_stateful_nat(&self) -> bool {
+        self.nat.as_ref().is_some_and(VpcExposeNat::is_stateful)
+    }
+
+    #[must_use]
+    pub fn has_stateless_nat(&self) -> bool {
+        self.nat.as_ref().is_some_and(VpcExposeNat::is_stateless)
+    }
+
+    #[must_use]
+    pub fn has_port_forwarding(&self) -> bool {
+        self.nat
+            .as_ref()
+            .is_some_and(VpcExposeNat::is_port_forwarding)
+    }
+
+    #[must_use]
+    pub fn nat(&self) -> Option<&VpcExposeNat> {
+        self.nat.as_ref()
+    }
+
+    #[must_use]
+    pub fn nat_config(&self) -> Option<&VpcExposeNatConfig> {
+        self.nat.as_ref().map(|nat| &nat.config)
+    }
+
+    #[must_use]
+    pub fn nat_proto(&self) -> Option<&L4Protocol> {
+        self.nat.as_ref().map(|nat| &nat.proto)
+    }
+
+    #[must_use]
+    pub fn idle_timeout(&self) -> Option<Duration> {
+        match self.nat_config()? {
+            VpcExposeNatConfig::Stateful(config) => config.idle_timeout,
+            VpcExposeNatConfig::PortForwarding(config) => config.idle_timeout,
+            VpcExposeNatConfig::Stateless(_) => None,
+        }
     }
 }
 

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -253,16 +253,6 @@ impl VpcExpose {
             &nat.not_as
         }
     }
-    #[must_use]
-    pub(crate) fn has_nat(&self) -> bool {
-        self.nat
-            .as_ref()
-            .is_some_and(|nat| !nat.as_range.is_empty())
-    }
-
-    pub(crate) fn has_stateless_nat(&self) -> bool {
-        self.nat.as_ref().is_some_and(VpcExposeNat::is_stateless)
-    }
 
     #[must_use]
     pub fn nat_config(&self) -> Option<&VpcExposeNatConfig> {
@@ -559,6 +549,13 @@ impl ValidatedExpose {
     }
 
     #[must_use]
+    pub(crate) fn has_nat(&self) -> bool {
+        self.nat
+            .as_ref()
+            .is_some_and(|nat| !nat.as_range.is_empty())
+    }
+
+    #[must_use]
     pub fn has_stateful_nat(&self) -> bool {
         self.nat.as_ref().is_some_and(VpcExposeNat::is_stateful)
     }
@@ -640,7 +637,7 @@ impl VpcManifest {
     /// # Errors
     ///
     /// Returns an error if the manifest configuration is invalid.
-    pub fn validate(&mut self) -> Result<ValidatedManifest, ConfigError> {
+    pub fn validate(&self) -> Result<ValidatedManifest, ConfigError> {
         if self.name.is_empty() {
             return Err(ConfigError::MissingIdentifier("Manifest name"));
         }

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -170,22 +170,11 @@ impl VpcExpose {
         Ok(self)
     }
 
-    #[must_use]
-    pub fn idle_timeout(&self) -> Option<Duration> {
-        self.nat.as_ref().and_then(|nat| match &nat.config {
-            VpcExposeNatConfig::Stateful(config) => config.idle_timeout,
-            VpcExposeNatConfig::PortForwarding(config) => config.idle_timeout,
-            VpcExposeNatConfig::Stateless(_) => None,
-        })
-    }
-
-    #[must_use]
-    pub fn as_range_or_empty(&self) -> &PrefixPortsSet {
+    fn as_range_or_empty(&self) -> &PrefixPortsSet {
         self.nat.as_ref().map_or(empty_set(), |nat| &nat.as_range)
     }
 
-    #[must_use]
-    pub fn not_as_or_empty(&self) -> &PrefixPortsSet {
+    fn not_as_or_empty(&self) -> &PrefixPortsSet {
         self.nat.as_ref().map_or(empty_set(), |nat| &nat.not_as)
     }
 
@@ -201,20 +190,6 @@ impl VpcExpose {
     #[must_use]
     pub fn ip(mut self, prefix: PrefixWithOptionalPorts) -> Self {
         self.ips.insert(prefix);
-        self
-    }
-    // If the as_range list is empty, then there's no NAT required for the expose, meaning that the
-    // public IPs are those from the "ips" list. This method extends the list of public prefixes,
-    // whether it's "ips" or "as_range".
-    #[must_use]
-    pub fn insert_public_ip(mut self, prefix: PrefixWithOptionalPorts) -> Self {
-        if let Some(nat) = self.nat.as_mut()
-            && !nat.as_range.is_empty()
-        {
-            nat.as_range.insert(prefix);
-        } else {
-            self.ips.insert(prefix);
-        }
         self
     }
     #[must_use]
@@ -297,69 +272,15 @@ impl VpcExpose {
             &nat.not_as
         }
     }
-    // This method returns true if the list of allowed prefixes is IPv4.
-    // This method assumes that all prefixes the list are of the same IP version. It does not
-    // validate the list for consistency.
     #[must_use]
-    pub fn is_v4(&self) -> bool {
-        self.ips.first().is_some_and(|p| p.prefix().is_ipv4())
-    }
-    // This method returns true if the list of allowed prefixes is IPv6.
-    // This method assumes that all prefixes the list are of the same IP version. It does not
-    // validate the list for consistency.
-    #[must_use]
-    pub fn is_v6(&self) -> bool {
-        self.ips.first().is_some_and(|p| p.prefix().is_ipv6())
-    }
-    // This method returns true if both allowed and translated prefixes are IPv4.
-    // This method assumes that all prefixes in each list are of the same IP version. It does not
-    // validate the list for consistency.
-    #[must_use]
-    pub fn is_44(&self) -> bool {
-        matches!(
-            (
-                self.ips.first().map(PrefixWithOptionalPorts::prefix),
-                self.as_range_or_empty()
-                    .first()
-                    .map(PrefixWithOptionalPorts::prefix)
-            ),
-            (Some(Prefix::IPV4(_)), Some(Prefix::IPV4(_)))
-        )
-    }
-    // This method returns true if both allowed and translated prefixes are IPv6.
-    // This method assumes that all prefixes in each list are of the same IP version. It does not
-    // validate the list for consistency.
-    #[must_use]
-    pub fn is_66(&self) -> bool {
-        matches!(
-            (
-                self.ips.first().map(PrefixWithOptionalPorts::prefix),
-                self.as_range_or_empty()
-                    .first()
-                    .map(PrefixWithOptionalPorts::prefix)
-            ),
-            (Some(Prefix::IPV6(_)), Some(Prefix::IPV6(_)))
-        )
-    }
-    #[must_use]
-    pub fn has_nat(&self) -> bool {
+    pub(crate) fn has_nat(&self) -> bool {
         self.nat
             .as_ref()
             .is_some_and(|nat| !nat.as_range.is_empty())
     }
 
-    pub fn has_stateful_nat(&self) -> bool {
-        self.nat.as_ref().is_some_and(VpcExposeNat::is_stateful)
-    }
-
-    pub fn has_stateless_nat(&self) -> bool {
+    pub(crate) fn has_stateless_nat(&self) -> bool {
         self.nat.as_ref().is_some_and(VpcExposeNat::is_stateless)
-    }
-
-    pub fn has_port_forwarding(&self) -> bool {
-        self.nat
-            .as_ref()
-            .is_some_and(VpcExposeNat::is_port_forwarding)
     }
 
     #[must_use]
@@ -685,7 +606,7 @@ pub struct VpcManifest {
     pub(crate) exposes: Vec<VpcExpose>,
     // Validated, exclusion-prefixes-free view of exposes. Populated by VpcManifest::validate.
     // Never to be used in VpcManifest; only with wrapper ValidatedManifest
-    pub valexp: Vec<ValidatedExpose>,
+    valexp: Vec<ValidatedExpose>,
 }
 impl VpcManifest {
     #[must_use]
@@ -709,9 +630,12 @@ impl VpcManifest {
         self
     }
 
-    #[must_use]
-    pub fn has_host_prefixes(&self) -> bool {
-        self.exposes.iter().any(VpcExpose::has_host_prefixes)
+    pub fn add_expose(&mut self, expose: VpcExpose) {
+        self.exposes.push(expose);
+    }
+
+    pub fn add_exposes(&mut self, exposes: impl IntoIterator<Item = VpcExpose>) {
+        self.exposes.extend(exposes);
     }
 
     #[must_use]
@@ -785,12 +709,7 @@ impl VpcManifest {
         }
         Ok(())
     }
-    pub fn add_expose(&mut self, expose: VpcExpose) {
-        self.exposes.push(expose);
-    }
-    pub fn add_exposes(&mut self, exposes: impl IntoIterator<Item = VpcExpose>) {
-        self.exposes.extend(exposes);
-    }
+
     /// Validate the [`VpcManifest`].
     ///
     /// # Errors
@@ -825,7 +744,7 @@ impl VpcManifest {
         Ok(())
     }
 
-    /// Consume `self` and produce a [`ValidatedManifest`] if it passes validation.
+    /// Validate the manifest and return a validated version
     ///
     /// # Errors
     ///
@@ -834,52 +753,7 @@ impl VpcManifest {
         self.validate()?;
         Ok(ValidatedManifest(self))
     }
-    pub fn stateless_nat_exposes(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_stateless_nat())
-    }
-    pub fn stateful_nat_exposes_44(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_stateful_nat())
-            .filter(|expose| expose.is_44())
-    }
-    pub fn stateful_nat_exposes_66(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_stateful_nat())
-            .filter(|expose| expose.is_66())
-    }
-    pub fn no_stateful_nat_exposes_v4(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| !expose.has_stateful_nat())
-            .filter(|expose| expose.is_v4())
-    }
-    pub fn no_stateful_nat_exposes_v6(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| !expose.has_stateful_nat())
-            .filter(|expose| expose.is_v6())
-    }
-    pub fn port_forwarding_exposes_44(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_port_forwarding())
-            .filter(|expose| expose.is_44())
-    }
-    pub fn port_forwarding_exposes_66(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_port_forwarding())
-            .filter(|expose| expose.is_66())
-    }
-    pub fn port_forwarding_exposes(&self) -> impl Iterator<Item = &VpcExpose> {
-        self.exposes
-            .iter()
-            .filter(|expose| expose.has_port_forwarding())
-    }
+
     #[must_use]
     pub fn default_expose(&self) -> Option<&VpcExpose> {
         self.exposes.iter().find(|expose| expose.default)

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -682,7 +682,7 @@ impl ValidatedExpose {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct VpcManifest {
     pub name: String, /* key: name of vpc */
-    pub exposes: Vec<VpcExpose>,
+    pub(crate) exposes: Vec<VpcExpose>,
     // Validated, exclusion-prefixes-free view of exposes. Populated by VpcManifest::validate.
     // Never to be used in VpcManifest; only with wrapper ValidatedManifest
     pub valexp: Vec<ValidatedExpose>,

--- a/config/src/external/underlay/mod.rs
+++ b/config/src/external/underlay/mod.rs
@@ -3,10 +3,10 @@
 
 //! Underlay configuration
 
+use crate::ConfigError;
 use crate::internal::interfaces::interface::{InterfaceConfig, InterfaceType};
 use crate::internal::routing::evpn::VtepConfig;
 use crate::internal::routing::vrf::VrfConfig;
-use crate::{ConfigError, ConfigResult};
 
 use net::eth::mac::SourceMac;
 use net::ipv4::UnicastIpv4Addr;
@@ -77,7 +77,7 @@ impl Underlay {
     /// # Errors
     ///
     /// Returns an error if any interface is invalid or VTEP configuration is wrong.
-    pub fn validate(&mut self) -> ConfigResult {
+    pub fn validate(&self) -> Result<Self, ConfigError> {
         debug!("Validating underlay configuration...");
 
         // validate interfaces
@@ -86,9 +86,10 @@ impl Underlay {
             .values()
             .try_for_each(InterfaceConfig::validate)?;
 
-        // set vtep information if a vtep interface has been specified in the config
-        self.vtep = self.get_vtep_info()?;
-
-        Ok(())
+        Ok(Self {
+            vrf: self.vrf.clone(),
+            // set vtep information if a vtep interface has been specified in the config
+            vtep: self.get_vtep_info()?,
+        })
     }
 }

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -118,6 +118,17 @@ impl GwConfig {
         debug!("Validating external config with genid {} ..", self.genid());
         self.external.validate()
     }
+
+    /// Consume `self` and produce a [`ValidatedGwConfig`] if validation succeeds.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConfigError`] if the external configuration fails validation.
+    pub fn validated(mut self) -> Result<ValidatedGwConfig, ConfigError> {
+        debug!("Validating external config with genid {} ..", self.genid());
+        self.external.validate()?;
+        Ok(ValidatedGwConfig(self))
+    }
 }
 
 #[repr(transparent)]

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -129,6 +129,21 @@ impl GwConfig {
         self.external.validate()?;
         Ok(ValidatedGwConfig(self))
     }
+
+    /// FOR TESTS ONLY. Fake validation for the config.
+    ///
+    /// # Safety
+    ///
+    /// All bets are off. Do not use outside of tests.
+    #[cfg(feature = "testing")]
+    #[allow(unsafe_code)]
+    #[must_use]
+    pub unsafe fn fake_validated_config_for_tests(mut self) -> ValidatedGwConfig {
+        unsafe {
+            self.external.overlay.fake_manifest_validation_for_tests();
+        }
+        ValidatedGwConfig(self)
+    }
 }
 
 #[repr(transparent)]

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -4,7 +4,7 @@
 //! Top-level configuration object for the dataplane
 
 use crate::errors::{ConfigError, ConfigResult};
-use crate::external::{ExternalConfig, GenId};
+use crate::external::{ExternalConfig, GenId, ValidatedExternalConfig};
 use crate::internal::InternalConfig;
 use arc_swap::ArcSwap;
 use std::sync::Arc;
@@ -117,5 +117,50 @@ impl GwConfig {
     pub fn validate(&mut self) -> ConfigResult {
         debug!("Validating external config with genid {} ..", self.genid());
         self.external.validate()
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct ValidatedGwConfig(GwConfig);
+
+impl ValidatedGwConfig {
+    /// Create a blank [`ValidatedGwConfig`] with an empty [`ExternalConfig`].
+    #[must_use]
+    pub fn blank() -> Self {
+        // The blank config has no overlay, peerings, or VPCs, so it trivially passes validation.
+        // A unit test verifies this invariant.
+        ValidatedGwConfig(GwConfig::blank())
+    }
+
+    #[must_use]
+    pub fn meta(&self) -> &ArcSwap<GwConfigMeta> {
+        &self.0.meta
+    }
+
+    #[must_use]
+    pub fn external(&self) -> &ValidatedExternalConfig {
+        // SAFETY: ValidatedExternalConfig is #[repr(transparent)] over ExternalConfig. A
+        // ValidatedGwConfig is only obtained from `GwConfig::validated`, which validates the
+        // external config.
+        #[allow(unsafe_code)]
+        unsafe {
+            &*(&raw const self.0.external).cast::<ValidatedExternalConfig>()
+        }
+    }
+
+    #[must_use]
+    pub fn internal(&self) -> Option<&InternalConfig> {
+        self.0.internal.as_ref()
+    }
+
+    /// Set an internal config object, once built.
+    pub fn set_internal_config(&mut self, internal: InternalConfig) {
+        self.0.internal = Some(internal);
+    }
+
+    #[must_use]
+    pub fn genid(&self) -> GenId {
+        self.0.external.genid
     }
 }

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -114,7 +114,7 @@ impl GwConfig {
     /// # Errors
     ///
     /// Returns a [`ConfigError`] if the external configuration fails validation.
-    pub fn validate(mut self) -> Result<ValidatedGwConfig, ConfigError> {
+    pub fn validate(self) -> Result<ValidatedGwConfig, ConfigError> {
         debug!("Validating external config with genid {} ..", self.genid());
         self.external.validate()?;
         Ok(ValidatedGwConfig(self))

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -116,8 +116,13 @@ impl GwConfig {
     /// Returns a [`ConfigError`] if the external configuration fails validation.
     pub fn validate(self) -> Result<ValidatedGwConfig, ConfigError> {
         debug!("Validating external config with genid {} ..", self.genid());
-        self.external.validate()?;
-        Ok(ValidatedGwConfig(self))
+        let validated_external = self.external.validate()?;
+
+        Ok(ValidatedGwConfig {
+            meta: self.meta,
+            external: validated_external,
+            internal: self.internal.clone(),
+        })
     }
 
     /// FOR TESTS ONLY. Fake validation for the config.
@@ -128,54 +133,59 @@ impl GwConfig {
     #[cfg(feature = "testing")]
     #[allow(unsafe_code)]
     #[must_use]
-    pub unsafe fn fake_validated_config_for_tests(mut self) -> ValidatedGwConfig {
-        unsafe {
-            self.external.overlay.fake_manifest_validation_for_tests();
+    pub unsafe fn fake_validated_config_for_tests(self) -> ValidatedGwConfig {
+        let fake_valid_external = unsafe { self.external.fake_validated_external_for_tests() };
+
+        ValidatedGwConfig {
+            meta: self.meta,
+            external: fake_valid_external,
+            internal: self.internal.clone(),
         }
-        ValidatedGwConfig(self)
     }
 }
 
-#[repr(transparent)]
 #[derive(Debug)]
-pub struct ValidatedGwConfig(GwConfig);
+pub struct ValidatedGwConfig {
+    meta: ArcSwap<GwConfigMeta>,
+    external: ValidatedExternalConfig,
+    internal: Option<InternalConfig>,
+}
 
 impl ValidatedGwConfig {
     #[must_use]
     pub fn blank() -> Self {
         // The blank config has no overlay, peerings, or VPCs, so it trivially passes validation.
         // A unit test verifies this invariant.
-        ValidatedGwConfig(GwConfig::blank())
-    }
-
-    #[must_use]
-    pub fn meta(&self) -> &ArcSwap<GwConfigMeta> {
-        &self.0.meta
-    }
-
-    #[must_use]
-    pub fn external(&self) -> &ValidatedExternalConfig {
-        // SAFETY: ValidatedExternalConfig is #[repr(transparent)] over ExternalConfig. A
-        // ValidatedGwConfig is only obtained from `GwConfig::validated`, which validates the
-        // external config.
-        #[allow(unsafe_code)]
-        unsafe {
-            &*(&raw const self.0.external).cast::<ValidatedExternalConfig>()
+        let external = ValidatedExternalConfig::blank();
+        Self {
+            meta: ArcSwap::new(Arc::from(GwConfigMeta::new(external.genid()))),
+            external,
+            internal: None,
         }
     }
 
     #[must_use]
+    pub fn meta(&self) -> &ArcSwap<GwConfigMeta> {
+        &self.meta
+    }
+
+    #[must_use]
+    pub fn external(&self) -> &ValidatedExternalConfig {
+        &self.external
+    }
+
+    #[must_use]
     pub fn internal(&self) -> Option<&InternalConfig> {
-        self.0.internal.as_ref()
+        self.internal.as_ref()
     }
 
     pub fn set_internal_config(&mut self, internal: InternalConfig) {
-        self.0.internal = Some(internal);
+        self.internal = Some(internal);
     }
 
     #[must_use]
     pub fn genid(&self) -> GenId {
-        self.0.external.genid
+        self.external.genid()
     }
 }
 

--- a/config/src/gwconfig.rs
+++ b/config/src/gwconfig.rs
@@ -114,17 +114,7 @@ impl GwConfig {
     /// # Errors
     ///
     /// Returns a [`ConfigError`] if the external configuration fails validation.
-    pub fn validate(&mut self) -> ConfigResult {
-        debug!("Validating external config with genid {} ..", self.genid());
-        self.external.validate()
-    }
-
-    /// Consume `self` and produce a [`ValidatedGwConfig`] if validation succeeds.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ConfigError`] if the external configuration fails validation.
-    pub fn validated(mut self) -> Result<ValidatedGwConfig, ConfigError> {
+    pub fn validate(mut self) -> Result<ValidatedGwConfig, ConfigError> {
         debug!("Validating external config with genid {} ..", self.genid());
         self.external.validate()?;
         Ok(ValidatedGwConfig(self))
@@ -151,7 +141,6 @@ impl GwConfig {
 pub struct ValidatedGwConfig(GwConfig);
 
 impl ValidatedGwConfig {
-    /// Create a blank [`ValidatedGwConfig`] with an empty [`ExternalConfig`].
     #[must_use]
     pub fn blank() -> Self {
         // The blank config has no overlay, peerings, or VPCs, so it trivially passes validation.
@@ -180,7 +169,6 @@ impl ValidatedGwConfig {
         self.0.internal.as_ref()
     }
 
-    /// Set an internal config object, once built.
     pub fn set_internal_config(&mut self, internal: InternalConfig) {
         self.0.internal = Some(internal);
     }
@@ -188,5 +176,17 @@ impl ValidatedGwConfig {
     #[must_use]
     pub fn genid(&self) -> GenId {
         self.0.external.genid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GwConfig;
+
+    #[test]
+    fn test_blank_config_is_valid() {
+        let _ = GwConfig::blank()
+            .validate()
+            .expect("Failed to validate blank config");
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -28,7 +28,7 @@ pub mod utils;
 pub use display::ConfigSummary;
 pub use errors::{ConfigError, ConfigResult, stringify};
 pub use external::{ExternalConfig, GenId};
-pub use gwconfig::{GwConfig, GwConfigMeta};
+pub use gwconfig::{GwConfig, GwConfigMeta, ValidatedGwConfig};
 pub use internal::InternalConfig;
 pub use internal::device::DeviceConfig;
 

--- a/config/src/utils/collapse.rs
+++ b/config/src/utils/collapse.rs
@@ -31,7 +31,7 @@ pub fn collapse_prefixes_peering(peering: &Peering) -> Peering {
     new_peering
 }
 
-fn collapse_prefixes(expose: &mut VpcExpose) {
+pub(crate) fn collapse_prefixes(expose: &mut VpcExpose) {
     let ips = collapse_prefix_lists(&expose.ips, &expose.nots);
     expose.ips = ips;
     expose.nots = PrefixPortsSet::new();

--- a/config/src/utils/collapse.rs
+++ b/config/src/utils/collapse.rs
@@ -1,35 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use crate::external::overlay::{vpc::Peering, vpcpeering::VpcExpose};
+use crate::external::overlay::vpcpeering::VpcExpose;
 use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet};
-
-// Collapse prefixes and exclusion prefixes in a Peering object: for each expose object, "apply"
-// exclusion prefixes to split allowed prefixes into smaller chunks, and remove exclusion prefixes
-// from the expose object.
-//
-// For example, for a given expose with "ips" as 1.0.0.0/16 and "nots" as 1.0.0.0/18, the resulting
-// expose will contain 1.0.128.0/17 and 1.0.64.0/18 as "ips" prefixes, and an empty "nots" list.
-//
-// Another example would be "ips" as 1.0.0.0/16, with associated port range 4000-5000, and "nots" as
-// 1.0.0.0/17, with associated port range 4000-4500. The resulting expose will contain (1.0.0.0/16,
-// 0-3999), (1.0.0.0/16, 4501-5000), and (1.0.128.0/17, 4000-4500) as "ips" prefixes, and again, an
-// empty "nots" list.
-#[must_use]
-pub fn collapse_prefixes_peering(peering: &Peering) -> Peering {
-    let mut new_peering = peering.clone();
-
-    for expose in new_peering
-        .local
-        .exposes
-        .iter_mut()
-        .chain(new_peering.remote.exposes.iter_mut())
-    {
-        collapse_prefixes(expose);
-    }
-
-    new_peering
-}
 
 pub(crate) fn collapse_prefixes(expose: &mut VpcExpose) {
     let ips = collapse_prefix_lists(&expose.ips, &expose.nots);
@@ -47,6 +20,14 @@ pub(crate) fn collapse_prefixes(expose: &mut VpcExpose) {
 // Collapse prefixes (first set) and exclusion prefixes (second set), by "applying" exclusion
 // prefixes to the allowed prefixes and split them into smaller allowed segments, to express the
 // same IP ranges without any exclusion prefixes.
+//
+// For example, for a given expose with "ips" as 1.0.0.0/16 and "nots" as 1.0.0.0/18, the resulting
+// expose will contain 1.0.128.0/17 and 1.0.64.0/18 as "ips" prefixes, and an empty "nots" list.
+//
+// Another example would be "ips" as 1.0.0.0/16, with associated port range 4000-5000, and "nots" as
+// 1.0.0.0/17, with associated port range 4000-4500. The resulting expose will contain (1.0.0.0/16,
+// 0-3999), (1.0.0.0/16, 4501-5000), and (1.0.128.0/17, 4000-4500) as "ips" prefixes, and again, an
+// empty "nots" list.
 fn collapse_prefix_lists(prefixes: &PrefixPortsSet, excludes: &PrefixPortsSet) -> PrefixPortsSet {
     let mut result = prefixes.clone();
     // Iterate over all exclusion prefixes
@@ -71,6 +52,7 @@ fn collapse_prefix_lists(prefixes: &PrefixPortsSet, excludes: &PrefixPortsSet) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::external::overlay::vpc::Peering;
     use crate::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
     use ipnet::IpNet;
     use lpm::prefix::{Prefix, PrefixWithOptionalPorts};
@@ -249,7 +231,7 @@ mod tests {
         let mut manifest = VpcManifest::new("VPC-1");
         manifest.add_expose(expose);
         let manifest_empty = VpcManifest::new("VPC-2");
-        let peering = Peering {
+        let mut peering = Peering {
             name: "test_peering".into(),
             local: manifest,
             remote: manifest_empty.clone(),
@@ -263,9 +245,16 @@ mod tests {
             .ip("2.0.2.0/25".into())
             .ip("3.0.0.0/17".into());
 
-        let collapsed_peering = collapse_prefixes_peering(&peering);
+        for expose in peering
+            .local
+            .exposes
+            .iter_mut()
+            .chain(peering.remote.exposes.iter_mut())
+        {
+            collapse_prefixes(expose);
+        }
 
-        assert_eq!(collapsed_peering.local.exposes[0], expected_expose);
+        assert_eq!(peering.local.exposes[0], expected_expose);
     }
 
     #[test]

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -7,6 +7,7 @@ mod collapse;
 mod overlap;
 
 pub use collapse::collapse_prefixes_peering;
+pub(crate) use collapse::collapse_prefixes;
 pub(crate) use overlap::{check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap};
 
 #[derive(thiserror::Error, Debug, Clone)]

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -6,7 +6,6 @@ use lpm::prefix::Prefix;
 mod collapse;
 mod overlap;
 
-pub use collapse::collapse_prefixes_peering;
 pub(crate) use collapse::collapse_prefixes;
 pub(crate) use overlap::{check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap};
 

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -2,22 +2,17 @@
 // Copyright Open Network Fabric Authors
 
 use crate::ConfigError;
-use crate::external::overlay::vpcpeering::VpcExpose;
-use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet, ppsize_zero};
+use crate::external::overlay::vpcpeering::ValidatedExpose;
+use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet};
 
 pub fn check_private_prefixes_dont_overlap(
-    expose_left: &VpcExpose,
-    expose_right: &VpcExpose,
+    expose_left: &ValidatedExpose,
+    expose_right: &ValidatedExpose,
 ) -> Result<(), ConfigError> {
     if port_forwarding_with_distinct_l4_protocols(expose_left, expose_right) {
         return Ok(());
     }
-    check_prefixes_dont_overlap(
-        &expose_left.ips,
-        &expose_left.nots,
-        &expose_right.ips,
-        &expose_right.nots,
-    )
+    check_prefixes_dont_overlap(expose_left.ips(), expose_right.ips())
 }
 
 // Check for overlap for the lists of public prefixes.
@@ -26,130 +21,44 @@ pub fn check_private_prefixes_dont_overlap(
 // - expose_left.ips      / expose_right.as_range
 // - expose_left.as_range / expose_right.ips
 // - expose_left.ips      / expose_right.ips
-// (along with the respective exclusion prefixes applied).
 pub fn check_public_prefixes_dont_overlap(
-    expose_left: &VpcExpose,
-    expose_right: &VpcExpose,
+    expose_left: &ValidatedExpose,
+    expose_right: &ValidatedExpose,
 ) -> Result<(), ConfigError> {
     if port_forwarding_with_distinct_l4_protocols(expose_left, expose_right) {
         return Ok(());
     }
-    check_prefixes_dont_overlap(
-        expose_left.public_ips(),
-        expose_left.public_excludes(),
-        expose_right.public_ips(),
-        expose_right.public_excludes(),
-    )
+    check_prefixes_dont_overlap(expose_left.public_ips(), expose_right.public_ips())
 }
 
-// If the two expose blocks have port fortwarding set up, one for TCP and one for UDP, then there is
+// If the two expose blocks have port forwarding set up, one for TCP and one for UDP, then there is
 // no overlap.
 fn port_forwarding_with_distinct_l4_protocols(
-    expose_left: &VpcExpose,
-    expose_right: &VpcExpose,
+    expose_left: &ValidatedExpose,
+    expose_right: &ValidatedExpose,
 ) -> bool {
-    if expose_left.has_port_forwarding()
+    expose_left.has_port_forwarding()
         && expose_right.has_port_forwarding()
-        && let Some(nat_left) = expose_left.nat.as_ref()
-        && let Some(nat_right) = expose_right.nat.as_ref()
-        && nat_left.proto.intersection(&nat_right.proto).is_none()
-    {
-        true
-    } else {
-        false
-    }
+        && expose_left.nat_proto().is_some_and(|proto_left| {
+            expose_right
+                .nat_proto()
+                .is_some_and(|proto_right| proto_left.intersection(proto_right).is_none())
+        })
 }
 
 // Validate that two sets of prefixes, with their exclusion prefixes applied, don't overlap
 fn check_prefixes_dont_overlap(
     prefixes_left: &PrefixPortsSet,
-    excludes_left: &PrefixPortsSet,
     prefixes_right: &PrefixPortsSet,
-    excludes_right: &PrefixPortsSet,
 ) -> Result<(), ConfigError> {
-    // Find colliding prefixes
-    let mut colliding = Vec::new();
     for prefix_left in prefixes_left {
         for prefix_right in prefixes_right {
             if prefix_left.overlaps(prefix_right) {
-                colliding.push((*prefix_left, *prefix_right));
+                return Err(ConfigError::OverlappingPrefixes(
+                    *prefix_left,
+                    *prefix_right,
+                ));
             }
-        }
-    }
-    // If not prefixes collide, we're good - exit.
-    if colliding.is_empty() {
-        return Ok(());
-    }
-
-    // How do we determine whether there is a collision between the set of available addresses on
-    // the left side, and the set of available addresses on the right side? A collision means:
-    //
-    // - Prefixes collide, in other words, they have a non-empty intersection (we've checked that
-    //   earlier)
-    //
-    // - This intersection is not fully covered by exclusion prefixes
-    //
-    // The idea in the loop below is that for each pair of colliding prefixes:
-    //
-    // - We retrieve the size of the intersection of the colliding prefixes.
-    //
-    // - We retrieve the size of the union of the intersections of all the exclusion prefixes (from
-    //   left and right sides) covering part of this intersection.
-    //
-    // - If the size of the intersection of colliding allowed prefixes is bigger than the size of
-    //   the union of the intersections of the exclusion prefixes applying to these allowed
-    //   prefixes, then it means that some addresses are effectively allowed in both the left-side
-    //   and the right-side set of available addresses, and this is an error. If the sizes are
-    //   identical, then all addresses in the intersection of the prefixes are excluded on at least
-    //   one side, so it's all good.
-    for (prefix_left, prefix_right) in colliding {
-        let intersection_prefix = prefix_left.intersection(&prefix_right).unwrap_or_else(|| {
-            unreachable!(); // These prefixes were paired precisely because they collide
-        });
-
-        // We need to compute the size of the union of the excluded prefixes. Start by adding the
-        // sizes of all exclusion prefixes, from both sides.
-        let mut union_excludes_size = ppsize_zero();
-
-        // Now we remove once the size of the intersection of each pair of excluded prefixes, to
-        // avoid double-counting some ranges. We know that all exclusion prefixes on the left side
-        // are disjoint, and all so are exclusion prefixes on the right side, which means that we
-        // cannot have more than two prefixes overlapping. It's enough to look for intersection of
-        // all left-side prefixes with each right-side prefix.
-        for exclude_left in excludes_left
-            .iter()
-            .filter(|exclude| exclude.overlaps(&intersection_prefix))
-        {
-            let exclude_covering_allowed_left = exclude_left
-                .intersection(&intersection_prefix)
-                .unwrap_or_else(|| {
-                    // We filtered prefixes with overlap with intersection_prefix
-                    unreachable!();
-                });
-            union_excludes_size += exclude_covering_allowed_left.size();
-            for exclude_right in excludes_right
-                .iter()
-                .filter(|exclude| exclude.overlaps(&intersection_prefix))
-            {
-                let exclude_covering_allowed_right = exclude_right
-                    .intersection(&intersection_prefix)
-                    .unwrap_or_else(|| {
-                        // We filtered prefixes with overlap with intersection_prefix
-                        unreachable!();
-                    });
-                union_excludes_size += exclude_covering_allowed_right.size();
-                // Remove size of intersection, to avoid double-counting for a given range
-                union_excludes_size -= exclude_covering_allowed_left
-                    .intersection(&exclude_covering_allowed_right)
-                    .map_or(ppsize_zero(), |p| p.size());
-            }
-        }
-
-        if union_excludes_size < intersection_prefix.size() {
-            // Some addresses at the intersection of both prefixes are not covered by the union of
-            // all exclusion prefixes, in other words, they are available from both prefixes. This
-            // is an error.
-            return Err(ConfigError::OverlappingPrefixes(prefix_left, prefix_right));
         }
     }
     Ok(())

--- a/flow-filter/Cargo.toml
+++ b/flow-filter/Cargo.toml
@@ -18,5 +18,6 @@ tracectl = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+config = { workspace = true, features = ["testing"] }
 lpm = { workspace = true, features = ["testing"] }
 tracing-test = { workspace = true, features = [] }

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -679,14 +679,14 @@ mod tests {
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
             vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let overlap = get_manifest_ips_overlap(
@@ -712,14 +712,14 @@ mod tests {
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
             vec![VpcExpose::empty().ip("10.0.0.0/25".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let overlap = get_manifest_ips_overlap(
@@ -751,7 +751,7 @@ mod tests {
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
@@ -761,7 +761,7 @@ mod tests {
                 Some(PortRange::new(100, 200).unwrap()),
             ))],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let overlap = get_manifest_ips_overlap(
@@ -801,7 +801,7 @@ mod tests {
                     .ip("20.0.0.128/25".into()),
             ],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
@@ -816,7 +816,7 @@ mod tests {
                 VpcExpose::empty().ip("20.0.0.0/24".into()),
             ],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let overlap = get_manifest_ips_overlap(
@@ -907,7 +907,7 @@ mod tests {
             ],
         );
         assert!(matches!(
-            manifest.clone().validated(),
+            manifest.clone().validate(),
             Err(ConfigError::OverlappingPrefixes(_, _))
         ));
         let manifest = unsafe { manifest.fake_valid_manifest_for_tests() };
@@ -1070,7 +1070,7 @@ mod tests {
             "manifest",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let overlaps = BTreeMap::new();
@@ -1103,7 +1103,7 @@ mod tests {
             "manifest",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let mut overlaps = BTreeMap::new();
@@ -1162,7 +1162,7 @@ mod tests {
             "manifest_a",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
         )
-        .validated()
+        .validate()
         .unwrap();
 
         let mut overlaps = BTreeMap::new();

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -4,11 +4,11 @@
 use crate::FlowFilterTable;
 use crate::tables::{FlowFilterSubtable, NatRequirement, RemoteData, VpcdLookupResult};
 use config::ConfigError;
+#[cfg(test)]
 use config::external::overlay::Overlay;
-use config::external::overlay::vpc::{Peering, Vpc};
-use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
-use config::internal::interfaces::interface::InterfaceConfigTable;
-use config::utils::collapse_prefixes_peering;
+use config::external::overlay::ValidatedOverlay;
+use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpc};
+use config::external::overlay::vpcpeering::{ValidatedExpose, ValidatedManifest};
 use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::packet::VpcDiscriminant;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -19,12 +19,11 @@ trace_target!("flow-filter-setup", LevelFilter::INFO, &[]);
 
 impl FlowFilterTable {
     /// Build a [`FlowFilterTable`] from an overlay
-    pub fn build_from_overlay(overlay: &Overlay) -> Result<Self, ConfigError> {
-        let clean_vpc_table = cleanup_vpc_table(overlay.vpc_table.values().collect())?;
+    pub fn build_from_overlay(overlay: &ValidatedOverlay) -> Result<Self, ConfigError> {
         let mut table = FlowFilterTable::new();
 
-        for vpc in &clean_vpc_table {
-            for peering in &vpc.peerings {
+        for vpc in overlay.vpc_table().values() {
+            for peering in vpc.peerings() {
                 table.add_peering(overlay, vpc, peering)?;
             }
         }
@@ -34,12 +33,12 @@ impl FlowFilterTable {
 
     fn add_peering(
         &mut self,
-        overlay: &Overlay,
-        vpc: &Vpc,
-        peering: &Peering,
+        overlay: &ValidatedOverlay,
+        vpc: &ValidatedVpc,
+        peering: &ValidatedPeering,
     ) -> Result<(), ConfigError> {
-        let local_vpcd = VpcDiscriminant::VNI(vpc.vni);
-        let dst_vpcd = VpcDiscriminant::VNI(overlay.vpc_table.get_remote_vni(peering));
+        let local_vpcd = VpcDiscriminant::VNI(vpc.vni());
+        let dst_vpcd = VpcDiscriminant::VNI(overlay.vpc_table().get_remote_vni(peering));
 
         let (local_prefixes, remote_prefixes) =
             get_prefixes_for_processing(overlay, vpc, peering, dst_vpcd, false);
@@ -49,8 +48,8 @@ impl FlowFilterTable {
             dst_vpcd,
             local_prefixes,
             remote_prefixes,
-            peering.local.default_expose(),
-            peering.remote.default_expose(),
+            peering.local().default_expose(),
+            peering.remote().default_expose(),
         )?;
 
         let (local_prefixes, remote_prefixes) =
@@ -61,8 +60,8 @@ impl FlowFilterTable {
             dst_vpcd,
             local_prefixes,
             remote_prefixes,
-            peering.local.default_expose(),
-            peering.remote.default_expose(),
+            peering.local().default_expose(),
+            peering.remote().default_expose(),
         )
     }
 }
@@ -74,9 +73,9 @@ type PrefixWithData = (
 );
 
 fn get_prefixes_for_processing(
-    overlay: &Overlay,
-    vpc: &Vpc,
-    peering: &Peering,
+    overlay: &ValidatedOverlay,
+    vpc: &ValidatedVpc,
+    peering: &ValidatedPeering,
     dst_vpcd: VpcDiscriminant,
     skip_ports: bool,
 ) -> (Vec<PrefixWithData>, Vec<PrefixWithData>) {
@@ -86,9 +85,9 @@ fn get_prefixes_for_processing(
     // Get list of local prefixes, splitting to account for overlapping, if necessary
     let overlap_trie = consolidate_overlap_list(local_manifests_overlap);
     let local_prefixes = get_split_prefixes_for_manifest(
-        &peering.local,
+        peering.local(),
         &dst_vpcd,
-        |expose| &expose.ips,
+        |expose| expose.ips(),
         overlap_trie,
         skip_ports,
     );
@@ -96,7 +95,7 @@ fn get_prefixes_for_processing(
     // Get list of remote prefixes, splitting to account for overlapping, if necessary
     let overlap_trie = consolidate_overlap_list(remote_manifests_overlap);
     let remote_prefixes = get_split_prefixes_for_manifest(
-        &peering.remote,
+        peering.remote(),
         &dst_vpcd,
         |expose| expose.public_ips(),
         overlap_trie,
@@ -113,8 +112,8 @@ impl FlowFilterSubtable {
         dst_vpcd: VpcDiscriminant,
         local_prefixes: Vec<PrefixWithData>,
         remote_prefixes: Vec<PrefixWithData>,
-        local_default_expose: Option<&VpcExpose>,
-        remote_default_expose: Option<&VpcExpose>,
+        local_default_expose: Option<&ValidatedExpose>,
+        remote_default_expose: Option<&ValidatedExpose>,
     ) -> Result<(), ConfigError> {
         // Handle local default expose (for all remote prefixes)
         if let Some(local_default_expose) = local_default_expose {
@@ -261,38 +260,13 @@ impl FlowFilterSubtable {
     }
 }
 
-fn cleanup_vpc_table(vpcs: Vec<&Vpc>) -> Result<Vec<Vpc>, ConfigError> {
-    let mut new_set = Vec::new();
-    for vpc in vpcs {
-        let mut new_vpc = clone_skipping_peerings(vpc);
-
-        for peering in &vpc.peerings {
-            // "Collapse" prefixes to get rid of exclusion prefixes
-            let collapsed_peering = collapse_prefixes_peering(peering);
-            new_vpc.peerings.push(collapsed_peering);
-        }
-        new_set.push(new_vpc);
-    }
-    Ok(new_set)
-}
-
-fn clone_skipping_peerings(vpc: &Vpc) -> Vpc {
-    Vpc {
-        name: vpc.name.clone(),
-        id: vpc.id.clone(),
-        vni: vpc.vni,
-        interfaces: InterfaceConfigTable::default(),
-        peerings: vec![],
-    }
-}
-
 // Compute lists of overlapping prefixes:
 // - between prefixes from remote manifest and prefixes from remote manifests for other peerings
 // - between prefixes from local manifest and prefixes from local manifests for other peerings
 fn get_manifests_overlap(
-    overlay: &Overlay,
-    vpc: &Vpc,
-    peering: &Peering,
+    overlay: &ValidatedOverlay,
+    vpc: &ValidatedVpc,
+    peering: &ValidatedPeering,
     dst_vpcd: VpcDiscriminant,
     skip_ports: bool,
 ) -> (
@@ -301,24 +275,25 @@ fn get_manifests_overlap(
 ) {
     let mut local_manifests_overlap = BTreeMap::new();
     let mut remote_manifests_overlap = BTreeMap::new();
-    for other_peering in &vpc.peerings {
-        let compare_to_self = other_peering.name == peering.name;
-        let other_dst_vpcd = VpcDiscriminant::VNI(overlay.vpc_table.get_remote_vni(other_peering));
+    for other_peering in vpc.peerings() {
+        let compare_to_self = other_peering.name() == peering.name();
+        let other_dst_vpcd =
+            VpcDiscriminant::VNI(overlay.vpc_table().get_remote_vni(other_peering));
 
         // Get overlap for prefixes related to source address
         let local_overlap = get_manifest_ips_overlap(
-            &peering.local,
-            &other_peering.local,
+            peering.local(),
+            other_peering.local(),
             dst_vpcd,
             other_dst_vpcd,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             compare_to_self,
             skip_ports,
         );
         // Get overlap for prefixes related to destination address
         let remote_overlap = get_manifest_ips_overlap(
-            &peering.remote,
-            &other_peering.remote,
+            peering.remote(),
+            other_peering.remote(),
             dst_vpcd,
             other_dst_vpcd,
             |expose| expose.public_ips(),
@@ -356,24 +331,24 @@ where
 //
 // Exclude the "default"-destination expose blocks from overlap calculation.
 fn get_manifest_ips_overlap(
-    manifest_left: &VpcManifest,
-    manifest_right: &VpcManifest,
+    manifest_left: &ValidatedManifest,
+    manifest_right: &ValidatedManifest,
     dst_vpcd_left: VpcDiscriminant,
     dst_vpcd_right: VpcDiscriminant,
-    get_ips: fn(&VpcExpose) -> &BTreeSet<PrefixWithOptionalPorts>,
+    get_ips: fn(&ValidatedExpose) -> &BTreeSet<PrefixWithOptionalPorts>,
     compare_to_self: bool,
     skip_ports: bool,
 ) -> BTreeMap<PrefixWithOptionalPorts, HashSet<RemoteData>> {
     let mut overlap: BTreeMap<PrefixWithOptionalPorts, HashSet<RemoteData>> = BTreeMap::new();
     for expose_left in manifest_left
-        .exposes
+        .valexp()
         .iter()
-        .filter(|expose| !expose.default)
+        .filter(|expose| !expose.is_default())
     {
         for expose_right in manifest_right
-            .exposes
+            .valexp()
             .iter()
-            .filter(|expose| !expose.default)
+            .filter(|expose| !expose.is_default())
         {
             if compare_to_self && expose_left == expose_right {
                 // We're comparing the expose to itself: skip
@@ -460,14 +435,14 @@ fn consolidate_overlap_list(
 //   with VPC C's 10.0.0.0/25)
 // - For VPC C: [10.0.0.0/25]
 fn get_split_prefixes_for_manifest(
-    manifest: &VpcManifest,
+    manifest: &ValidatedManifest,
     vpcd: &VpcDiscriminant,
-    get_ips: fn(&VpcExpose) -> &PrefixPortsSet,
+    get_ips: fn(&ValidatedExpose) -> &PrefixPortsSet,
     overlaps: BTreeMap<PrefixWithOptionalPorts, HashSet<RemoteData>>,
     skip_ports: bool,
 ) -> Vec<PrefixWithData> {
     let mut prefixes_with_vpcd = Vec::new();
-    for expose in &manifest.exposes {
+    for expose in manifest.valexp() {
         let nat_req = get_nat_requirement(expose);
         for prefix in get_ips(expose) {
             if skip_ports && prefix.ports().is_some() {
@@ -530,8 +505,8 @@ fn split_overlapping(
     split_prefixes
 }
 
-fn get_nat_requirement(expose: &VpcExpose) -> Option<NatRequirement> {
-    expose.nat.as_ref().map(NatRequirement::from_nat)
+fn get_nat_requirement(expose: &ValidatedExpose) -> Option<NatRequirement> {
+    expose.nat().map(NatRequirement::from_nat)
 }
 
 #[cfg(test)]
@@ -539,8 +514,10 @@ mod tests {
     use crate::tables::VpcdLookupResult;
 
     use super::*;
-    use config::external::overlay::vpc::{Vpc, VpcTable};
-    use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest, VpcPeeringTable};
+    use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
+    use config::external::overlay::vpcpeering::{
+        VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable,
+    };
     use lpm::prefix::{L4Protocol, PortRange, Prefix, ppsize_zero};
     use net::packet::VpcDiscriminant;
     use net::vxlan::Vni;
@@ -701,19 +678,23 @@ mod tests {
         let manifest1 = VpcManifest::with_exposes(
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
             vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let overlap = get_manifest_ips_overlap(
             &manifest1,
             &manifest2,
             vpcd1,
             vpcd2,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             false,
             false,
         );
@@ -730,19 +711,23 @@ mod tests {
         let manifest1 = VpcManifest::with_exposes(
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
             vec![VpcExpose::empty().ip("10.0.0.0/25".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let overlap = get_manifest_ips_overlap(
             &manifest1,
             &manifest2,
             vpcd1,
             vpcd2,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             false,
             false,
         );
@@ -765,7 +750,9 @@ mod tests {
         let manifest1 = VpcManifest::with_exposes(
             "manifest1",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
@@ -773,14 +760,16 @@ mod tests {
                 "10.0.0.0/25".into(),
                 Some(PortRange::new(100, 200).unwrap()),
             ))],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let overlap = get_manifest_ips_overlap(
             &manifest1,
             &manifest2,
             vpcd1,
             vpcd2,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             false,
             false,
         );
@@ -811,7 +800,9 @@ mod tests {
                     .ip("10.0.0.0/24".into())
                     .ip("20.0.0.128/25".into()),
             ],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let manifest2 = VpcManifest::with_exposes(
             "manifest2",
@@ -819,17 +810,21 @@ mod tests {
                 VpcExpose::empty()
                     .make_stateful_nat(None)
                     .unwrap()
-                    .ip("10.0.0.0/25".into()),
+                    .ip("10.0.0.0/25".into())
+                    .as_range("100.0.0.0/25".into())
+                    .unwrap(),
                 VpcExpose::empty().ip("20.0.0.0/24".into()),
             ],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let overlap = get_manifest_ips_overlap(
             &manifest1,
             &manifest2,
             vpcd1,
             vpcd2,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             false,
             false,
         );
@@ -911,6 +906,11 @@ mod tests {
                     .unwrap(),
             ],
         );
+        assert!(matches!(
+            manifest.clone().validated(),
+            Err(ConfigError::OverlappingPrefixes(_, _))
+        ));
+        let manifest = unsafe { manifest.fake_valid_manifest_for_tests() };
 
         let overlap = get_manifest_ips_overlap(
             &manifest,
@@ -1069,14 +1069,16 @@ mod tests {
         let manifest = VpcManifest::with_exposes(
             "manifest",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let overlaps = BTreeMap::new();
 
         let result = get_split_prefixes_for_manifest(
             &manifest,
             &vpcd,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             overlaps,
             false,
         );
@@ -1100,7 +1102,9 @@ mod tests {
         let manifest = VpcManifest::with_exposes(
             "manifest",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let mut overlaps = BTreeMap::new();
         // The overlap covers part of the manifest's prefix
@@ -1112,7 +1116,7 @@ mod tests {
         let mut result = get_split_prefixes_for_manifest(
             &manifest,
             &vpcd,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             overlaps,
             false,
         );
@@ -1157,7 +1161,9 @@ mod tests {
         let manifest = VpcManifest::with_exposes(
             "manifest_a",
             vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-        );
+        )
+        .validated()
+        .unwrap();
 
         let mut overlaps = BTreeMap::new();
         // Overlap 1: 10.0.0.0/25 is shared between A and B
@@ -1174,7 +1180,7 @@ mod tests {
         let mut result = get_split_prefixes_for_manifest(
             &manifest,
             &vpcd_a,
-            |expose| &expose.ips,
+            |expose| expose.ips(),
             overlaps,
             false,
         );
@@ -1235,11 +1241,14 @@ mod tests {
         let overlay = Overlay {
             vpc_table,
             peering_table: VpcPeeringTable::new(),
-        };
+        }
+        .validated()
+        .unwrap();
 
+        let vpc1 = vpc1.validated().unwrap();
         let mut table = FlowFilterTable::new();
         table
-            .add_peering(&overlay, &vpc1, &vpc1.peerings[0])
+            .add_peering(&overlay, &vpc1, &vpc1.peerings()[0])
             .unwrap();
 
         let src_vpcd = vni1.into();
@@ -1305,11 +1314,20 @@ mod tests {
         let overlay = Overlay {
             vpc_table,
             peering_table: VpcPeeringTable::new(),
-        };
+        }
+        .validated()
+        .unwrap();
+
+        // vpc1 is not valid, we have to fake its transformation into a ValidatedVpc for this test
+        assert!(matches!(
+            vpc1.clone().validated(),
+            Err(ConfigError::OverlappingPrefixes(_, _))
+        ));
+        let vpc1 = unsafe { vpc1.fake_validated_vpc_for_tests() };
 
         let mut table = FlowFilterTable::new();
         table
-            .add_peering(&overlay, &vpc1, &vpc1.peerings[0])
+            .add_peering(&overlay, &vpc1, &vpc1.peerings()[0])
             .unwrap();
 
         let src_vpcd = vni1.into();
@@ -1342,90 +1360,41 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_skipping_peerings() {
-        let mut vpc = Vpc::new("test-vpc", "VPC01", 100).unwrap();
-
-        vpc.peerings.push(Peering {
-            name: "peering1".to_string(),
-            local: VpcManifest::with_exposes("local1", vec![]),
-            remote: VpcManifest::with_exposes("remote1", vec![]),
-            remote_id: "VPC02".try_into().unwrap(),
-            gwgroup: None,
-        });
-
-        let cloned = clone_skipping_peerings(&vpc);
-
-        assert_eq!(cloned.name, vpc.name);
-        assert_eq!(cloned.id, vpc.id);
-        assert_eq!(cloned.vni, vpc.vni);
-        assert_eq!(cloned.peerings.len(), 0);
-    }
-
-    #[test]
-    fn test_cleanup_vpc_table() {
-        let mut vpc = Vpc::new("test-vpc", "VPC01", 100).unwrap();
-
-        vpc.peerings.push(Peering {
-            name: "peering1".to_string(),
-            local: VpcManifest::with_exposes(
-                "local1",
-                vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-            ),
-            remote: VpcManifest::with_exposes(
-                "remote1",
-                vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
-            ),
-            remote_id: "VPC02".try_into().unwrap(),
-            gwgroup: None,
-        });
-
-        let vpcs = vec![&vpc];
-        let result = cleanup_vpc_table(vpcs);
-
-        assert!(result.is_ok());
-        let cleaned_vpcs = result.unwrap();
-        assert_eq!(cleaned_vpcs.len(), 1);
-        assert_eq!(cleaned_vpcs[0].name, vpc.name);
-    }
-
-    #[test]
     fn test_build_from_overlay() {
         // Create a simple overlay with two VPCs and a peering
-        let mut vpc_table = VpcTable::new();
-
         let vni1 = Vni::new_checked(100).unwrap();
         let vni2 = Vni::new_checked(200).unwrap();
-
-        let mut vpc1 = Vpc::new("vpc1", "VPC01", vni1.as_u32()).unwrap();
+        let vpc1 = Vpc::new("vpc1", "VPC01", vni1.as_u32()).unwrap();
         let vpc2 = Vpc::new("vpc2", "VPC02", vni2.as_u32()).unwrap();
-
-        // Add peering from vpc1 to vpc2
-        vpc1.peerings.push(Peering {
-            name: "vpc1-to-vpc2".to_string(),
-            local: VpcManifest::with_exposes(
-                "vpc1-local",
-                vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
-            ),
-            remote: VpcManifest::with_exposes(
-                "vpc2-remote",
-                vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
-            ),
-            remote_id: "VPC02".try_into().unwrap(),
-            gwgroup: None,
-        });
-
+        let mut vpc_table = VpcTable::new();
         vpc_table.add(vpc1).unwrap();
         vpc_table.add(vpc2).unwrap();
 
+        let mut peering_table = VpcPeeringTable::new();
+        // Add peering between vpc1 to vpc2
+        peering_table
+            .add(VpcPeering::with_default_group(
+                "vpc1-to-vpc2",
+                VpcManifest::with_exposes(
+                    "vpc1",
+                    vec![VpcExpose::empty().ip("10.0.0.0/24".into())],
+                ),
+                VpcManifest::with_exposes(
+                    "vpc2",
+                    vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
+                ),
+            ))
+            .unwrap();
+
         let overlay = Overlay {
             vpc_table,
-            peering_table: VpcPeeringTable::new(),
-        };
+            peering_table,
+        }
+        .validated()
+        .unwrap();
 
-        let result = FlowFilterTable::build_from_overlay(&overlay);
-        assert!(result.is_ok());
+        let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
 
-        let table = result.unwrap();
         // Should be able to look up flows
         let src_vpcd = VpcDiscriminant::VNI(vni1);
         let src_addr = "10.0.0.5".parse().unwrap();

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -1245,7 +1245,7 @@ mod tests {
         .validated()
         .unwrap();
 
-        let vpc1 = vpc1.validated().unwrap();
+        let vpc1 = vpc1.validate().unwrap();
         let mut table = FlowFilterTable::new();
         table
             .add_peering(&overlay, &vpc1, &vpc1.peerings()[0])
@@ -1320,7 +1320,7 @@ mod tests {
 
         // vpc1 is not valid, we have to fake its transformation into a ValidatedVpc for this test
         assert!(matches!(
-            vpc1.clone().validated(),
+            vpc1.clone().validate(),
             Err(ConfigError::OverlappingPrefixes(_, _))
         ));
         let vpc1 = unsafe { vpc1.fake_validated_vpc_for_tests() };

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -1242,7 +1242,7 @@ mod tests {
             vpc_table,
             peering_table: VpcPeeringTable::new(),
         }
-        .validated()
+        .validate()
         .unwrap();
 
         let vpc1 = vpc1.validate().unwrap();
@@ -1315,7 +1315,7 @@ mod tests {
             vpc_table,
             peering_table: VpcPeeringTable::new(),
         }
-        .validated()
+        .validate()
         .unwrap();
 
         // vpc1 is not valid, we have to fake its transformation into a ValidatedVpc for this test
@@ -1390,7 +1390,7 @@ mod tests {
             vpc_table,
             peering_table,
         }
-        .validated()
+        .validate()
         .unwrap();
 
         let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();

--- a/flow-filter/src/tests.rs
+++ b/flow-filter/src/tests.rs
@@ -5,6 +5,7 @@ use crate::tables::NatRequirement;
 use crate::{
     FlowFilter, FlowFilterTable, FlowFilterTableWriter, FlowTuple, RemoteData, VpcdLookupResult,
 };
+use config::ConfigError;
 use config::external::overlay::Overlay;
 use config::external::overlay::vpc::{Vpc, VpcTable};
 use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest, VpcPeering, VpcPeeringTable};
@@ -440,17 +441,19 @@ fn test_flow_filter_table_overlap_cases() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
     // Build overlay.vpc_table's peerings from peering_table, with no validation.
     // We don't validate because overlapping prefixes actually make the config invalid; but it
     // doesn't matter for the test.
-    overlay.collect_peerings();
+    let mut overlay = Overlay::new(vpc_table, peering_table);
+    assert!(matches!(
+        overlay.validate(),
+        Err(ConfigError::OverlappingPrefixes(_, _))
+    ));
+    let overlay = unsafe { overlay.fake_validated_overlay_for_tests() };
 
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -669,15 +672,10 @@ fn test_flow_filter_table_from_overlay() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Validation is necessary to build overlay.vpc_table's peerings from peering_table
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -758,15 +756,10 @@ fn test_flow_filter_table_check_send_from_default() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Validation is necessary to build overlay.vpc_table's peerings from peering_table
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with a packet
@@ -804,15 +797,16 @@ fn test_flow_filter_table_check_default_to_default() {
         ))
         .unwrap();
 
+    // Build overlay.vpc_table's peerings from peering_table, with no validation.
+    // We don't validate because overlapping prefixes actually make the config invalid; but it
+    // doesn't matter for the test.
     let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Build overlay.vpc_table's peerings from peering_table, with no validation
-    overlay.collect_peerings();
+    assert!(matches!(overlay.validate(), Err(ConfigError::Forbidden(_))));
+    let overlay = unsafe { overlay.fake_validated_overlay_for_tests() };
 
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -886,15 +880,16 @@ fn test_flow_filter_table_check_nat_requirements() {
         ))
         .unwrap();
 
+    // Build overlay.vpc_table's peerings from peering_table, with no validation.
+    // We don't validate because overlapping prefixes actually make the config invalid; but it
+    // doesn't matter for the test.
     let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Build overlay.vpc_table's peerings from peering_table, with no validation
-    overlay.collect_peerings();
+    assert!(matches!(overlay.validate(), Err(ConfigError::Forbidden(_))));
+    let overlay = unsafe { overlay.fake_validated_overlay_for_tests() };
 
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -1003,11 +998,8 @@ fn test_flow_filter_table_check_stateful_nat_plus_peer_forwarding() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
 
@@ -1208,14 +1200,10 @@ fn test_flow_filter_protocol_aware_port_forwarding() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Source side: VPC 1 -> VPC 2
@@ -1339,14 +1327,10 @@ fn test_flow_filter_protocol_any_port_forwarding() {
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Destination side: TCP packet -> port forwarding
@@ -1499,15 +1483,10 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Validation is necessary to build overlay.vpc_table's peerings from peering_table
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -1731,15 +1710,10 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Validation is necessary to build overlay.vpc_table's peerings from peering_table
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets
@@ -1853,15 +1827,10 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let mut overlay = Overlay::new(vpc_table, peering_table);
-    // Validation is necessary to build overlay.vpc_table's peerings from peering_table
-    overlay.validate().unwrap();
-
+    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
-
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
-
     let mut flow_filter = FlowFilter::new("test-filter", writer.get_reader());
 
     // Test with packets

--- a/flow-filter/src/tests.rs
+++ b/flow-filter/src/tests.rs
@@ -444,7 +444,7 @@ fn test_flow_filter_table_overlap_cases() {
     // Build overlay.vpc_table's peerings from peering_table, with no validation.
     // We don't validate because overlapping prefixes actually make the config invalid; but it
     // doesn't matter for the test.
-    let mut overlay = Overlay::new(vpc_table, peering_table);
+    let overlay = Overlay::new(vpc_table, peering_table);
     assert!(matches!(
         overlay.validate(),
         Err(ConfigError::OverlappingPrefixes(_, _))
@@ -672,7 +672,7 @@ fn test_flow_filter_table_from_overlay() {
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -756,7 +756,7 @@ fn test_flow_filter_table_check_send_from_default() {
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -800,7 +800,7 @@ fn test_flow_filter_table_check_default_to_default() {
     // Build overlay.vpc_table's peerings from peering_table, with no validation.
     // We don't validate because overlapping prefixes actually make the config invalid; but it
     // doesn't matter for the test.
-    let mut overlay = Overlay::new(vpc_table, peering_table);
+    let overlay = Overlay::new(vpc_table, peering_table);
     assert!(matches!(overlay.validate(), Err(ConfigError::Forbidden(_))));
     let overlay = unsafe { overlay.fake_validated_overlay_for_tests() };
 
@@ -883,7 +883,7 @@ fn test_flow_filter_table_check_nat_requirements() {
     // Build overlay.vpc_table's peerings from peering_table, with no validation.
     // We don't validate because overlapping prefixes actually make the config invalid; but it
     // doesn't matter for the test.
-    let mut overlay = Overlay::new(vpc_table, peering_table);
+    let overlay = Overlay::new(vpc_table, peering_table);
     assert!(matches!(overlay.validate(), Err(ConfigError::Forbidden(_))));
     let overlay = unsafe { overlay.fake_validated_overlay_for_tests() };
 
@@ -998,7 +998,7 @@ fn test_flow_filter_table_check_stateful_nat_plus_peer_forwarding() {
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -1200,7 +1200,7 @@ fn test_flow_filter_protocol_aware_port_forwarding() {
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -1327,7 +1327,7 @@ fn test_flow_filter_protocol_any_port_forwarding() {
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -1483,7 +1483,7 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -1710,7 +1710,7 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);
@@ -1827,7 +1827,7 @@ fn test_flow_filter_table_from_overlay_masquerade_port_forwarding_private_ips_ov
         ))
         .unwrap();
 
-    let overlay = Overlay::new(vpc_table, peering_table).validated().unwrap();
+    let overlay = Overlay::new(vpc_table, peering_table).validate().unwrap();
     let table = FlowFilterTable::build_from_overlay(&overlay).unwrap();
     let mut writer = FlowFilterTableWriter::new();
     writer.update_flow_filter_table(table);

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -23,7 +23,7 @@ where
 }
 
 #[must_use]
-pub fn ppsize_zero() -> PrefixWithPortsSize {
+pub const fn ppsize_zero() -> PrefixWithPortsSize {
     n!(0)
 }
 
@@ -178,6 +178,18 @@ impl PrefixPortsSet {
             }
         }
         result
+    }
+
+    /// Return the total "size" of all prefixes in the set.
+    ///
+    /// The "size" is the number of IP addresses in the IP prefix, multiplied by the number of ports
+    /// in the associated port range, if any.
+    #[must_use]
+    pub fn total_prefixes_size(&self) -> PrefixWithPortsSize {
+        self.0
+            .iter()
+            .map(PrefixWithOptionalPorts::size)
+            .sum::<PrefixWithPortsSize>()
     }
 }
 

--- a/mgmt/src/processor/confbuild/internal.rs
+++ b/mgmt/src/processor/confbuild/internal.rs
@@ -11,8 +11,8 @@ const IMPORT_VRFS: bool = false;
 use config::external::communities::PriorityCommunityTable;
 use config::external::gwgroup::GwGroupTable;
 use config::external::overlay::ValidatedOverlay;
-use config::external::overlay::vpc::{Peering, Vpc};
-use config::external::overlay::vpcpeering::VpcManifest;
+use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpc};
+use config::external::overlay::vpcpeering::ValidatedManifest;
 use config::{ConfigError, ConfigResult};
 
 use lpm::prefix::Prefix;
@@ -35,27 +35,21 @@ use config::internal::routing::statics::StaticRoute;
 use config::internal::routing::vrf::VrfConfig;
 use config::{InternalConfig, ValidatedGwConfig};
 
-/// Build a drop route
-#[must_use]
-fn build_drop_route(prefix: &Prefix) -> StaticRoute {
-    StaticRoute::new(*prefix).nhop_reject()
-}
-
 /// Populate a prefix list to import routes into a vpc vrf
 fn vpc_import_prefix_list_for_peer(
-    vpc: &Vpc,
-    rmanifest: &VpcManifest,
+    vpc: &ValidatedVpc,
+    rmanifest: &ValidatedManifest,
 ) -> Result<PrefixList, ConfigError> {
     let mut plist = PrefixList::new(
-        &vpc.import_plist_peer(&rmanifest.name),
+        &vpc.import_plist_peer(rmanifest.name()),
         IpVer::V4,
-        Some(vpc.import_plist_peer_desc(&rmanifest.name)),
+        Some(vpc.import_plist_peer_desc(rmanifest.name())),
     );
-    for expose in rmanifest.raw_exposes() {
+    for expose in rmanifest.valexp() {
         // allow native prefixes, natted or not
         let native_prefixes =
             expose
-                .ips
+                .ips()
                 .iter()
                 .filter(|p| p.prefix().is_ipv4())
                 .map(|prefix_with_ports| {
@@ -66,41 +60,13 @@ fn vpc_import_prefix_list_for_peer(
                     )
                 });
         plist.add_entries(native_prefixes)?;
-
-        // disallow prefix exceptions, whether there's nat or not
-        let nots = expose
-            .nots
-            .iter()
-            .filter(|p| p.prefix().is_ipv4())
-            .map(|prefix_with_ports| {
-                PrefixListEntry::new(
-                    PrefixListAction::Deny,
-                    PrefixListPrefix::Prefix(prefix_with_ports.prefix()),
-                    None,
-                )
-            });
-        plist.add_entries(nots)?;
     }
     Ok(plist)
 }
 
-#[must_use]
-fn build_vpc_drop_routes(rmanifest: &VpcManifest) -> Vec<StaticRoute> {
-    let mut sroute_vec: Vec<StaticRoute> = vec![];
-    for expose in rmanifest.raw_exposes() {
-        let mut statics: Vec<StaticRoute> = expose
-            .nots
-            .iter()
-            .map(|prefix_with_ports| build_drop_route(&prefix_with_ports.prefix()))
-            .collect();
-        sroute_vec.append(&mut statics);
-    }
-    sroute_vec
-}
-
 /// Build AF l2vpn EVPN config for a VPC VRF
 #[must_use]
-fn vpc_bgp_af_l2vpn_evpn(vpc: &Vpc) -> AfL2vpnEvpn {
+fn vpc_bgp_af_l2vpn_evpn(vpc: &ValidatedVpc) -> AfL2vpnEvpn {
     AfL2vpnEvpn::new()
         .set_adv_all_vni(false)
         .set_adv_default_gw(false)
@@ -137,7 +103,7 @@ struct VpcRoutingConfigIpv4 {
 }
 impl VpcRoutingConfigIpv4 {
     #[must_use]
-    fn new(vpc: &Vpc) -> Self {
+    fn new(vpc: &ValidatedVpc) -> Self {
         Self {
             import_rmap: RouteMap::new(&vpc.import_rmap_ipv4()),
             import_plists: Vec::with_capacity(vpc.num_peerings()),
@@ -150,28 +116,27 @@ impl VpcRoutingConfigIpv4 {
     }
     fn build_routing_config_peer(
         &mut self,
-        vpc: &Vpc,
-        peer: &Peering,
+        vpc: &ValidatedVpc,
+        peer: &ValidatedPeering,
         community: Community,
     ) -> ConfigResult {
         /* remote manifest */
-        let rmanifest = &peer.remote;
-
-        /* static drops for excluded prefixes (optional) */
-        let mut statics = build_vpc_drop_routes(rmanifest);
-        self.sroutes.append(&mut statics);
+        let rmanifest = peer.remote();
 
         /* create import route-map entry */
         if IMPORT_VRFS {
             /* we import from this vrf */
-            self.vrf_imports.add_vrf(peer.remote_id.vrf_name().as_ref());
+            self.vrf_imports
+                .add_vrf(peer.remote_id().vrf_name().as_ref());
 
             /* build prefix list for the peer from its remote manifest */
             let plist = vpc_import_prefix_list_for_peer(vpc, rmanifest)?;
 
             let import_rmap_e = RouteMapEntry::new(MatchingPolicy::Permit)
                 .add_match(RouteMapMatch::Ipv4AddressPrefixList(plist.name.clone()))
-                .add_match(RouteMapMatch::SrcVrf(peer.remote_id.vrf_name().to_string()));
+                .add_match(RouteMapMatch::SrcVrf(
+                    peer.remote_id().vrf_name().to_string(),
+                ));
 
             /* add entry */
             self.import_rmap.add_entry(None, import_rmap_e)?;
@@ -181,20 +146,17 @@ impl VpcRoutingConfigIpv4 {
         }
 
         /* advertise */
-        let nets = rmanifest
-            .raw_exposes()
-            .iter()
-            .flat_map(|e| e.adv_prefixes());
+        let nets = rmanifest.valexp().iter().flat_map(|e| e.adv_prefixes());
 
         self.adv_nets.extend(nets);
 
         /* build adv prefix list and route-map */
         let mut adv_plist = PrefixList::new(
-            &vpc.adv_plist(&rmanifest.name),
+            &vpc.adv_plist(rmanifest.name()),
             IpVer::V4,
-            Some(vpc.adv_plist_desc(&rmanifest.name)),
+            Some(vpc.adv_plist_desc(rmanifest.name())),
         );
-        for expose in rmanifest.raw_exposes() {
+        for expose in rmanifest.valexp() {
             let prefixes = expose.adv_prefixes().into_iter();
             let plists = prefixes.map(|p| {
                 PrefixListEntry::new(PrefixListAction::Permit, PrefixListPrefix::Prefix(p), None)
@@ -207,7 +169,7 @@ impl VpcRoutingConfigIpv4 {
         let mut adv_rmape = RouteMapEntry::new(MatchingPolicy::Permit);
         adv_rmape = adv_rmape
             .add_match(RouteMapMatch::Ipv4AddressPrefixList(
-                vpc.adv_plist(&rmanifest.name),
+                vpc.adv_plist(rmanifest.name()),
             ))
             .add_action(RouteMapSetAction::Community(vec![community], true));
 
@@ -219,12 +181,12 @@ impl VpcRoutingConfigIpv4 {
     fn build_routing_config(
         &mut self,
         gwname: &str,
-        vpc: &Vpc,
+        vpc: &ValidatedVpc,
         grouptable: &GwGroupTable,
         commtable: &PriorityCommunityTable,
     ) -> ConfigResult {
-        for peer in vpc.peerings.iter() {
-            if let Some(group) = &peer.gwgroup
+        for peer in vpc.peerings().iter() {
+            if let Some(group) = &peer.gwgroup()
                 && let Some(rank) = grouptable.get_group_member_rank(group, gwname)
                 && let Some(comm) = commtable.get_community(rank)
             {
@@ -236,7 +198,7 @@ impl VpcRoutingConfigIpv4 {
 }
 
 /// Build BGP config for a VPC VRF (bmp is applied elsewhere)
-fn vpc_vrf_bgp_config(vpc: &Vpc, asn: u32, router_id: Option<Ipv4Addr>) -> BgpConfig {
+fn vpc_vrf_bgp_config(vpc: &ValidatedVpc, asn: u32, router_id: Option<Ipv4Addr>) -> BgpConfig {
     let mut bgp = BgpConfig::new(asn).set_vrf_name(vpc.vrf_name());
     if let Some(router_id) = router_id {
         bgp.set_router_id(router_id);
@@ -246,27 +208,27 @@ fn vpc_vrf_bgp_config(vpc: &Vpc, asn: u32, router_id: Option<Ipv4Addr>) -> BgpCo
 }
 
 /// Build VRF config for a VPC
-fn vpc_vrf_config(vpc: &Vpc) -> Result<VrfConfig, ConfigError> {
-    debug!("Building VRF config for vpc '{}'", vpc.name);
+fn vpc_vrf_config(vpc: &ValidatedVpc) -> Result<VrfConfig, ConfigError> {
+    debug!("Building VRF config for vpc '{}'", vpc.name());
     /* build vrf config */
-    let mut vrf_cfg = VrfConfig::new(&vpc.vrf_name(), Some(vpc.vni), false)
-        .set_vpc_id(vpc.id.clone())
-        .set_description(&vpc.name);
+    let mut vrf_cfg = VrfConfig::new(&vpc.vrf_name(), Some(vpc.vni()), false)
+        .set_vpc_id(vpc.id().clone())
+        .set_description(vpc.name());
 
     // Here we set the table-id for the VRF. This is the table-id that will be used to create a VRF net device.
     // Table ids should be unique per VRF. We could track them and pick unused ones. Alternatively, we need
     // a 1:1 mapping to VNIs which are guaranteed to be unique. The easiest is to let table ids match the Vni,
     // except for Vnis that could match reserved table ids such as 253-255
-    let table_id = match vpc.vni.as_u32() {
+    let table_id = match vpc.vni().as_u32() {
         253_u32 => Vni::MAX + 1, // local
         254_u32 => Vni::MAX + 2, // main
         255_u32 => Vni::MAX + 3, // default
-        _ => vpc.vni.as_u32(),
+        _ => vpc.vni().as_u32(),
     };
     let table_id = RouteTableId::try_from(table_id).map_err(|_| {
         let emsg = format!(
             "Could not create RouteTableId from {table_id} for VPC {}",
-            vpc.name
+            vpc.name()
         );
         error!(emsg);
         ConfigError::InternalFailure(emsg)
@@ -286,12 +248,12 @@ fn vpc_bgp_af_ipv4_unicast(vpc_rconf: &VpcRoutingConfigIpv4) -> AfIpv4Ucast {
 }
 
 fn build_vpc_internal_config(
-    vpc: &Vpc,
+    vpc: &ValidatedVpc,
     asn: u32,
     router_id: Option<Ipv4Addr>,
     internal: &mut InternalConfig,
 ) -> ConfigResult {
-    debug!("Building internal config for vpc '{}'", vpc.name);
+    debug!("Building internal config for vpc '{}'", vpc.name());
 
     /* build VRF config */
     let mut vrf_cfg = vpc_vrf_config(vpc)?;
@@ -339,7 +301,7 @@ fn build_internal_overlay_config(
 
     /* Vpcs and peerings */
     for vpc in overlay.vpc_table().values() {
-        build_vpc_internal_config(vpc.inner(), asn, router_id, internal)?;
+        build_vpc_internal_config(vpc, asn, router_id, internal)?;
     }
     Ok(())
 }
@@ -391,7 +353,7 @@ pub fn build_internal_config(
     if let (Some(mut bmp_opts), Some(bgp_default)) = (bmp, default_vrf.bgp.as_mut()) {
         // Collect all overlay VRF names to import
         for vpc in external.overlay().vpc_table().values() {
-            bmp_opts.push_import_vrf_view(vpc.inner().vrf_name());
+            bmp_opts.push_import_vrf_view(vpc.vrf_name());
         }
         // Inject BMP into default VRF BGP
         bgp_default.set_bmp_options(bmp_opts);

--- a/mgmt/src/processor/confbuild/internal.rs
+++ b/mgmt/src/processor/confbuild/internal.rs
@@ -10,7 +10,7 @@ const IMPORT_VRFS: bool = false;
 
 use config::external::communities::PriorityCommunityTable;
 use config::external::gwgroup::GwGroupTable;
-use config::external::overlay::Overlay;
+use config::external::overlay::ValidatedOverlay;
 use config::external::overlay::vpc::{Peering, Vpc};
 use config::external::overlay::vpcpeering::VpcManifest;
 use config::{ConfigError, ConfigResult};
@@ -33,7 +33,7 @@ use config::internal::routing::routemap::{
 };
 use config::internal::routing::statics::StaticRoute;
 use config::internal::routing::vrf::VrfConfig;
-use config::{GwConfig, InternalConfig};
+use config::{InternalConfig, ValidatedGwConfig};
 
 /// Build a drop route
 #[must_use]
@@ -51,7 +51,7 @@ fn vpc_import_prefix_list_for_peer(
         IpVer::V4,
         Some(vpc.import_plist_peer_desc(&rmanifest.name)),
     );
-    for expose in &rmanifest.exposes {
+    for expose in rmanifest.raw_exposes() {
         // allow native prefixes, natted or not
         let native_prefixes =
             expose
@@ -87,7 +87,7 @@ fn vpc_import_prefix_list_for_peer(
 #[must_use]
 fn build_vpc_drop_routes(rmanifest: &VpcManifest) -> Vec<StaticRoute> {
     let mut sroute_vec: Vec<StaticRoute> = vec![];
-    for expose in &rmanifest.exposes {
+    for expose in rmanifest.raw_exposes() {
         let mut statics: Vec<StaticRoute> = expose
             .nots
             .iter()
@@ -181,7 +181,10 @@ impl VpcRoutingConfigIpv4 {
         }
 
         /* advertise */
-        let nets = rmanifest.exposes.iter().flat_map(|e| e.adv_prefixes());
+        let nets = rmanifest
+            .raw_exposes()
+            .iter()
+            .flat_map(|e| e.adv_prefixes());
 
         self.adv_nets.extend(nets);
 
@@ -191,7 +194,7 @@ impl VpcRoutingConfigIpv4 {
             IpVer::V4,
             Some(vpc.adv_plist_desc(&rmanifest.name)),
         );
-        for expose in rmanifest.exposes.iter() {
+        for expose in rmanifest.raw_exposes() {
             let prefixes = expose.adv_prefixes().into_iter();
             let plists = prefixes.map(|p| {
                 PrefixListEntry::new(PrefixListAction::Permit, PrefixListPrefix::Prefix(p), None)
@@ -324,16 +327,19 @@ fn build_vpc_internal_config(
 }
 
 fn build_internal_overlay_config(
-    overlay: &Overlay,
+    overlay: &ValidatedOverlay,
     asn: u32,
     router_id: Option<Ipv4Addr>,
     internal: &mut InternalConfig,
 ) -> ConfigResult {
-    debug!("Building overlay config ({} VPCs)", overlay.vpc_table.len());
+    debug!(
+        "Building overlay config ({} VPCs)",
+        overlay.vpc_table().len()
+    );
 
     /* Vpcs and peerings */
-    for vpc in overlay.vpc_table.values() {
-        build_vpc_internal_config(vpc, asn, router_id, internal)?;
+    for vpc in overlay.vpc_table().values() {
+        build_vpc_internal_config(vpc.inner(), asn, router_id, internal)?;
     }
     Ok(())
 }
@@ -371,47 +377,47 @@ fn configure_bgp_peers(vrf: &mut VrfConfig, internal: &mut InternalConfig) {
 
 /// Public entry — build with BMP (global options injected into default VRF and import views)
 pub fn build_internal_config(
-    config: &GwConfig,
+    config: &ValidatedGwConfig,
     bmp: Option<BmpOptions>,
 ) -> Result<InternalConfig, ConfigError> {
     let genid = config.genid();
     debug!("Building internal config for gen {genid}");
-    let external = &config.external;
+    let external = config.external();
 
     // Prepare default VRF (possibly inject global BMP with VRF import views)
-    let mut default_vrf = external.underlay.vrf.clone();
+    let mut default_vrf = external.underlay().vrf.clone();
 
     // If BMP is provided and default VRF has BGP, attach BMP there and add import views
     if let (Some(mut bmp_opts), Some(bgp_default)) = (bmp, default_vrf.bgp.as_mut()) {
         // Collect all overlay VRF names to import
-        for vpc in external.overlay.vpc_table.values() {
-            bmp_opts.push_import_vrf_view(vpc.vrf_name());
+        for vpc in external.overlay().vpc_table().values() {
+            bmp_opts.push_import_vrf_view(vpc.inner().vrf_name());
         }
         // Inject BMP into default VRF BGP
         bgp_default.set_bmp_options(bmp_opts);
     }
 
     // Build internal config: device and underlay configs are copied as received (with adjusted default_vrf)
-    let mut internal = InternalConfig::new(&external.gwname, external.device.clone());
+    let mut internal = InternalConfig::new(external.gwname(), external.device().clone());
 
     configure_bgp_peers(&mut default_vrf, &mut internal);
 
     internal.add_vrf_config(default_vrf)?;
-    internal.set_vtep(external.underlay.vtep.clone());
-    internal.gwgrouptable = external.gwgroups.sorted();
-    internal.commtable = external.communities.clone();
+    internal.set_vtep(external.underlay().vtep.clone());
+    internal.gwgrouptable = external.gwgroups().sorted();
+    internal.commtable = external.communities().clone();
 
     // Build BFD peers from underlay BGP neighbors
-    if let Some(bgp) = &external.underlay.vrf.bgp {
+    if let Some(bgp) = &external.underlay().vrf.bgp {
         internal.set_bfd_peers(peers_from_bgp_neighbors(&bgp.neighbors));
     }
 
     // Build overlay config
-    if let Some(bgp) = &external.underlay.vrf.bgp {
+    if let Some(bgp) = &external.underlay().vrf.bgp {
         let asn = bgp.asn;
         let router_id = bgp.router_id;
-        if !external.overlay.vpc_table.is_empty() {
-            build_internal_overlay_config(&external.overlay, asn, router_id, &mut internal)?;
+        if !external.overlay().vpc_table().is_empty() {
+            build_internal_overlay_config(external.overlay(), asn, router_id, &mut internal)?;
         } else {
             debug!("The configuration does not specify any VPCs...");
         }

--- a/mgmt/src/processor/confbuild/namegen.rs
+++ b/mgmt/src/processor/confbuild/namegen.rs
@@ -11,7 +11,7 @@
 
 #![allow(unused)]
 
-use config::external::overlay::vpc::{Vpc, VpcId};
+use config::external::overlay::vpc::{ValidatedVpc, VpcId};
 use net::interface::InterfaceName;
 
 ////////////////////////////////////////////////////////////////////////
@@ -53,42 +53,42 @@ pub(crate) trait VpcConfigNames {
     fn adv_rmap(&self) -> String;
 }
 
-impl VpcConfigNames for Vpc {
+impl VpcConfigNames for ValidatedVpc {
     fn vrf_name(&self) -> String {
-        self.id.vrf_name().to_string()
+        self.id().vrf_name().to_string()
     }
     fn import_rmap_ipv4(&self) -> String {
-        format!("{}-IPV4-IMPORTS", self.name.to_uppercase())
+        format!("{}-IPV4-IMPORTS", self.name().to_uppercase())
     }
     fn import_rmap_ipv6(&self) -> String {
-        format!("{}-IPV6-IMPORTS", self.name.to_uppercase())
+        format!("{}-IPV6-IMPORTS", self.name().to_uppercase())
     }
     fn import_plist_peer(&self, remote_name: &str) -> String {
         format!(
             "{}-FROM-{}",
-            &self.name.to_uppercase(),
+            &self.name().to_uppercase(),
             remote_name.to_uppercase()
         )
     }
     fn import_plist_peer_desc(&self, remote_name: &str) -> String {
-        format!("Prefixes of {} reachable by {}", remote_name, self.name)
+        format!("Prefixes of {} reachable by {}", remote_name, self.name())
     }
 
     fn adv_plist(&self, remote_name: &str) -> String {
         format!(
             "ADV-TO-{}-FOR-{}",
-            &self.name.to_uppercase(),
+            &self.name().to_uppercase(),
             remote_name.to_uppercase()
         )
     }
     fn adv_plist_desc(&self, remote_name: &str) -> String {
         format!(
             "Prefixes advertised to {} for {}",
-            &self.name.to_uppercase(),
+            &self.name().to_uppercase(),
             remote_name.to_uppercase()
         )
     }
     fn adv_rmap(&self) -> String {
-        format!("ADV-TO-{}", &self.name.to_uppercase())
+        format!("ADV-TO-{}", &self.name().to_uppercase())
     }
 }

--- a/mgmt/src/processor/confbuild/router.rs
+++ b/mgmt/src/processor/confbuild/router.rs
@@ -16,7 +16,7 @@ use tracing::{debug, error};
 
 use config::internal::interfaces::interface::InterfaceConfig;
 use config::internal::routing::vrf::VrfConfig;
-use config::{ConfigError, GwConfig, InternalConfig};
+use config::{ConfigError, InternalConfig, ValidatedGwConfig};
 use net::eth::mac::{Mac, SourceMac};
 use net::interface::{Interface, InterfaceIndex, InterfaceName, Mtu};
 
@@ -183,13 +183,13 @@ fn generate_router_interfaces_config(
 }
 pub(crate) fn generate_router_config(
     kernel_vrfs: &HashMap<InterfaceName, Interface>,
-    config: Arc<GwConfig>,
+    config: Arc<ValidatedGwConfig>,
 ) -> Result<RouterConfig, ConfigError> {
     let genid = config.genid();
     debug!("Generating router config for genid {genid}...");
 
     /* get internal config -- should not fail by construction */
-    let internal = config.internal.as_ref().unwrap_or_else(|| unreachable!());
+    let internal = config.internal().unwrap_or_else(|| unreachable!());
 
     /* create a new, empty RouterConfig and populate it with vrf, vtep and interface configs */
     let mut router_config = RouterConfig::new(genid);

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -4,21 +4,21 @@
 //! Configuration database
 
 use crate::processor::confbuild::internal::build_internal_config;
-use config::{ConfigSummary, GenId, GwConfig, GwConfigMeta};
+use config::{ConfigSummary, GenId, GwConfigMeta, ValidatedGwConfig};
 use std::sync::Arc;
 use tracing::{debug, info};
 
 /// Configuration database, keeps a set of [`GwConfig`]s keyed by generation id [`GenId`]
 pub(crate) struct GwConfigDatabase {
-    applied: Arc<GwConfig>,     /* Currently applied config or blank */
-    history: Vec<GwConfigMeta>, /* event history */
+    applied: Arc<ValidatedGwConfig>, /* Currently applied config or blank */
+    history: Vec<GwConfigMeta>,      /* event history */
 }
 
 impl GwConfigDatabase {
     #[must_use]
     pub fn new() -> Self {
         debug!("Building config database...");
-        let mut blank = GwConfig::blank();
+        let mut blank = ValidatedGwConfig::blank();
         let internal = build_internal_config(&blank, None).unwrap_or_else(|_| unreachable!());
         blank.set_internal_config(internal);
         GwConfigDatabase {
@@ -43,13 +43,13 @@ impl GwConfigDatabase {
     }
 
     /// Store the given config
-    pub fn store(&mut self, config: Arc<GwConfig>) {
+    pub fn store(&mut self, config: Arc<ValidatedGwConfig>) {
         info!("Storing config for generation '{}' in db", config.genid());
         self.applied = config;
     }
 
     /// Get a refcounted reference to the applied `GwConfig`
-    pub fn get_applied(&self) -> Arc<GwConfig> {
+    pub fn get_applied(&self) -> Arc<ValidatedGwConfig> {
         self.applied.clone()
     }
 
@@ -61,7 +61,7 @@ impl GwConfigDatabase {
 
     /// Get a reference to the config currently applied, if any.
     #[must_use]
-    pub fn get_current_config(&self) -> Arc<GwConfig> {
+    pub fn get_current_config(&self) -> Arc<ValidatedGwConfig> {
         self.applied.clone()
     }
 }

--- a/mgmt/src/processor/k8s_client.rs
+++ b/mgmt/src/processor/k8s_client.rs
@@ -50,7 +50,7 @@ pub(crate) async fn build_gateway_status(
     let (last_applied_gen, last_applied_time) = match config_client.get_current_config().await {
         Ok(config) => (
             config.genid(),
-            to_datetime(config.meta.load().apply_t.as_ref()),
+            to_datetime(config.meta().load().apply_t.as_ref()),
         ),
         Err(e) => {
             error!("Failed to get current config, skipping status update: {e}");

--- a/mgmt/src/processor/mgmt_client.rs
+++ b/mgmt/src/processor/mgmt_client.rs
@@ -6,8 +6,8 @@
 use config::ConfigError;
 use config::ConfigResult;
 use config::GenId;
-use config::GwConfig;
 use config::internal::status::DataplaneStatus;
+use config::{GwConfig, ValidatedGwConfig};
 
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
@@ -31,7 +31,7 @@ pub(crate) enum ConfigRequest {
 #[derive(Debug)]
 pub(crate) enum ConfigResponse {
     ApplyConfig(ConfigResult),
-    GetCurrentConfig(Arc<GwConfig>),
+    GetCurrentConfig(Arc<ValidatedGwConfig>),
     GetGeneration(GenId),
     GetDataplaneStatus(Box<DataplaneStatus>),
 }
@@ -96,7 +96,7 @@ impl ConfigClient {
     /// # Errors
     /// This method returns `ConfigProcessorError` if the request could not be sent or the response
     /// could not be received.
-    pub async fn get_current_config(&self) -> Result<Arc<GwConfig>, ConfigProcessorError> {
+    pub async fn get_current_config(&self) -> Result<Arc<ValidatedGwConfig>, ConfigProcessorError> {
         let (req, rx) = ConfigChannelRequest::new(ConfigRequest::GetCurrentConfig);
         self.tx.send(req).await?;
         let gwconfig = match rx.await? {

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -140,7 +140,7 @@ impl ConfigProcessor {
 
     /// Main entry point for new configurations
     pub(crate) async fn process_incoming_config(&mut self, config: GwConfig) -> ConfigResult {
-        let mut validated_config = config.validated()?;
+        let mut validated_config = config.validate()?;
         let internal =
             build_internal_config(&validated_config, self.proc_params.bmp_options.clone())?;
         validated_config.set_internal_config(internal);

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -4,21 +4,21 @@
 //! Configuration processor
 
 use concurrency::sync::Arc;
+use config::external::overlay::ValidatedOverlay;
 use flow_entry::flow_table::FlowTable;
 use std::collections::{HashMap, HashSet};
-use std::num::NonZero;
 use tokio::sync::RwLock;
 
 use tokio::spawn;
 use tokio::sync::mpsc;
 
-use config::external::overlay::vpc::VpcTable;
+use config::external::overlay::vpc::ValidatedVpcTable;
+use config::internal::device::tracecfg::TracingConfig;
 use config::internal::status::{
     DataplaneStatus, FrrStatus, VpcCounters, VpcPeeringCounters, VpcStatus,
 };
 use config::{ConfigError, ConfigResult, stringify};
-use config::{DeviceConfig, ExternalConfig, GenId, GwConfig, InternalConfig};
-use config::{external::overlay::Overlay, internal::device::tracecfg::TracingConfig};
+use config::{DeviceConfig, ExternalConfig, GenId, GwConfig, InternalConfig, ValidatedGwConfig};
 
 use crate::processor::confbuild::internal::build_internal_config;
 use crate::processor::confbuild::router::generate_router_config;
@@ -139,27 +139,28 @@ impl ConfigProcessor {
     }
 
     /// Main entry point for new configurations
-    pub(crate) async fn process_incoming_config(&mut self, mut config: GwConfig) -> ConfigResult {
-        config.validate()?;
-        let internal = build_internal_config(&config, self.proc_params.bmp_options.clone())?;
-        config.set_internal_config(internal);
-        self.apply(config).await
+    pub(crate) async fn process_incoming_config(&mut self, config: GwConfig) -> ConfigResult {
+        let mut validated_config = config.validated()?;
+        let internal =
+            build_internal_config(&validated_config, self.proc_params.bmp_options.clone())?;
+        validated_config.set_internal_config(internal);
+        self.apply(validated_config).await
     }
 
     async fn update_history(
         &mut self,
-        config: &GwConfig,
+        config: &ValidatedGwConfig,
         result: &ConfigResult,
         is_rollback: bool,
     ) {
-        let guard = config.meta.load();
+        let guard = config.meta().load();
         let mut meta = guard.as_ref().clone();
         meta.apply_time();
         meta.error(result);
         meta.is_rollback = is_rollback;
         self.config_db.history_mut().push(meta.clone());
         if !is_rollback {
-            config.meta.store(Arc::from(meta));
+            config.meta().store(Arc::from(meta));
         }
         let history = Arc::from(self.config_db.history().clone());
         let router_ctl = &mut self.proc_params.router_ctl;
@@ -168,7 +169,7 @@ impl ConfigProcessor {
     }
 
     /// Apply a configuration. On success, store it. On failure, roll-back. Update the history in either case.
-    async fn apply(&mut self, config: GwConfig) -> ConfigResult {
+    async fn apply(&mut self, config: ValidatedGwConfig) -> ConfigResult {
         let config = Arc::from(config);
         let result = self.apply_gw_config(config.clone()).await;
         self.update_history(&config, &result, false).await;
@@ -448,7 +449,7 @@ impl VpcManager<RequiredInformationBase> {
 /// Build router config and apply it over the router control channel
 async fn apply_router_config(
     kernel_vrfs: &HashMap<InterfaceName, Interface>,
-    config: Arc<GwConfig>,
+    config: Arc<ValidatedGwConfig>,
     router_ctl: &mut RouterCtlSender,
 ) -> ConfigResult {
     let genid = config.genid();
@@ -470,19 +471,19 @@ async fn apply_router_config(
 ///
 /// Returns the list of `(VpcDiscriminant, name)` so the caller can seed the stats store.
 fn update_stats_vpc_mappings(
-    config: &GwConfig,
+    config: &ValidatedGwConfig,
     vpcmapw: &mut VpcMapWriter<VpcMapName>,
 ) -> Vec<(VpcDiscriminant, String)> {
     // create a mapping table from the vpc table in the config
     // FIXME(fredi): visibility
     // FIXME(fredi): generalize the vpcmapName table
-    let vpc_table = &config.external.overlay.vpc_table;
+    let vpc_table = config.external().overlay().vpc_table();
     let mut vpcmap = VpcMap::<VpcMapName>::new();
     let mut pairs: Vec<(VpcDiscriminant, String)> = Vec::with_capacity(vpc_table.len());
 
     for vpc in vpc_table.values() {
-        let disc = VpcDiscriminant::VNI(vpc.vni);
-        let name = vpc.name.clone();
+        let disc = VpcDiscriminant::VNI(vpc.vni());
+        let name = vpc.name().to_string();
         let map = VpcMapName::new(disc, &name);
         vpcmap.add(disc, map).unwrap_or_else(|_| unreachable!());
         pairs.push((disc, name));
@@ -494,7 +495,7 @@ fn update_stats_vpc_mappings(
 
 /// Update the Nat tables for stateless NAT
 fn apply_stateless_nat_config(
-    vpc_table: &VpcTable,
+    vpc_table: &ValidatedVpcTable,
     nattablesw: &mut NatTablesWriter,
 ) -> ConfigResult {
     let nat_table = build_nat_configuration(vpc_table)?;
@@ -506,7 +507,7 @@ fn apply_stateless_nat_config(
 /// Update the config for stateful NAT.
 /// This is now infallible. Validation should ensure it is.
 fn apply_stateful_nat_config(
-    vpc_table: &VpcTable,
+    vpc_table: &ValidatedVpcTable,
     flow_table: &FlowTable,
     natallocatorw: &mut NatAllocatorWriter,
     genid: GenId,
@@ -517,7 +518,7 @@ fn apply_stateful_nat_config(
 }
 
 fn apply_flow_filtering_config(
-    overlay: &Overlay,
+    overlay: &ValidatedOverlay,
     flowfilterw: &mut FlowFilterTableWriter,
 ) -> ConfigResult {
     let flow_filter_table = FlowFilterTable::build_from_overlay(overlay)?;
@@ -527,7 +528,7 @@ fn apply_flow_filtering_config(
 }
 
 fn apply_port_forwarding_config(
-    vpc_table: &VpcTable,
+    vpc_table: &ValidatedVpcTable,
     portfw_w: &mut PortFwTableWriter,
 ) -> ConfigResult {
     let ruleset = build_port_forwarding_configuration(vpc_table)?;
@@ -562,7 +563,7 @@ fn apply_device_config(device: &DeviceConfig) -> ConfigResult {
 
 impl ConfigProcessor {
     /// Main method to apply a config
-    async fn apply_gw_config(&mut self, config: Arc<GwConfig>) -> Result<(), ConfigError> {
+    async fn apply_gw_config(&mut self, config: Arc<ValidatedGwConfig>) -> Result<(), ConfigError> {
         let genid = config.genid();
         debug!("Applying config with genid '{genid}'...");
 
@@ -576,17 +577,17 @@ impl ConfigProcessor {
         let flow_table = &self.proc_params.flow_table;
 
         // internal config should be available
-        let internal = config.internal.as_ref().unwrap_or_else(|| unreachable!());
+        let internal = config.internal().unwrap_or_else(|| unreachable!());
 
         /* apply device config */
-        apply_device_config(&config.external.device)?;
+        apply_device_config(config.external().device())?;
 
         /* apply flow table capacity (falls back to default when not explicitly configured) */
         self.proc_params.flow_table.set_capacity(
             config
-                .external
-                .flow_table_capacity
-                .map_or(FlowTable::DEFAULT_CAPACITY, NonZero::get),
+                .external()
+                .flow_table_capacity()
+                .map_or(FlowTable::DEFAULT_CAPACITY, |gwc| gwc.get()),
         );
 
         if genid == ExternalConfig::BLANK_GENID {
@@ -609,21 +610,21 @@ impl ConfigProcessor {
         let kernel_vrfs = vpc_mgr.get_kernel_vrfs().await?;
 
         /* apply stateless NAT config */
-        apply_stateless_nat_config(&config.external.overlay.vpc_table, nattablesw)?;
+        apply_stateless_nat_config(config.external().overlay().vpc_table(), nattablesw)?;
 
         /* apply stateful NAT config */
         apply_stateful_nat_config(
-            &config.external.overlay.vpc_table,
+            config.external().overlay().vpc_table(),
             flow_table.as_ref(),
             natallocatorw,
             genid,
         );
 
         /* apply flow filtering config */
-        apply_flow_filtering_config(&config.external.overlay, flowfilterw)?;
+        apply_flow_filtering_config(config.external().overlay(), flowfilterw)?;
 
         /* apply port-forwarding config */
-        apply_port_forwarding_config(&config.external.overlay.vpc_table, portfw_w)?;
+        apply_port_forwarding_config(config.external().overlay().vpc_table(), portfw_w)?;
 
         /* update stats mappings and seed names to the stats store */
         let _ = update_stats_vpc_mappings(&config, vpcmapw);

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -394,7 +394,7 @@ pub mod test {
         /* Not really a test but a tool to check generated FRR configs given a gateway config */
         let external = sample_external_config();
         let config = GwConfig::new(external);
-        let validated_config = config.validated().expect("Config validation failed");
+        let validated_config = config.validate().expect("Config validation failed");
         if false {
             let vpc_table = validated_config.external().overlay().vpc_table();
             let peering_table = validated_config.external().overlay().peering_table();

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -393,16 +393,17 @@ pub mod test {
     fn check_frr_config() {
         /* Not really a test but a tool to check generated FRR configs given a gateway config */
         let external = sample_external_config();
-        let mut config = GwConfig::new(external);
-        config.validate().expect("Config validation failed");
+        let config = GwConfig::new(external);
+        let validated_config = config.validated().expect("Config validation failed");
         if false {
-            let vpc_table = &config.external.overlay.vpc_table;
-            let peering_table = &config.external.overlay.peering_table;
+            let vpc_table = validated_config.external().overlay().vpc_table();
+            let peering_table = validated_config.external().overlay().peering_table();
             println!("\n{}\n{peering_table}", vpc_table.as_summary());
         }
         let bmp_config = None;
-        let internal = build_internal_config(&config, bmp_config).expect("Should succeed");
-        let rendered = internal.render(&config.genid());
+        let internal =
+            build_internal_config(&validated_config, bmp_config).expect("Should succeed");
+        let rendered = internal.render(&validated_config.genid());
         println!("{rendered}");
     }
 

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 # internal
+config = { workspace = true, features = ["testing"] }
 fixin = { workspace = true }
 flow-filter = { workspace = true }
 test-utils = { workspace = true }

--- a/nat/src/portfw/portfwtable/setup.rs
+++ b/nat/src/portfw/portfwtable/setup.rs
@@ -6,27 +6,27 @@
 
 use crate::portfw::{PortFwEntry, PortFwKey, PortFwTableError};
 use config::ConfigError;
-use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
-use config::external::overlay::vpcpeering::VpcExpose;
+use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpc, ValidatedVpcTable};
+use config::external::overlay::vpcpeering::ValidatedExpose;
 use lpm::prefix::{L4Protocol, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use net::packet::VpcDiscriminant;
 
-fn port_fw_proto(expose: &VpcExpose) -> L4Protocol {
-    expose.nat.as_ref().unwrap_or_else(|| unreachable!()).proto
+fn port_fw_proto(expose: &ValidatedExpose) -> L4Protocol {
+    expose.nat().unwrap_or_else(|| unreachable!()).proto
 }
 
 fn expose_to_portfw_rule(
-    expose: &VpcExpose,
+    expose: &ValidatedExpose,
     proto: NextHeader,
     src_vpc: VpcDiscriminant,
     dst_vpc: VpcDiscriminant,
 ) -> Result<PortFwEntry, PortFwTableError> {
-    let nat = expose.nat.as_ref().unwrap_or_else(|| unreachable!());
+    let nat = expose.nat().unwrap_or_else(|| unreachable!());
     debug_assert!(nat.is_port_forwarding());
     debug_assert_eq!(nat.as_range.len(), 1);
-    debug_assert_eq!(expose.ips.len(), 1);
-    let ips = expose.ips.first().unwrap_or_else(|| unreachable!());
+    debug_assert_eq!(expose.ips().len(), 1);
+    let ips = expose.ips().first().unwrap_or_else(|| unreachable!());
     let (prefix, ports) = match ips {
         PrefixWithOptionalPorts::Prefix(_) => unreachable!(),
         PrefixWithOptionalPorts::PrefixPorts(e) => (e.prefix(), e.ports()),
@@ -55,12 +55,12 @@ fn expose_to_portfw_rule(
     )
 }
 fn vpc_port_fw_peering(
-    vpc_table: &VpcTable,
+    vpc_table: &ValidatedVpcTable,
     dst_vpc: VpcDiscriminant,
-    peering: &Peering,
+    peering: &ValidatedPeering,
 ) -> Result<Vec<PortFwEntry>, PortFwTableError> {
     let mut rules = vec![];
-    for expose in peering.local.port_forwarding_exposes() {
+    for expose in peering.local().port_forwarding_exposes() {
         let remote_vpc_vni = vpc_table.get_remote_vni(peering);
         let src_vpc = VpcDiscriminant::from_vni(remote_vpc_vni);
         match port_fw_proto(expose) {
@@ -83,10 +83,13 @@ fn vpc_port_fw_peering(
     }
     Ok(rules)
 }
-fn vpc_port_fw(vpc_table: &VpcTable, vpc: &Vpc) -> Result<Vec<PortFwEntry>, PortFwTableError> {
+fn vpc_port_fw(
+    vpc_table: &ValidatedVpcTable,
+    vpc: &ValidatedVpc,
+) -> Result<Vec<PortFwEntry>, PortFwTableError> {
     let mut collected = vec![];
-    let dst_vpc = VpcDiscriminant::from_vni(vpc.vni);
-    for peering in &vpc.peerings {
+    let dst_vpc = VpcDiscriminant::from_vni(vpc.vni());
+    for peering in vpc.peerings() {
         let mut rules = vpc_port_fw_peering(vpc_table, dst_vpc, peering)?;
         collected.append(&mut rules);
     }
@@ -94,7 +97,7 @@ fn vpc_port_fw(vpc_table: &VpcTable, vpc: &Vpc) -> Result<Vec<PortFwEntry>, Port
 }
 
 pub fn build_port_forwarding_configuration(
-    vpc_table: &VpcTable,
+    vpc_table: &ValidatedVpcTable,
 ) -> Result<Vec<PortFwEntry>, ConfigError> {
     let mut ruleset = vec![];
     for vpc in vpc_table.values() {

--- a/nat/src/stateful/allocator_writer.rs
+++ b/nat/src/stateful/allocator_writer.rs
@@ -4,9 +4,8 @@
 use crate::stateful::apalloc::NatAllocator;
 use arc_swap::ArcSwapOption;
 use config::GenId;
-use config::external::overlay::vpc::Peering;
-use config::external::overlay::vpc::VpcTable;
-use config::external::overlay::vpcpeering::VpcExpose;
+use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpcTable};
+use config::external::overlay::vpcpeering::ValidatedExpose;
 use flow_entry::flow_table::FlowTable;
 use net::packet::VpcDiscriminant;
 use std::sync::Arc;
@@ -20,7 +19,7 @@ use crate::stateful::flows::upgrade_all_masquerading_flows;
 pub(crate) struct StatefulNatPeering {
     pub(crate) src_vpcd: VpcDiscriminant,
     pub(crate) dst_vpcd: VpcDiscriminant,
-    pub(crate) peering: Peering,
+    pub(crate) peering: ValidatedPeering,
 }
 #[derive(Debug, Default, Clone)]
 pub struct StatefulNatConfig {
@@ -37,12 +36,12 @@ impl PartialEq for StatefulNatConfig {
 
 impl StatefulNatConfig {
     #[must_use]
-    pub fn new(vpc_table: &VpcTable, genid: GenId) -> Self {
+    pub fn new(vpc_table: &ValidatedVpcTable, genid: GenId) -> Self {
         let mut peerings = Vec::new();
         for vpc in vpc_table.values() {
             for peering in vpc.local_stateful_nat_peerings() {
                 peerings.push(StatefulNatPeering {
-                    src_vpcd: VpcDiscriminant::from_vni(vpc.vni),
+                    src_vpcd: VpcDiscriminant::from_vni(vpc.vni()),
                     dst_vpcd: VpcDiscriminant::from_vni(vpc_table.get_remote_vni(peering)),
                     peering: peering.clone(),
                 });
@@ -76,10 +75,12 @@ impl StatefulNatConfig {
     }
 
     pub(crate) fn has_masquerading_peerings(&self) -> bool {
-        self.peerings
-            .iter()
-            .map(|p| &p.peering)
-            .any(|p| p.local.exposes.iter().any(VpcExpose::has_stateful_nat))
+        self.peerings.iter().map(|p| &p.peering).any(|p| {
+            p.local()
+                .valexp()
+                .iter()
+                .any(ValidatedExpose::has_stateful_nat)
+        })
     }
 
     pub(crate) fn get_peering(

--- a/nat/src/stateful/apalloc/setup.rs
+++ b/nat/src/stateful/apalloc/setup.rs
@@ -6,9 +6,8 @@ use super::alloc::{IpAllocator, NatPool, PoolBitmap};
 use super::{NatAllocator, PoolTable, PoolTableKey};
 use crate::ranges::IpRange;
 use crate::stateful::natip::NatIp;
-use config::external::overlay::vpc::Peering;
-use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
-use config::utils::collapse_prefixes_peering;
+use config::external::overlay::vpc::ValidatedPeering;
+use config::external::overlay::vpcpeering::{ValidatedExpose, ValidatedManifest};
 use lpm::prefix::range_map::DisjointRangesBTreeMap;
 use lpm::prefix::{
     IpPrefix, L4Protocol, PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts,
@@ -22,24 +21,26 @@ use tracing::error;
 const DEFAULT_MASQUERADE_IDLE_TIMEOUT: Duration = Duration::from_mins(2);
 
 impl NatAllocator {
-    pub(crate) fn add_peering_addresses(&mut self, peering: &Peering, dst_vpc_id: VpcDiscriminant) {
-        let new_peering = collapse_prefixes_peering(peering);
-
+    pub(crate) fn add_peering_addresses(
+        &mut self,
+        peering: &ValidatedPeering,
+        dst_vpc_id: VpcDiscriminant,
+    ) {
         build_nat_pool_generic(
-            &new_peering.local,
+            peering.local(),
             dst_vpc_id,
-            VpcManifest::stateful_nat_exposes_44,
-            VpcManifest::port_forwarding_exposes_44,
+            ValidatedManifest::stateful_nat_exposes_44,
+            ValidatedManifest::port_forwarding_exposes_44,
             &mut self.pools_src44,
             NextHeader::ICMP,
             self.randomize,
         );
 
         build_nat_pool_generic(
-            &new_peering.local,
+            peering.local(),
             dst_vpc_id,
-            VpcManifest::stateful_nat_exposes_66,
-            VpcManifest::port_forwarding_exposes_66,
+            ValidatedManifest::stateful_nat_exposes_66,
+            ValidatedManifest::port_forwarding_exposes_66,
             &mut self.pools_src66,
             NextHeader::ICMP6,
             self.randomize,
@@ -49,7 +50,7 @@ impl NatAllocator {
 
 #[allow(clippy::too_many_arguments)]
 fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, P, PIter>(
-    manifest: &'a VpcManifest,
+    manifest: &'a ValidatedManifest,
     dst_vpc_id: VpcDiscriminant,
     // A filter to select relevant exposes: those with stateful NAT, for the relevant IP version
     exposes_filter: F,
@@ -59,12 +60,12 @@ fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, 
     icmp_proto: NextHeader,
     randomize: bool,
 ) where
-    F: FnOnce(&'a VpcManifest) -> FIter,
-    FIter: Iterator<Item = &'a VpcExpose>,
-    P: FnOnce(&'a VpcManifest) -> PIter,
-    PIter: Iterator<Item = &'a VpcExpose>,
+    F: FnOnce(&'a ValidatedManifest) -> FIter,
+    FIter: Iterator<Item = &'a ValidatedExpose>,
+    P: FnOnce(&'a ValidatedManifest) -> PIter,
+    PIter: Iterator<Item = &'a ValidatedExpose>,
 {
-    let port_forwarding_exposes: Vec<&'a VpcExpose> =
+    let port_forwarding_exposes: Vec<&'a ValidatedExpose> =
         port_forwarding_exposes_filter(manifest).collect();
 
     exposes_filter(manifest).for_each(|expose| {
@@ -102,7 +103,7 @@ fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, 
 
         add_pool_entries(
             table,
-            &expose.ips,
+            expose.ips(),
             dst_vpc_id,
             &tcp_ip_allocator,
             &udp_ip_allocator,
@@ -119,19 +120,21 @@ struct ReserveSets {
 }
 
 fn find_masquerade_portfw_overlap<'a>(
-    port_forwarding_exposes: &Vec<&'a VpcExpose>,
-    expose: &'a VpcExpose,
+    port_forwarding_exposes: &Vec<&'a ValidatedExpose>,
+    expose: &'a ValidatedExpose,
 ) -> ReserveSets {
-    let expose_nat = expose.nat.as_ref().unwrap_or_else(|| unreachable!());
+    let expose_nat = expose.nat().unwrap_or_else(|| unreachable!());
     let mut reserve_sets = ReserveSets::default();
 
     for pf_expose in port_forwarding_exposes {
-        let pf_nat = pf_expose.nat.as_ref().unwrap_or_else(|| unreachable!());
+        let pf_nat = pf_expose.nat().unwrap_or_else(|| unreachable!());
         let Some(relevant_proto) = expose_nat.proto.intersection(&pf_nat.proto) else {
             // No overlap on L4 protocols, so no overlap for prefixes and ports.
             continue;
         };
-        let ranges_intersection = pf_expose.ips.intersection_prefixes_and_ports(&expose.ips);
+        let ranges_intersection = pf_expose
+            .ips()
+            .intersection_prefixes_and_ports(expose.ips());
         match relevant_proto {
             L4Protocol::Tcp => reserve_sets.tcp.extend(ranges_intersection),
             L4Protocol::Udp => reserve_sets.udp.extend(ranges_intersection),
@@ -309,15 +312,27 @@ mod tests {
             .make_stateful_nat(None)
             .unwrap()
             .ip("10.0.0.0/16".into())
-            .ip("172.16.0.0/16".into());
+            .ip("172.16.0.0/16".into())
+            .as_range("192.168.0.0/16".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose1 = VpcExpose::empty()
             .make_port_forwarding(None, None)
             .unwrap()
-            .ip("10.0.1.0/24".into());
+            .ip("10.0.1.0/24".into())
+            .as_range("192.168.1.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose2 = VpcExpose::empty()
             .make_port_forwarding(None, None)
             .unwrap()
-            .ip("172.16.5.0/24".into());
+            .ip("172.16.5.0/24".into())
+            .as_range("192.168.2.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_exposes_vec = vec![&pf_expose1, &pf_expose2];
         let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
         assert_eq!(
@@ -334,11 +349,19 @@ mod tests {
         let expose = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
-            .ip("10.0.0.0/24".into());
+            .ip("10.0.0.0/24".into())
+            .as_range("192.168.0.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose = VpcExpose::empty()
             .make_port_forwarding(None, None)
             .unwrap()
-            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090));
+            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090))
+            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_exposes_vec = vec![&pf_expose];
         let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
         assert_eq!(
@@ -355,11 +378,19 @@ mod tests {
         let expose = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
-            .ip("10.0.0.0/24".into());
+            .ip("10.0.0.0/24".into())
+            .as_range("192.168.0.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose = VpcExpose::empty()
             .make_port_forwarding(None, Some(L4Protocol::Tcp)) // TCP only
             .unwrap()
-            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090));
+            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090))
+            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_exposes_vec = vec![&pf_expose];
         let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
         assert_eq!(
@@ -377,15 +408,27 @@ mod tests {
         let expose = VpcExpose::empty()
             .make_stateful_nat(None)
             .unwrap()
-            .ip("10.0.0.0/16".into());
+            .ip("10.0.0.0/16".into())
+            .as_range("192.168.0.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose1 = VpcExpose::empty()
             .make_port_forwarding(None, None)
             .unwrap()
-            .ip("10.0.1.0/24".into());
+            .ip("10.0.1.0/24".into())
+            .as_range("192.168.1.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_expose2 = VpcExpose::empty()
             .make_port_forwarding(None, None)
             .unwrap()
-            .ip("10.0.1.0/24".into());
+            .ip("10.0.1.0/24".into())
+            .as_range("192.168.1.0/24".into())
+            .unwrap()
+            .validate()
+            .unwrap();
         let pf_exposes_vec = vec![&pf_expose1, &pf_expose2];
         let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
         assert_eq!(

--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -11,7 +11,7 @@ mod context {
     use crate::stateful::allocator_writer::StatefulNatConfig;
     use crate::stateful::apalloc::alloc::IpAllocator;
     use crate::stateful::apalloc::{NatAllocator, PoolTable, PoolTableKey};
-    use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
+    use config::external::overlay::vpc::{Peering, ValidatedVpcTable, Vpc, VpcTable};
     use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
     use net::ip::NextHeader;
     use net::packet::VpcDiscriminant;
@@ -70,7 +70,7 @@ mod context {
         .unwrap()
     }
 
-    fn build_context() -> VpcTable {
+    fn build_context() -> ValidatedVpcTable {
         // Exposes and manifests
         let expose1 = VpcExpose::empty()
             .make_stateful_nat(None)
@@ -87,12 +87,8 @@ mod context {
         let manifest1 = VpcManifest::with_exposes("VPC-1", vec![expose1, expose2]);
 
         let expose3 = VpcExpose::empty()
-            .make_stateful_nat(None)
-            .unwrap()
             .ip("3.0.0.0/24".into())
-            .ip("3.0.1.0/24".into())
-            .as_range("10.3.0.0/30".into())
-            .unwrap();
+            .ip("3.0.2.0/24".into());
         let expose4 = VpcExpose::empty().ip("4.0.0.0/16".into());
 
         let manifest2 = VpcManifest::with_exposes("VPC-2", vec![expose3, expose4]);
@@ -126,7 +122,7 @@ mod context {
         vpctable.add(vpc1).unwrap();
         vpctable.add(vpc2).unwrap();
 
-        vpctable
+        vpctable.validated().unwrap()
     }
 
     pub fn build_allocator() -> NatAllocator {
@@ -174,7 +170,7 @@ mod std_tests {
                 .keys()
                 .filter(|k| k.protocol == NextHeader::TCP)
                 .count(),
-            5
+            3
         );
         assert_eq!(
             allocator
@@ -183,7 +179,7 @@ mod std_tests {
                 .keys()
                 .filter(|k| k.protocol == NextHeader::UDP)
                 .count(),
-            5
+            3
         );
 
         assert_eq!(allocator.pools_src66.0.len(), 0);

--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -122,7 +122,7 @@ mod context {
         vpctable.add(vpc1).unwrap();
         vpctable.add(vpc2).unwrap();
 
-        vpctable.validated().unwrap()
+        vpctable.validate().unwrap()
     }
 
     pub fn build_allocator() -> NatAllocator {

--- a/nat/src/stateful/flows.rs
+++ b/nat/src/stateful/flows.rs
@@ -120,9 +120,9 @@ pub(crate) fn check_masquerading_flow(
     // Check if such a peering has ANY expose with masquerading that includes the address currently
     // used to masquerade the flow.
     debug!("Peering exists between {src_vpcd} and {dst_vpcd}");
-    if nat_peering.peering.local.exposes.iter().any(|e| {
+    if nat_peering.peering.local().valexp().iter().any(|e| {
         e.has_stateful_nat()
-            && e.nat.as_ref().is_some_and(|enat| {
+            && e.nat().is_some_and(|enat| {
                 enat.as_range
                     .iter()
                     .any(|pfx| pfx.covers(&PrefixWithOptionalPorts::Prefix(ip.into())))

--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -106,12 +106,12 @@ fn setup_pipeline_stateful_nat(
 
 fn test_setup(
     genid: GenId,
-    mut overlay: Overlay,
+    overlay: Overlay,
 ) -> (Arc<FlowTable>, DynPipeline<TestBuffer>, NatAllocatorWriter) {
-    overlay.validate().unwrap();
+    let overlay = overlay.validated().unwrap();
 
     // build the configuration for the nat allocator
-    let nat_config = StatefulNatConfig::new(&overlay.vpc_table, genid);
+    let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid);
 
     // build the config for the test flow filter and the flow filter
     let peerings: Vec<_> = nat_config
@@ -376,14 +376,15 @@ fn flow_lookup<Buf: PacketBufferMut>(flow_table: &FlowTable, packet: &mut Packet
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_full_config() {
-    let mut config = build_gwconfig_from_overlay(build_overlay_4vpcs());
-    config.validate().unwrap();
+    let config = build_gwconfig_from_overlay(build_overlay_4vpcs())
+        .validated()
+        .unwrap();
 
     let flow_table = FlowTable::new(16);
 
     // Check that we can validate the allocator
     let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
     allocator.update_nat_allocator(nat_config, &flow_table);
 
     // No NAT
@@ -455,9 +456,10 @@ async fn test_full_config() {
     assert_eq!(idle_timeout, ONE_MINUTE);
 
     // Update config and allocator
-    let mut new_config = build_gwconfig_from_overlay(build_overlay_2vpcs());
-    new_config.validate().unwrap();
-    let nat_config = StatefulNatConfig::new(&new_config.external.overlay.vpc_table, 2);
+    let new_config = build_gwconfig_from_overlay(build_overlay_2vpcs())
+        .validated()
+        .unwrap();
+    let nat_config = StatefulNatConfig::new(new_config.external().overlay().vpc_table(), 2);
     allocator.update_nat_allocator(nat_config, &flow_table);
 
     // Check existing connection
@@ -544,12 +546,13 @@ fn build_overlay_2vpcs_no_nat() -> Overlay {
 #[test]
 #[traced_test]
 fn test_full_config_no_nat() {
-    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_no_nat());
-    config.validate().unwrap();
+    let config = build_gwconfig_from_overlay(build_overlay_2vpcs_no_nat())
+        .validated()
+        .unwrap();
 
     // Check that we can validate the allocator
     let (_, mut allocator) = StatefulNat::new_with_defaults();
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
     allocator.update_nat_allocator(nat_config, &FlowTable::new(16));
 }
 
@@ -614,12 +617,13 @@ fn check_packet_icmp_echo_new(
 #[tokio::test]
 #[traced_test]
 async fn test_icmp_echo_nat() {
-    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs());
-    config.validate().unwrap();
+    let config = build_gwconfig_from_overlay(build_overlay_2vpcs())
+        .validated()
+        .unwrap();
 
     // Check that we can validate the allocator
     let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
     allocator.update_nat_allocator(nat_config, &FlowTable::new(16));
 
     // No NAT
@@ -928,12 +932,13 @@ fn build_overlay_2vpcs_with_default() -> Overlay {
 
 #[tokio::test]
 async fn test_default_expose() {
-    let mut config = build_gwconfig_from_overlay(build_overlay_2vpcs_with_default());
-    config.validate().unwrap();
+    let config = build_gwconfig_from_overlay(build_overlay_2vpcs_with_default())
+        .validated()
+        .unwrap();
 
     // Check that we can validate the allocator
     let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
     allocator.update_nat_allocator(nat_config, &FlowTable::new(16));
 
     // Using the expose with a prefix
@@ -1127,12 +1132,13 @@ async fn test_full_config_unidirectional_nat_overlapping_destination() {
     let tctl = get_trace_ctl();
     let _ = tctl.setup_from_string("vpc-routing=debug,flow-lookup=debug,stateful-nat=debug");
 
-    let mut config =
-        build_gwconfig_from_overlay(build_overlay_3vpcs_unidirectional_nat_overlapping_addr());
-    config.validate().unwrap();
+    let config =
+        build_gwconfig_from_overlay(build_overlay_3vpcs_unidirectional_nat_overlapping_addr())
+            .validated()
+            .unwrap();
 
     // Build VPC discriminant lookup stage
-    let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
+    let vpcd_tables = FlowFilterTable::build_from_overlay(config.external().overlay()).unwrap();
     let mut vpcdtablesw = FlowFilterTableWriter::new();
     vpcdtablesw.update_flow_filter_table(vpcd_tables);
     let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
@@ -1144,7 +1150,7 @@ async fn test_full_config_unidirectional_nat_overlapping_destination() {
 
     // Build NAT stage
     let (mut nat, mut allocator) = StatefulNat::new_with_defaults();
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
 
     // Check that we can validate the allocator
     allocator.update_nat_allocator(nat_config, &FlowTable::new(16));
@@ -1212,7 +1218,7 @@ async fn test_full_config_unidirectional_nat_overlapping_destination() {
     let mut allocator = NatAllocatorWriter::new();
     let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
     let nat_config =
-        StatefulNatConfig::new(&config.external.overlay.vpc_table, 2).set_randomize(false);
+        StatefulNatConfig::new(config.external().overlay().vpc_table(), 2).set_randomize(false);
 
     // Check that we can validate the allocator
     //
@@ -1410,20 +1416,23 @@ fn build_overlay_2vpcs_unidirectional_nat_overlapping_exposes() -> Overlay {
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_full_config_unidirectional_nat_overlapping_exposes_for_single_peering() {
-    let mut config =
+    let config =
         build_gwconfig_from_overlay(build_overlay_2vpcs_unidirectional_nat_overlapping_exposes());
     // Validation fails - We currently forbid multiple peerings between any pair of VPCs. We
     // could probably allow them for stateful NAT, but we still need the restriction for
     // stateless NAT. We can carry on with the test anyway.
-    assert_eq!(
-        config.validate(),
-        Err(ConfigError::DuplicateVpcPeerings(
-            "VPC-1--VPC-2--2".to_owned()
-        ))
+    assert!(
+        config
+            .validated()
+            .is_err_and(|e| e == ConfigError::DuplicateVpcPeerings("VPC-1--VPC-2--2".to_owned()))
     );
+    let config = unsafe {
+        build_gwconfig_from_overlay(build_overlay_2vpcs_unidirectional_nat_overlapping_exposes())
+            .fake_validated_config_for_tests()
+    };
 
     // Build VPC discriminant lookup stage
-    let vpcd_tables = FlowFilterTable::build_from_overlay(&config.external.overlay).unwrap();
+    let vpcd_tables = FlowFilterTable::build_from_overlay(config.external().overlay()).unwrap();
     let mut vpcdtablesw = FlowFilterTableWriter::new();
     vpcdtablesw.update_flow_filter_table(vpcd_tables);
     let mut vpcdlookup = FlowFilter::new("vpcd-lookup", vpcdtablesw.get_reader());
@@ -1439,7 +1448,7 @@ async fn test_full_config_unidirectional_nat_overlapping_exposes_for_single_peer
     // Build a new NAT stage
     let mut allocator = NatAllocatorWriter::new();
     let mut nat = StatefulNat::new("stateful-nat", flow_table.clone(), allocator.get_reader());
-    let nat_config = StatefulNatConfig::new(&config.external.overlay.vpc_table, 1);
+    let nat_config = StatefulNatConfig::new(config.external().overlay().vpc_table(), 1);
 
     // Check that we can validate the allocator
     allocator.update_nat_allocator(nat_config, &FlowTable::new(16));
@@ -1820,9 +1829,8 @@ async fn test_masquerade_reconfig_keep_flow() {
     assert_eq!(flow_genid(&out).unwrap(), genid);
 
     // update the NAT allocator with an identical config
-    let mut overlay = build_overlay_2vpcs();
-    overlay.validate().unwrap();
-    let nat_config = StatefulNatConfig::new(&overlay.vpc_table, genid + 1);
+    let overlay = build_overlay_2vpcs().validated().unwrap();
+    let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid + 1);
     allocw.update_nat_allocator(nat_config, &flow_table);
 
     // process a packet: it should hit identical flows, except for genid
@@ -1857,9 +1865,8 @@ async fn test_masquerade_reconfig_drop_flow() {
     assert_eq!(flow_genid(&out).unwrap(), genid);
 
     // update the NAT allocator with an identical config
-    let mut overlay = build_overlay_2vpcs_modified();
-    overlay.validate().unwrap();
-    let nat_config = StatefulNatConfig::new(&overlay.vpc_table, genid + 1);
+    let overlay = build_overlay_2vpcs_modified().validated().unwrap();
+    let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid + 1);
     allocw.update_nat_allocator(nat_config, &flow_table);
 
     // process a packet: it should hit identical flows

--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -377,7 +377,7 @@ fn flow_lookup<Buf: PacketBufferMut>(flow_table: &FlowTable, packet: &mut Packet
 #[allow(clippy::too_many_lines)]
 async fn test_full_config() {
     let config = build_gwconfig_from_overlay(build_overlay_4vpcs())
-        .validated()
+        .validate()
         .unwrap();
 
     let flow_table = FlowTable::new(16);
@@ -457,7 +457,7 @@ async fn test_full_config() {
 
     // Update config and allocator
     let new_config = build_gwconfig_from_overlay(build_overlay_2vpcs())
-        .validated()
+        .validate()
         .unwrap();
     let nat_config = StatefulNatConfig::new(new_config.external().overlay().vpc_table(), 2);
     allocator.update_nat_allocator(nat_config, &flow_table);
@@ -547,7 +547,7 @@ fn build_overlay_2vpcs_no_nat() -> Overlay {
 #[traced_test]
 fn test_full_config_no_nat() {
     let config = build_gwconfig_from_overlay(build_overlay_2vpcs_no_nat())
-        .validated()
+        .validate()
         .unwrap();
 
     // Check that we can validate the allocator
@@ -618,7 +618,7 @@ fn check_packet_icmp_echo_new(
 #[traced_test]
 async fn test_icmp_echo_nat() {
     let config = build_gwconfig_from_overlay(build_overlay_2vpcs())
-        .validated()
+        .validate()
         .unwrap();
 
     // Check that we can validate the allocator
@@ -933,7 +933,7 @@ fn build_overlay_2vpcs_with_default() -> Overlay {
 #[tokio::test]
 async fn test_default_expose() {
     let config = build_gwconfig_from_overlay(build_overlay_2vpcs_with_default())
-        .validated()
+        .validate()
         .unwrap();
 
     // Check that we can validate the allocator
@@ -1134,7 +1134,7 @@ async fn test_full_config_unidirectional_nat_overlapping_destination() {
 
     let config =
         build_gwconfig_from_overlay(build_overlay_3vpcs_unidirectional_nat_overlapping_addr())
-            .validated()
+            .validate()
             .unwrap();
 
     // Build VPC discriminant lookup stage
@@ -1423,7 +1423,7 @@ async fn test_full_config_unidirectional_nat_overlapping_exposes_for_single_peer
     // stateless NAT. We can carry on with the test anyway.
     assert!(
         config
-            .validated()
+            .validate()
             .is_err_and(|e| e == ConfigError::DuplicateVpcPeerings("VPC-1--VPC-2--2".to_owned()))
     );
     let config = unsafe {

--- a/nat/src/stateful/test.rs
+++ b/nat/src/stateful/test.rs
@@ -106,9 +106,9 @@ fn setup_pipeline_stateful_nat(
 
 fn test_setup(
     genid: GenId,
-    overlay: Overlay,
+    overlay: &Overlay,
 ) -> (Arc<FlowTable>, DynPipeline<TestBuffer>, NatAllocatorWriter) {
-    let overlay = overlay.validated().unwrap();
+    let overlay = overlay.validate().unwrap();
 
     // build the configuration for the nat allocator
     let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid);
@@ -785,7 +785,7 @@ fn check_packet_icmp_error(
 #[traced_test]
 async fn test_icmp_error_nat() {
     // build setup: 2 vpcs with masquerading, vni 100 -> vni 200
-    let (flow_table, mut pipeline, _allocw) = test_setup(1, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, _allocw) = test_setup(1, &build_overlay_2vpcs());
 
     // ICMP Error msg: expose211 -> expose121, no previous session for inner packet
     test_case("Processing icmp error with no prior state");
@@ -1728,7 +1728,7 @@ fn establish_tcp_connection(pipeline: &mut DynPipeline<TestBuffer>) {
 #[traced_test]
 async fn test_masquerade_tcp_establish() {
     // build setup: 2 vpcs with masquerading (vni 100 -> vni 200)
-    let (flow_table, mut pipeline, _allocw) = test_setup(1, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, _allocw) = test_setup(1, &build_overlay_2vpcs());
     establish_tcp_connection(&mut pipeline);
     assert_eq!(flow_table.active_len(), Some(2));
 }
@@ -1737,7 +1737,7 @@ async fn test_masquerade_tcp_establish() {
 #[traced_test]
 async fn test_masquerade_check() {
     // build setup: 2 vpcs with masquerading (vni 100 -> vni 200)
-    let (flow_table, mut pipeline, _allocw) = test_setup(1, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, _allocw) = test_setup(1, &build_overlay_2vpcs());
 
     test_case("Establish TCP over masquerade peering");
     establish_tcp_connection(&mut pipeline);
@@ -1777,7 +1777,7 @@ async fn test_masquerade_check() {
 #[traced_test]
 async fn test_masquerade_tcp_reset() {
     // build setup: 2 vpcs with masquerading (vni 100 -> vni 200)
-    let (flow_table, mut pipeline, _allocw) = test_setup(1, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, _allocw) = test_setup(1, &build_overlay_2vpcs());
     establish_tcp_connection(&mut pipeline);
     assert_eq!(flow_table.active_len(), Some(2));
 
@@ -1813,7 +1813,7 @@ async fn test_masquerade_tcp_reset() {
 async fn test_masquerade_reconfig_keep_flow() {
     let genid = 1;
     // build setup: 2 vpcs with masquerading (vni 100 -> vni 200)
-    let (flow_table, mut pipeline, mut allocw) = test_setup(genid, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, mut allocw) = test_setup(genid, &build_overlay_2vpcs());
     establish_tcp_connection(&mut pipeline);
     assert_eq!(flow_table.active_len(), Some(2));
 
@@ -1829,7 +1829,7 @@ async fn test_masquerade_reconfig_keep_flow() {
     assert_eq!(flow_genid(&out).unwrap(), genid);
 
     // update the NAT allocator with an identical config
-    let overlay = build_overlay_2vpcs().validated().unwrap();
+    let overlay = build_overlay_2vpcs().validate().unwrap();
     let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid + 1);
     allocw.update_nat_allocator(nat_config, &flow_table);
 
@@ -1849,7 +1849,7 @@ async fn test_masquerade_reconfig_keep_flow() {
 async fn test_masquerade_reconfig_drop_flow() {
     let genid = 1;
     // build setup: 2 vpcs with masquerading (vni 100 -> vni 200)
-    let (flow_table, mut pipeline, mut allocw) = test_setup(genid, build_overlay_2vpcs());
+    let (flow_table, mut pipeline, mut allocw) = test_setup(genid, &build_overlay_2vpcs());
     establish_tcp_connection(&mut pipeline);
     assert_eq!(flow_table.active_len(), Some(2));
 
@@ -1865,7 +1865,7 @@ async fn test_masquerade_reconfig_drop_flow() {
     assert_eq!(flow_genid(&out).unwrap(), genid);
 
     // update the NAT allocator with an identical config
-    let overlay = build_overlay_2vpcs_modified().validated().unwrap();
+    let overlay = build_overlay_2vpcs_modified().validate().unwrap();
     let nat_config = StatefulNatConfig::new(overlay.vpc_table(), genid + 1);
     allocw.update_nat_allocator(nat_config, &flow_table);
 

--- a/nat/src/stateless/setup/mod.rs
+++ b/nat/src/stateless/setup/mod.rs
@@ -198,7 +198,7 @@ mod tests {
 
         let mut vni_table = PerVniTable::new();
         vni_table
-            .add_peering(&peering.validated().unwrap(), dst_vni)
+            .add_peering(&peering.validate().unwrap(), dst_vni)
             .expect("Failed to build NAT tables");
     }
 }

--- a/nat/src/stateless/setup/mod.rs
+++ b/nat/src/stateless/setup/mod.rs
@@ -12,9 +12,8 @@ pub mod tables;
 
 use crate::stateless::{NatTableValue, NatTables, PerVniTable};
 use config::ConfigError;
-use config::external::overlay::vpc::{Peering, VpcTable};
-use config::external::overlay::vpcpeering::VpcExpose;
-use config::utils::collapse_prefixes_peering;
+use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpcTable};
+use config::external::overlay::vpcpeering::ValidatedExpose;
 use lpm::prefix::{Prefix, PrefixWithOptionalPorts};
 use net::vxlan::Vni;
 use std::collections::BTreeSet;
@@ -35,15 +34,15 @@ pub(crate) fn generate_nat_values<'a>(
 }
 
 fn generate_public_values(
-    expose: &VpcExpose,
+    expose: &ValidatedExpose,
 ) -> impl Iterator<Item = Result<(Prefix, NatTableValue), NatPeeringError>> {
-    generate_nat_values(&expose.ips, expose.as_range_or_empty())
+    generate_nat_values(expose.ips(), expose.as_range_or_empty())
 }
 
 fn generate_private_values(
-    expose: &VpcExpose,
+    expose: &ValidatedExpose,
 ) -> impl Iterator<Item = Result<(Prefix, NatTableValue), NatPeeringError>> {
-    generate_nat_values(expose.as_range_or_empty(), &expose.ips)
+    generate_nat_values(expose.as_range_or_empty(), expose.ips())
 }
 
 impl PerVniTable {
@@ -54,13 +53,11 @@ impl PerVniTable {
     /// Returns an error if some lists of prefixes contain duplicates
     pub(crate) fn add_peering(
         &mut self,
-        peering: &Peering,
+        peering: &ValidatedPeering,
         dst_vni: Vni,
     ) -> Result<(), NatPeeringError> {
-        let new_peering = collapse_prefixes_peering(peering);
-
-        new_peering
-            .local
+        peering
+            .local()
             .stateless_nat_exposes()
             .try_for_each(|expose| {
                 if expose.as_range_or_empty().is_empty() {
@@ -82,8 +79,8 @@ impl PerVniTable {
             })?;
 
         // Update table for destination NAT
-        new_peering
-            .remote
+        peering
+            .remote()
             .stateless_nat_exposes()
             .try_for_each(|expose| {
                 // For each public prefix, add an entry containing the set of private prefixes
@@ -105,17 +102,17 @@ impl PerVniTable {
 /// # Errors
 ///
 /// Returns [`ConfigError::FailureApply`] if the configuration for some NAT peering cannot be built.
-pub fn build_nat_configuration(vpc_table: &VpcTable) -> Result<NatTables, ConfigError> {
+pub fn build_nat_configuration(vpc_table: &ValidatedVpcTable) -> Result<NatTables, ConfigError> {
     let mut nat_tables = NatTables::new();
     for vpc in vpc_table.values() {
         let mut table = PerVniTable::new();
-        for peering in &vpc.peerings {
+        for peering in vpc.peerings() {
             let dst_vni = vpc_table.get_remote_vni(peering);
             table
                 .add_peering(peering, dst_vni)
                 .map_err(|e| ConfigError::FailureApply(e.to_string()))?;
         }
-        nat_tables.add_table(table, vpc.vni);
+        nat_tables.add_table(table, vpc.vni());
     }
     Ok(nat_tables)
 }
@@ -123,8 +120,8 @@ pub fn build_nat_configuration(vpc_table: &VpcTable) -> Result<NatTables, Config
 #[cfg(test)]
 mod tests {
     use super::*;
-    use config::external::overlay::vpc::{Vpc, VpcTable};
-    use config::external::overlay::vpcpeering::VpcManifest;
+    use config::external::overlay::vpc::{Peering, Vpc, VpcTable};
+    use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
     use net::vxlan::Vni;
 
     #[test]
@@ -201,7 +198,7 @@ mod tests {
 
         let mut vni_table = PerVniTable::new();
         vni_table
-            .add_peering(&peering, dst_vni)
+            .add_peering(&peering.validated().unwrap(), dst_vni)
             .expect("Failed to build NAT tables");
     }
 }

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -5,7 +5,6 @@
 
 #![cfg(test)]
 
-use config::GwConfig;
 use config::external::ExternalConfigBuilder;
 use config::external::communities::PriorityCommunityTable;
 use config::external::gwgroup::{GwGroup, GwGroupTable};
@@ -18,6 +17,7 @@ use config::internal::interfaces::interface::InterfaceConfig;
 use config::internal::interfaces::interface::{IfVtepConfig, InterfaceType};
 use config::internal::routing::bgp::BgpConfig;
 use config::internal::routing::vrf::VrfConfig;
+use config::{GwConfig, ValidatedGwConfig};
 
 use crate::StatelessNat;
 use crate::stateless::setup::build_nat_configuration;
@@ -252,12 +252,12 @@ fn build_context() -> NatTables {
 
     let mut vni_table1 = PerVniTable::new();
     vni_table1
-        .add_peering(&peering1, vni2)
+        .add_peering(&peering1.validated().unwrap(), vni2)
         .expect("Failed to build NAT tables");
 
     let mut vni_table2 = PerVniTable::new();
     vni_table2
-        .add_peering(&peering2, vni1)
+        .add_peering(&peering2.validated().unwrap(), vni1)
         .expect("Failed to build NAT tables");
 
     nat_table.add_table(vni_table1, vni1);
@@ -363,7 +363,7 @@ fn test_nat_icmp_error_msg_stateless_44() {
 }
 
 #[allow(clippy::too_many_lines)]
-fn build_sample_config() -> GwConfig {
+fn build_sample_config() -> ValidatedGwConfig {
     fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
         manifest.add_expose(expose);
     }
@@ -546,7 +546,7 @@ fn build_sample_config() -> GwConfig {
 
     let overlay = Overlay::new(vpc_table, peering_table);
 
-    build_gwconfig_from_overlay(overlay)
+    build_gwconfig_from_overlay(overlay).validated().unwrap()
 }
 
 // Use the provided overlay with some default configuration to build a valid GwConfig. This
@@ -619,10 +619,9 @@ fn check_packet(
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 fn test_full_config() {
-    let mut config = build_sample_config();
-    config.validate().expect("Failed to validate config");
+    let config = build_sample_config();
 
-    let nat_tables = build_nat_configuration(&config.external.overlay.vpc_table).unwrap();
+    let nat_tables = build_nat_configuration(config.external().overlay().vpc_table()).unwrap();
     println!("Nat tables: {:#?}", &nat_tables);
 
     let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
@@ -777,7 +776,7 @@ fn test_full_config() {
 fn build_gwconfig_from_exposes(
     exposes_left: Vec<VpcExpose>,
     exposes_right: Vec<VpcExpose>,
-) -> GwConfig {
+) -> ValidatedGwConfig {
     fn add_expose(manifest: &mut VpcManifest, expose: VpcExpose) {
         manifest.add_expose(expose);
     }
@@ -802,14 +801,9 @@ fn build_gwconfig_from_exposes(
 
     let overlay = Overlay::new(vpc_table, peering_table);
 
-    let mut gw_config = build_gwconfig_from_overlay(overlay);
-    let validation = gw_config.validate();
-    assert!(
-        validation.is_ok(),
-        "GwConfig validation failed: {validation:?}"
-    );
-
-    gw_config
+    build_gwconfig_from_overlay(overlay.clone())
+        .validated()
+        .unwrap()
 }
 
 fn check_packet_with_ports(
@@ -862,7 +856,7 @@ fn test_config_with_port_ranges_basic() {
     ));
 
     let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
-    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let nat_tables = build_nat_configuration(gw_config.external().overlay().vpc_table()).unwrap();
     let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
     tablesw.update_nat_tables(nat_tables);
 
@@ -986,7 +980,7 @@ fn test_config_with_port_ranges_complex() {
     // First address/port (assuming ordered ranges)
 
     let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
-    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let nat_tables = build_nat_configuration(gw_config.external().overlay().vpc_table()).unwrap();
     let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
     tablesw.update_nat_tables(nat_tables);
 
@@ -1171,7 +1165,7 @@ fn test_config_with_port_ranges_with_default() {
     let expose3 = VpcExpose::empty().set_default();
 
     let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2, expose3]);
-    let nat_tables = build_nat_configuration(&gw_config.external.overlay.vpc_table).unwrap();
+    let nat_tables = build_nat_configuration(gw_config.external().overlay().vpc_table()).unwrap();
     let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");
     tablesw.update_nat_tables(nat_tables);
 

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -546,7 +546,7 @@ fn build_sample_config() -> ValidatedGwConfig {
 
     let overlay = Overlay::new(vpc_table, peering_table);
 
-    build_gwconfig_from_overlay(overlay).validated().unwrap()
+    build_gwconfig_from_overlay(overlay).validate().unwrap()
 }
 
 // Use the provided overlay with some default configuration to build a valid GwConfig. This
@@ -802,7 +802,7 @@ fn build_gwconfig_from_exposes(
     let overlay = Overlay::new(vpc_table, peering_table);
 
     build_gwconfig_from_overlay(overlay.clone())
-        .validated()
+        .validate()
         .unwrap()
 }
 

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -252,12 +252,12 @@ fn build_context() -> NatTables {
 
     let mut vni_table1 = PerVniTable::new();
     vni_table1
-        .add_peering(&peering1.validated().unwrap(), vni2)
+        .add_peering(&peering1.validate().unwrap(), vni2)
         .expect("Failed to build NAT tables");
 
     let mut vni_table2 = PerVniTable::new();
     vni_table2
-        .add_peering(&peering2.validated().unwrap(), vni1)
+        .add_peering(&peering2.validate().unwrap(), vni1)
         .expect("Failed to build NAT tables");
 
     nat_table.add_table(vni_table1, vni1);

--- a/routing/src/cli/handler.rs
+++ b/routing/src/cli/handler.rs
@@ -22,7 +22,7 @@ use crate::routingdb::RoutingDb;
 
 use chrono::Local;
 use cli::cliproto::{CliAction, CliError, CliRequest, CliResponse, RequestArgs, RouteProtocol};
-use config::{ConfigSummary, GwConfig, GwConfigMeta};
+use config::{ConfigSummary, GwConfigMeta, ValidatedGwConfig};
 use lpm::prefix::{Ipv4Prefix, Ipv6Prefix};
 use net::vxlan::Vni;
 use std::os::unix::net::SocketAddr;
@@ -384,19 +384,19 @@ fn show_provider(
     CliResponse::from_request_ok(request, data)
 }
 
-fn show_config(request: CliRequest, config: Option<&Arc<GwConfig>>) -> CliResponse {
+fn show_config(request: CliRequest, config: Option<&Arc<ValidatedGwConfig>>) -> CliResponse {
     let Some(config) = config else {
         return CliResponse::from_request_ok(request, "No configuration is applied".to_string());
     };
-    let vpc_table = &config.external.overlay.vpc_table;
+    let vpc_table = &config.external().overlay().vpc_table();
     let contents = match request.action {
         CliAction::ShowVpc => vpc_table.as_summary().to_string(),
         CliAction::ShowVpcPeerings => vpc_table.as_peerings().to_string(),
-        CliAction::ShowGatewayGroups => config.external.gwgroups.to_string(),
-        CliAction::ShowGatewayCommunities => config.external.communities.to_string(),
+        CliAction::ShowGatewayGroups => config.external().gwgroups().to_string(),
+        CliAction::ShowGatewayCommunities => config.external().communities().to_string(),
         CliAction::ShowConfigInternal => {
             let heading = Heading("Internal configuration").to_string();
-            format!("{heading}{:#?}", config.internal)
+            format!("{heading}{:#?}", config.internal())
         }
         _ => unreachable!(),
     };

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -3,7 +3,7 @@
 
 //! Control channel for the router
 
-use config::{GwConfig, GwConfigMeta};
+use config::{GwConfigMeta, ValidatedGwConfig};
 use mio::Interest;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
@@ -51,7 +51,7 @@ pub(crate) enum RouterCtlMsg {
     GuardedUnlock,
     Configure(RouterConfig, RouterCtlReplyTx),
     GetFrrAppliedConfig(RouterCtlReplyTx),
-    Config(Arc<GwConfig>),
+    Config(Arc<ValidatedGwConfig>),
     ConfigHistory(Arc<Vec<GwConfigMeta>>),
 }
 
@@ -136,12 +136,12 @@ impl RouterCtlSender {
         };
         Ok(frr_cfg)
     }
-    pub async fn send_config(&mut self, config: Arc<GwConfig>) -> Result<(), RouterError> {
+    pub async fn send_config(&mut self, config: Arc<ValidatedGwConfig>) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::Config(config);
         self.0
             .send(msg)
             .await
-            .map_err(|_| RouterError::Internal("Failed to send GwConfig"))?;
+            .map_err(|_| RouterError::Internal("Failed to send ValidatedGwConfig"))?;
         Ok(())
     }
     pub async fn send_config_history(
@@ -231,7 +231,7 @@ fn handle_get_frr_applied_config(rio: &Rio, reply_to: RouterCtlReplyTx) {
         });
 }
 
-fn handle_config(rio: &mut Rio, config: Arc<GwConfig>) {
+fn handle_config(rio: &mut Rio, config: Arc<ValidatedGwConfig>) {
     rio.gwconfig = Some(config);
 }
 fn handle_config_history(rio: &mut Rio, history: Arc<Vec<GwConfigMeta>>) {

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -20,7 +20,7 @@ use crate::routingdb::RoutingDb;
 use bytes::BytesMut;
 use cli::IoCache;
 use cli::cliproto::{CLI_RX_BUFF_SIZE, CliRequest};
-use config::{GwConfig, GwConfigMeta};
+use config::{GwConfigMeta, ValidatedGwConfig};
 use dplane_rpc::socks::RpcCachedSock;
 
 use mio::unix::SourceFd;
@@ -125,7 +125,7 @@ pub(crate) struct Rio {
     pub(crate) ctl_rx: Receiver<RouterCtlMsg>,
     pub(crate) cpistats: CpiStats,
     stale_timeout: Option<Instant>,
-    pub(crate) gwconfig: Option<Arc<GwConfig>>,
+    pub(crate) gwconfig: Option<Arc<ValidatedGwConfig>>,
     pub(crate) cfg_history: Arc<Vec<GwConfigMeta>>,
     pub(crate) cli_cache: IoCache,
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -128,8 +128,8 @@ fn validate(gwagent_json: &str) -> Result<(), ValidateError> {
         _ => ValidateError::ConversionError(e.to_string()),
     })?;
 
-    let mut gwconfig = GwConfig::new(external);
-    gwconfig.validate().map_err(|e| {
+    let gwconfig = GwConfig::new(external);
+    let _ = gwconfig.validated().map_err(|e| {
         let mut config = ConfigErrors::default();
         config.errors.push(e.to_string());
         ValidateError::Configuration(config)

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -129,7 +129,7 @@ fn validate(gwagent_json: &str) -> Result<(), ValidateError> {
     })?;
 
     let gwconfig = GwConfig::new(external);
-    let _ = gwconfig.validated().map_err(|e| {
+    let _ = gwconfig.validate().map_err(|e| {
         let mut config = ConfigErrors::default();
         config.errors.push(e.to_string());
         ValidateError::Configuration(config)


### PR DESCRIPTION
This is a PR to introduce "validated" types for `VpcExpose`, `VpcManifest`, `Peering`, `Vpc`, `VpcTable`, `Overlay`, `ExternalConfig`, and `GwConfig` objects (all cascading from the validated expose blocks).

There are two main objectives: one is to provide "vetted types" holding true some invariants, so that the compiler can reason based on that. We don't leverage this aspect that much in the PR, but the split of types between the pre-validation and post-validation stage should help for using more assumptions in the future.

The second objectif is to move some of the processing for the expose blocks to an earlier location, and make the processed prefixes available everywhere down the line. More specifically, we used to call three times the helper for "collapsing" exclusion prefixes into the allowed prefixes: once for the stateless NAT, once for the masquerading, and one for the flow-filter context builds. After the changes, we only run it once, and can expose a list of "validated" expose blocks to every location that needs it, after that.

The Pull Request is large, because the changes propagate, a lot. I think I did a reasonable job at splitting the first commits; but the last part is horrible, because there's no easy way to go incrementally with the changes once we start to propagate the new types to the consumers. So we've got some huuuuuge commits... and no real way to make it easy to review, sorry.

The code is mine, I've used Claude to rebase it (multiple times) on the recent NAT changes, as well as to assist, to some extent, to the commit split.

Feedback welcome on the new "validated" wrapper types.
