### PR TITLE
everything is wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,5 +14,11 @@ CARGO_LLVM_COV_BUILD_DIR = { value = "target/llvm-cov/target", relative = true, 
 [build]
 rustflags = ["--cfg=tokio_unstable"]
 
+[target.wasm32-wasip1]
+# Trailing `--` separates wasmtime's CLI from the module + module args
+# that cargo appends, so e.g. `--nocapture` from libtest reaches the
+# wasm module instead of being parsed as a wasmtime option.
+runner = "wasmtime run --dir . --"
+
 [alias]
 nt = "nextest"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -457,6 +457,8 @@ jobs:
     needs:
       - check_changes
       - check
+      - miri
+      - wasm
     permissions:
       checks: "write"
       pull-requests: "read"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -394,18 +394,17 @@ jobs:
           recipe_args: "--package=dataplane-quiescent --features=_strict_provenance"
       - *tmate
 
-  must-build:
+  wasm:
     if: >-
       ${{
         needs.check_changes.outputs.devfiles == 'true'
         || startsWith(github.event.ref, 'refs/tags/v')
         || github.event_name == 'workflow_dispatch'
       }}
-    name: "must-build/${{ matrix.platform }}/${{ matrix.libc }}/${{ matrix.profile }}"
+    name: "${{ matrix.platform }}/${{ matrix.libc }}/${{ matrix.profile }}"
     runs-on: "lab"
     needs:
       - check_changes
-      # - check # TODO: add dependency before PR lands
     permissions:
       checks: "write"
       pull-requests: "read"
@@ -422,23 +421,9 @@ jobs:
           - platform: "wasm32-wasip1"
             profile: "release"
             libc: "unknown"
-            recipe: "build-each"
-            args: ""
-          - platform: "zen5"
-            profile: "release"
-            libc: "musl"
-            recipe: "build-container"
-            args: "dataplane"
-          - platform: "bluefield3"
-            profile: "debug"
-            libc: "gnu"
-            recipe: "build-container"
-            args: "dataplane"
-          - platform: "bluefield3"
-            profile: "debug"
-            libc: "musl"
-            recipe: "build-container"
-            args: "dataplane"
+            recipe:
+              name: "check"
+              args: ""
     steps:
       - *checkout
       - *nix-setup
@@ -450,8 +435,66 @@ jobs:
             profile=${{ matrix.profile }}
             libc=${{ matrix.libc }}
         with:
-          recipe: "${{ matrix.recipe }}"
-          recipe_args: "${{ matrix.args }}"
+          recipe: "${{ matrix.recipe.name }}"
+          recipe_args: "${{ matrix.recipe.args }}"
+      - *tmate
+
+  cross:
+    if: >-
+      ${{
+        github.event_name == 'pull_request'
+        && (
+          contains(github.event.pull_request.labels.*.name, 'ci:+cross')
+        )
+        || (github.event_name == 'push' || github.event_name == 'merge_group')
+      }}
+    name: "${{ matrix.recipe.name }}/${{ matrix.recipe.args }}/${{ matrix.platform }}/${{ matrix.libc }}"
+    runs-on: "lab"
+    # Cross is advisory: leg failures show red on the job badge but the
+    # workflow run as a whole still passes.  `needs.cross.result` reports
+    # `success` to dependents regardless of outcome, so don't gate on it.
+    continue-on-error: true
+    needs:
+      - check_changes
+      - check
+    permissions:
+      checks: "write"
+      pull-requests: "read"
+      contents: "read"
+      packages: "read"
+      id-token: "write"
+    env:
+      USER: "runner"
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        platform:
+          - "aarch64"
+          - "bluefield3"
+        libc:
+          - "gnu"
+          - "musl"
+        profile:
+          - "debug"
+        recipe:
+          - name: "build-container"
+            args: "dataplane"
+          - name: "build-container"
+            args: "frr.dataplane"
+    steps:
+      - *checkout
+      - *nix-setup
+      - name: "${{ matrix.platform }}/${{ matrix.libc }}/${{ matrix.profile }}/${{ matrix.recipe.args }}"
+        uses: *just
+        env:
+          JUST_VARS: >-
+            platform=${{ matrix.platform }}
+            profile=${{ matrix.profile }}
+            libc=${{ matrix.libc }}
+        with:
+          recipe: "${{ matrix.recipe.name }}"
+          recipe_args: "${{ matrix.recipe.args }}"
       - *tmate
 
   features:
@@ -590,7 +633,8 @@ jobs:
       - vlab
       - test_each
       - miri
-      - must-build
+      - wasm
+      - cross
     # Run always so this job can aggregate results even when one of its
     # dependencies failed or was skipped.
     #
@@ -629,10 +673,10 @@ jobs:
         run: |
           echo '::error:: Some build job(s) failed'
           exit 1
-      - name: "Flag any must-build matrix failures"
-        if: ${{ needs.must-build.result != 'success' && needs.must-build.result != 'skipped' }}
+      - name: "Flag any wasm failures"
+        if: ${{ needs.wasm.result != 'success' && needs.wasm.result != 'skipped' }}
         run: |
-          echo '::error:: Some must-build job(s) failed'
+          echo '::error:: Some wasm job(s) failed'
           exit 1
       - name: "Flag any vlab matrix failures"
         if: ${{ needs.vlab.result != 'success' && needs.vlab.result != 'skipped' }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -420,7 +420,7 @@ jobs:
         include:
           - platform: "wasm32-wasip1"
             profile: "release"
-            libc: "unknown"
+            libc: "none"
             recipe:
               name: "check"
               args: ""

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -394,6 +394,66 @@ jobs:
           recipe_args: "--package=dataplane-quiescent --features=_strict_provenance"
       - *tmate
 
+  must-build:
+    if: >-
+      ${{
+        needs.check_changes.outputs.devfiles == 'true'
+        || startsWith(github.event.ref, 'refs/tags/v')
+        || github.event_name == 'workflow_dispatch'
+      }}
+    name: "must-build/${{ matrix.platform }}/${{ matrix.libc }}/${{ matrix.profile }}"
+    runs-on: "lab"
+    needs:
+      - check_changes
+      # - check # TODO: add dependency before PR lands
+    permissions:
+      checks: "write"
+      pull-requests: "read"
+      contents: "read"
+      packages: "read"
+      id-token: "write"
+    env:
+      USER: "runner"
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - platform: "wasm32-wasip1"
+            profile: "release"
+            libc: "unknown"
+            recipe: "build-each"
+            args: ""
+          - platform: "zen5"
+            profile: "release"
+            libc: "musl"
+            recipe: "build-container"
+            args: "dataplane"
+          - platform: "bluefield3"
+            profile: "debug"
+            libc: "gnu"
+            recipe: "build-container"
+            args: "dataplane"
+          - platform: "bluefield3"
+            profile: "debug"
+            libc: "musl"
+            recipe: "build-container"
+            args: "dataplane"
+    steps:
+      - *checkout
+      - *nix-setup
+      - name: "${{ matrix.platform }}/${{ matrix.libc }}/${{ matrix.profile }}"
+        uses: *just
+        env:
+          JUST_VARS: >-
+            platform=${{ matrix.platform }}
+            profile=${{ matrix.profile }}
+            libc=${{ matrix.libc }}
+        with:
+          recipe: "${{ matrix.recipe }}"
+          recipe_args: "${{ matrix.args }}"
+      - *tmate
+
   features:
     if: >-
       ${{
@@ -530,6 +590,7 @@ jobs:
       - vlab
       - test_each
       - miri
+      - must-build
     # Run always so this job can aggregate results even when one of its
     # dependencies failed or was skipped.
     #
@@ -567,6 +628,11 @@ jobs:
         if: ${{ needs.build.result != 'success' && needs.build.result != 'skipped' }}
         run: |
           echo '::error:: Some build job(s) failed'
+          exit 1
+      - name: "Flag any must-build matrix failures"
+        if: ${{ needs.must-build.result != 'success' && needs.must-build.result != 'skipped' }}
+        run: |
+          echo '::error:: Some must-build job(s) failed'
           exit 1
       - name: "Flag any vlab matrix failures"
         if: ${{ needs.vlab.result != 'success' && needs.vlab.result != 'skipped' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,13 @@ repository = "https://github.com/githedgehog/dataplane/"
 
 [workspace.dependencies]
 
+# NOTE: please do not enable features in this file.  Enable the specific features you need (and only those features) in
+# the individual packages.  Enabling features here opts _everything_ into those features, which is actually quite
+# problematic from the perspective of
+#
+# 1. correctly documenting what each package actually depends on,
+# 2. allowing builds under different environments (e.g. cross-compilation, wasm, miri, and so on).
+
 # Internal
 args = { path = "./args", package = "dataplane-args", features = [] }
 cli = { path = "./cli", package = "dataplane-cli", features = [] }
@@ -87,7 +94,7 @@ vpcmap = { path = "./vpcmap", package = "dataplane-vpcmap", features = [] }
 # External
 afpacket = { version = "0.2.3", default-features = false, features = [] }
 ahash = { version = "0.8.12", default-features = false, features = [] }
-anyhow = { version = "1.0.102", default-features = false, features = ["std"] }
+anyhow = { version = "1.0.102", default-features = false, features = [] }
 arc-swap = { version = "1.9.1", default-features = false, features = [] }
 arrayvec = { version = "0.7.6", default-features = false, features = [] }
 async-trait = { version = "0.1.89", default-features = false, features = [] }
@@ -115,7 +122,7 @@ dyn-iter = { version = "1.0.1", default-features = false, features = [] }
 etherparse = { version = "0.20.1", default-features = false, features = [] }
 fixin = { git = "https://github.com/githedgehog/fixin", branch = "main", features = [] }
 futures = { version = "0.3.32", default-features = false, features = [] }
-futures-util = { version = "0.3.32", default-features = false, features = ["std"] }
+futures-util = { version = "0.3.32", default-features = false, features = [] }
 hashbrown = { version = "0.17.1", default-features = false, features = [] }
 hwlocality = { version = "1.0.0-alpha.12", default-features = false, features = [] }
 hyper = { version = "1.9.0", default-features = false, features = [] }
@@ -142,7 +149,7 @@ multi_index_map = { version = "0.15.1", default-features = false, features = [] 
 n-vm = { git = "https://github.com/githedgehog/testn.git", tag = "v0.0.9", default-features = false, features = [], package = "n-vm" }
 netdev = { version = "0.43.0", default-features = false, features = [] }
 netgauze-bgp-pkt = { version = "0.11.0", features = [] }
-netgauze-bmp-pkt = { version = "0.11.0", features = ["codec"] }
+netgauze-bmp-pkt = { version = "0.11.0", features = [] }
 nix = { version = "0.31.2", default-features = false, features = [] }
 num-derive = { version = "0.4.2", default-features = false, features = [] }
 num-traits = { version = "0.2.19", default-features = false, features = [] }
@@ -155,9 +162,9 @@ pretty_assertions = { version = "1.4.1", default-features = false, features = []
 priority-queue = { version = "2.7.0", default-features = false, features = [] }
 proc-macro2 = { version = "1.0.106", default-features = false, features = [] }
 procfs = { version = "0.18.0", default-features = false, features = [] }
-pyroscope = { version = "2.0.3", default-features = false, features = ["backend-pprof-rs"] }
+pyroscope = { version = "2.0.3", default-features = false, features = [] }
 quote = { version = "1.0.45", default-features = false, features = [] }
-rand = { version = "0.10.1", default-features = false, features = ["thread_rng"] }
+rand = { version = "0.10.1", default-features = false, features = [] }
 rapidhash = { version = "4.4.1", default-features = false, features = [] }
 reedline = { version = "0.47.0", default-features = false, features = [] }
 rkyv = { version = "0.8.16", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,18 +46,6 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/githedgehog/dataplane/"
 
-[workspace.metadata.package]
-# these packages have either hardware or os level interactions which make them impossible to test on miri
-dataplane = { miri = false, package = "dataplane" }
-dpdk = { miri = false, package = "dataplane-dpdk" }
-dpdk-sys = { miri = false, package = "dataplane-dpdk-sys" }
-hardware = { miri = false, package = "dataplane-hardware" }
-init = { miri = false, package = "dataplane-init" }
-interface-manager = { miri = false, package = "dataplane-interface-manager" }
-mgmt = { miri = false, package = "dataplane-mgmt" }
-sysfs = { miri = false, package = "dataplane-sysfs" }
-tracectl = { miri = false, package = "dataplane-tracectl" }
-
 [workspace.dependencies]
 
 # Internal
@@ -222,3 +210,126 @@ rpath = true
 inherits = "release"
 debug-assertions = true
 overflow-checks = true
+
+# Some packages have either hardware or os level interactions which make them impossible to test on miri or use in wasm
+# We encode exclusions for our wasm and miri builds into the metadata here.
+# I have tried to divide the packages into miri/wasm enabled and disabled categories.
+#
+# hopeless + pointless: packages that are either hardware or os level interactions and are impossible to test on miri or
+#                       use in wasm.  These aren't just "fail to compile in this environment" - they are actually
+#                       impossible to compile or use in wasm/miri.  Even if you could somehow compile them, they simply
+#                       don't make any sense to use in wasm/miri.
+# split: crates which are at least potentially useful in wasm/miri, but which also contain hardware or os level
+#        interactions which are impossible or nonsensical in wasm/miri.  These crates would need to be split or
+#        modified to use conditional compilation to work in wasm/miri.
+# miss: packages that are not logically hopeless, or pointless in wasm/miri, but which currently just happen to contain
+#       logic which can and should eventually be factored out or abstracted into something suitable for wasm/miri.
+[workspace.metadata.package.args]
+package = "dataplane-args"
+miri = true
+wasm = false # miss
+
+[workspace.metadata.package.cli]
+package = "dataplane-cli"
+miri = true
+wasm = false # split
+
+[workspace.metadata.package.dataplane]
+package = "dataplane"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.dpdk]
+package = "dataplane-dpdk"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.dpdk-sys]
+package = "dataplane-dpdk-sys"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.flow-entry]
+package = "dataplane-flow-entry"
+miri = true
+wasm = false # miss
+
+[workspace.metadata.package.flow-filter]
+package = "dataplane-flow-filter"
+miri = true
+wasm = false # miss
+
+[workspace.metadata.package.hardware]
+package = "dataplane-hardware"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.init]
+package = "dataplane-init"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.interface-manager]
+package = "dataplane-interface-manager"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.k8s-intf]
+package = "dataplane-k8s-intf"
+miri = true
+wasm = false # split
+
+[workspace.metadata.package.k8s-less]
+package = "dataplane-k8s-less"
+miri = true
+wasm = false # split
+
+[workspace.metadata.package.mgmt]
+package = "dataplane-mgmt"
+miri = false
+wasm = false # split
+
+[workspace.metadata.package.nat]
+package = "dataplane-nat"
+miri = true
+wasm = false # split
+
+[workspace.metadata.package.pipeline]
+package = "dataplane-pipeline"
+miri = true
+wasm = false # miss
+
+[workspace.metadata.package.routing]
+package = "dataplane-routing"
+miri = true
+wasm = false # split
+
+[workspace.metadata.package.stats]
+package = "dataplane-stats"
+miri = true
+wasm = false # miss
+
+[workspace.metadata.package.sysfs]
+package = "dataplane-sysfs"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.test-utils]
+package = "dataplane-test-utils"
+miri = true
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.tracectl]
+package = "dataplane-tracectl"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.quiescent]
+package = "dataplane-quiescent"
+miri = true
+wasm = false # works but pointless
+
+[workspace.metadata.package.vpcmap]
+package = "dataplane-vpcmap"
+miri = true
+wasm = false # miss

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { workspace = true, features = ["thread_rng"] }
 
 
 [build-dependencies]

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = { workspace = true }
 ordermap = { workspace = true, features = ["std"] }
 parking_lot = { workspace = true }
 pipeline = { workspace = true }
