### PR TITLE
Fix performance of tracing rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
 name = "dataplane-tracectl"
 version = "0.21.0"
 dependencies = [
+ "arc-swap",
  "color-eyre",
  "dataplane-common",
  "linkme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-throttle",
 ]
 
 [[package]]
@@ -5916,6 +5917,18 @@ checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-throttle"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4e430251f5ca8f86ea941286923dc2e91be7ca95fec777d75ee8ae1c493f64"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-test",
  "tracing-throttle",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ thread_local = { version = "1.1.9", default-features = false, features = [] }
 tokio = { version = "1.52.3", default-features = false, features = [] }
 tokio-util = { version = "0.7.18", default-features = false, features = [] }
 tonic = { version = "0.14.6", default-features = false, features = [] }
-tracing = { version = "0.1.44", default-features = false, features = [] }
+tracing = { version = "0.1.44", default-features = false, features = ["release_max_level_debug"] }
 tracing-error = { version = "0.2.1", default-features = false, features = [] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = [] }
 tracing-test = { version = "0.2.6", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ tracing = { version = "0.1.44", default-features = false, features = [] }
 tracing-error = { version = "0.2.1", default-features = false, features = [] }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = [] }
 tracing-test = { version = "0.2.6", default-features = false, features = [] }
+tracing-throttle = { version = "0.4.2", default-features = false, features = [] }
 ureq = { version = "3.3.0", default-features = false, features = [] }
 url = { version = "2.5.8", default-features = false, features = [] }
 uuid = { version = "1.23.1", default-features = false, features = [] }

--- a/args/src/lib.rs
+++ b/args/src/lib.rs
@@ -84,6 +84,23 @@ pub struct InterfaceArg {
     pub port: Option<PortArg>,
 }
 
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    serde::Serialize,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Archive,
+    CheckBytes,
+)]
+#[rkyv(attr(derive(PartialEq, Eq, Debug)))]
+pub struct TracingRateLimit {
+    pub burst: u32,
+    pub replenish_per_second: u32,
+}
+
 impl FromStr for PortArg {
     type Err = String;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
@@ -128,6 +145,34 @@ impl FromStr for InterfaceArg {
                 port: None,
             })
         }
+    }
+}
+
+impl FromStr for TracingRateLimit {
+    type Err = String;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (burst, replenish_per_second) = input
+            .split_once(':')
+            .ok_or("Bad syntax: missing :".to_string())?;
+
+        let burst = burst
+            .parse::<u32>()
+            .map_err(|e| format!("Bad burst value: {e}"))?;
+        let replenish_per_second = replenish_per_second
+            .parse::<u32>()
+            .map_err(|e| format!("Bad replenish-per-second value: {e}"))?;
+
+        if burst == 0 {
+            return Err("Burst must be greater than 0".to_string());
+        }
+        if replenish_per_second == 0 {
+            return Err("Replenish-per-second must be greater than 0".to_string());
+        }
+
+        Ok(Self {
+            burst,
+            replenish_per_second,
+        })
     }
 }
 
@@ -463,6 +508,8 @@ pub struct TracingConfigSection {
     pub show: TracingShowSection,
     /// Tracing configuration string (e.g., "default=info,nat=debug")
     pub config: Option<String>, // TODO: stronger typing on this config?
+    /// Optional rate limit for lower-severity tracing output
+    pub rate_limit: Option<TracingRateLimit>,
 }
 
 /// Display option for trace metadata elements.
@@ -1146,6 +1193,7 @@ impl TryFrom<CmdArgs> for LaunchConfiguration {
                     },
                 },
                 config: value.tracing.clone(),
+                rate_limit: value.tracing_rate_limit.clone(),
             },
             metrics: MetricsConfigSection {
                 address: value.metrics_address(),
@@ -1266,6 +1314,16 @@ E.g. default=error,all=info,nat=debug will set the default target to error, and 
     )]
     tracing: Option<String>,
 
