### PR TITLE
refactor(lpm): Merge traits IpPrefix{Covering,Colliding} into IpPrefix

### DIFF
--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -92,14 +92,14 @@ pub trait IpPrefix: Debug + Clone + From<Self::Addr> + PartialEq {
             Self::new(split_address, self.len() + 1).unwrap_or_else(|_| unreachable!()),
         ))
     }
-}
 
-pub trait IpPrefixCovering<Other> {
-    fn covers(&self, other: &Other) -> bool;
-}
+    fn covers(&self, other: &Self) -> bool;
 
-pub trait IpPrefixColliding<Other> {
-    fn collides_with(&self, other: &Other) -> bool;
+    fn covers_addr(&self, other: &Self::Addr) -> bool;
+
+    fn collides_with(&self, other: &Self) -> bool {
+        self.covers(other) || other.covers(self)
+    }
 }
 
 ////////////////////////////////////////////////////////////
@@ -174,23 +174,11 @@ impl IpPrefix for Ipv4Prefix {
     fn size(&self) -> PrefixSize {
         PrefixSize::U128(2u128.pow(32 - u32::from(self.len())))
     }
-}
-
-impl IpPrefixCovering<Ipv4Addr> for Ipv4Prefix {
-    fn covers(&self, other: &Ipv4Addr) -> bool {
-        self.0.contains(other)
-    }
-}
-
-impl IpPrefixCovering<Ipv4Prefix> for Ipv4Prefix {
-    fn covers(&self, other: &Ipv4Prefix) -> bool {
+    fn covers(&self, other: &Self) -> bool {
         self.0.contains(&other.0)
     }
-}
-
-impl IpPrefixColliding<Ipv4Prefix> for Ipv4Prefix {
-    fn collides_with(&self, other: &Ipv4Prefix) -> bool {
-        self.covers(other) || other.covers(self)
+    fn covers_addr(&self, other: &Self::Addr) -> bool {
+        self.0.contains(other)
     }
 }
 
@@ -318,23 +306,11 @@ impl IpPrefix for Ipv6Prefix {
             PrefixSize::U128(2u128.pow(128 - u32::from(self.len())))
         }
     }
-}
-
-impl IpPrefixCovering<Ipv6Addr> for Ipv6Prefix {
-    fn covers(&self, other: &Ipv6Addr) -> bool {
-        self.0.contains(other)
-    }
-}
-
-impl IpPrefixCovering<Ipv6Prefix> for Ipv6Prefix {
-    fn covers(&self, other: &Ipv6Prefix) -> bool {
+    fn covers(&self, other: &Self) -> bool {
         self.0.contains(&other.0)
     }
-}
-
-impl IpPrefixColliding<Ipv6Prefix> for Ipv6Prefix {
-    fn collides_with(&self, other: &Ipv6Prefix) -> bool {
-        self.covers(other) || other.covers(self)
+    fn covers_addr(&self, other: &Self::Addr) -> bool {
+        self.0.contains(other)
     }
 }
 
@@ -434,8 +410,8 @@ mod tests {
     fn test_ipv4_covers() {
         // IP Address is covered by prefix
         let prefix = "192.168.1.0/24".parse::<Ipv4Prefix>().unwrap();
-        assert!(prefix.covers(&Ipv4Addr::new(192, 168, 1, 1)));
-        assert!(!prefix.covers(&Ipv4Addr::new(192, 168, 2, 1)));
+        assert!(prefix.covers_addr(&Ipv4Addr::new(192, 168, 1, 1)));
+        assert!(!prefix.covers_addr(&Ipv4Addr::new(192, 168, 2, 1)));
 
         // Prefix is covered by prefix
         assert!(prefix.covers(&prefix));
@@ -467,9 +443,9 @@ mod tests {
     fn test_ipv6_covers() {
         // IP Address is covered by prefix
         let prefix = "2001:db8::/32".parse::<Ipv6Prefix>().unwrap();
-        assert!(prefix.covers(&Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
-        assert!(prefix.covers(&Ipv6Addr::new(0x2001, 0xdb8, 0xabcd, 0, 0, 0, 0, 0)));
-        assert!(!prefix.covers(&Ipv6Addr::new(0x2001, 0xdb9, 0, 0, 0, 0, 0, 0)));
+        assert!(prefix.covers_addr(&Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
+        assert!(prefix.covers_addr(&Ipv6Addr::new(0x2001, 0xdb8, 0xabcd, 0, 0, 0, 0, 0)));
+        assert!(!prefix.covers_addr(&Ipv6Addr::new(0x2001, 0xdb9, 0, 0, 0, 0, 0, 0)));
 
         // Prefix is covered by prefix
         assert!(prefix.covers(&prefix));
@@ -496,7 +472,7 @@ mod tests {
         assert!(!p2.covers(&p1));
     }
 
-    fn prefix_contract<P: IpPrefix + IpPrefixCovering<P>>(prefix: &P) {
+    fn prefix_contract<P: IpPrefix>(prefix: &P) {
         assert!(P::ROOT.covers(prefix));
         let len = prefix.len();
         if len > 0 {

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -4,14 +4,13 @@
 //! Type to represent IP-version neutral network prefixes.
 
 pub mod ip;
-pub use ip::{IpPrefix, IpPrefixCovering, Ipv4Prefix, Ipv6Prefix};
+pub use ip::{IpPrefix, Ipv4Prefix, Ipv6Prefix};
 
 pub mod range_map;
 
 pub mod with_ports;
 pub use with_ports::*;
 
-use crate::prefix::ip::IpPrefixColliding;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use serde::ser::SerializeStructVariant;
 use serde::{Deserialize, Serialize};
@@ -155,8 +154,8 @@ impl Prefix {
     #[must_use]
     pub fn covers_addr(&self, addr: &IpAddr) -> bool {
         match (self, addr) {
-            (Prefix::IPV4(p), IpAddr::V4(a)) => p.covers(a),
-            (Prefix::IPV6(p), IpAddr::V6(a)) => p.covers(a),
+            (Prefix::IPV4(p), IpAddr::V4(a)) => p.covers_addr(a),
+            (Prefix::IPV6(p), IpAddr::V6(a)) => p.covers_addr(a),
             _ => false,
         }
     }

--- a/nat/src/portfw/portfwtable/rangeset.rs
+++ b/nat/src/portfw/portfwtable/rangeset.rs
@@ -8,7 +8,7 @@
 
 use crate::portfw::PortFwTableError;
 use lpm::prefix::ip::Representable;
-use lpm::prefix::{IpPrefix, IpPrefixCovering, Ipv4Prefix, Ipv6Prefix, Prefix};
+use lpm::prefix::{IpPrefix, Ipv4Prefix, Ipv6Prefix, Prefix};
 use std::collections::BTreeMap;
 use std::default;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};


### PR DESCRIPTION
There's no good reason to keep these traits separate, let's merge them into IpPrefix.

This is a small clean-up that I came up with while looking at larger changes for the IP prefixes types. I'm not sure to complete this larger piece of work, so here's at least the small clean-up.