-pyroscope = { workspace = true }
+pyroscope = { workspace = true, features = ["backend-pprof-rs"] }
 routing = { workspace = true }
 rtnetlink = { workspace = true, features = ["default", "tokio"] }
 serde = { workspace = true, features = ["derive"] }

--- a/default.nix
+++ b/default.nix
@@ -414,6 +414,38 @@ let
     }
   ) package-list;
 
+  workspace-check =
+    {
+      pname ? null,
+      cargoArtifacts ? null,
+    }:
+    pkgs.callPackage invoke {
+      builder = craneLib.buildPackage;
+      args = {
+        inherit pname cargoArtifacts;
+        buildPhaseCargoCommand = builtins.concatStringsSep " " (
+          [
+            "cargoBuildLog=$(mktemp cargoBuildLogXXXX.json);"
+            "cargo"
+            "check"
+            "--package=${pname}"
+            "--profile=${cargo-profile}"
+          ]
+          ++ cargo-cmd-prefix
+          ++ [
+            "--message-format json-render-diagnostics > $cargoBuildLog"
+          ]
+        );
+      };
+    };
+
+  check = builtins.mapAttrs (
+    dir: pname:
+    workspace-check {
+      inherit pname;
+    }
+  ) package-list;
+
   test-builder =
     {
       package ? null,
@@ -884,12 +916,13 @@ let
 in
 {
   inherit
+    check
     clippy
     containers
+    dataplane
     devenv
     devroot
     docs
-    dataplane
     package-list
     pkgs
     sources

--- a/default.nix
+++ b/default.nix
@@ -118,13 +118,19 @@ let
     paths = [
       clangd-config
     ]
-    ++ (with pkgs.pkgsBuildHost.llvmPackages'; [
+    # pkgsBuildBuild (not pkgsBuildHost): dev-shell tools run on, and target,
+    # the build host.  pkgsBuildHost is "runs on build, targets host", which
+    # under a cross pkgs (e.g. libc=musl, platform=bluefield3) installs only
+    # target-prefixed binaries (e.g. x86_64-unknown-linux-musl-pkg-config) --
+    # cargo build scripts that invoke `pkg-config`/`clang` unprefixed then fail
+    # to find them in PATH.
+    ++ (with pkgs.pkgsBuildBuild.llvmPackages'; [
       bintools
       clang
       libclang.lib
       lld
     ])
-    ++ (with pkgs.pkgsBuildHost; [
+    ++ (with pkgs.pkgsBuildBuild; [
       actionlint
       bash
       cargo-bolero

--- a/default.nix
+++ b/default.nix
@@ -157,6 +157,7 @@ let
       rust-toolchain
       shellcheck
       skopeo
+      wasmtime
       wget
       yq
     ]);

--- a/default.nix
+++ b/default.nix
@@ -222,11 +222,18 @@ let
           TOMLQ = "${pkgs.pkgsBuildHost.yq}/bin/tomlq";
           JQ = "${pkgs.pkgsBuildHost.jq}/bin/jq";
         }
-        ''
-          $TOMLQ -r '.workspace.members | sort[]' ${src}/Cargo.toml | while read -r p; do
-            $TOMLQ --arg p "$p" -r '{ ($p): .package.name }' ${src}/$p/Cargo.toml
-          done | $JQ --sort-keys --slurp 'add' > $out
-        ''
+        (
+          if platform == "wasm32-wasip1" then
+            ''
+              $TOMLQ -r '.workspace as $ws | [$ws.members[] | select($ws.metadata.package[.].wasm != false) as $p | { ($p): $ws.dependencies[$p].package }] | add' ${src}/Cargo.toml > $out
+            ''
+          else
+            ''
+              $TOMLQ -r '.workspace.members | sort[]' ${src}/Cargo.toml | while read -r p; do
+                  $TOMLQ --arg p "$p" -r '{ ($p): .package.name }' ${src}/$p/Cargo.toml
+              done | $JQ --sort-keys --slurp 'add' > $out
+            ''
+        )
     )
   );
   version = (craneLib.crateNameFromCargoToml { inherit src; }).version;

--- a/default.nix
+++ b/default.nix
@@ -251,7 +251,13 @@ let
   cargo-cmd-prefix = [
     "-Zunstable-options"
     "-Zbuild-std=compiler_builtins,core,alloc,std,panic_unwind,panic_abort,sysroot,unwind"
-    "-Zbuild-std-features=backtrace,panic-unwind,mem,compiler-builtins-mem"
+    # glibc Rust binaries unwind through libgcc_s.so.1.  Non-glibc targets
+    # (musl, wasi) have no libgcc consumer; ask build-std to pull in LLVM's
+    # libunwind from the sysroot so panic-unwind has an actual unwinder.
+    (
+      "-Zbuild-std-features=backtrace,panic-unwind,mem,compiler-builtins-mem"
+      + (if libc != "gnu" then ",system-llvm-libunwind" else "")
+    )
     "--target=${rustc-target}"
   ]
   ++ (if default-features == "false" then [ "--no-default-features" ] else [ ])

--- a/default.nix
+++ b/default.nix
@@ -205,7 +205,7 @@ let
       "wasm32-wasip1"
     else
       pkgs.stdenv'.targetPlatform.rust.rustcTarget;
-  is-cross-compile = pkgs.stdenv'.hostPlatform.rust.rustcTarget != ctarget;
+  is-cross-compile = pkgs.stdenv'.buildPlatform.rust.rustcTarget != ctarget;
   cxx = if is-cross-compile then "${ctarget}-clang++" else "clang++";
   strip = if is-cross-compile then "${ctarget}-strip" else "strip";
   objcopy = if is-cross-compile then "${ctarget}-objcopy" else "objcopy";

--- a/default.nix
+++ b/default.nix
@@ -111,7 +111,7 @@ let
     executable = false;
     destination = "/.clangd";
   };