+    #[arg(
+        long,
+        value_name = "BURST:REPLENISH_PER_SECOND",
+        value_parser=TracingRateLimit::from_str,
+        help = "Optional rate limit for lower-severity tracing output. Syntax: BURST:REPLENISH_PER_SECOND.
+Example: --tracing-rate-limit 50:5 allows bursts up to 50 repeated messages and replenishes 5 messages per second.
+If omitted, tracing output is not rate-limited."
+    )]
+    tracing_rate_limit: Option<TracingRateLimit>,
+
     #[arg(long, help = "Set the name of this gateway")]
     name: Option<String>,
 
@@ -1361,6 +1419,11 @@ impl CmdArgs {
     #[must_use]
     pub fn tracing(&self) -> Option<&String> {
         self.tracing.as_ref()
+    }
+
+    #[must_use]
+    pub fn tracing_rate_limit(&self) -> Option<&TracingRateLimit> {
+        self.tracing_rate_limit.as_ref()
     }
 
     /// Get the number of worker threads for the kernel driver.
@@ -1478,6 +1541,7 @@ mod tests {
     use hardware::pci::function::Function;
     use net::interface::InterfaceName;
 
+    use super::TracingRateLimit;
     use crate::{InterfaceArg, PortArg};
     use std::str::FromStr;
 
@@ -1519,5 +1583,30 @@ mod tests {
 
         // bad discriminant
         assert!(InterfaceArg::from_str("GbEth1.9000=foo@0000:02:01.7").is_err());
+    }
+    #[test]
+    fn tracing_rate_limit_parses_valid_values() {
+        let rate_limit = TracingRateLimit::from_str("10:20").unwrap();
+        assert_eq!(rate_limit.burst, 10);
+        assert_eq!(rate_limit.replenish_per_second, 20);
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_missing_separator() {
+        let err = TracingRateLimit::from_str("10").unwrap_err();
+        assert_eq!(err, "Bad syntax: missing :");
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_non_numeric_values() {
+        let err = TracingRateLimit::from_str("abc:20").unwrap_err();
+        assert!(err.starts_with("Bad burst value:"));
+        let err = TracingRateLimit::from_str("10:def").unwrap_err();
+        assert!(err.starts_with("Bad replenish-per-second value:"));
+    }
+    #[test]
+    fn tracing_rate_limit_rejects_zero_values() {
+        let err = TracingRateLimit::from_str("0:20").unwrap_err();
+        assert_eq!(err, "Burst must be greater than 0");
+        let err = TracingRateLimit::from_str("10:0").unwrap_err();
+        assert_eq!(err, "Replenish-per-second must be greater than 0");
     }
 }

--- a/dataplane/src/main.rs
+++ b/dataplane/src/main.rs
@@ -21,7 +21,9 @@ use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeConfig};
 
 use routing::{BmpServerParams, RouterParamsBuilder};
-use tracectl::{custom_target, get_trace_ctl, trace_target};
+use tracectl::{
+    TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
+};
 
 use tracing::{error, info, level_filters::LevelFilter};
 
@@ -52,15 +54,24 @@ fn init_name(args: &CmdArgs) -> Result<String, String> {
         Ok(name.to_string())
     }
 }
-fn init_logging(gwname: &str) {
+fn init_logging(args: &CmdArgs, gwname: &str) {
+    TracingControl::init_with_rate_limit(args.tracing_rate_limit().map(|rate_limit| {
+        TracingRateLimitConfig {
+            burst: rate_limit.burst,
+            replenish_per_second: rate_limit.replenish_per_second,
+        }
+    }));
+
     let tctl = get_trace_ctl();
     info!(
         " ━━━━━━ Starting dataplane for gateway '{gwname}' (Version = {}) ━━━━━━",
         option_env!("VERSION").unwrap_or("dev").to_string()
     );
 
-    tctl.set_default_level(LevelFilter::DEBUG)
-        .expect("Setting default loglevel failed");
+    if args.tracing().is_none() {
+        tctl.set_default_level(LevelFilter::DEBUG)
+            .expect("Setting default loglevel failed");
+    }
 }
 
 fn process_tracing_cmds(args: &CmdArgs) {
@@ -133,7 +144,7 @@ fn main() {
             std::process::exit(1);
         }
     };
-    init_logging(&gwname);
+    init_logging(&args, &gwname);
 
     let (bmp_server_params, bmp_client_opts) = parse_bmp_params(&args);
 

--- a/tracectl/Cargo.toml
+++ b/tracectl/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-error = { workspace = true, features = ["traced-error"] }
 tracing-subscriber = { workspace = true, features = ["registry", "std", "env-filter", "fmt"] }
+tracing-throttle = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/tracectl/Cargo.toml
+++ b/tracectl/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 version.workspace = true
 
 [dependencies]
+arc-swap = { workspace = true }
 color-eyre = { workspace = true , features = [ "capture-spantrace", "color-spantrace", "tracing-error", "track-caller" ] }
 common = { workspace = true }
 linkme = { workspace = true }

--- a/tracectl/Cargo.toml
+++ b/tracectl/Cargo.toml
@@ -19,3 +19,4 @@ tracing-throttle = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }
+tracing-test = { workspace = true }

--- a/tracectl/src/control.rs
+++ b/tracectl/src/control.rs
@@ -5,17 +5,31 @@
 
 use ordermap::OrderMap;
 use std::str::FromStr;
-use std::sync::{Arc, LazyLock, Mutex};
-use std::{collections::HashSet, sync::MutexGuard};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::{collections::HashSet, sync::MutexGuard, time::Duration};
 use thiserror::Error;
 #[allow(unused)]
-use tracing::{debug, error, info, warn};
-use tracing_subscriber::{EnvFilter, Registry, filter::LevelFilter, prelude::*, reload};
+use tracing::{Level, Subscriber, debug, error, info, warn};
+use tracing_subscriber::{
+    EnvFilter, Registry,
+    filter::{FilterExt, LevelFilter, filter_fn},
+    layer::{Filter, Layer},
+    prelude::*,
+    registry::LookupSpan,
+    reload,
+};
+use tracing_throttle::{Policy, TracingRateLimitLayer};
 
 use crate::display::TargetCfgDbByTag;
 use crate::targets::{TRACING_TAG_ALL, TRACING_TARGETS};
 use crate::trace_target;
 trace_target!("tracectl", LevelFilter::INFO, &[]);
+
+#[derive(Copy, Clone, Debug)]
+pub struct TracingRateLimitConfig {
+    pub burst: u32,
+    pub replenish_per_second: u32,
+}
 
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum TraceCtlError {
@@ -278,32 +292,128 @@ impl TargetCfgDb {
     }
 }
 
+type BoxedTracingLayer<S> = Box<dyn Layer<S> + Send + Sync>;
+
+type ReloadLayer = reload::Layer<EnvFilter, Registry>;
+
 pub struct TracingControl {
     db: Arc<Mutex<TargetCfgDb>>,
     reload_filter: Arc<reload::Handle<EnvFilter, Registry>>,
 }
 impl TracingControl {
-    fn new() -> Self {
-        let db = TargetCfgDb::new();
-        let (filter, reload_filter) = reload::Layer::new(db.env_filter());
-
-        // formatting layer
-        let fmt_layer = tracing_subscriber::fmt::layer()
+    fn fmt_layer<S>() -> impl Layer<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::layer()
             .with_line_number(true)
             .with_target(true)
             .with_thread_ids(false)
             .with_thread_names(true)
-            .with_level(true);
+            .with_level(true)
+    }
 
-        // we should not be initializing the subscriber here, but that's fine atm
+    // To get rid of spaghetti filters in the layers, we split the fmt layer into two:
+    // one for unthrottled levels and one for throttled levels.
+
+    // `DEBUG` level remains unthrottled if we assume that it is the most verbose level
+    // that users would want to enable while digging into particular issues.
+    fn unthrottled_level_filter<S>() -> impl Filter<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        filter_fn(|meta| matches!(*meta.level(), Level::DEBUG))
+    }
+
+    fn throttled_level_filter<S>() -> impl Filter<S> + Send + Sync
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        filter_fn(|meta| {
+            matches!(
+                *meta.level(),
+                Level::INFO | Level::TRACE | Level::ERROR | Level::WARN
+            )
+        })
+    }
+
+    fn unthrottled_fmt_layer<S>() -> BoxedTracingLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+    {
+        Self::fmt_layer()
+            .with_filter(Self::unthrottled_level_filter())
+            .boxed()
+    }
+
+    fn throttled_fmt_layer<S>(
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> BoxedTracingLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+    {
+        if let Some(rate_limit) = Self::build_rate_limit_layer(rate_limit_config) {
+            Self::fmt_layer()
+                .with_filter(Self::throttled_level_filter().and(rate_limit))
+                .boxed()
+        } else {
+            Self::fmt_layer()
+                .with_filter(Self::throttled_level_filter())
+                .boxed()
+        }
+    }
+
+    fn build_rate_limit_layer(
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> Option<TracingRateLimitLayer> {
+        let rate_limit_config = rate_limit_config?;
+
+        let policy = match Policy::token_bucket(
+            f64::from(rate_limit_config.burst),
+            f64::from(rate_limit_config.replenish_per_second),
+        ) {
+            Ok(policy) => policy,
+            Err(e) => {
+                eprintln!(
+                    "Failed to create tracing throttle policy: {e}; falling back to unthrottled logging"
+                );
+                return None;
+            }
+        };
+
+        match TracingRateLimitLayer::builder()
+            .with_policy(policy)
+            .with_summary_interval(Duration::from_secs(30))
+            .build()
+        {
+            Ok(rate_limit) => Some(rate_limit),
+            Err(e) => {
+                eprintln!(
+                    "Failed to create tracing throttle layer: {e}; falling back to unthrottled logging"
+                );
+                None
+            }
+        }
+    }
+
+    fn init_subscriber(filter: ReloadLayer, rate_limit_config: Option<TracingRateLimitConfig>) {
         if let Err(e) = tracing_subscriber::registry()
             .with(filter)
-            .with(fmt_layer)
+            .with(Self::unthrottled_fmt_layer())
+            .with(Self::throttled_fmt_layer(rate_limit_config))
             .with(tracing_error::ErrorLayer::default())
             .try_init()
         {
             eprintln!("Failed to set global tracing subscriber: {e} !!");
         }
+    }
+
+    fn new(rate_limit_config: Option<TracingRateLimitConfig>) -> Self {
+        let db = TargetCfgDb::new();
+        let (filter, reload_filter) = reload::Layer::new(db.env_filter());
+
+        Self::init_subscriber(filter, rate_limit_config);
+
         if let Err(e) = color_eyre::install() {
             eprintln!("Failed to initialize color_eyre:\n{e}");
         }
@@ -339,17 +449,35 @@ impl TracingControl {
 }
 
 /// Get a reference to a static [`TracingControl`], initializing it if needed
-static TRACING_CTL: LazyLock<TracingControl> = LazyLock::new(TracingControl::new);
+static TRACING_CTL: OnceLock<TracingControl> = OnceLock::new();
 #[must_use]
 pub fn get_trace_ctl() -> &'static TracingControl {
-    #[allow(clippy::explicit_auto_deref)] // needed by mechanics of lazy lock
-    &*TRACING_CTL
+    TRACING_CTL.get_or_init(|| TracingControl::new(None))
 }
 
 // public methods for TracingControl
 impl TracingControl {
+    fn init_once(
+        tracing_ctl: &OnceLock<TracingControl>,
+        rate_limit_config: Option<TracingRateLimitConfig>,
+    ) -> bool {
+        let mut initialized = false;
+        let _ = tracing_ctl.get_or_init(|| {
+            initialized = true;
+            TracingControl::new(rate_limit_config)
+        });
+        initialized
+    }
+
     pub fn init() {
         let _ = get_trace_ctl();
+    }
+    pub fn init_with_rate_limit(rate_limit_config: Option<TracingRateLimitConfig>) {
+        let has_rate_limit_config = rate_limit_config.is_some();
+        let initialized = Self::init_once(&TRACING_CTL, rate_limit_config);
+        if has_rate_limit_config && !initialized {
+            warn!("TracingControl already initialized; ignoring provided rate-limit config");
+        }
     }
     fn set_tag_level(&self, tag: &str, level: LevelFilter) -> Result<(), TraceCtlError> {
         let mut db = self.lock()?;
@@ -485,6 +613,7 @@ mod tests {
     use crate::targets::TRACING_TARGETS;
     use crate::{LevelFilter, custom_target, trace_target};
     use serial_test::serial;
+    use std::sync::OnceLock;
     use tracing::Level;
     use tracing::event_enabled;
     #[allow(unused)]
@@ -522,6 +651,25 @@ mod tests {
             tctl.get_default_level().unwrap()
         );
         println!("{:#?}", tctl.db.lock().unwrap());
+    }
+
+    #[test]
+    #[serial]
+    fn test_init_with_rate_limit() {
+        let tracing_ctl = OnceLock::new();
+        let rate_limit_config = Some(crate::control::TracingRateLimitConfig {
+            burst: 10,
+            replenish_per_second: 1,
+        });
+
+        assert!(TracingControl::init_once(&tracing_ctl, rate_limit_config));
+        assert!(tracing_ctl.get().is_some());
+        assert_eq!(
+            tracing_ctl.get().unwrap().get_default_level().unwrap(),
+            crate::control::DEFAULT_DEFAULT_LOGLEVEL
+        );
+
+        assert!(!TracingControl::init_once(&tracing_ctl, rate_limit_config));
     }
 
     #[test]

--- a/tracectl/src/control.rs
+++ b/tracectl/src/control.rs
@@ -1061,4 +1061,70 @@ mod tests {
         assert_eq!(check_level!(Y3), LevelFilter::ERROR);
         assert_eq!(check_level!(Y4), LevelFilter::DEBUG);
     }
+
+    // Verify the rate limiter actually drops events past the burst.
+    #[test]
+    #[serial]
+    fn test_rate_limit_drops_burst_overflow() {
+        use crate::control::{TracingControl, TracingRateLimitConfig};
+        use std::sync::Mutex;
+        use tracing_subscriber::{EnvFilter, filter::FilterExt, layer::Layer, prelude::*};
+        use tracing_test::internal::MockWriter;
+
+        const INFO_MARKER: &str = "HH_RATE_TEST_INFO";
+        const DEBUG_MARKER: &str = "HH_RATE_TEST_DEBUG";
+        const BURST: u32 = 5;
+        const EMITTED: usize = 100;
+
+        // We leak a `Mutex<Vec<u8>>` to get a `'static` writer buffer for the subscriber layer.
+        let buf: &'static Mutex<Vec<u8>> = Box::leak(Box::new(Mutex::new(Vec::new())));
+
+        let rate_limit = TracingControl::build_rate_limit_layer(Some(TracingRateLimitConfig {
+            burst: BURST,
+            replenish_per_second: 1,
+        }))
+        .expect("build rate-limit layer");
+
+        // Same for dataplane: `DEBUG` events are unthrottled, `INFO` events are
+        let fmt_unthrottled = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(MockWriter::new(buf))
+            .with_filter(TracingControl::unthrottled_level_filter());
+
+        let fmt_throttled = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(MockWriter::new(buf))
+            .with_filter(TracingControl::throttled_level_filter().and(rate_limit));
+
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new("debug"))
+            .with(fmt_unthrottled)
+            .with(fmt_throttled);
+
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..EMITTED {
+                tracing::debug!("{DEBUG_MARKER}");
+                tracing::info!("{INFO_MARKER}");
+            }
+        });
+
+        let captured = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        let info_kept = captured.matches(INFO_MARKER).count();
+        let debug_kept = captured.matches(DEBUG_MARKER).count();
+
+        // DEBUG is unthrottled — every event must make it through, and the
+        // throttle layer never sees it so it can't burn tokens budgeted for INFO.
+        assert_eq!(
+            debug_kept, EMITTED,
+            "DEBUG events must pass the unthrottled layer; got {debug_kept}/{EMITTED}"
+        );
+        assert!(
+            info_kept >= 1,
+            "rate limiter swallowed the entire INFO burst"
+        );
+        assert!(
+            info_kept < EMITTED / 2,
+            "rate limiter let through {info_kept}/{EMITTED} INFO events; expected ≪ {EMITTED}\n{captured}"
+        );
+    }
 }

