### PR TITLE
Quiescent State Based Reclaim :hot_pepper: :hot_pepper: :hot_pepper: 

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -347,6 +347,18 @@ jobs:
           - *release-build
         features:
           - "shuttle"
+          - "loom"
+        include:
+          # The `loom` feature flips `concurrency::sync` to loom's
+          # primitives workspace-wide, which breaks crates that rely on
+          # `Weak`, `Arc::downgrade`, etc. (those aren't in
+          # `loom::sync`).  Scope the loom build to only the quiescent
+          # package so workspace feature unification doesn't poison
+          # unrelated crates.
+          - features: "loom"
+            test_package: "quiescent"
+          - features: "shuttle"
+            test_package: ""
     steps:
       - *checkout
       - *nix-setup
@@ -354,6 +366,7 @@ jobs:
         uses: *just
         with:
           recipe: "test"
+          recipe_args: "${{ matrix.test_package }}"
       - *tmate
 
   vlab:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-quiescent"
+version = "0.21.0"
+dependencies = [
+ "arc-swap",
+ "bolero",
+ "dataplane-concurrency",
+ "loom",
+ "shuttle",
+ "static_assertions",
+]
+
+[[package]]
 name = "dataplane-rekon"
 version = "0.21.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "nat",
     "net",
     "pipeline",
+    "quiescent",
     "rekon",
     "routing",
     "stats",
@@ -73,6 +74,7 @@ mgmt = { path = "./mgmt", package = "dataplane-mgmt", features = [] }
 nat = { path = "./nat", package = "dataplane-nat", features = [] }
 net = { path = "./net", package = "dataplane-net", features = [] }
 pipeline = { path = "./pipeline", package = "dataplane-pipeline", features = [] }
+quiescent = { path = "./quiescent", package = "dataplane-quiescent", features = [] }
 rekon = { path = "./rekon", package = "dataplane-rekon", features = [] }
 routing = { path = "./routing", package = "dataplane-routing", features = [] }
 stats = { path = "./stats", package = "dataplane-stats", features = [] }

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ _cargo_feature_flags := \
 _cargo_profile_flag := if profile == "debug" { "" } else { "--profile " + profile }
 
 # filters for nextest
-filter := if features == "shuttle" { "shuttle" } else { "" }
+filter := if features == "shuttle" { "shuttle" } else if features == "loom" { "-E 'binary(loom)'" } else { "" }
 
 # instrumentation mode (none/coverage)
 instrument := "none"

--- a/quiescent/Cargo.toml
+++ b/quiescent/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "dataplane-quiescent"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[features]
+# Mutually exclusive with `shuttle`.
+loom = ["concurrency/loom", "dep:loom"]
+# Shuttle equivalent.  Mutually exclusive with `loom`.
+shuttle = ["concurrency/shuttle", "dep:shuttle"]
+
+[dependencies]
+# internal
+concurrency = { workspace = true }
+
+# external
+arc-swap = { workspace = true }
+loom = { workspace = true, optional = true }
+shuttle = { workspace = true, optional = true }
+static_assertions = { workspace = true }
+
+[dev-dependencies]
+bolero = { workspace = true, features = ["std"] }