-  crane = import sources.crane { };
+  crane = import sources.crane { inherit pkgs; };
   craneLib = crane.craneLib.overrideToolchain pkgs.rust-toolchain;
   devroot = pkgs.symlinkJoin {
     name = "dataplane-dev-shell";

--- a/default.nix
+++ b/default.nix
@@ -564,7 +564,7 @@ let
     buildPhase =
       let
         # `libc-pkg` and not `libc` so the outer function-arg `libc` (the
-        # string "gnu" / "musl" / "unknown") stays visible inside this scope
+        # string "gnu" / "musl" / "none") stays visible inside this scope
         # for the conditional below.
         libc-pkg = pkgs.pkgsHostHost.libc;
         # libgcc_s.so.1 is consumed by glibc-dynamic Rust binaries for

--- a/default.nix
+++ b/default.nix
@@ -173,6 +173,16 @@ let
       PKG_CONFIG_PATH = "${sysroot}/lib/pkgconfig";
       LIBCLANG_PATH = "${devroot}/lib";
       GW_CRD_PATH = "${pkgs.pkgsBuildHost.gateway-crd}/src/fabric/config/crd/bases";
+      # Pin native cargo invocations (cargo build/clippy/test --doc) to the
+      # same target the dev sysroot is built for.  Without this, cargo defaults
+      # to the build-host triple while LIBRARY_PATH/PKG_CONFIG_PATH point at
+      # cross-target libs, and the link picks up a libc that doesn't match the
+      # rust-std it's compiling against (e.g. glibc rust-std + musl libc =
+      # undefined `open64`/`fstat64`/...).
+      CARGO_BUILD_TARGET = rustc-target;
+      # Rust's pkg-config crate refuses cross-target builds by default; opt in
+      # since our PKG_CONFIG_PATH already points at the matching cross sysroot.
+      PKG_CONFIG_ALLOW_CROSS = "1";
     };
   };
   justfileFilter = p: _type: builtins.match ".*\.justfile$" p != null;