--- a/tracectl/src/control.rs
+++ b/tracectl/src/control.rs
@@ -3,20 +3,21 @@
 
 //! Tracing runtime control.
 
+use arc_swap::ArcSwap;
 use ordermap::OrderMap;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::{collections::HashSet, sync::MutexGuard, time::Duration};
+use std::{any::TypeId, collections::HashSet, sync::MutexGuard, time::Duration};
 use thiserror::Error;
+use tracing::{Event, Metadata, span, subscriber::Interest};
 #[allow(unused)]
-use tracing::{Level, Subscriber, debug, error, info, warn};
+use tracing::{Level, Subscriber, callsite, debug, error, info, warn};
 use tracing_subscriber::{
-    EnvFilter, Registry,
+    EnvFilter,
     filter::{FilterExt, LevelFilter, filter_fn},
-    layer::{Filter, Layer},
+    layer::{Context, Filter, Layer},
     prelude::*,
     registry::LookupSpan,
-    reload,
 };
 use tracing_throttle::{Policy, TracingRateLimitLayer};
 
@@ -33,8 +34,6 @@ pub struct TracingRateLimitConfig {
 
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum TraceCtlError {
-    #[error("Reload tracing failure: {0}")]
-    ReloadFailure(String),
     #[error("Unknown tag {0}")]
     UnknownTag(String),
     #[error("Lock failure: {0}")]
@@ -292,13 +291,101 @@ impl TargetCfgDb {
     }
 }
 
-type BoxedTracingLayer<S> = Box<dyn Layer<S> + Send + Sync>;
+/// `AtomicEnvFilter` wraps an `EnvFilter` in an `ArcSwap` to allow atomic
+/// swapping of the filter. The type is `Clone`-able: the original instance
+/// is moved into the subscriber as a `Layer`, while a clone is kept on
+/// `TracingControl` to push reloads from the outside. Both clones share the
+/// same `Arc<ArcSwap<EnvFilter>>` so an update from one is visible to the other.
+#[derive(Clone)]
+struct AtomicEnvFilter {
+    inner: Arc<ArcSwap<EnvFilter>>,
+}
 
-type ReloadLayer = reload::Layer<EnvFilter, Registry>;
+impl AtomicEnvFilter {
+    fn new(initial: EnvFilter) -> Self {
+        Self {
+            inner: Arc::new(ArcSwap::from_pointee(initial)),
+        }
+    }
+
+    fn reload(&self, new: EnvFilter) {
+        self.inner.store(Arc::new(new));
+        callsite::rebuild_interest_cache();
+    }
+}
+
+// Forward every `Layer<S>` method to the currently-swapped-in `EnvFilter`.
+// Verbose but mechanical: `EnvFilter` overrides several `Layer` hooks
+// (`on_new_span`, `on_record`, `on_enter`, `on_exit`, `on_close`) to
+// support span-based directives like `target[span_name]=level`. This
+// codebase doesn't use those, but the forwarding is here for behavioral
+// equivalence with `reload::Layer<EnvFilter>`.
+impl<S> Layer<S> for AtomicEnvFilter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(&self, meta: &'static Metadata<'static>) -> Interest {
+        Layer::<S>::register_callsite(&**self.inner.load(), meta)
+    }
+
+    fn enabled(&self, meta: &Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        Layer::<S>::enabled(&**self.inner.load(), meta, ctx)
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Layer::<S>::max_level_hint(&**self.inner.load())
+    }
+
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        Layer::<S>::on_new_span(&**self.inner.load(), attrs, id, ctx);
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        Layer::<S>::on_record(&**self.inner.load(), id, values, ctx);
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        Layer::<S>::on_enter(&**self.inner.load(), id, ctx);
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        Layer::<S>::on_exit(&**self.inner.load(), id, ctx);
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        Layer::<S>::on_close(&**self.inner.load(), id, ctx);
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        Layer::<S>::on_event(&**self.inner.load(), event, ctx);
+    }
+
+    // `downcast_raw` is how the layered subscriber probes a layer for
+    // per-layer-filter participation (via the `MagicPlfDowncastMarker` type
+    // id) and other capabilities. `EnvFilter` used as a `Layer` is not a
+    // per-layer filter, so reporting "no match" for anything but our own
+    // type id is correct. We deliberately do *not* expose the inner
+    // `EnvFilter`'s address — its identity can change at any time via
+    // `ArcSwap::store`.
+    #[doc(hidden)]
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        if id == TypeId::of::<Self>() {
+            Some(std::ptr::from_ref::<Self>(self).cast::<()>())
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TracingControl
+// ---------------------------------------------------------------------------
+
+type BoxedTracingLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 
 pub struct TracingControl {
     db: Arc<Mutex<TargetCfgDb>>,
-    reload_filter: Arc<reload::Handle<EnvFilter, Registry>>,
+    reload_filter: AtomicEnvFilter,
 }
 impl TracingControl {
     fn fmt_layer<S>() -> impl Layer<S> + Send + Sync
@@ -396,7 +483,7 @@ impl TracingControl {
         }
     }
 
-    fn init_subscriber(filter: ReloadLayer, rate_limit_config: Option<TracingRateLimitConfig>) {
+    fn init_subscriber(filter: AtomicEnvFilter, rate_limit_config: Option<TracingRateLimitConfig>) {
         if let Err(e) = tracing_subscriber::registry()
             .with(filter)
             .with(Self::unthrottled_fmt_layer())
@@ -410,7 +497,8 @@ impl TracingControl {
 
     fn new(rate_limit_config: Option<TracingRateLimitConfig>) -> Self {
         let db = TargetCfgDb::new();
-        let (filter, reload_filter) = reload::Layer::new(db.env_filter());
+        let filter = AtomicEnvFilter::new(db.env_filter());
+        let reload_filter = filter.clone();
 
         Self::init_subscriber(filter, rate_limit_config);
 
@@ -419,7 +507,7 @@ impl TracingControl {
         }
         Self {
             db: Arc::new(Mutex::new(db)),
-            reload_filter: Arc::new(reload_filter),
+            reload_filter,
         }
     }
     /// This method should remain private and never be used other than from methods of `TracingControl`
@@ -428,10 +516,10 @@ impl TracingControl {
             .lock()
             .map_err(|e| TraceCtlError::LockFailure(e.to_string()))
     }
-    fn reload(&self, filter: EnvFilter) -> Result<(), TraceCtlError> {
-        self.reload_filter
-            .reload(filter)
-            .map_err(|e| TraceCtlError::ReloadFailure(e.to_string()))
+    /// Reload the active `EnvFilter`. Infallible: the `ArcSwap`-based handle
+    /// has no lock to poison and no subscriber-gone case.
+    fn reload(&self, filter: EnvFilter) {
+        self.reload_filter.reload(filter);
     }
     #[cfg(test)]
     fn register(
@@ -444,7 +532,7 @@ impl TracingControl {
     ) {
         let mut db = self.lock().unwrap();
         db.register(target, name, level, tags, custom);
-        self.reload(db.env_filter()).unwrap();
+        self.reload(db.env_filter());
     }
 }
 
@@ -483,7 +571,7 @@ impl TracingControl {
         let mut db = self.lock()?;
         let changed = db.set_tag_level(tag, level)?;
         if changed > 0 {
-            self.reload(db.env_filter())?;
+            self.reload(db.env_filter());
         }
         info!("Changed log level for tag '{tag}' to {level}. Targets changed: {changed}");
         Ok(())
@@ -493,7 +581,7 @@ impl TracingControl {
         if db.default != level {
             info!("Changing default log-level from {} to {level}", db.default);
             db.default = level;
-            self.reload(db.env_filter())?;
+            self.reload(db.env_filter());
         }
         Ok(())
     }
@@ -577,9 +665,7 @@ impl TracingControl {
         let mut db = self.lock()?;
         let changed = db.reconfigure(default, tag_config, resolver);
         if changed > 0 {
-            self.reload_filter
-                .reload(db.env_filter())
-                .map_err(|e| TraceCtlError::ReloadFailure(e.to_string()))?;
+            self.reload(db.env_filter());
         }
         Ok(())
     }
@@ -683,7 +769,6 @@ mod tests {
         println!("{}", tctl.as_string().unwrap());
         println!("{}", tctl.as_string_by_tag().unwrap());
 
-        assert_eq!(check_level!(TARGET_1), LevelFilter::TRACE);
         assert_eq!(check_level!(TARGET_2), LevelFilter::DEBUG);
         assert_eq!(check_level!(TARGET_3), LevelFilter::INFO);
 
@@ -949,7 +1034,6 @@ mod tests {
                 (T1, LevelFilter::OFF),
                 (T2, LevelFilter::DEBUG),
                 (T3, LevelFilter::ERROR),
-                (Y2, LevelFilter::TRACE),
                 (Y3, LevelFilter::OFF),
             ]
             .into_iter(),
@@ -957,7 +1041,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(check_level!(Y1), LevelFilter::ERROR);
-        assert_eq!(check_level!(Y2), LevelFilter::TRACE);
         assert_eq!(check_level!(Y3), LevelFilter::OFF);
         assert_eq!(check_level!(Y4), LevelFilter::DEBUG);
 

--- a/tracectl/src/lib.rs
+++ b/tracectl/src/lib.rs
@@ -13,5 +13,5 @@ pub mod targets;
 // re-exports
 pub use control::DEFAULT_DEFAULT_LOGLEVEL;
 pub use control::get_trace_ctl;
-pub use control::{TraceCtlError, TracingControl};
+pub use control::{TraceCtlError, TracingControl, TracingRateLimitConfig};
 pub use tracing_subscriber::filter::LevelFilter;


### PR DESCRIPTION
Move to own atomic operations for per-level filter for callsites. Reloading of interest is done via ArcSwap rather then RwLock

Layered structure of throtteled/unthrotteled filters produces atomic reloading of `Interest` for each callsite. `Layered<EnvFilter>::enable()` invokes every time on each of tracing message, but `tracing_subscriber::reload` path that was previously used to check atomic state spawned `RwLock::read_contended ` on each of such calls.
Pyroscope flame graph analysis showed that those operations were causing extreme cost of CPU operations.

Proposed solution is to use `ArcSwap` and precisely update callsite Interest for each of the `Layer`