--- a/quiescent/README.md
+++ b/quiescent/README.md
@@ -1,0 +1,426 @@
+# quiescent
+
+A small, generic Quiescent State Based Reclamation (QSBR) primitive.
+
+The crate publishes immutable snapshots of a value of type `T` to many
+single-thread subscribers, and guarantees that the **destructor of any
+published value runs on the publisher's thread**. That guarantee
+matters when `T` (or anything `T` transitively owns) has a thread-bound
+`Drop`; a DPDK ACL context, an `rte_flow` handle, a hardware-table
+descriptor, anything that has to be freed from the same lcore that
+allocated it.
+
+```mermaid
+graph TD
+    P["Publisher<br/>(one thread)"]
+    SF["SubscriberFactory<br/>(Send + Sync + Copy)"]
+    R["retired<br/>(Vec of Arc)"]
+    S["Subscriber x N<br/>(per-thread)"]
+    P -->|atomic publish| SF
+    P -->|"retains Arc clones<br/>until safe to drop"| R
+    SF -->|"spawns; borrows<br/>from Publisher"| S
+```
+
+## Quick start
+
+```rust,ignore
+use dataplane_quiescent::channel;
+
+#[derive(Debug)]
+struct MyConfig { /* ... */ }
+
+let publisher = channel(MyConfig { /* ... */ });
+
+std::thread::scope(|s| {
+    // Spawn one or more consumer threads.
+    let factory = publisher.factory();
+    for _ in 0..n_consumers {
+        let factory = factory; // factory is Copy
+        s.spawn(move || {
+            let mut sub = factory.subscriber();
+            for _ in 0..many_batches {
+                let cfg = sub.snapshot();
+                // ... use cfg for this batch ...
+            }
+        });
+    }
+
+    // Publish updates from the calling thread.
+    publisher.publish(MyConfig { /* updated */ });
+});
+// Publisher drops here.  All retired MyConfig values drop on this
+// thread.  Drop affinity preserved.
+```
+
+## The problem QSBR solves
+
+A dataplane has one thread that mutates configuration (the _publisher_)
+and many threads that read configuration on the hot path (the
+_subscribers_). Updating shared state without coordination would race;
+locking on the read side would tank latency.
+
+The classic fix is copy-on-write: the publisher allocates a new version
+of the state and atomically swaps it in. Old subscribers keep using
+the old version until they're ready to look at the new one; new
+subscribers immediately see the new version.
+
+The leftover problem is **when can the old version be freed?** As long
+as some subscriber still holds a pointer to it, freeing is a
+use-after-free.
+
+QSBR's answer: have each subscriber periodically declare a _quiescent
+state_; an explicit "I am not currently holding any reference to a
+shared snapshot." Old versions are reclaimable once **every**
+subscriber has passed through a quiescent state since the version
+became old. In a packet-batch dataplane, the natural quiescent state
+is the **batch boundary**: between two batches, the lcore holds no
+borrows to the configuration.
+
+Memory reclamation is the headline benefit, but the load-bearing
+property in this crate is one step stronger:
+
+> **The destructor of every published value runs on the publisher's
+> thread.**
+
+This is what makes the crate safe to use with FFI handles whose
+`Drop` impls have a thread requirement.
+
+## The algorithm in one diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as Publisher
+    participant S as Slot
+    participant Sub as Subscriber
+    participant E as "Subscriber's Epoch cell"
+    participant D as "Domain (cell registry)"
+
+    Note over P,Sub: Steady state: subscriber is observing version V
+
+    P->>S: swap(Arc[V+1]) returns Arc[V]
+    P->>P: retired.push(Arc[V])
+    Note over P: Publisher now holds the only clone of V<br/>besides the subscriber's cached copy
+
+    Sub->>S: load_full() returns Arc[V+1]
+    Sub->>Sub: cached = Some(Arc[V+1])  -- drops old cached(V): 2 to 1
+    Note over Sub: V's refcount fell, but Publisher still has the clone in retired<br/>so V's destructor has NOT run yet
+    Sub->>E: observe(V+1) [Release]
+    Note over Sub: This is the signal that unblocks reclamation of V
+
+    P->>D: min_observed() (lock + scan)
+    D->>E: load() [Acquire] returns V+1
+    D-->>P: Some(V+1)
+    P->>P: retired.retain(|v| v.version >= V+1)
+    Note over P: drops Arc[V] 1 to 0, V drop() runs HERE on the Publisher thread
+```
+
+The two non-obvious facts encoded in that diagram:
+
+1. **The publisher always holds the last clone of any retired
+   version.** Subscribers' `cached` Arcs are merely _additional_
+   clones; they keep the allocation alive but never trigger the inner
+   `Drop`. The publisher's `retired` Vec is what decides when the
+   destructor fires and on which thread.
+
+2. **Subscribers signal "I have moved past V" by storing into their
+   epoch cell after replacing their cached Arc.** The Release-Acquire
+   pair on the cell carries the publisher safely from "V is pinned" to
+   "V is reclaimable."
+
+## API shape
+
+Three types and one constructor. Each type's role and threading
+profile:
+
+| Type                         | Owns                                                         | `Send`/`Sync`/etc.   | Lifetime                 |
+| ---------------------------- | ------------------------------------------------------------ | -------------------- | ------------------------ |
+| [`Publisher<T>`]             | publication slot, retired list, version counter, QSBR domain | `Send + !Sync`       | owns its state           |
+| [`SubscriberFactory<'p, T>`] | a pair of references to the Publisher's slot and domain      | `Send + Sync + Copy` | borrows from `Publisher` |
+| [`Subscriber<'p, T>`]        | a per-thread observation cell, a per-thread cached Arc       | `Send + !Sync`       | borrows from `Publisher` |
+
+Construction:
+
+```rust,ignore
+use dataplane_quiescent::channel;
+
+let publisher = channel(initial_value);
+```
+
+[`channel`] returns the [`Publisher`] alone. Subscribers are obtained
+via [`Publisher::factory`]. The factory and any subscribers it spawns
+borrow from the publisher; the borrow checker enforces "subscribers
+cannot outlive publisher" at compile time, which is what makes the
+drop-affinity guarantee structural.
+
+## Threading model
+
+```mermaid
+graph TD
+    PT[Publisher thread<br/>builds, publishes, reclaims]
+    SF[SubscriberFactory<br/>Copy + Send + Sync]
+    ST1[Subscriber thread 1<br/>per-batch snapshots]
+    ST2[Subscriber thread 2]
+    ST3[Subscriber thread N]
+
+    PT -->|publisher.factory| SF
+    SF -.->|copy| ST1
+    SF -.->|copy| ST2
+    SF -.->|copy| ST3
+    ST1 -->|factory.subscriber| ST1S[Subscriber<br/>!Sync, single thread]
+    ST2 -->|factory.subscriber| ST2S[Subscriber]
+    ST3 -->|factory.subscriber| ST3S[Subscriber]
+```
+
+- Exactly **one Publisher thread**. `Publisher: !Sync` means the
+  Publisher value can't even be borrow-shared across threads, much
+  less mutated from two threads. The `Send` side of `!Sync` lets you
+  move the Publisher to its owning thread once at startup.
+- Many **`SubscriberFactory`** clones, freely shareable across threads.
+  The factory holds nothing but borrowed references -- `Copy` is sound,
+  cloning is basically free.
+- Many **`Subscriber`** instances, one per consumer thread.
+  `Subscriber: !Sync` ensures one snapshot per subscriber per batch;
+  the embedded epoch cell tracks one specific thread's observed
+  version; sharing it would scramble QSBR.
+
+In production, the consumer threads are typically DPDK lcores spawned
+inside a `std::thread::scope`; the publisher's thread is the build
+worker spawned in the same scope. The scope's lifetime is what `'p`
+binds to.
+
+## Snapshot: cache, then observe (load-bearing order)
+
+The single most important line in the implementation:
+
+```rust,ignore
+self.cached = Some(latest);  // <-- drop the old cached Arc FIRST
+self.epoch.observe(version); // <-- THEN tell the publisher we've moved
+```
+
+Reordering those two statements would be a soundness bug. The
+sequence diagrams below show why.
+
+### Correct order: drop-old, then observe
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Sub as Subscriber
+    participant E as Epoch cell
+    participant P as Publisher
+
+    Note over Sub,P: cached = Arc[V_old], cell = V_old, Publisher's retired = [Arc[V_old]] refcount of V_old is 2 (Subscriber & Publisher)
+
+    Sub->>Sub: cached = Some(Arc[V_new])
+    Note over Sub: drops the old Arc[V_old], refcount 2 to 1 (Publisher still holds it, no Drop body fires)
+
+    Sub->>E: observe(V_new) [Release]
+    Note over P: Publisher's next reclaim is now allowed to drop V_old
+
+    P->>P: reclaim observes V_new, drops Arc[V_old], 1 to 0
+    Note over P: V_old drop() runs on Publisher thread
+```
+
+### What goes wrong if you reorder them
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Sub as Subscriber
+    participant E as Epoch cell
+    participant P as Publisher
+
+    Note over Sub,P: cached = Arc[V_old], cell = V_old, refcount V_old = 2
+
+    Sub->>E: observe(V_new) [Release]
+    Note over P: Publisher's reclaim now thinks V_old is unpinned!
+
+    P->>P: reclaim drops Arc[V_old], refcount 2 to 1 (only Subscriber's clone remains)
+
+    Sub->>Sub: cached = Some(Arc[V_new])
+    Note over Sub: drops Arc[V_old], refcount 1 to 0 V_old drop() runs on Subscriber thread (BUG)
+```
+
+The fix-by-construction is just "do these two statements in this
+order, always."
+
+## Subscriber drop: cache, then epoch (also load-bearing)
+
+The same principle applies when a `Subscriber` drops: `cached` must
+drop before `epoch`.  Field declaration order on `Subscriber` puts
+`cached` before `epoch`, so Rust's default field-drop order already
+honours this.  The crate's `Drop` impl explicitly clears `cached`
+first as belt-and-suspenders, so the invariant survives anyone
+reordering the fields without thinking about it:
+
+```rust,ignore
+impl<T> Drop for Subscriber<'_, T> {
+    fn drop(&mut self) {
+        self.cached = None; // drop the Versioned Arc clone FIRST
+        // remaining fields drop after this; in particular the Epoch
+        // (whose Arc<CachePaddedCounter> drop is what tells the
+        // Publisher's reclaim "this Subscriber is gone").
+    }
+}
+```
+
+The reasoning mirrors the snapshot ordering: the Subscriber must drop
+its Arc clone of the cached `Versioned` before the `Publisher` learns
+it's safe to reclaim, otherwise the `Subscriber`'s drop becomes the last
+clone-drop and the inner destructor runs on the wrong thread.
+
+## Reclaim discipline: the registry and the 0-sentinel
+
+The Publisher's `reclaim` consults its internal `Domain` (the registry
+of per-Subscriber observation cells) to compute the **lowest version
+any live `Subscriber` is currently pinning**. Every retired version below
+that watermark is reclaimable.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant P as "Publisher::reclaim"
+    participant D as "Domain (Mutex[Vec[Arc[Cell]]])"
+    participant Cs as "Subscriber cells"
+
+    P->>D: lock active list
+    loop for each cell in active
+        D->>D: strong_count(cell) == 1?
+        alt yes (Subscriber gone)
+            D->>D: drop entry (false)
+        else no (Subscriber live)
+            D->>Cs: load() [Acquire]
+            Cs-->>D: observed
+            alt observed == 0 (registered, mid first snapshot, or idle)
+                D->>D: any_in_flight = true (forces Some(Version::INITIAL); pins all retired)
+            else observed > 0
+                D->>D: track min if observed < min
+            end
+        end
+    end
+    D-->>P: Option[Version]
+    alt Some(min)
+        P->>P: retired.retain(|v| v.version >= min)
+    else None (no live Subscribers)
+        P->>P: retired.clear()
+    end
+```
+
+Two sentinels worth highlighting:
+
+- **`Arc::strong_count(cell) == 1`** means only the Domain holds the
+  cell -- the corresponding Subscriber is gone. The Subscriber's
+  `Epoch` was the only other strong reference, and it dropped when
+  the `Subscriber` dropped.
+- **`observed == 0`** means the `Subscriber` is either freshly
+  registered or in the middle of its first `snapshot()` call (between
+  `load_full` returning and `observe` running).  In the latter case
+  the `Subscriber` already holds an `Arc<Versioned>` via the snapshot
+  function's local variable that `min_observed` cannot see, so we
+  conservatively **pin every retired version** until the `Subscriber`
+  observes a real `Version`.  Once a `Subscriber` has called `observe`
+  once, its cell is monotonically non-zero for the rest of its life
+  (`Version` is `NonZero<u64>`), so the `0`-cell window closes
+  permanently after that first observation.
+
+  The corollary: a `Subscriber` that is registered but never calls
+  `snapshot()` (e.g. its consumer thread parks before the first batch,
+  or registration happens far ahead of first use) keeps its cell at
+  `0` indefinitely, and reclamation stays pinned for as long as that
+  `Subscriber` lives.  This is an unbounded-memory failure mode for
+  callers that hold idle `Subscriber`s -- construct each `Subscriber`
+  immediately before its first batch, not at thread startup.
+
+## Lifetime invariant: subscribers cannot outlive the publisher
+
+```mermaid
+graph LR
+    P["Publisher<br/>owns Slot, Domain, retired"]
+    F["SubscriberFactory['p]<br/>= 2 references"]
+    S["Subscriber['p]<br/>= reference + Epoch + cached"]
+    P -->|"factory()"| F
+    F -->|"subscriber()"| S
+    S -.borrows from.-> P
+    F -.borrows from.-> P
+```
+
+Every `SubscriberFactory<'p, T>` and `Subscriber<'p, T>` carries a
+lifetime brand `'p` tied to a `&Publisher<T>` borrow. The borrow
+checker therefore refuses any program in which a `Subscriber` outlives
+the `Publisher`. This makes the destructor-thread-affinity guarantee a
+**compile-time** property, not a documented contract.
+
+In practice:
+
+```rust,ignore
+use dataplane_quiescent::channel;
+
+let publisher = channel(initial);
+
+std::thread::scope(|s| {
+    let factory = publisher.factory();
+    s.spawn(move || {
+        let mut sub = factory.subscriber();
+        loop {
+            let snap = sub.snapshot();
+            // ... use snap for one batch ...
+        }
+    });
+
+    // Publisher operations happen here on the calling thread, freely
+    // interleaved with the spawned thread:
+    publisher.publish(new_value);
+    publisher.reclaim();
+});
+// Scope joins all spawned threads.  Subscribers all dropped.
+// Publisher drops next, on this (calling) thread.  Last clones of
+// retired Versioneds drop here too.
+```
+
+`Publisher::publish` and `Publisher::reclaim` take `&self` rather than
+`&mut self`. This is necessary because the factory borrows the
+`Publisher` shared, and a `&mut self` method would conflict. Internal
+mutability is `RefCell` for `retired` and `Cell` for `next_version`;
+no runtime cost in release builds, and the `!Sync` invariant means the
+borrow checks the `RefCell` performs _cannot_ actually fail.
+
+## Memory ordering
+
+Cross-thread synchronization rests on three pairs:
+
+| Operation                        | Publisher side                   | Subscriber side                    |
+| -------------------------------- | -------------------------------- | ---------------------------------- |
+| The publication itself           | `Slot::swap` (Release)           | `Slot::load_full` (Acquire)        |
+| The "I have moved past V" signal | `cell.load` (Acquire) in reclaim | `cell.store` (Release) in snapshot |
+| The active-list registry         | `Mutex` lock/unlock              | `Mutex` lock/unlock                |
+
+Combined with the cache-then-observe ordering on the `Subscriber` side
+and the always-retain-a-clone discipline on the `Publisher` side, this
+is sufficient for QSBR correctness.
+
+## Limitations
+
+- **Single publisher.** The `!Sync` Publisher and `&self` publish/
+  reclaim methods enforce single-thread-publish via interior mutability
+  on the publisher's own thread. Multi-publisher would require a
+  different design.
+- **Reclaim runs synchronously on every publish.**
+  `Publisher::publish` runs a reclaim pass before returning, which
+  adds the cost of one `min_observed` scan (a `Mutex` acquire on the
+  QSBR domain plus a `strong_count` + `cell.load` per registered
+  Subscriber) to every publish.  The standalone `Publisher::reclaim`
+  is exposed for callers who want to drive reclamation between
+  publishes; it does not skip the reclaim that `publish` already
+  performs.  We don't currently expose a "publish without reclaim"
+  variant because the typical control-plane publish rate is sub-Hz,
+  but if the scan cost ever becomes load-bearing that is the knob to
+  add.  There is no way to _force_ reclamation past a stuck
+  Subscriber other than dropping that Subscriber.
+- **Subscribers must be inside a `thread::scope`** (or otherwise
+  lifetime-bounded by the Publisher). `std::thread::spawn` won't work
+  because it requires `'static`.
+- **Loom cannot exhaustively test the lifetime-bounded API** because
+  loom 0.7.2 doesn't expose `thread::scope`. The crate's loom tests
+  use a `Box::into_raw` / `Box::from_raw` shim to lift the Publisher
+  to `'static` for the iteration; see `tests/loom.rs`.

