### PR TITLE
ci(dependabot): Add cooldown for cargo dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 10
     labels:
       - "automated"
       - "dependencies"


### PR DESCRIPTION
Similar to the cooldown we have in place for GitHub Actions updates by Dependabot, add a cooldown for cargo dependencies updates. The motivation is the following: we prefer updating these dependencies via our automated workflow (.github/workflows/bump.yml), which runs weekly, because it also runs "cargo upgrade". Handling both the automated workflow and the Dependabot Pull Requests is more, unnecessary effort; so as long as the automated workflow works, we don't want Dependabot to open PRs non-security updates. The 10-day cooldown should ensure that we get a good chance to merge recent updates from the automated workflow before Dependabot creates its PR, but at the same time Dependabot would still offer its updates if our workflow hasn't run if, for example, something broke.
