### PR TITLE
Bolero prefix generator fixes

### DIFF
--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -396,30 +396,24 @@ mod contract {
 
     impl TypeGenerator for Ipv4Prefix {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            let addr = Ipv4Addr::from_bits(driver.produce()?);
-            let len = Ipv4Prefix::MAX_LEN
-                - driver.gen_u8(
-                    Bound::Included(&0),
-                    Bound::Included(
-                        &u8::try_from(addr.to_bits().trailing_zeros())
-                            .unwrap_or_else(|_| unreachable!()),
-                    ),
-                )?;
+            let mut bits = driver.produce()?;
+            let len = driver.gen_u8(Bound::Included(&0), Bound::Included(&Self::MAX_LEN))?;
+            bits &= u32::MAX
+                .checked_shl(u32::from(Self::MAX_LEN - len))
+                .unwrap_or(0);
+            let addr = Ipv4Addr::from_bits(bits);
             Some(Ipv4Prefix::new(addr, len).unwrap_or_else(|_| unreachable!()))
         }
     }
 
     impl TypeGenerator for Ipv6Prefix {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            let addr = Ipv6Addr::from_bits(driver.produce()?);
-            let len = Ipv6Prefix::MAX_LEN
-                - driver.gen_u8(
-                    Bound::Included(&0),
-                    Bound::Included(
-                        &u8::try_from(addr.to_bits().trailing_zeros())
-                            .unwrap_or_else(|_| unreachable!()),
-                    ),
-                )?;
+            let mut bits = driver.produce()?;
+            let len = driver.gen_u8(Bound::Included(&0), Bound::Included(&Self::MAX_LEN))?;
+            bits &= u128::MAX
+                .checked_shl(u32::from(Self::MAX_LEN - len))
+                .unwrap_or(0);
+            let addr = Ipv6Addr::from_bits(bits);
             Some(Ipv6Prefix::new(addr, len).unwrap_or_else(|_| unreachable!()))
         }
     }

--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -389,7 +389,7 @@ impl TryFrom<Prefix> for Ipv6Prefix {
 
 #[cfg(any(test, feature = "testing"))]
 mod contract {
-    use crate::prefix::{IpPrefix, Ipv4Prefix, Ipv6Prefix, Prefix};
+    use crate::prefix::{IpPrefix, Ipv4Prefix, Ipv6Prefix};
     use bolero::{Driver, TypeGenerator};
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::ops::Bound;
@@ -415,16 +415,6 @@ mod contract {
                 .unwrap_or(0);
             let addr = Ipv6Addr::from_bits(bits);
             Some(Ipv6Prefix::new(addr, len).unwrap_or_else(|_| unreachable!()))
-        }
-    }
-
-    impl TypeGenerator for Prefix {
-        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
-            Some(if driver.gen_bool(None)? {
-                Prefix::IPV4(driver.produce()?)
-            } else {
-                Prefix::IPV6(driver.produce()?)
-            })
         }
     }
 }

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -38,6 +38,7 @@ pub enum PrefixError {
 /// Since we will not store prefixes, putting Ipv6 on the same basket as IPv4 will not penalize the
 /// memory requirements of Ipv4
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(any(test, feature = "testing"), derive(bolero::TypeGenerator))]
 pub enum Prefix {
     IPV4(Ipv4Prefix),
     IPV6(Ipv6Prefix),


### PR DESCRIPTION
The Bolero generator for Ipv4Prefix (and Ipv6Prefix) would first generate a string of bits, and then derive the prefix length from the number of trailing zeros at the end of it. This would create a strong bias towards very short prefixes: most of them have zero, one, or two ending zeros, and very few have more than that, resulting in most generated prefixes being /32, /31, or /30 CIDRs. In several runs of a Bolero test, I saw only one CIDR with a mask length under 20.

To fix this, pick an arbitrary mask length first, and adjust the address bits based on that. This results in a fairer representation of prefixes, although Bolero apparently loves zeroes and tend to produce a large quantity of 0.0.0.0/0 prefixes.