--- a/default.nix
+++ b/default.nix
@@ -513,7 +513,32 @@ let
     dontPatchElf = true;
     buildPhase =
       let
-        libc = pkgs.pkgsHostHost.libc;
+        # `libc-pkg` and not `libc` so the outer function-arg `libc` (the
+        # string "gnu" / "musl" / "unknown") stays visible inside this scope
+        # for the conditional below.
+        libc-pkg = pkgs.pkgsHostHost.libc;
+        # libgcc_s.so.1 is consumed by glibc-dynamic Rust binaries for
+        # unwinding.  musl Rust targets static-link musl + Rust's
+        # compiler-builtins, so libgcc has no consumer; bundling it would
+        # waste closure space and pull in glibc-targeted build outputs that
+        # are wrong for a musl container.
+        #
+        # IMPORTANT: must be the path baked into the matching ld-linux's
+        # compiled-in search list, which is `pkgs.pkgsHostHost.glibc.libgcc`
+        # (the `xgcc-...-libgcc` / cross `libgcc-<triple>-...` derivation).
+        # `pkgs.stdenv.cc.cc.lib` ships the same `libgcc_s.so.1` content but
+        # at a different store path that ld-linux doesn't search, so the
+        # binary can't find it at runtime even though the file exists in
+        # the tar.
+        libgcc-tar-input = if libc == "gnu" then "${pkgs.pkgsHostHost.glibc.libgcc}" else "";
+        # libc.out is needed by anything dynamically linked in the tar,
+        # regardless of libc choice.  The Rust binaries on musl are
+        # statically linked and don't need it, but busybox (bundled below
+        # for `/bin/*` shell utilities) is dynamically linked against
+        # whichever libc its pkgset uses.  Omitting libc.out on musl leaves
+        # busybox applets referencing a `ld-musl-*.so.1` / `libc.so` that
+        # isn't present in the image.
+        libc-tar-input = "${libc-pkg.out}";
       in
       ''
         tmp="$(mktemp -d)"