--- a/quiescent/src/lib.rs
+++ b/quiescent/src/lib.rs
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![forbid(unsafe_code)]
+#![deny(
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+mod slot;
+
+use core::cell::{Cell, RefCell};
+use core::marker::PhantomData;
+use core::num::NonZero;
+
+use concurrency::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+
+use crate::slot::Slot;
+
+struct Versioned<T> {
+    /// Monotonic version stamp assigned by the Publisher.
+    version: Version,
+    inner: T,
+}
+
+struct Domain {
+    /// Registry of per-Subscriber observation cells.  Mutex-guarded
+    /// because `register` (any thread holding a `SubscriberFactory`)
+    /// and the Publisher's reclaim scan (`min_observed`) both mutate
+    /// the Vec.  The snapshot fast path never touches this; `register`
+    /// is a once-per-Subscriber cost at spawn time.  `min_observed`
+    /// shares the same lock and is called from `reclaim` (which
+    /// `publish` invokes on every call), so this Mutex sits on the
+    /// publish path -- keep its critical section tight.
+    ///
+    /// Each entry is the same `Arc<CachePaddedCounter>` the
+    /// corresponding `Subscriber` holds via its `Epoch`.  When a
+    /// `Subscriber` drops, the strong-count of its cell falls from 2
+    /// (Subscriber + Domain) to 1 (Domain only); the next
+    /// `min_observed` scan removes such entries.  We use
+    /// `Arc::strong_count` rather than `Weak` because loom's
+    /// `loom::sync` doesn't expose a `Weak`, and `strong_count`
+    /// carries the same information with one fewer indirection.
+    active: Mutex<Vec<Arc<CachePaddedCounter>>>,
+}
+
+impl Domain {
+    /// Initial capacity for the active-Subscriber registry.  Sized to
+    /// roughly the typical maximum lcore count for our deployments;
+    /// over-sizing the Vec is cheap (one allocation of pointer-sized
+    /// slots) and we avoid early reallocations during burst spawns.
+    const SUBSCRIBER_GUESS: usize = 256;
+
+    fn new() -> Self {
+        Self {
+            active: Mutex::new(Vec::with_capacity(Self::SUBSCRIBER_GUESS)),
+        }
+    }
+
+    fn register(&self) -> Epoch {
+        let epoch = Epoch::new();
+        #[allow(clippy::expect_used)] // the mutex is poisoned only in unrecoverable error cases
+        self.active
+            .lock()
+            .expect("qsbr mutex poisoned")
+            .push(Arc::clone(&epoch.cell));
+        epoch
+    }
+
+    fn min_observed(&self) -> Option<Version> {
+        #[allow(clippy::expect_used)] // the mutex is poisoned only in unrecoverable error cases
+        let mut active = self.active.lock().expect("qsbr mutex poisoned");
+        let mut min = u64::MAX;
+        let mut any_in_flight = false;
+        active.retain(|cell| {
+            if Arc::strong_count(cell) == 1 {
+                // Only the Domain still holds this cell -- the corresponding
+                // Subscriber is gone.  Drop the entry.
+                //
+                // Load-bearing Acquire fence: `Arc::strong_count` is a
+                // Relaxed load in std, but the Subscriber's drop sequence
+                // is `cached = None` (Release on `Versioned`'s strong
+                // count) followed by `epoch` field drop (Release on this
+                // cell's strong count).  Without a synchronization
+                // edge, on weak-memory architectures the Publisher's
+                // subsequent decrement of the same `Versioned` (in
+                // `reclaim`) could be reordered before the Subscriber's
+                // -- leaving the Subscriber's decrement as the last one,
+                // and therefore running the destructor on the wrong
+                // thread.  This Acquire fence pairs with the
+                // Subscriber's `epoch` Release decrement: the Relaxed
+                // `strong_count` load above sees the result of that
+                // Release, and the fence lifts every later operation
+                // on this thread to happen-after it.  In particular,
+                // any subsequent `retired.clear()` decrement of the
+                // matching `Versioned` is now ordered after the
+                // Subscriber's prior `cached = None` decrement.
+                concurrency::sync::atomic::fence(Ordering::Acquire);
+                return false;
+            }
+            let observed = cell.load();
+            if observed == 0 {
+                // Cell == 0 means the Subscriber is either freshly
+                // registered or in the middle of its first snapshot
+                // (between `load_full` and `observe`).  In the latter
+                // case the Subscriber may already be holding an
+                // `Arc<Versioned>` via the local `latest` variable
+                // that `min_observed` cannot see, so we cannot
+                // conclude "no pin" -- that would let `reclaim` drop a
+                // retired version the Subscriber is about to cache,
+                // and the destructor would then run on the
+                // Subscriber's thread when the cached Arc is finally
+                // dropped.  Conservatively pin every retired version
+                // until this Subscriber observes a real Version.  Once
+                // a Subscriber has called `observe` once, its cell is
+                // monotonically non-zero for the rest of its life
+                // (Version is `NonZero<u64>`), so this is a one-shot
+                // window per Subscriber rather than a permanent block.
+                any_in_flight = true;
+                return true;
+            }
+            if observed < min {
+                min = observed;
+            }
+            true
+        });
+        if any_in_flight {
+            // Pin everything from the lowest possible version onward;
+            // the caller's `retain |x| x.version >= INITIAL` keeps all
+            // retired entries.
+            return Some(Version::INITIAL);
+        }
+        if min == u64::MAX {
+            return None;
+        }
+        Some(Version(NonZero::new(min).unwrap_or_else(|| unreachable!())))
+    }
+}
+
+#[repr(transparent)]
+struct Epoch {
+    cell: Arc<CachePaddedCounter>,
+}
+
+#[repr(align(64))] // cache padding to avoid false sharing if something else ends up in the same cache line
+struct CachePaddedCounter(AtomicU64);
+
+impl CachePaddedCounter {
+    fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    #[inline]
+    fn store(&self, val: u64) {
+        self.0.store(val, Ordering::Release);
+    }
+
+    #[inline]
+    fn load(&self) -> u64 {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+impl Epoch {
+    fn new() -> Self {
+        Self {
+            cell: Arc::new(CachePaddedCounter::new()),
+        }
+    }
+
+    fn observe(&self, version: Version) {
+        self.cell.store(version.get());
+    }
+}
+
+/// Monotonic version stamp assigned to each publication.  Returned by
+/// [`Publisher::publish`] and useful for tracking "has the world
+/// advanced past this point?" without holding a snapshot ref.
+///
+/// Strictly increasing across the lifetime of a [`Publisher`].  The
+/// initial publication carries the lowest non-zero version (`1`); each
+/// subsequent `publish` returns a version one greater than the
+/// previous one.
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
+pub struct Version(NonZero<u64>);
+
+impl Version {
+    const INITIAL: Self = Self(NonZero::<u64>::MIN);
+
+    /// Extract the raw monotonic counter.  Useful for tracing, metrics,
+    /// or comparing against externally-stored versions.
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    #[inline]
+    const fn next(self) -> Self {
+        if let Some(nz) = self.0.checked_add(1) {
+            Self(nz)
+        } else {
+            core::hint::cold_path();
+            #[allow(clippy::panic)]
+            {
+                // This whole path is technically reachable, but only technically.
+                // If you got config updates 1B times per second on average it would
+                // still take 584 years to wrap around.  Even that requires us to receive
+                // and process config updates faster than the line rate of an 800Gb/s NIC.
+                // For hundreds of years.  With no reboot.
+                //
+                // The only realistic way to reach this point is via a bug in this code,
+                // not via normal operation.
+                panic!("Version wrapped!  This is a bug");
+            }
+        }
+    }
+}
+
+/// Owns the publication slot and the QSBR domain.  Hands out
+/// [`SubscriberFactory`] handles via [`Publisher::factory`]; both the
+/// factory and any [`Subscriber`]s it spawns borrow from this Publisher
+/// and therefore cannot outlive it.  This makes "the last `Versioned`
+/// destructor runs on the Publisher's thread" a compile-time guarantee.
+///
+/// Methods that mutate Publisher state ([`publish`](Self::publish),
+/// [`reclaim`](Self::reclaim)) take `&self` because handing out
+/// `SubscriberFactory<'_, T>` borrows the Publisher shared.  Single-
+/// thread use is enforced by the `RefCell`/`Cell` interior -- Publisher
+/// is `!Sync`.  Send is preserved so the Publisher can be moved to its
+/// owning thread once at startup.
+pub struct Publisher<T: Send + Sync> {
+    publication: Arc<Slot<Versioned<T>>>,
+    domain: Arc<Domain>,
+    retired: RefCell<Vec<Arc<Versioned<T>>>>,
+    next_version: Cell<Version>,
+}
+
+/// Construct a fresh QSBR channel with `initial` as the version-1
+/// publication.  Returns the [`Publisher`] alone; subscribers are
+/// obtained via [`Publisher::factory`].
+#[must_use]
+pub fn channel<T: Send + Sync>(initial: T) -> Publisher<T> {
+    let domain = Arc::new(Domain::new());
+    let publication = Arc::new(Slot::from_pointee(Versioned {
+        version: Version::INITIAL,
+        inner: initial,
+    }));
+    Publisher {
+        publication,
+        domain,
+        retired: RefCell::new(Vec::with_capacity(8)),
+        next_version: Cell::new(Version::INITIAL.next()),
+    }
+}
+
+impl<T: Send + Sync> Publisher<T> {
+    /// Atomically publish `message` as a new version of the channel
+    /// and run an opportunistic [`reclaim`](Self::reclaim) pass.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the retired list is currently borrowed (this should be
+    /// impossible unless unsafe code is involved).
+    pub fn publish(&self, message: T) -> Version {
+        let generation = self.next_version.get();
+        self.next_version.set(generation.next());
+        let new_arc = Arc::new(Versioned {
+            version: generation,
+            inner: message,
+        });
+        let prev_arc = self.publication.swap(new_arc);
+        #[allow(clippy::expect_used)] // !Sync invariant means no concurrent borrow
+        self.retired
+            .try_borrow_mut()
+            .expect("retired RefCell concurrently borrowed")
+            .push(prev_arc);
+        self.reclaim();
+        generation
+    }
+
+    /// Reclaim any retired `Versioned`s whose version is below every
+    /// live Subscriber's observed version.  Called automatically by
+    /// [`publish`](Self::publish); exposed for callers who want to
+    /// drive reclamation explicitly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the retired list is currently borrowed (this should be
+    /// impossible unless unsafe code is involved).
+    pub fn reclaim(&self) {
+        #[allow(clippy::expect_used)] // !Sync invariant means no concurrent borrow
+        let mut retired = self
+            .retired
+            .try_borrow_mut()
+            .expect("retired RefCell concurrently borrowed");
+        match self.domain.min_observed() {
+            Some(version) => retired.retain(|x| x.version >= version),
+            None => retired.clear(),
+        }
+    }
+
+    /// Number of retired `Versioned`s still pending reclamation.
+    /// Useful for diagnostics.
+    #[must_use]
+    pub fn pending_reclamation(&self) -> usize {
+        self.retired.borrow().len()
+    }
+
+    /// Hand out a [`SubscriberFactory`] tied to this Publisher's
+    /// lifetime.  The factory and any Subscribers it spawns cannot
+    /// outlive the Publisher -- the borrow checker enforces this.
+    #[must_use]
+    pub fn factory(&self) -> SubscriberFactory<'_, T> {
+        SubscriberFactory {
+            publication: &self.publication,
+            domain: &self.domain,
+        }
+    }
+}
+
+/// Spawns [`Subscriber`]s tied to a [`Publisher`].  Cheap to clone (a
+/// pair of references); send clones into Subscriber threads inside a
+/// `thread::scope`.
+pub struct SubscriberFactory<'p, T: Send + Sync> {
+    publication: &'p Arc<Slot<Versioned<T>>>,
+    domain: &'p Arc<Domain>,
+}
+
+impl<T: Send + Sync> Clone for SubscriberFactory<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Send + Sync> Copy for SubscriberFactory<'_, T> {}
+
+impl<'p, T: Send + Sync> SubscriberFactory<'p, T> {
+    /// Construct a new [`Subscriber`] registered with the Publisher's
+    /// QSBR domain.  Each Subscriber should live on a single thread.
+    #[must_use]
+    pub fn subscriber(&self) -> Subscriber<'p, T> {
+        Subscriber {
+            publication: self.publication,
+            cached: None,
+            epoch: self.domain.register(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Per-thread snapshot handle.  Borrows from the [`Publisher`] via
+/// `'p`; cannot outlive the Publisher.  `Send + !Sync`: ownership can
+/// move to its destination thread once at setup, but the embedded
+/// epoch is meaningful only for one thread's observations.
+///
+/// Field order is load-bearing: `cached` must drop **before** `epoch`.
+/// See the [`Drop`] impl for the full reasoning.  Default field-drop
+/// order (declared order) honours this; the explicit `Drop` impl is
+/// belt-and-suspenders so the invariant survives someone reordering
+/// the fields.
+pub struct Subscriber<'p, T: Send + Sync> {
+    publication: &'p Arc<Slot<Versioned<T>>>,
+    cached: Option<Arc<Versioned<T>>>,
+    epoch: Epoch,
+    /// `&'p ()` carries the covariant Publisher-lifetime brand;
+    /// `Cell<()>` makes the Subscriber `!Sync` (the embedded epoch is
+    /// meaningful only for one thread's observations, and `cached` is
+    /// a per-thread cache).  `PhantomData` of a tuple gives us both at
+    /// zero cost.
+    _marker: PhantomData<(&'p (), Cell<()>)>,
+}
+
+impl<T: Send + Sync> Subscriber<'_, T> {
+    /// Refresh the per-thread cache from the latest publication and
+    /// return a borrow of the underlying value.  The borrow is bounded
+    /// by `&mut self`, so two snapshots from the same Subscriber
+    /// cannot coexist -- one snapshot per Subscriber per batch.
+    pub fn snapshot(&mut self) -> &T {
+        let latest = self.publication.load_full();
+        let needs_refresh = self
+            .cached
+            .as_ref()
+            .is_none_or(|cached| cached.version < latest.version);
+        if needs_refresh {
+            let version = latest.version;
+            // Cache update MUST happen before `observe` call!  Reordering
+            // would let the Publisher's reclaim drop its retained clone
+            // while we still hold the old `cached` Arc, so the
+            // `Versioned` destructor would run on this (Subscriber)
+            // thread instead of the Publisher's.
+            self.cached = Some(latest);
+            self.epoch.observe(version);
+        }
+        &self
+            .cached
+            .as_ref()
+            .unwrap_or_else(|| unreachable!("cache populated"))
+            .inner
+    }
+}
+
+impl<T: Send + Sync> Drop for Subscriber<'_, T> {
+    fn drop(&mut self) {
+        // Load-bearing: cached must drop BEFORE epoch.  If epoch dies
+        // first, the cell's strong-count falls to 1, the Publisher's
+        // next `min_observed` scan prunes our entry -- but our
+        // still-live `cached` Arc would be the last clone of
+        // `Versioned<V>`, so its destructor would run on this
+        // (Subscriber) thread, violating QSBR drop affinity.  Drop
+        // cached first so the Publisher always holds the last clone.
+        //
+        // The field declaration order on `Subscriber` already places
+        // `cached` before `epoch`, so default field-drop order honours
+        // this.  The explicit `cached = None` here is belt-and-
+        // suspenders: if anyone reorders the fields without thinking
+        // about it, this Drop impl still gets it right.
+        self.cached = None;
+    }
+}
+
+// =====================================================================
+// Auto-trait assertions: load-bearing properties of the public API.  A
+// regression silently changing any of these would break QSBR safety;
+// the build error here forces us to acknowledge the change.
+// =====================================================================
+
+// Publisher: Send (movable to its owning thread once at startup) but
+// !Sync (single-thread invariant -- interior mutability via `RefCell`/
+// `Cell` is unsafe to share).
+static_assertions::assert_impl_all!(Publisher<()>: Send);
+static_assertions::assert_not_impl_any!(Publisher<()>: Sync);
+
+// SubscriberFactory: Send + Sync + Copy.  Cloned freely and shared
+// across threads to spawn Subscribers per-lcore.
+static_assertions::assert_impl_all!(SubscriberFactory<'static, ()>: Send, Sync, Copy);
+
+// Subscriber: Send (movable to its destination thread once at setup)
+// but !Sync (the embedded epoch represents one specific thread's
+// observed version; sharing would scramble QSBR).
+static_assertions::assert_impl_all!(Subscriber<'static, ()>: Send);
+static_assertions::assert_not_impl_any!(Subscriber<'static, ()>: Sync);

--- a/quiescent/src/lib.rs
+++ b/quiescent/src/lib.rs
@@ -208,6 +208,8 @@ impl Version {
         if let Some(nz) = self.0.checked_add(1) {
             Self(nz)
         } else {
+            // LCOV_EXCL_START - reaching this path is itself the failure;
+            // chasing coverage of it is absurd.  See the comment below.
             core::hint::cold_path();
             #[allow(clippy::panic)]
             {
@@ -221,6 +223,7 @@ impl Version {
                 // not via normal operation.
                 panic!("Version wrapped!  This is a bug");
             }
+            // LCOV_EXCL_STOP
         }
     }
 }

--- a/quiescent/src/lib.rs
+++ b/quiescent/src/lib.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
+#![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 #![deny(
+    missing_docs,
     clippy::pedantic,
     clippy::unwrap_used,
     clippy::expect_used,

--- a/quiescent/src/slot.rs
+++ b/quiescent/src/slot.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Single-slot atomic publication.
+//!
+//! In production this is `arc_swap::ArcSwap` -- lock-free read fast path,
+//! which is what makes [`Subscriber::snapshot`] cheap on the data-plane.
+//!
+//! When the `loom` or `shuttle` feature is enabled (via the
+//! `concurrency` crate) it falls back to `Mutex<Arc<T>>` because neither
+//! model checker sees `arc_swap`'s internals (hazard pointers + lower-
+//! level atomics).  The two implementations are observably equivalent
+//! for the QSBR protocol -- atomic publish, atomic load -- which is all
+//! the model checker needs to see.
+//!
+//! [`Subscriber::snapshot`]: crate::Subscriber::snapshot
+
+use concurrency::sync::Arc;
+
+#[cfg(not(any(feature = "loom", feature = "shuttle")))]
+mod imp {
+    use super::Arc;
+    use arc_swap::ArcSwap;
+
+    pub(crate) struct Slot<T>(ArcSwap<T>);
+
+    impl<T> Slot<T> {
+        #[inline]
+        pub(crate) fn from_pointee(value: T) -> Self {
+            Self(ArcSwap::from_pointee(value))
+        }
+
+        #[inline]
+        pub(crate) fn load_full(&self) -> Arc<T> {
+            self.0.load_full()
+        }
+
+        #[inline]
+        pub(crate) fn swap(&self, new: Arc<T>) -> Arc<T> {
+            self.0.swap(new)
+        }
+    }
+}
+
+#[cfg(any(feature = "loom", feature = "shuttle"))]
+mod imp {
+    use super::Arc;
+    use concurrency::sync::Mutex;
+
+    pub(crate) struct Slot<T>(Mutex<Arc<T>>);
+
+    impl<T> Slot<T> {
+        pub(crate) fn from_pointee(value: T) -> Self {
+            Self(Mutex::new(Arc::new(value)))
+        }
+
+        pub(crate) fn load_full(&self) -> Arc<T> {
+            #[allow(clippy::expect_used)] // poisoned only in unrecoverable cases
+            Arc::clone(&self.0.lock().expect("slot mutex poisoned"))
+        }
+
+        pub(crate) fn swap(&self, new: Arc<T>) -> Arc<T> {
+            #[allow(clippy::expect_used)]
+            let mut guard = self.0.lock().expect("slot mutex poisoned");
+            core::mem::replace(&mut *guard, new)
+        }
+    }
+}
+
+pub(crate) use imp::Slot;

--- a/quiescent/tests/loom.rs
+++ b/quiescent/tests/loom.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Loom model-checking tests for `dataplane_quiescent`.
+//!
+//! These tests run only under `--features loom`.  Standard protocol
+//! tests live in `tests/protocol.rs`; bolero properties in
+//! `tests/properties.rs`; bolero x shuttle in `tests/shuttle.rs`.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo test --release -p dataplane-quiescent --features loom --test loom
+//! ```
+//!
+//! ## Why the `unsafe`
+//!
+//! Loom 0.7.2 doesn't expose `thread::scope`, only `thread::spawn`,
+//! which requires `'static`.  But the new lifetime-bounded API gives
+//! us a `Subscriber<'p, T>` that borrows from the `Publisher` -- there
+//! is no `'static` to satisfy `thread::spawn` with.
+//!
+//! Workaround: each `loom::model` iteration boxes a fresh `Publisher`,
+//! lifts it to `&'static` via `Box::into_raw` for the body of the
+//! iteration, and recovers the `Box` at the end (so loom's Arc-leak
+//! audit is satisfied).  The unsafe is local, narrow, and well-paired:
+//! every `into_raw` has a matching `from_raw`.
+//!
+//! `Box::leak` on its own would not work -- loom audits `Arc` cleanup
+//! at the end of every model iteration and panics on leaked clones.
+//!
+//! ## Sizing
+//!
+//! Loom explores all legal interleavings of the operations inside each
+//! `loom::model(|| { ... })` block.  Keep test bodies minimal -- each
+//! extra atomic op multiplies the search space.  Two threads with one
+//! atomic op each is roughly the right shape; "2 publishes + 2
+//! subscribers + a drop" already explodes.
+
+#![cfg(feature = "loom")]
+
+use loom::thread;
+
+use dataplane_quiescent::{Publisher, channel};
+
+/// Run `body` with a `&'static` reference to a freshly-constructed
+/// `Publisher`.  After `body` returns, recover the `Box` and drop the
+/// `Publisher` so loom's Arc-leak audit is satisfied.
+///
+/// The `'static` lifetime is real for the duration of `body` (the
+/// `Publisher` is live in heap-allocated memory until `Box::from_raw`
+/// runs after `body`).  Caller must not retain any references derived
+/// from the `&'static Publisher` past the return of `body`.
+fn with_static_publisher<F>(body: F)
+where
+    F: FnOnce(&'static Publisher<u32>),
+{
+    let raw: *mut Publisher<u32> = Box::into_raw(Box::new(channel(0u32)));
+    // SAFETY: `raw` was just produced by `Box::into_raw` and is not
+    // freed until the matching `Box::from_raw` below.  No aliasing
+    // occurs: `body` consumes the only handle.
+    let publisher: &'static Publisher<u32> = unsafe { &*raw };
+    body(publisher);
+    // SAFETY: `body` has returned and the contract requires no
+    // outstanding references to `publisher`.  `raw` is still the
+    // unique pointer to the heap allocation.
+    drop(unsafe { Box::from_raw(raw) });
+}
+
+/// A snapshot taken after a publish must observe a value the Publisher
+/// ever stored.  Under any interleaving of `publish` vs `snapshot`, the
+/// Subscriber sees either the initial or the published value, never
+/// anything else (no torn reads, no use-after-free).
+#[test]
+fn snapshot_observes_a_legal_value() {
+    loom::model(|| {
+        with_static_publisher(|publisher| {
+            let factory = publisher.factory();
+
+            let sub_handle = thread::spawn(move || {
+                let mut sub = factory.subscriber();
+                let observed = *sub.snapshot();
+                assert!(
+                    observed == 0 || observed == 1,
+                    "Subscriber observed illegal value {observed}",
+                );
+            });
+
+            publisher.publish(1u32);
+            sub_handle.join().unwrap();
+        });
+    });
+}
+
+/// A Subscriber that takes a snapshot before the Publisher publishes,
+/// then is dropped concurrently with the Publisher's reclaim, must not
+/// deadlock and must not leave the protocol in an inconsistent state.
+#[test]
+fn subscriber_drop_during_publish_is_safe() {
+    loom::model(|| {
+        with_static_publisher(|publisher| {
+            let factory = publisher.factory();
+
+            let sub_handle = thread::spawn(move || {
+                let mut sub = factory.subscriber();
+                let _ = *sub.snapshot();
+                // Subscriber drops at end of thread; concurrent with publisher below.
+            });
+
+            publisher.publish(1u32);
+            publisher.reclaim();
+            sub_handle.join().unwrap();
+        });
+    });
+}
+
+/// A Subscriber that snapshots after `publish` returns must observe the
+/// published value, not the initial.  This pins down the
+/// publish-then-snapshot ordering.
+#[test]
+fn snapshot_after_publish_observes_published() {
+    loom::model(|| {
+        with_static_publisher(|publisher| {
+            let mut sub = publisher.factory().subscriber();
+            publisher.publish(1u32);
+            let observed = *sub.snapshot();
+            assert_eq!(
+                observed, 1,
+                "snapshot taken after publish() returns must observe the published value",
+            );
+        });
+    });
+}
+
+/// Subscriber registered before publish, snapshot taken after -- should
+/// observe the published value.  The 0-sentinel branch in
+/// `min_observed` must not turn this into a use-after-free.
+#[test]
+fn registered_then_publish_then_snapshot() {
+    loom::model(|| {
+        with_static_publisher(|publisher| {
+            let factory = publisher.factory();
+
+            let sub_handle = thread::spawn(move || {
+                let mut sub = factory.subscriber();
+                // Snapshot may race with publish.  Either way, we must see
+                // a legal value.
+                let observed = *sub.snapshot();
+                assert!(observed == 0 || observed == 1);
+            });
+
+            publisher.publish(1u32);
+            publisher.reclaim();
+            sub_handle.join().unwrap();
+        });
+    });
+}
+
+// =====================================================================
+// Drop affinity: every `Versioned` destructor must run on the
+// Publisher's thread.  This is the headline guarantee of the crate;
+// the existing tests above check legality and absence of deadlocks but
+// do not verify the drop-thread invariant under all interleavings.
+// =====================================================================
+
+/// Payload whose `Drop` records the thread on which it ran.  We use
+/// `std::sync::Mutex` for the recording slot because loom doesn't need
+/// to model contention on it (only one drop per `Versioned`, and we
+/// only care about the thread id, not the order of records).
+struct DropMarker {
+    drops: std::sync::Arc<std::sync::Mutex<Vec<loom::thread::ThreadId>>>,
+}
+
+impl Drop for DropMarker {
+    fn drop(&mut self) {
+        self.drops
+            .lock()
+            .expect("recording mutex poisoned")
+            .push(loom::thread::current().id());
+    }
+}
+
+/// Verifies the drop-affinity invariant under all loom interleavings.
+///
+/// Setup: Publisher publishes a fresh marker (the initial goes into
+/// `retired`) while a Subscriber thread snapshots and then drops.  Any
+/// interleaving of those two threads must result in **all**
+/// `Versioned` destructors running on the Publisher's thread.  In
+/// particular: the race where Subscriber's `cached = None` decrement
+/// of `Versioned`'s strong count and Publisher's `retired.clear()`
+/// decrement of the same atomic could (on weak memory) reorder, is
+/// enforced by the Acquire fence in `min_observed` after the
+/// `Arc::strong_count == 1` check.
+#[test]
+fn destructor_of_initial_runs_on_publisher_thread() {
+    loom::model(|| {
+        let drops: std::sync::Arc<std::sync::Mutex<Vec<loom::thread::ThreadId>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let initial = DropMarker {
+            drops: std::sync::Arc::clone(&drops),
+        };
+        let raw: *mut Publisher<DropMarker> = Box::into_raw(Box::new(channel(initial)));
+        // SAFETY: `raw` is the unique pointer to the heap allocation;
+        // the matching `Box::from_raw` runs after all spawned work has
+        // joined and no references derived from `publisher` survive.
+        let publisher: &'static Publisher<DropMarker> = unsafe { &*raw };
+
+        let publisher_thread = loom::thread::current().id();
+
+        // Subscriber thread: snapshot then drop.  Race against the
+        // publisher's publish/reclaim below.
+        let factory = publisher.factory();
+        let drops_for_pub = std::sync::Arc::clone(&drops);
+        let sub_handle = thread::spawn(move || {
+            let mut sub = factory.subscriber();
+            let _ = sub.snapshot();
+            // sub drops at end of thread; concurrent with publisher.
+        });
+
+        // Publisher publishes a new marker (initial goes into retired).
+        publisher.publish(DropMarker {
+            drops: drops_for_pub,
+        });
+
+        sub_handle.join().unwrap();
+        // Force a final reclaim pass so retired drains deterministically.
+        publisher.reclaim();
+
+        // SAFETY: subscriber thread has joined; no references derived
+        // from `publisher` are still in use.
+        drop(unsafe { Box::from_raw(raw) });
+
+        // Every recorded drop must have happened on the publisher
+        // (main) thread.
+        let recorded = drops.lock().expect("recording mutex poisoned");
+        for (i, t) in recorded.iter().enumerate() {
+            assert_eq!(
+                *t, publisher_thread,
+                "DropMarker {i} ran its destructor on {t:?}, \
+                 not the publisher thread {publisher_thread:?}",
+            );
+        }
+    });
+}

--- a/quiescent/tests/properties.rs
+++ b/quiescent/tests/properties.rs
@@ -164,3 +164,15 @@ fn protocol_invariants() {
             );
         });
 }
+
+/// `SubscriberFactory: Copy`, so every other test in this crate exercises
+/// the factory by implicit copy and never goes through the explicit
+/// `Clone::clone` impl.  This pins it down so coverage doesn't show a
+/// gap on a function that only differs from the auto-derive in name.
+#[test]
+fn factory_clone_uses_explicit_impl() {
+    let publisher = dataplane_quiescent::channel(0u32);
+    let factory = publisher.factory();
+    #[allow(clippy::clone_on_copy)]
+    let _factory_clone = factory.clone();
+}

--- a/quiescent/tests/properties.rs
+++ b/quiescent/tests/properties.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Property-based protocol tests for `dataplane_quiescent`.
+//!
+//! Generates random sequences of [`Op`]s and checks the
+//! single-threaded protocol invariants after every step:
+//!
+//! 1. **Snapshot legality** -- every value a Subscriber observes was
+//!    actually published by the Publisher.
+//! 2. **Per-Subscriber monotonicity** -- successive snapshots from the
+//!    same Subscriber return non-decreasing payloads (the Publisher
+//!    publishes a strictly increasing counter, so this is a tight
+//!    bound).
+//! 3. **Conservation of `Versioned` allocations** -- at every quiescent
+//!    point, every `Versioned<Marker>` ever created is either:
+//!    - the current publication (exactly 1),
+//!    - retained in the Publisher's `retired` list
+//!      (`publisher.pending_reclamation()` of them),
+//!    - or already dropped (counted by the marker's `Drop` impl).
+//!
+//! The conservation invariant is the strongest single thing we can
+//! check at this layer: if a `Versioned` is leaked, double-dropped, or
+//! resurrected, this assertion fires.
+//!
+//! Multi-threaded tests (drop affinity, concurrent stress) live in
+//! `tests/protocol.rs`; loom-modeled tests live in `tests/loom.rs`.
+
+#![cfg(not(any(feature = "loom", feature = "shuttle")))]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use bolero::TypeGenerator;
+use dataplane_quiescent::channel;
+
+// ---------- ops & state ----------
+
+/// One step of an operation sequence.  Indices into `subscribers` are
+/// taken modulo `subscribers.len()`, so the bolero driver doesn't need
+/// to know how many Subscribers exist at any given step.
+#[derive(Debug, TypeGenerator)]
+enum Op {
+    /// Publish the next sequential payload.
+    Publish,
+    /// Register a new Subscriber.
+    AddSubscriber,
+    /// Snapshot the Subscriber at index `idx % subscribers.len()`.
+    /// No-op if no Subscribers are registered.
+    Snapshot { idx: u8 },
+    /// Drop the Subscriber at index `idx % subscribers.len()`.  No-op
+    /// if no Subscribers are registered.
+    DropSubscriber { idx: u8 },
+    /// Force a reclaim pass on the Publisher.
+    Reclaim,
+}
+
+/// Counts its own drops; payload doubles as a "what value is this?" tag.
+struct Marker {
+    payload: u32,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Drop for Marker {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn marker(payload: u32, drops: &Arc<AtomicUsize>) -> Marker {
+    Marker {
+        payload,
+        drops: Arc::clone(drops),
+    }
+}
+
+// ---------- the property ----------
+
+#[test]
+fn protocol_invariants() {
+    bolero::check!()
+        .with_type::<Vec<Op>>()
+        .for_each(|ops: &Vec<Op>| {
+            let drops = Arc::new(AtomicUsize::new(0));
+            let publisher = channel(marker(0, &drops));
+            let factory = publisher.factory();
+            let mut subscribers = Vec::new();
+            let mut last_seen: Vec<u32> = Vec::new();
+            // Initial publication counts as published, so we start at 1.
+            let mut total_published: u32 = 1;
+            let mut next_payload: u32 = 1;
+
+            for op in ops {
+                match op {
+                    Op::Publish => {
+                        // Bound the test even on adversarial generators.
+                        if total_published >= 1 << 16 {
+                            continue;
+                        }
+                        publisher.publish(marker(next_payload, &drops));
+                        next_payload += 1;
+                        total_published += 1;
+                    }
+                    Op::AddSubscriber => {
+                        subscribers.push(factory.subscriber());
+                        last_seen.push(0);
+                    }
+                    Op::Snapshot { idx } => {
+                        if !subscribers.is_empty() {
+                            let i = (*idx as usize) % subscribers.len();
+                            let observed = subscribers[i].snapshot().payload;
+
+                            assert!(
+                                observed >= last_seen[i],
+                                "Subscriber {i} regressed: saw {observed} after {last}",
+                                last = last_seen[i],
+                            );
+                            assert!(
+                                observed < total_published,
+                                "snapshot {observed} but total_published = {total_published}",
+                            );
+                            last_seen[i] = observed;
+                        }
+                    }
+                    Op::DropSubscriber { idx } => {
+                        if !subscribers.is_empty() {
+                            let i = (*idx as usize) % subscribers.len();
+                            subscribers.swap_remove(i);
+                            last_seen.swap_remove(i);
+                        }
+                    }
+                    Op::Reclaim => {
+                        publisher.reclaim();
+                    }
+                }
+
+                // Conservation: every `Versioned` that was ever published
+                // is either the current slot (1), in `retired`
+                // (`pending_reclamation()` of them), or dropped.  A
+                // Subscriber's `cached` Arc shares an allocation with one
+                // of those; it does not introduce a fourth bucket.
+                let alive = 1 + publisher.pending_reclamation();
+                let dropped = drops.load(Ordering::Relaxed);
+                assert_eq!(
+                    dropped + alive,
+                    total_published as usize,
+                    "conservation: dropped {dropped} + alive {alive} != published {total_published}",
+                );
+            }
+
+            // Tear-down: subscribers hold borrows tied to the
+            // publisher's lifetime, so they must drop first.  `factory`
+            // is `Copy`, so its borrow is released by NLL at last use --
+            // no explicit drop needed.  Drop the publisher last so the
+            // final-drops assertion below has a well-defined point to
+            // fire at.
+            drop(subscribers);
+            drop(publisher);
+
+            let final_drops = drops.load(Ordering::Relaxed);
+            assert_eq!(
+                final_drops, total_published as usize,
+                "after tear-down, every Versioned should have been dropped exactly once",
+            );
+        });
+}

--- a/quiescent/tests/protocol.rs
+++ b/quiescent/tests/protocol.rs
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Multi-threaded protocol tests for `dataplane_quiescent`.
+//!
+//! The single-threaded protocol invariants (snapshot legality,
+//! reclamation gating, conservation of `Versioned` allocations) are
+//! covered by the bolero property tests in `tests/properties.rs`.
+//! This file holds only the tests that genuinely need real OS threads:
+//!
+//! - **Drop affinity**: drops must run on the Publisher's
+//!   thread, even when the last Subscriber drops concurrently with
+//!   reclaim.
+//! - **Concurrent stress**: Subscriber/Publisher interaction across
+//!   realistic scheduling.
+//!
+//! Subscribers are spawned inside `thread::scope` because
+//! `SubscriberFactory<'p>` and `Subscriber<'p>` borrow from the
+//! `Publisher` and so cannot outlive it.  `thread::spawn` (which
+//! requires `'static`) won't work; `thread::scope` matches the
+//! lifetime exactly.
+//!
+//! Loom-modeled tests live in `tests/loom.rs`.
+
+#![cfg(not(any(feature = "loom", feature = "shuttle")))]
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use dataplane_quiescent::channel;
+
+// ---------- helpers ----------
+
+/// Payload that counts its own drops and (optionally) records the
+/// thread on which its destructor ran.  Multiple markers can share a
+/// single recording slot -- each push extends the `Vec`, so the test
+/// can audit every drop's thread, not just the most recent one.
+struct Marker {
+    drop_counter: Arc<AtomicUsize>,
+    drop_threads: Option<Arc<Mutex<Vec<thread::ThreadId>>>>,
+    payload: u32,
+}
+
+impl Drop for Marker {
+    fn drop(&mut self) {
+        self.drop_counter.fetch_add(1, Ordering::Relaxed);
+        if let Some(slot) = &self.drop_threads {
+            slot.lock().unwrap().push(thread::current().id());
+        }
+    }
+}
+
+fn marker(payload: u32, drops: &Arc<AtomicUsize>) -> Marker {
+    Marker {
+        drop_counter: Arc::clone(drops),
+        drop_threads: None,
+        payload,
+    }
+}
+
+fn marker_threaded(
+    payload: u32,
+    drops: &Arc<AtomicUsize>,
+    slot: &Arc<Mutex<Vec<thread::ThreadId>>>,
+) -> Marker {
+    Marker {
+        drop_counter: Arc::clone(drops),
+        drop_threads: Some(Arc::clone(slot)),
+        payload,
+    }
+}
+
+// ---------- drop affinity ----------
+
+#[test]
+fn destructor_of_initial_runs_on_publisher_thread() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let initial_drop_threads = Arc::new(Mutex::new(Vec::new()));
+    let publisher_thread_id = thread::current().id();
+
+    let publisher = channel(marker_threaded(0, &drops, &initial_drop_threads));
+
+    thread::scope(|s| {
+        let factory = publisher.factory();
+        // Subscriber thread observes initial, then exits.
+        s.spawn(move || {
+            let mut sub = factory.subscriber();
+            let _ = sub.snapshot();
+        });
+    });
+
+    // Publisher publishes a new value and reclaims; the initial's destructor
+    // should fire here on this (publisher) thread, NOT on the subscriber thread.
+    publisher.publish(marker(1, &drops));
+    publisher.reclaim();
+
+    let observed = initial_drop_threads.lock().unwrap();
+    assert_eq!(
+        observed.as_slice(),
+        &[publisher_thread_id],
+        "initial value's destructor must run exactly once on the Publisher's thread (recorded {observed:?})",
+    );
+}
+
+#[test]
+fn destructor_runs_on_publisher_when_last_subscriber_drops_concurrently() {
+    // Stronger version: the Subscriber is dropped while the Publisher
+    // is busy publishing.  With the `Drop` impl on `Subscriber`
+    // ensuring `cached` dies before `epoch`, the destructor must still
+    // resolve on the Publisher's thread -- for **every** marker, not
+    // just the initial one.  Each iteration publishes tracked markers
+    // so every destructor records its drop thread.
+    let drops = Arc::new(AtomicUsize::new(0));
+    let drop_threads = Arc::new(Mutex::new(Vec::new()));
+    let publisher_thread_id = thread::current().id();
+
+    let publisher = channel(marker_threaded(0, &drops, &drop_threads));
+
+    // Repeat to expose the race window across timings.
+    for _ in 0..8 {
+        thread::scope(|s| {
+            let factory = publisher.factory();
+            s.spawn(move || {
+                let mut sub = factory.subscriber();
+                let _ = sub.snapshot();
+                // sub drops at end of scope-thread
+            });
+
+            // Publisher churns concurrently with tracked markers.
+            for i in 1..=4u32 {
+                publisher.publish(marker_threaded(i, &drops, &drop_threads));
+            }
+        });
+        publisher.reclaim();
+    }
+
+    let observed = drop_threads.lock().unwrap();
+    assert!(
+        !observed.is_empty(),
+        "no drops recorded; the test setup never exercised the Drop path",
+    );
+    for (i, t) in observed.iter().enumerate() {
+        assert_eq!(
+            *t, publisher_thread_id,
+            "drop {i} ran on {t:?}, not the Publisher's thread {publisher_thread_id:?} \
+             (full record: {observed:?})",
+        );
+    }
+}
+
+// ---------- concurrent stress ----------
+
+#[test]
+fn concurrent_subscriber_observes_monotone_sequence() {
+    let drops = Arc::new(AtomicUsize::new(0));
+    let publisher = channel(marker(0, &drops));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    thread::scope(|s| {
+        let factory = publisher.factory();
+        let stop_for_sub = Arc::clone(&stop);
+        s.spawn(move || {
+            let mut sub = factory.subscriber();
+            let mut last = 0u32;
+            while !stop_for_sub.load(Ordering::Acquire) {
+                let v = sub.snapshot().payload;
+                assert!(v >= last, "snapshot regressed: saw {v} after {last}");
+                last = v;
+            }
+        });
+
+        for i in 1..=200u32 {
+            publisher.publish(marker(i, &drops));
+            thread::sleep(Duration::from_micros(5));
+        }
+
+        stop.store(true, Ordering::Release);
+    });
+
+    publisher.reclaim();
+    let final_drops = drops.load(Ordering::Relaxed);
+    // 201 markers were created (initial + 200 publishes).  After the
+    // scope joins all subscribers and we run an explicit reclaim, the
+    // retired list must be drained; only the current slot value
+    // (marker 200) is still alive -- so exactly 200 destructors must
+    // have run.
+    assert_eq!(
+        final_drops, 200,
+        "expected exactly 200 markers reclaimed (initial + first 199 \
+         publishes); current slot value (marker 200) is still alive in \
+         the publisher",
+    );
+}
+
+#[test]
+fn many_subscribers_dropping_does_not_strand_retired() {
+    // Spin up many short-lived Subscribers concurrent with steady
+    // publishes; by the end, the retired list should not have grown
+    // unboundedly.
+    let drops = Arc::new(AtomicUsize::new(0));
+    let publisher = channel(marker(0, &drops));
+
+    thread::scope(|s| {
+        for _ in 0..16 {
+            let factory = publisher.factory();
+            s.spawn(move || {
+                let mut sub = factory.subscriber();
+                for _ in 0..50 {
+                    let _ = sub.snapshot();
+                    thread::sleep(Duration::from_micros(1));
+                }
+            });
+        }
+
+        for i in 1..=100u32 {
+            publisher.publish(marker(i, &drops));
+            thread::sleep(Duration::from_micros(2));
+        }
+    });
+
+    publisher.reclaim();
+
+    // After the scope has joined all Subscribers and we've run an
+    // explicit reclaim, retired must be empty.  `pending_reclamation`
+    // counts only retired entries -- the current slot value isn't
+    // included -- so 0 is the correct expectation.
+    let pending = publisher.pending_reclamation();
+    assert_eq!(
+        pending, 0,
+        "retired list should be fully drained after Subscribers exit \
+         and reclaim runs: pending = {pending}",
+    );
+}

--- a/quiescent/tests/shuttle.rs
+++ b/quiescent/tests/shuttle.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Bolero x shuttle property tests.
+//!
+//! Generates a [`Plan`] (Publisher ops + Subscriber ops, dispatched to
+//! two separate threads) via bolero, then runs each plan once under
+//! shuttle's random schedule controller.  Each bolero iteration
+//! explores one shape x one interleaving; thousands of bolero
+//! iterations widen both axes cheaply.
+//!
+//! This is the cheap-per-call counterpart to `tests/loom.rs`'s
+//! exhaustive small-shape model checking.  Loom proves "no
+//! interleaving of these shapes breaks"; shuttle says "we tried many
+//! interleavings of many shapes and didn't see a break."  Together
+//! they cover the protocol from two complementary angles.
+//!
+//! You can't really productively run this suite under loom because the
+//! cost absolutely explodes with large plans.
+
+#![cfg(not(feature = "loom"))]
+
+use std::panic::RefUnwindSafe;
+
+use bolero::TypeGenerator;
+use concurrency::sync::Arc;
+use concurrency::sync::atomic::{AtomicUsize, Ordering};
+use concurrency::thread;
+
+use dataplane_quiescent::{Subscriber, channel};
+
+// ---------- ops & plan ----------
+
+#[derive(Clone, Debug, TypeGenerator)]
+enum PublisherOp {
+    Publish,
+    Reclaim,
+}
+
+#[derive(Clone, Debug, TypeGenerator)]
+enum SubscriberOp {
+    AddSubscriber,
+    Snapshot { idx: u8 },
+    DropSubscriber { idx: u8 },
+}
+
+#[derive(Clone, Debug, TypeGenerator)]
+struct Plan {
+    publisher_ops: Vec<PublisherOp>,
+    subscriber_ops: Vec<SubscriberOp>,
+}
+
+struct Marker {
+    payload: u32,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Drop for Marker {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn run_plan(plan: &Plan) {
+    let drops = Arc::new(AtomicUsize::new(0));
+    // The initial publication counts as one published value.
+    let total = Arc::new(AtomicUsize::new(1));
+    let initial = Marker {
+        payload: 0,
+        drops: Arc::clone(&drops),
+    };
+    let publisher = channel(initial);
+
+    // Subscriber ops run in a spawned scope thread; Publisher ops run
+    // on this (calling) thread.  That gives shuttle two threads to
+    // interleave (this one + the spawned one).
+    thread::scope(|s| {
+        let factory = publisher.factory();
+        let total_for_sub = Arc::clone(&total);
+        let subscriber_ops = plan.subscriber_ops.clone();
+        s.spawn(move || {
+            let mut subscribers: Vec<Subscriber<'_, Marker>> = Vec::new();
+            let mut last_seen: Vec<u32> = Vec::new();
+            for op in &subscriber_ops {
+                match op {
+                    SubscriberOp::AddSubscriber => {
+                        subscribers.push(factory.subscriber());
+                        last_seen.push(0);
+                    }
+                    SubscriberOp::Snapshot { idx } => {
+                        if !subscribers.is_empty() {
+                            let i = (*idx as usize) % subscribers.len();
+                            let observed = subscribers[i].snapshot().payload;
+                            let total_at = total_for_sub.load(Ordering::SeqCst);
+                            assert!(
+                                observed >= last_seen[i],
+                                "Subscriber {i} regressed: saw {observed} after {prev}",
+                                prev = last_seen[i],
+                            );
+                            assert!(
+                                (observed as usize) < total_at,
+                                "snapshot {observed} but total {total_at}",
+                            );
+                            last_seen[i] = observed;
+                        }
+                    }
+                    SubscriberOp::DropSubscriber { idx } => {
+                        if !subscribers.is_empty() {
+                            let i = (*idx as usize) % subscribers.len();
+                            subscribers.swap_remove(i);
+                            last_seen.swap_remove(i);
+                        }
+                    }
+                }
+            }
+            // subscribers drop here on the subscriber thread
+        });
+
+        let mut next_payload: u32 = 1;
+        for op in &plan.publisher_ops {
+            match op {
+                PublisherOp::Publish => {
+                    let p = next_payload;
+                    next_payload += 1;
+                    // Bump `total` BEFORE the publish so any Subscriber
+                    // observing payload `p` is guaranteed to see
+                    // `total >= p + 1` on the snapshot legality check.
+                    // SeqCst keeps the ordering story simple under
+                    // shuttle's model.
+                    total.fetch_add(1, Ordering::SeqCst);
+                    publisher.publish(Marker {
+                        payload: p,
+                        drops: Arc::clone(&drops),
+                    });
+                }
+                PublisherOp::Reclaim => publisher.reclaim(),
+            }
+        }
+    });
+    // After scope: subscriber thread joined, factory dropped.
+
+    drop(publisher);
+
+    // After full tear-down, every Marker should have run its destructor
+    // exactly once.
+    let final_drops = drops.load(Ordering::SeqCst);
+    let total_count = total.load(Ordering::SeqCst);
+    assert_eq!(
+        final_drops, total_count,
+        "after tear-down, drops {final_drops} != total {total_count}",
+    );
+}
+
+const TEST_TIME: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn fuzz_test<Arg: Clone + TypeGenerator + RefUnwindSafe + std::fmt::Debug>(
+    test: impl Fn(Arg) + RefUnwindSafe,
+) {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .with_test_time(TEST_TIME)
+        .for_each(test);
+}
+
+#[test]
+#[cfg(feature = "shuttle")]
+fn protocol_under_shuttle() {
+    fuzz_test(|plan: Plan| shuttle::check_random(move || run_plan(&plan), 1));
+}
+
+#[test]
+#[cfg(feature = "shuttle")]
+fn protocol_under_shuttle_pct() {
+    fuzz_test(|plan: Plan| {
+        // PCT requires both threads to actually do atomic ops; if
+        // either side is effectively empty, shuttle's PCT scheduler
+        // panics with "test closure did not exercise any concurrency".
+        //
+        // For the subscriber thread, "effectively empty" means no
+        // `AddSubscriber` op: `Snapshot` and `DropSubscriber` are
+        // no-ops until at least one Subscriber has been registered, so
+        // the subscriber thread does no atomic work in that case.
+        if plan.publisher_ops.is_empty()
+            || !plan
+                .subscriber_ops
+                .iter()
+                .any(|op| matches!(op, SubscriberOp::AddSubscriber))
+        {
+            return;
+        }
+        shuttle::check_pct(move || run_plan(&plan), 16, 3);
+    });
+}
+
+#[test]
+#[cfg(not(feature = "shuttle"))]
+fn protocol_under_std() {
+    fuzz_test(|plan: Plan| run_plan(&plan));
+}


### PR DESCRIPTION
The purpose of the `quiescent` crate is to introduce the QSBR data structure.  QSBR provides a way to transmit shared data between the source thread (usually config or mgmt) to the workers.  While we could use left/right to transfer data from the config thread(s) to worker threads, some data may be allocated by the DPDK EAL (for the ACL lib for example), and others may not, we want to ensure that the object is only dropped in a legal thread (it is illegal to drop an EAL object in a non-EAL thread).  To do this, QSBR ensures that the thread that created the object also drops the object.  That way EAL objects are always dropped in a DPDK thread.  The requirement is stricter than what we need from EAL but it is simpler to implement this stricter rule.  We can relax it later if we need to.

This is a mostly lock-free data structure that transfers data at very low (near zero) cost for readers.  But the implementation is tricky.  Loom is used to exhaustively check the implementation against the memory model guaranteed by rust.  Please review with care.

See `README.md` for implementation details.