@@ -556,10 +581,10 @@ let
           --no-selinux \
           \
           `# we already copied this stuff in to /etc directly, no need to copy it into the store again.` \
-          --exclude '${libc}/etc' \
+          --exclude '${libc-pkg}/etc' \
           \
           `# There are a few components of glibc which have absolutely nothing to do with our goals and present` \
-          `# material and trivially avoided hazzards just by their presence.  Thus, we filter them out here.` \
+          `# material and trivially avoided hazards just by their presence.  Thus, we filter them out here.` \
           `# None of this applies to musl (if we ever decide to ship with musl).  That said, these filters will` \
           `# just not do anything in that case. ` \
            \
@@ -570,7 +595,7 @@ let
           `# Go check out this one, it is a classic: ` \
           `# https://www.exploit-db.com/exploits/18105 ` \
           \
-          --exclude '${libc}/lib/audit*' \
+          --exclude '${libc-pkg}/lib/audit*' \
           \
           `# The glibc character set conversion code is not only useless to us, is is an increasingly common attack ` \
           `# vector (see CVE-2024-2961 for example).  We are 100% unicode only, so all of these legacy character ` \
@@ -579,20 +604,20 @@ let
           `# and it wouldn't be respected by rust's core/std libs anyway. ` \
           `# This is also how fedora packages glibc, and for the same basic reasons.` \
           `# See https://fedoraproject.org/wiki/Changes/Gconv_package_split_in_glibc` \
-          --exclude '${libc}/lib/gconv*' \
-          --exclude '${libc}/share/i18n*' \
-          --exclude '${libc}/share/locale*' \
+          --exclude '${libc-pkg}/lib/gconv*' \
+          --exclude '${libc-pkg}/share/i18n*' \
+          --exclude '${libc-pkg}/share/locale*' \
           \
           `# getconf isn't even shipped in the container so this is useless.  You couldn't change limits in the ` \
           `# container like this anyway.  Even if we needed to and could, we wouldn't use setconf et al.` \
-          --exclude '${libc}/libexec*' \
+          --exclude '${libc-pkg}/libexec*' \
           \
           --verbose \
           --file "$out" \
           \
           . \
-          ${libc.out} \
-          ${pkgs.pkgsHostHost.glibc.libgcc} \
+          ${libc-tar-input} \
+          ${libgcc-tar-input} \
           ${workspace.dataplane} \
           ${workspace.init} \
           ${workspace.cli} \

--- a/default.nix
+++ b/default.nix
@@ -707,7 +707,6 @@ let
     pkgs.less
     pkgs.libc.bin
     pkgs.libc.out
-    pkgs.libgcc.libgcc
     pkgs.man
     pkgs.nano
     pkgs.procps
@@ -717,6 +716,8 @@ let
     pkgs.wget
     pkgs.yq
     pkgs.zstd
+  ] ++ lib.optionals (libc == "gnu") [
+    pkgs.pkgsHostHost.glibc.libgcc
   ];
 
   containers.debug-tools = pkgs.dockerTools.buildLayeredImage {

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,7 @@ let
     .${profile};
   overlays = import ./nix/overlays {
     inherit
+      libc
       nightly
       sanitizers
       sources

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ _just_debuggable_ := if debug_justfile == "true" { "set -x" } else { "" }
 jobs := "8"
 
 # libc
-libc := if platform == "wasm32-wasip1" { "unknown" } else { "gnu" }
+libc := if platform == "wasm32-wasip1" { "none" } else { "gnu" }
 
 # kernel (linux or wasip1)
 kernel := if platform == "wasm32-wasip1" { "wasip1" } else { "linux" }

--- a/justfile
+++ b/justfile
@@ -133,6 +133,9 @@ test package="tests.all" *args: (build (if package == "tests.all" { "tests.all" 
     declare -r target="{{ if package == "tests.all" { "tests.all" } else { "tests.pkg." + package } }}"
     cargo nextest run --archive-file results/${target}/*.tar.zst --workspace-remap $(pwd) {{ filter }}
 
+[script]
+build-each *args: (build "workspace" args)
+    {{ _just_debuggable_ }}
 
 [script]
 test-each *args: (build "tests.pkg" args)

--- a/justfile
+++ b/justfile
@@ -190,11 +190,21 @@ build-container target="dataplane" *args: (build (if target == "dataplane" { "da
     declare -xr DOCKER_HOST="${DOCKER_HOST:-unix://{{docker_sock}}}"
     case "{{target}}" in
         "dataplane")
+            declare docker_platform
+            case "{{platform}}" in
+                aarch64|bluefield2|bluefield3) docker_platform="linux/arm64" ;;
+                x86-64-v3|x86-64-v4|zen3|zen4|zen5) docker_platform="linux/amd64" ;;
+                *)
+                    >&2 echo "build-container: no docker platform mapping for {{platform}}"
+                    exit 1
+                    ;;
+            esac
+            declare -r docker_platform
             declare img
-            img="$(docker import --change 'ENTRYPOINT ["/bin/dataplane"]' ./results/dataplane.tar)"
+            img="$(docker import --platform "${docker_platform}" --change 'ENTRYPOINT ["/bin/dataplane"]' ./results/dataplane.tar)"
             declare -r img
             docker tag "${img}" "{{oci_image_dataplane}}"
-            echo "imported {{ oci_image_dataplane }}"
+            echo "imported {{ oci_image_dataplane }} (${docker_platform})"
             ;;
         "dataplane-debugger")
             docker load < ./results/containers.dataplane-debugger

--- a/justfile
+++ b/justfile
@@ -138,6 +138,14 @@ build-each *args: (build "workspace" args)
     {{ _just_debuggable_ }}
 
 [script]
+check package="" *args: (build (if package == "" { "check" } else { "check." + package }) args)
+    {{ _just_debuggable_ }}
+
+[script]
+check-each *args: (build "check" args)
+    {{ _just_debuggable_ }}
+
+[script]
 test-each *args: (build "tests.pkg" args)
     {{ _just_debuggable_ }}
     declare -a fail=()

--- a/nix/overlays/frr.nix
+++ b/nix/overlays/frr.nix
@@ -253,11 +253,26 @@ in
         # build-host variant so the `nuke-refs` script's substituted perl is
         # runnable on the build host under cross compilation.
         nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ final.buildPackages.nukeReferences ];
+        # On musl, force `+crt-static` so the C runtime and libgcc_eh
+        # are linked statically.  Without this, nixpkgs' musl
+        # `rustPlatform` (which `frr-agent` is built with) emits a
+        # binary with `DT_NEEDED libgcc_s.so.1` and `_Unwind_*@GCC_*`
+        # references -- there's no `libgcc_s.so.1` in the musl image
+        # and the loader bails before `main`.  TODO: switch
+        # `frr-agent` to the same crane/`system-llvm-libunwind` path
+        # the rest of the workspace uses so we get a proper LLVM
+        # libunwind link instead of pulling in libgcc_eh.
+        env = (orig.env or { }) // (
+          if libc == "musl" then {
+            RUSTFLAGS = ((orig.env or { }).RUSTFLAGS or "") + " -C target-feature=+crt-static";
+          } else { }
+        );
         # Keep refs to libc and (on glibc only) the libgcc path the
         # ld-linux search list points at -- that's where glibc-dynamic
-        # Rust binaries find `libgcc_s.so.1` for unwinding.  Musl Rust
-        # uses llvm-libunwind and has no libgcc_s consumer, so don't
-        # bake glibc-targeted outputs into a musl image.
+        # Rust binaries find `libgcc_s.so.1` for unwinding.  On musl
+        # we've forced `+crt-static` above, so there's no `libgcc_s`
+        # consumer at runtime and we deliberately don't bake the
+        # glibc-targeted libgcc into the image.
         fixupPhase = ''
           find "$out" \
               -exec nuke-refs \

--- a/nix/overlays/frr.nix
+++ b/nix/overlays/frr.nix
@@ -5,6 +5,7 @@
   sanitizers,
   platform,
   profile,
+  libc,
   ...
 }:
 final: prev:
@@ -39,11 +40,36 @@ let
             (orig.LDFLAGS or "")
             + " -L${final.fancy.readline}/lib -lreadline "
             + " -L${final.fancy.json_c}/lib -ljson-c "
-            + " -Wl,--push-state,--as-needed,--no-whole-archive,-Bstatic "
+            # libatomic must end up as a single dynamic dep in the process:
+            # libatomic's lock_for_pointer state is per-image, so a static
+            # copy inside libfrr.so cannot synchronize with any other
+            # consumer that picks up libatomic.so dynamically.  Path differs
+            # by libc because the libatomic.so that pairs with the chosen
+            # cross-compiler stdenv lives in a different store path:
+            #
+            #   glibc: `${fancy.libgccjit}/lib/libatomic.so.1`
+            #     The libgccjit overlay is currently built with the host
+            #     stdenv (see TODO note on the libgccjit override below), so
+            #     the libatomic next to it is glibc-targeted -- safe to link
+            #     against a glibc FRR.
+            #
+            #   musl: `${stdenv.cc.cc.lib}/${triple}/lib/libatomic.so.1`
+            #     This is the gcc-libs output of the cross-musl gcc that
+            #     backs the cross-musl clang stdenv (note: stdenv, not
+            #     stdenv' -- the prime is the clang stdenv whose cc.cc is
+            #     clang and contains no libatomic at all).
+            + (
+              if libc == "musl" then
+                " -L${final.stdenv.cc.cc.lib}/${final.stdenv.hostPlatform.config}/lib -latomic "
+              else if libc == "gnu" then
+                " -L${final.fancy.libgccjit}/lib -latomic "
+              else
+                throw "unhandled libc=${libc} for FRR -latomic LDFLAGS"
+            )
             + " -L${final.fancy.libxcrypt}/lib -lcrypt "
+            + " -Wl,--push-state,--as-needed,--no-whole-archive,-Bstatic "
             + " -L${final.fancy.pcre2}/lib -lpcre2-8 "
             + " -L${final.fancy.xxhash}/lib -lxxhash "
-            + " -L${final.fancy.libgccjit}/lib -latomic "
             + " -Wl,--pop-state";
           configureFlags = orig.configureFlags ++ [
             "--enable-shared"
@@ -62,8 +88,10 @@ let
                 -e ${final.stdenv'.cc.libc} \
                 -e ${final.python3Minimal} \
                 -e ${final.fancy.readline} \
-                -e ${final.fancy.libgccjit} \
+                -e ${final.fancy.libxcrypt} \
                 -e ${final.fancy.json_c} \
+                ${if libc == "gnu" then "-e ${final.fancy.libgccjit}" else ""} \
+                ${if libc == "musl" then "-e ${final.stdenv.cc.cc.lib}" else ""} \
                 '{}' +;
           '';
         })
@@ -210,7 +238,24 @@ in
         ];
       })
     );
-    frr-agent = dep (final.callPackage ../pkgs/frr-agent final.fancy);
+    frr-agent = dep (
+      (final.callPackage ../pkgs/frr-agent final.fancy).overrideAttrs (orig: {
+        nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ prev.nukeReferences ];
+        # Keep refs to libc and (on glibc only) the libgcc path the
+        # ld-linux search list points at -- that's where glibc-dynamic
+        # Rust binaries find `libgcc_s.so.1` for unwinding.  Musl Rust
+        # uses llvm-libunwind and has no libgcc_s consumer, so don't
+        # bake glibc-targeted outputs into a musl image.
+        fixupPhase = ''
+          find "$out" \
+              -exec nuke-refs \
+              -e "$out" \
+              -e ${final.stdenv.cc.libc} \
+              ${if libc == "gnu" then "-e ${final.pkgsHostHost.glibc.libgcc}" else ""} \
+              '{}' +;
+        '';
+      })
+    );
     frr-config = dep (final.callPackage ../pkgs/frr-config final.fancy);
     dplane-rpc = dep (final.callPackage ../pkgs/dplane-rpc final.fancy);
     dplane-plugin = dep (final.callPackage ../pkgs/dplane-plugin final.fancy);

--- a/nix/overlays/frr.nix
+++ b/nix/overlays/frr.nix
@@ -105,7 +105,7 @@ in
           makeFlags = [
             "lib=lib"
             "PAM_CAP=no"
-            "CC:=clang"
+            "CC:=${final.stdenv'.cc.targetPrefix}clang"
             "SHARED=no"
             "LIBCSTATIC=no"
             "GOLANG=no"

--- a/nix/overlays/frr.nix
+++ b/nix/overlays/frr.nix
@@ -106,6 +106,10 @@ in
             "lib=lib"
             "PAM_CAP=no"
             "CC:=${final.stdenv'.cc.targetPrefix}clang"
+            # _makenames is a build-host helper run during the build; pin it to
+            # a build-host clang so cross-arch builds (e.g. bluefield3) don't
+            # produce an aarch64 binary the build host cannot execute.
+            "BUILD_CC:=${final.pkgsBuildBuild.llvmPackages'.clang}/bin/clang"
             "SHARED=no"
             "LIBCSTATIC=no"
             "GOLANG=no"

--- a/nix/overlays/frr.nix
+++ b/nix/overlays/frr.nix
@@ -78,7 +78,16 @@ let
             # this overrides the base package's --enable-static-bin.
             "--disable-static-bin"
           ];
-          nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ prev.nukeReferences ];
+          # `buildPackages.nukeReferences` rather than `prev.nukeReferences`:
+          # the `nuke-refs` script substitutes a perl path at build time, and
+          # under a cross pkgset `prev.nukeReferences` picks up target-arch
+          # perl.  The script is executed during this derivation's build
+          # phase on the build host, so the target-arch perl interpreter is
+          # unrunnable ("Exec format error").  `buildPackages` resolves to
+          # the build-host variant.  `removeReferencesTo` is shell-only and
+          # picks up build-host bash via `stdenvNoCC.shell` regardless of
+          # which pkgset it came from, so no equivalent fix is needed there.
+          nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ final.buildPackages.nukeReferences ];
           # disallowedReferences = (orig.disallowedReferences or []) ++ [ final.stdenv'.cc ];
           preFixup = ''
             find "$out" \
@@ -240,7 +249,10 @@ in
     );
     frr-agent = dep (
       (final.callPackage ../pkgs/frr-agent final.fancy).overrideAttrs (orig: {
-        nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ prev.nukeReferences ];
+        # See `nukeReferences` note in `frr-build` above: must be the
+        # build-host variant so the `nuke-refs` script's substituted perl is
+        # runnable on the build host under cross compilation.
+        nativeBuildInputs = (orig.nativeBuildInputs or [ ]) ++ [ final.buildPackages.nukeReferences ];
         # Keep refs to libc and (on glibc only) the libgcc path the
         # ld-linux search list points at -- that's where glibc-dynamic
         # Rust binaries find `libgcc_s.so.1` for unwinding.  Musl Rust

--- a/nix/pkgs/dplane-plugin/default.nix
+++ b/nix/pkgs/dplane-plugin/default.nix
@@ -21,11 +21,18 @@ stdenv.mkDerivation (finalAttrs: {
   version = sources.dplane-plugin.revision;
   src = sources.dplane-plugin.outPath;
 
+  # workaround: src/hh_dp_msg.c reaches into a glibc-internal anonymous
+  # union name (`.__in6_u.__u6_addr8`) on struct in6_addr.  musl exposes
+  # the POSIX-standard `.s6_addr` member directly without that wrapping
+  # union, so the access fails to compile.
+  # remove once fixed upstream in githedgehog/dplane-plugin.
+  postPatch = ''
+    sed -i 's/\.__in6_u\.__u6_addr8/.s6_addr/g' src/hh_dp_msg.c
+  '';
+
   doCheck = false;
   doFixup = false;
   enableParallelBuilding = true;
-
-  dontUnpack = true;
 
   nativeBuildInputs = [
     cmake
@@ -51,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
       -DHH_FRR_SRC=${frr.dataplane.build}/src/frr \
       -DHH_FRR_INCLUDE=${frr.dataplane}/include/frr \
       -DCMAKE_C_STANDARD=23 \
-      -S "$src"
+      -S .
   '';
 
   buildPhase = ''

--- a/nix/pkgs/dplane-plugin/default.nix
+++ b/nix/pkgs/dplane-plugin/default.nix
@@ -8,7 +8,6 @@
   frr,
   libyang,
   pcre2,
-  protobufc,
   json_c,
 
   # args
@@ -44,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     json_c
     libyang
     pcre2
-    protobufc
   ];
 
   configurePhase = ''

--- a/nix/pkgs/dplane-rpc/default.nix
+++ b/nix/pkgs/dplane-rpc/default.nix
@@ -16,6 +16,15 @@ stdenv.mkDerivation
   version = sources.dplane-rpc.revision;
   src = sources.dplane-rpc.outPath;
 
+  # workaround: cpmock.c uses memset/strcpy/strerror/memcmp without including
+  # <string.h>.  glibc transitively exposes those declarations through
+  # unrelated system headers; musl's header layout doesn't, so the compile
+  # fails with `call to undeclared library function 'memset'` under -std=c23.
+  # remove once fixed upstream in githedgehog/dplane-rpc.
+  postPatch = ''
+    sed -i '1i#include <string.h>' clib/bin/cpmock.c
+  '';
+
   doCheck = false;
   enableParallelBuilding = true;
 

--- a/nix/pkgs/frr-agent/default.nix
+++ b/nix/pkgs/frr-agent/default.nix
@@ -1,20 +1,13 @@
 {
   sources,
   rustPlatform,
-  nukeReferences,
-  libgcc,
-  stdenv,
   ...
 }:
 rustPlatform.buildRustPackage (final: {
   pname = "frr-agent";
   version = sources.frr-agent.revision;
   src = sources.frr-agent.outPath;
-  nativeBuildInputs = [ nukeReferences ];
   cargoLock = {
     lockFile = final.src + "/Cargo.lock";
   };
-  fixupPhase = ''
-    find "$out" -exec nuke-refs -e "$out" -e "${stdenv.cc.libc}" -e "${libgcc.lib}" '{}' +;
-  '';
 })

--- a/nix/pkgs/frr/default.nix
+++ b/nix/pkgs/frr/default.nix
@@ -98,13 +98,18 @@ stdenv.mkDerivation (finalAttrs: {
     c-ares
     json_c
     libcap
-    libgccjit
     libxcrypt
     libyang
     pcre2
     python3Minimal
     readline
   ]
+  # libgccjit is only the carrier for libatomic.so.1 on glibc targets
+  # (see the LDFLAGS comment in nix/overlays/frr.nix).  On musl FRR pulls
+  # libatomic from the cross-musl gcc-libs output via `stdenv.cc.cc.lib`
+  # in the overlay, so pulling libgccjit into the build closure here just
+  # bloats the runtime image without contributing any symbol.
+  ++ lib.optionals stdenv.hostPlatform.isGnu [ libgccjit ]
   ++ lib.optionals bgpRpki [ rtrlib ];
 
   # cross-compiling: clippy is compiled with the build host toolchain, split it out to ease
@@ -131,8 +136,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-config-rollbacks=no"
     "--disable-doc"
     "--disable-doc-html"
-    "--enable-grpc=no"
-    "--enable-protobuf=no"
+    "--disable-grpc"
+    "--disable-protobuf"
     "--enable-scripting=no"
     "--enable-sysrepo=no"
     "--enable-zeromq=no"

--- a/nix/platforms.nix
+++ b/nix/platforms.nix
@@ -52,8 +52,21 @@ let
         NIX_CFLAGS_LINK = [ ];
       };
     };
-    bluefield2 = rec {
+    aarch64 = rec {
       arch = "aarch64";
+      march = "generic";
+      numa = {
+        max-nodes = 8;
+      };
+      override = {
+        stdenv.env = rec {
+          NIX_CFLAGS_COMPILE = [ ];
+          NIX_CXXFLAGS_COMPILE = NIX_CFLAGS_COMPILE;
+          NIX_CFLAGS_LINK = [ ];
+        };
+      };
+    };
+    bluefield2 = lib.recursiveUpdate aarch64 rec {
       march = "armv8.2-a";
       mcpu = "cortex-a72";
       numa = {
@@ -95,6 +108,7 @@ lib.fix (
     name =
       {
         bluefield2 = "bluefield";
+        aarch64 = "generic";
       }
       .${platform} or platform;
     info =

--- a/nix/platforms.nix
+++ b/nix/platforms.nix
@@ -147,7 +147,7 @@ lib.fix (
         };
         wasm32 = {
           wasip1 = {
-            unknown = {
+            none = {
               target = "wasm32-wasip1";
               machine = "wasm32";
               nixarch = "wasi32";

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -35,7 +35,7 @@ left-right = { workspace = true }
 linkme = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
 netgauze-bgp-pkt = { workspace = true }
-netgauze-bmp-pkt = { workspace = true }
+netgauze-bmp-pkt = { workspace = true, features = ["codec"] }
 nix = { workspace = true, features = ["socket"] }
 serde = { workspace = true, features = ["derive"] }
 strum =  { workspace = true }


### PR DESCRIPTION
# :notes: everything is WASM :musical_score:

<img width="300" height="168" alt="image" src="https://github.com/user-attachments/assets/50ff4844-f862-4e6c-9bb6-784c5cc86af3" />

Add `wasm32-wasip1` build checks for packages that aren't explicitly
excluded, and tune up the cross-compile path so aarch64 and musl builds
reliably succeed.

- **wasm32-wasip1 check path**: a `cargo check` derivation per workspace
  package (`check.<name>`), a `wasmtime` runner in `.cargo/config.toml`,
  and per-package `[workspace.metadata.package]` carrying a `wasm` flag
  so `default.nix` can filter the package list.  CI gains a `wasm` job
  (blocker; same triggers as the previous `must-build`) that runs the
  `check` recipe on `wasm32-wasip1`.

- **Workspace feature hygiene**: stop enabling features at
  `[workspace.dependencies]` -- those bleed into every consumer and
  break builds under restricted environments (wasm, cross, miri).  Move
  feature enablement down to the individual packages that actually need
  them, and document the rule in a comment.

- **musl cross-compilation**: rewrite glibc-internal `__in6_u` to POSIX
  `s6_addr` in `dplane-plugin`; patch missing `<string.h>` into
  `dplane-rpc`'s `cpmock.c`; route FRR's `-latomic` to the cross-musl
  `gcc-libs` path under musl and preserve its store path through
  `nuke-refs`; drop the glibc-only `libgccjit` buildInput from the musl
  FRR build; gate `glibc.libgcc` bundling (in both `dataplane.tar` and
  the `debug-tools` container) on `libc == "gnu"` so musl images don't
  pull glibc-targeted outputs, while keeping `libc.out` bundled on both
  libcs so the dynamically-linked busybox can resolve its
  `ld-musl-<arch>.so.1` interpreter; reach into
  `buildPackages.nukeReferences` in the FRR overlay so the substituted
  perl in `nuke-refs` is build-host and not the target-arch binary that
  the build host can't execute.

- **aarch64 cross-compilation**: add a generic `aarch64` platform
  alongside the existing `bluefield3` (vendor-specific aarch64) entry,
  and fix the correctness bugs the new matrix flushed out: pin libcap's
  `BUILD_CC` to a build-host clang and pass the wrapped cross-clang as
  the target `CC`; use `pkgsBuildBuild` for dev-shell tooling; compare
  `buildPlatform` (not `hostPlatform`) when deciding whether we're
  cross-compiling; pass the cross `pkgs` set through to crane; enable
  `system-llvm-libunwind` on non-glibc Rust targets; pin the dev-shell
  cargo target to the sysroot triple.

- **CI**: split `must-build` into two jobs ---
  - **`wasm`**: fast wasm sanity check, blocker on devfile changes /
    tags / dispatch.
  - **`cross`**: `{aarch64, bluefield3} x {gnu, musl} x {debug} x
    {build-container dataplane, build-container frr.dataplane}`,
    gated by `ci:+cross` label or push/merge_group.  Job-level
    `continue-on-error: true`: a failing leg still reports `failure`
    to its own conclusion (the leg badge goes red and the leg is
    visible in the run summary), but the workflow's overall conclusion
    ignores the failure so cross is non-blocking.
    `needs.cross.result` reports `success` to dependents under
    job-level CoE, so the summary aggregator does not (and cannot)
    gate on cross; treat it as purely informational.

  Plus `build-each` / `check-each` `just` recipes for local iteration,
  and a `docker import --platform` fix so cross-built `dataplane.tar`
  rootfs imports are tagged with the right architecture instead of
  silently inheriting the runner's.
