### PR TITLE
Support overlapping prefixes in expose blocks

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -34,7 +34,7 @@ tracectl = { workspace = true }
 [dev-dependencies]
 # internal
 pipeline = { workspace = true } # should be removed w/ NAT
-lpm = { workspace = true, features = ["testing"] }
+lpm = { workspace = true, features = ["bolero", "testing"] }
 k8s-intf = { workspace = true, features = ["bolero"] }
 
 # external

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -151,6 +151,18 @@ pub mod test {
             .unwrap();
         assert!(expose.validate().is_ok());
 
+        // Overlapping prefixes
+        let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
+            .ip("10.0.0.0/16".into())
+            .ip("10.0.0.0/17".into())
+            .as_range("2.0.0.0/17".into())
+            .unwrap()
+            .as_range("2.0.0.0/16".into())
+            .unwrap();
+        assert!(expose.validate().is_ok());
+
         // Out-of-range exclusion prefix
         let expose = VpcExpose::empty()
             .make_stateful_nat(None)
@@ -203,24 +215,6 @@ pub mod test {
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
-        );
-
-        // Incorrect: prefix overlapping
-        let expose = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip("10.0.0.0/16".into())
-            .ip("10.0.0.0/17".into())
-            .as_range("2.0.0.0/16".into())
-            .unwrap()
-            .as_range("3.0.0.0/17".into())
-            .unwrap();
-        assert_eq!(
-            expose.validate(),
-            Err(ConfigError::OverlappingPrefixes(
-                "10.0.0.0/16".into(),
-                "10.0.0.0/17".into(),
-            ))
         );
 
         // Incorrect: all prefixes excluded
@@ -787,6 +781,30 @@ pub mod test {
             ));
         assert!(expose.validate().is_ok());
 
+        // Overlapping prefixes
+        let expose = VpcExpose::empty()
+            .make_stateless_nat()
+            .unwrap()
+            .ip(PrefixWithOptionalPorts::new(
+                "10.0.0.0/16".into(),
+                Some(PortRange::new(5001, 6000).unwrap()),
+            ))
+            .ip(PrefixWithOptionalPorts::new(
+                "10.0.0.0/17".into(),
+                Some(PortRange::new(5001, 5500).unwrap()),
+            ))
+            .as_range(PrefixWithOptionalPorts::new(
+                "2.0.0.0/16".into(),
+                Some(PortRange::new(8001, 9000).unwrap()),
+            ))
+            .unwrap()
+            .as_range(PrefixWithOptionalPorts::new(
+                "2.0.0.0/17".into(),
+                Some(PortRange::new(8001, 8500).unwrap()),
+            ))
+            .unwrap();
+        assert!(expose.validate().is_ok());
+
         // Out-of-range exclusion prefix (IPs)
         let expose = VpcExpose::empty()
             .ip(PrefixWithOptionalPorts::new(
@@ -870,42 +888,6 @@ pub mod test {
         assert_eq!(
             expose.validate(),
             Err(ConfigError::InconsistentIpVersion(Box::new(expose.clone())))
-        );
-
-        // Incorrect: prefix overlapping
-        let expose = VpcExpose::empty()
-            .make_stateless_nat()
-            .unwrap()
-            .ip(PrefixWithOptionalPorts::new(
-                "10.0.0.0/16".into(),
-                Some(PortRange::new(5001, 6000).unwrap()),
-            ))
-            .ip(PrefixWithOptionalPorts::new(
-                "10.0.0.0/17".into(),
-                Some(PortRange::new(5001, 5500).unwrap()),
-            ))
-            .as_range(PrefixWithOptionalPorts::new(
-                "2.0.0.0/16".into(),
-                Some(PortRange::new(8001, 9000).unwrap()),
-            ))
-            .unwrap()
-            .as_range(PrefixWithOptionalPorts::new(
-                "3.0.0.0/17".into(),
-                Some(PortRange::new(8001, 8500).unwrap()),
-            ))
-            .unwrap();
-        assert_eq!(
-            expose.validate(),
-            Err(ConfigError::OverlappingPrefixes(
-                PrefixWithOptionalPorts::new(
-                    "10.0.0.0/16".into(),
-                    Some(PortRange::new(5001, 6000).unwrap())
-                ),
-                PrefixWithOptionalPorts::new(
-                    "10.0.0.0/17".into(),
-                    Some(PortRange::new(5001, 5500).unwrap())
-                ),
-            ))
         );
 
         // Incorrect: all prefixes excluded

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -292,19 +292,32 @@ impl VpcExpose {
             ));
         }
 
-        // Static NAT: Check that all prefixes in a list are of the same IP version, as we don't
-        // support NAT46 or NAT64 at the moment.
-        //
-        // TODO: We can loosen this restriction in the future. When we do, some additional
-        //       considerations might be required to validate independently the IPv4 and the IPv6
-        //       prefixes and exclusion prefixes in the rest of this function.
-        let mut is_ipv4_opt = None;
         let prefix_sets = [
             &self.ips,
             &self.nots,
             self.as_range_or_empty(),
             self.not_as_or_empty(),
         ];
+
+        // Check that all prefixes in a list are of the same IP version, as we don't support NAT46
+        // or NAT64 at the moment.
+        //
+        // TODO: We can loosen this restriction in the future. When we do, some additional
+        //       considerations might be required to validate independently the IPv4 and the IPv6
+        //       prefixes and exclusion prefixes in the rest of this function.
+        let mut is_ipv4_opt = None;
+        for prefixes in prefix_sets {
+            if prefixes.iter().any(|p| {
+                if let Some(is_ipv4) = is_ipv4_opt {
+                    p.prefix().is_ipv4() != is_ipv4
+                } else {
+                    is_ipv4_opt = Some(p.prefix().is_ipv4());
+                    false
+                }
+            }) {
+                return Err(ConfigError::InconsistentIpVersion(Box::new(self.clone())));
+            }
+        }
 
         // Port 0 is not allowed in the exposed ranges. We do not check the excluded ranges here,
         // as they are only used to remove prefixes/ports from the effective configuration.
@@ -317,19 +330,6 @@ impl VpcExpose {
                         "Port 0 is not allowed in expose prefix port ranges",
                     ));
                 }
-            }
-        }
-
-        for prefixes in prefix_sets {
-            if prefixes.iter().any(|p| {
-                if let Some(is_ipv4) = is_ipv4_opt {
-                    p.prefix().is_ipv4() != is_ipv4
-                } else {
-                    is_ipv4_opt = Some(p.prefix().is_ipv4());
-                    false
-                }
-            }) {
-                return Err(ConfigError::InconsistentIpVersion(Box::new(self.clone())));
             }
         }
 

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -9,7 +9,6 @@ use crate::utils::{
 };
 use lpm::prefix::{IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
 use std::collections::BTreeMap;
-use std::ops::Bound::{Excluded, Unbounded};
 use std::time::Duration;
 use tracing::warn;
 
@@ -330,23 +329,6 @@ impl VpcExpose {
                     return Err(ConfigError::Forbidden(
                         "Port 0 is not allowed in expose prefix port ranges",
                     ));
-                }
-            }
-        }
-
-        // Check that items in prefix lists of each kind don't overlap
-        for prefixes in prefix_sets {
-            for prefix_with_ports in prefixes {
-                // Loop over the remaining prefixes in the tree
-                for other_prefix in prefixes.range((Excluded(prefix_with_ports), Unbounded)) {
-                    if prefix_with_ports.overlaps(other_prefix)
-                        || other_prefix.overlaps(prefix_with_ports)
-                    {
-                        return Err(ConfigError::OverlappingPrefixes(
-                            *prefix_with_ports,
-                            *other_prefix,
-                        ));
-                    }
                 }
             }
         }

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -5,7 +5,7 @@
 
 use crate::utils::{
     check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, collapse_prefixes,
-    merge_overlapping_prefixes,
+    merge_contiguous_prefixes, merge_overlapping_prefixes,
 };
 use lpm::prefix::{IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
 use std::collections::BTreeMap;
@@ -369,8 +369,10 @@ impl VpcExpose {
         let mut clone = self.clone();
         collapse_prefixes(&mut clone);
         merge_overlapping_prefixes(&mut clone.ips);
+        merge_contiguous_prefixes(&mut clone.ips);
         if let Some(nat) = &mut clone.nat {
             merge_overlapping_prefixes(&mut nat.as_range);
+            merge_contiguous_prefixes(&mut nat.as_range);
         }
         let collapsed_expose = ValidatedExpose {
             default: clone.default,

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -5,6 +5,7 @@
 
 use crate::utils::{
     check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, collapse_prefixes,
+    merge_overlapping_prefixes,
 };
 use lpm::prefix::{IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
 use std::collections::BTreeMap;
@@ -367,6 +368,10 @@ impl VpcExpose {
         // Apply exclusion prefixes
         let mut clone = self.clone();
         collapse_prefixes(&mut clone);
+        merge_overlapping_prefixes(&mut clone.ips);
+        if let Some(nat) = &mut clone.nat {
+            merge_overlapping_prefixes(&mut nat.as_range);
+        }
         let collapsed_expose = ValidatedExpose {
             default: clone.default,
             ips: clone.ips,

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -292,13 +292,6 @@ impl VpcExpose {
             ));
         }
 
-        let prefix_sets = [
-            &self.ips,
-            &self.nots,
-            self.as_range_or_empty(),
-            self.not_as_or_empty(),
-        ];
-
         // Check that all prefixes in a list are of the same IP version, as we don't support NAT46
         // or NAT64 at the moment.
         //
@@ -306,7 +299,12 @@ impl VpcExpose {
         //       considerations might be required to validate independently the IPv4 and the IPv6
         //       prefixes and exclusion prefixes in the rest of this function.
         let mut is_ipv4_opt = None;
-        for prefixes in prefix_sets {
+        for prefixes in [
+            &self.ips,
+            &self.nots,
+            self.as_range_or_empty(),
+            self.not_as_or_empty(),
+        ] {
             if prefixes.iter().any(|p| {
                 if let Some(is_ipv4) = is_ipv4_opt {
                     p.prefix().is_ipv4() != is_ipv4
@@ -335,8 +333,8 @@ impl VpcExpose {
 
         // Warn if any exclusion prefix does not overlap with any allowed prefix.
         for (prefixes, excludes) in [
-            (prefix_sets[0], prefix_sets[1]),
-            (prefix_sets[2], prefix_sets[3]),
+            (&self.ips, &self.nots),
+            (self.as_range_or_empty(), self.not_as_or_empty()),
         ] {
             for exclude in excludes {
                 if !prefixes.iter().any(|p| p.overlaps(exclude)) {

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -7,7 +7,10 @@ mod collapse;
 mod overlap;
 
 pub(crate) use collapse::collapse_prefixes;
-pub(crate) use overlap::{check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap};
+pub(crate) use overlap::{
+    check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap,
+    merge_overlapping_prefixes,
+};
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum ConfigUtilError {

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -9,7 +9,7 @@ mod overlap;
 pub(crate) use collapse::collapse_prefixes;
 pub(crate) use overlap::{
     check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap,
-    merge_overlapping_prefixes,
+    merge_contiguous_prefixes, merge_overlapping_prefixes,
 };
 
 #[derive(thiserror::Error, Debug, Clone)]

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -3,7 +3,7 @@
 
 use crate::ConfigError;
 use crate::external::overlay::vpcpeering::ValidatedExpose;
-use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet};
+use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet, PrefixWithOptionalPorts};
 
 pub fn check_private_prefixes_dont_overlap(
     expose_left: &ValidatedExpose,
@@ -62,4 +62,25 @@ fn check_prefixes_dont_overlap(
         }
     }
     Ok(())
+}
+
+pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
+    let mut prefixes_to_merge = prefixes
+        .iter()
+        .copied()
+        .collect::<Vec<PrefixWithOptionalPorts>>();
+    let mut merged_prefixes = PrefixPortsSet::default();
+
+    'next_prefix: while let Some(prefix_left) = prefixes_to_merge.pop() {
+        for prefix_right in &prefixes_to_merge {
+            if prefix_left.overlaps(prefix_right) {
+                let fragments_left = prefix_left.subtract(prefix_right);
+                prefixes_to_merge.extend(fragments_left);
+                continue 'next_prefix;
+            }
+        }
+        merged_prefixes.insert(prefix_left);
+    }
+
+    *prefixes = merged_prefixes;
 }

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -131,6 +131,198 @@ pub fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
 }
 
 #[cfg(test)]
+mod tests {
+    use super::*;
+    use lpm::prefix::PortRange;
+
+    #[test]
+    fn test_merge_contiguous_prefixes_simple() {
+        let mut prefixes = PrefixPortsSet::from([
+            PrefixWithOptionalPorts::new("192.168.0.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.1.0/24".parse().unwrap(), None),
+        ]);
+        merge_contiguous_prefixes(&mut prefixes);
+        assert_eq!(prefixes.len(), 1, "{prefixes:?}");
+        assert_eq!(
+            prefixes.iter().next().unwrap(),
+            &PrefixWithOptionalPorts::new("192.168.0.0/23".parse().unwrap(), None)
+        );
+    }
+
+    #[test]
+    fn test_merge_contiguous_prefixes_complex() {
+        let mut prefixes = PrefixPortsSet::from([
+            PrefixWithOptionalPorts::new("192.168.0.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.2.0/23".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.8.0/21".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.5.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.1.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.6.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.7.0/24".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new("192.168.4.0/24".parse().unwrap(), None),
+        ]);
+        merge_contiguous_prefixes(&mut prefixes);
+        assert_eq!(prefixes.len(), 1, "{prefixes:?}");
+        assert_eq!(
+            prefixes.iter().next().unwrap(),
+            &PrefixWithOptionalPorts::new("192.168.0.0/20".parse().unwrap(), None)
+        );
+    }
+
+    #[test]
+    fn test_merge_contiguous_port_ranges() {
+        let mut prefixes = PrefixPortsSet::from([
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 80).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(81, 100).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(1, 79).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(101, 180).unwrap()),
+            ),
+        ]);
+        merge_contiguous_prefixes(&mut prefixes);
+        assert_eq!(prefixes.len(), 1, "{prefixes:?}");
+        assert_eq!(
+            prefixes.iter().next().unwrap(),
+            &PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(1, 180).unwrap())
+            )
+        );
+    }
+
+    #[test]
+    fn test_merge_contiguous_prefixes_and_ports() {
+        let mut prefixes = PrefixPortsSet::from([
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 100).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.1.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 100).unwrap()),
+            ), // merges with 192.168.0.0/24, 80-100 to do 192.168.0.0/23, 80-100
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/23".parse().unwrap(),
+                Some(PortRange::new(101, 200).unwrap()),
+            ), // merges with 192.168.0.0/23, 80-100 to do 192.168.0.0/23, 101-200
+            PrefixWithOptionalPorts::new(
+                "192.168.2.0/23".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ), // merges with 192.168.0.0/23, 80-200 to do 192.168.0.0/22, 80-200
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 80).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/24".parse().unwrap(),
+                Some(PortRange::new(81, 110).unwrap()),
+            ), // merges with 192.168.4.0/24, 80-80 to do 192.168.4.0/24, 80-110
+            PrefixWithOptionalPorts::new(
+                "192.168.5.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 110).unwrap()),
+            ), // merges with 192.168.4.0/24, 80-110 to do 192.168.4.0/23, 80-110
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/23".parse().unwrap(),
+                Some(PortRange::new(110, 200).unwrap()),
+            ), // merges with 192.168.4.0/23, 80-110 to do 192.168.4.0/23, 80-200
+            PrefixWithOptionalPorts::new(
+                "192.168.6.0/23".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ), // merges with 192.168.4.0/23, 80-200 to do 192.168.4.0/22, 80-200;
+            // then merges with 192.168.0.0/22, 80-200 to do 192.168.0.0/21, 80-200
+            PrefixWithOptionalPorts::new(
+                "192.168.8.0/21".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ), // merges with 192.168.0.0/21, 80-200 to do 192.168.0.0/20, 80-200
+        ]);
+        merge_contiguous_prefixes(&mut prefixes);
+        assert_eq!(prefixes.len(), 1, "{prefixes:?}");
+        assert_eq!(
+            prefixes.iter().next().unwrap(),
+            &PrefixWithOptionalPorts::new(
+                "192.168.0.0/20".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap())
+            )
+        );
+    }
+
+    #[test]
+    fn test_merge_contiguous_prefixes_full_mix() {
+        let mut prefixes = PrefixPortsSet::from([
+            // Same prefixes and ports as in test_merge_contiguous_prefixes_and_ports(), with a
+            // different order, and the addition of more prefixes to cover all ports, plus more
+            // prefixes without associated port ranges.
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/20".parse().unwrap(),
+                Some(PortRange::new(0, 79).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 100).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.1.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 100).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new("192.168.16.0/21".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 80).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/23".parse().unwrap(),
+                Some(PortRange::new(101, 200).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.2.0/23".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/24".parse().unwrap(),
+                Some(PortRange::new(81, 110).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.5.0/24".parse().unwrap(),
+                Some(PortRange::new(80, 110).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.6.0/23".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new("192.168.24.0/21".parse().unwrap(), None),
+            PrefixWithOptionalPorts::new(
+                "192.168.8.0/21".parse().unwrap(),
+                Some(PortRange::new(80, 200).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.4.0/23".parse().unwrap(),
+                Some(PortRange::new(110, 200).unwrap()),
+            ),
+            PrefixWithOptionalPorts::new(
+                "192.168.0.0/20".parse().unwrap(),
+                Some(PortRange::new(201, u16::MAX).unwrap()),
+            ),
+        ]);
+        merge_contiguous_prefixes(&mut prefixes);
+        assert_eq!(prefixes.len(), 1, "{prefixes:?}");
+        assert_eq!(
+            prefixes.iter().next().unwrap(),
+            &PrefixWithOptionalPorts::new("192.168.0.0/19".parse().unwrap(), None)
+        );
+    }
+}
+
+#[cfg(test)]
 mod bolero_tests {
     use super::*;
     use std::ops::Bound::{Excluded, Unbounded};

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -113,7 +113,8 @@ pub fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
                 continue 'next_prefix;
             }
         }
-        merged_prefixes.insert(prefix_left);
+        // Also "simplify" the prefix before inserting: remove the associated port range if relevant
+        merged_prefixes.insert(prefix_left.simplify());
     }
     *prefixes = merged_prefixes;
 

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -84,3 +84,24 @@ pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
 
     *prefixes = merged_prefixes;
 }
+
+#[cfg(test)]
+mod bolero_tests {
+    use super::*;
+    use std::ops::Bound::{Excluded, Unbounded};
+
+    #[test]
+    fn test_merge_overlapping_prefixes() {
+        bolero::check!()
+            .with_type()
+            .for_each(|set: &PrefixPortsSet| {
+                let mut set_clone = set.clone();
+                merge_overlapping_prefixes(&mut set_clone);
+                for prefix_left in &set_clone {
+                    for prefix_right in set_clone.range((Excluded(prefix_left), Unbounded)) {
+                        assert!(!prefix_left.overlaps(prefix_right));
+                    }
+                }
+            });
+    }
+}

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -65,10 +65,7 @@ fn check_prefixes_dont_overlap(
 }
 
 pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
-    let mut prefixes_to_merge = prefixes
-        .iter()
-        .copied()
-        .collect::<Vec<PrefixWithOptionalPorts>>();
+    let mut prefixes_to_merge = prefixes.iter().copied().collect::<Vec<_>>();
     let mut merged_prefixes = PrefixPortsSet::default();
 
     'next_prefix: while let Some(prefix_left) = prefixes_to_merge.pop() {
@@ -83,6 +80,53 @@ pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
     }
 
     *prefixes = merged_prefixes;
+}
+
+pub fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
+    let mut uses_ports = false;
+    let mut did_merge = false;
+    let mut merged_prefixes = PrefixPortsSet::default();
+
+    // Sort the exclusion prefixes by length in ascending order (meaning a /16 comes before a /24).
+    // Then start processing from the end of the vector, so we can merge smaller prefixes (bigger
+    // mask lengths) together before trying to merge the results into larger ones.
+    let mut sorted_prefixes = prefixes.iter().copied().collect::<Vec<_>>();
+    sorted_prefixes.sort_by_key(|p| p.prefix().length());
+
+    'next_prefix: while let Some(prefix_left) = sorted_prefixes.pop() {
+        if matches!(prefix_left, PrefixWithOptionalPorts::PrefixPorts(_)) {
+            uses_ports = true;
+        }
+        for (index_right, prefix_right) in sorted_prefixes.iter().enumerate() {
+            if let Some(merged_prefix) = prefix_left.merge(prefix_right) {
+                did_merge = true;
+                sorted_prefixes.remove(index_right);
+                // Get the new index based on the new prefix length, so we can re-insert it and
+                // preserve the length order, to potentially merge this prefix again with one of the
+                // same size later - including prefixes we'll only create later by merging together
+                // other smaller prefixes.
+                let new_index = sorted_prefixes
+                    .iter()
+                    .position(|p| p.prefix().length() > merged_prefix.prefix().length())
+                    .unwrap_or(sorted_prefixes.len());
+                sorted_prefixes.insert(new_index, merged_prefix);
+                continue 'next_prefix;
+            }
+        }
+        merged_prefixes.insert(prefix_left);
+    }
+    *prefixes = merged_prefixes;
+
+    // If we merged any prefixes and we have prefixes with ports, then maybe we produced a set of
+    // prefixes that could now be merged again. Recursively call the function until no more merges
+    // are possible.
+    //
+    // If we don't use port ranges, then sorting the prefixes by length ensures that we merge
+    // prefixes from longest to shortest (/32 together then /31 together, etc.), so we process new
+    // "mergeable" pairs without needing another pass.
+    if uses_ports && did_merge {
+        merge_contiguous_prefixes(prefixes);
+    }
 }
 
 #[cfg(test)]

--- a/lpm/Cargo.toml
+++ b/lpm/Cargo.toml
@@ -6,7 +6,8 @@ publish.workspace = true
 version.workspace = true
 
 [features]
-testing = ["dep:bolero"]
+bolero = ["dep:bolero"]
+testing = []
 
 [dependencies]
 bnum = { workspace = true }

--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -59,6 +59,8 @@ pub trait IpPrefix: Debug + Clone + From<Self::Addr> + PartialEq {
 
     fn network(&self) -> Self::Addr;
 
+    fn parent(&self) -> Option<Self>;
+
     fn last_address(&self) -> Self::Addr;
 
     fn len(&self) -> u8;
@@ -164,6 +166,9 @@ impl IpPrefix for Ipv4Prefix {
 
     fn network(&self) -> Self::Addr {
         self.0.network()
+    }
+    fn parent(&self) -> Option<Self> {
+        self.0.supernet().map(Self)
     }
     fn last_address(&self) -> Self::Addr {
         self.0.broadcast()
@@ -292,6 +297,9 @@ impl IpPrefix for Ipv6Prefix {
     }
     fn network(&self) -> Self::Addr {
         self.0.network()
+    }
+    fn parent(&self) -> Option<Self> {
+        self.0.supernet().map(Self)
     }
     fn last_address(&self) -> Self::Addr {
         self.0.broadcast()

--- a/lpm/src/prefix/ip.rs
+++ b/lpm/src/prefix/ip.rs
@@ -371,7 +371,7 @@ impl TryFrom<Prefix> for Ipv6Prefix {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "bolero"))]
 mod contract {
     use crate::prefix::{IpPrefix, Ipv4Prefix, Ipv6Prefix};
     use bolero::{Driver, TypeGenerator};

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -132,6 +132,14 @@ impl Prefix {
         }
     }
 
+    #[must_use]
+    pub fn parent(&self) -> Option<Self> {
+        match *self {
+            Prefix::IPV4(p) => p.parent().map(Prefix::IPV4),
+            Prefix::IPV6(p) => p.parent().map(Prefix::IPV6),
+        }
+    }
+
     /// Get prefix length
     #[must_use]
     pub fn length(&self) -> u8 {
@@ -343,6 +351,13 @@ impl Prefix {
     ///     Some(prefix_v4("1.0.1.0/24"))
     /// );
     ///
+    /// let prefix1 = prefix_v4("1.0.1.128/25");
+    /// let prefix2 = prefix_v4("1.0.1.0/25");
+    /// assert_eq!(
+    ///     prefix1.merge(&prefix2),
+    ///     Some(prefix_v4("1.0.1.0/24"))
+    /// );
+    ///
     /// let prefix1 = prefix_v4("1.0.0.0/24");
     /// let prefix2 = prefix_v4("1.0.1.0/24");
     /// assert_eq!(
@@ -399,15 +414,9 @@ impl Prefix {
         debug_assert_ne!(self.length(), 0);
         debug_assert_ne!(other.length(), 0);
 
-        let parent = match self {
-            Prefix::IPV4(prefix) => {
-                Prefix::IPV4(Ipv4Prefix::new(prefix.network(), prefix.len() - 1).ok()?)
-            }
-            Prefix::IPV6(prefix) => {
-                Prefix::IPV6(Ipv6Prefix::new(prefix.network(), prefix.len() - 1).ok()?)
-            }
-        };
-        if parent.covers(other) {
+        if let Some(parent) = self.parent()
+            && parent.covers(other)
+        {
             // The immediate parent CIDR covers both distinct prefixes, so we're good
             Some(parent)
         } else {

--- a/lpm/src/prefix/mod.rs
+++ b/lpm/src/prefix/mod.rs
@@ -37,7 +37,7 @@ pub enum PrefixError {
 /// Since we will not store prefixes, putting Ipv6 on the same basket as IPv4 will not penalize the
 /// memory requirements of Ipv4
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(any(test, feature = "testing"), derive(bolero::TypeGenerator))]
+#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
 pub enum Prefix {
     IPV4(Ipv4Prefix),
     IPV6(Ipv6Prefix),

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -62,6 +62,7 @@ pub trait IpRangeWithPorts {
 
 /// A structure containing a prefix and a port range.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
 pub struct PrefixWithPorts {
     prefix: Prefix,
     ports: PortRange,
@@ -148,6 +149,7 @@ impl IpRangeWithPorts for PrefixWithPorts {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
 pub struct PrefixPortsSet(BTreeSet<PrefixWithOptionalPorts>);
 
 impl PrefixPortsSet {
@@ -232,6 +234,7 @@ impl std::ops::DerefMut for PrefixPortsSet {
 
 /// A structure containing a prefix and an optional port range.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
 pub enum PrefixWithOptionalPorts {
     Prefix(Prefix),
     PrefixPorts(PrefixWithPorts),
@@ -722,6 +725,20 @@ impl L4Protocol {
             (self_proto, L4Protocol::Any) => Some(*self_proto),
             (self_proto, other_proto) if self_proto == other_proto => Some(*self_proto),
             _ => None,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::PortRange;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for PortRange {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let start: u16 = driver.produce()?;
+            let end: u16 = driver.produce()?;
+            Some(PortRange::new(start.min(end), start.max(end)).unwrap_or_else(|_| unreachable!()))
         }
     }
 }

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -271,6 +271,19 @@ impl PrefixWithOptionalPorts {
             }
         }
     }
+
+    /// Change variant from `PrefixPorts` to `Prefix` if the port range is the full range.
+    #[must_use]
+    pub fn simplify(&self) -> Self {
+        match self {
+            PrefixWithOptionalPorts::PrefixPorts(prefix_with_ports)
+                if prefix_with_ports.ports().is_max_range() =>
+            {
+                PrefixWithOptionalPorts::Prefix(prefix_with_ports.prefix())
+            }
+            _ => *self,
+        }
+    }
 }
 
 impl IpRangeWithPorts for PrefixWithOptionalPorts {

--- a/nat/src/stateful/apalloc/test_alloc.rs
+++ b/nat/src/stateful/apalloc/test_alloc.rs
@@ -76,8 +76,7 @@ mod context {
             .make_stateful_nat(None)
             .unwrap()
             .ip("1.1.0.0/16".into())
-            .ip("1.2.0.0/16".into())
-            .ip("1.3.0.0/16".into())
+            .ip("1.2.0.0/15".into())
             .as_range("10.1.0.0/30".into())
             .unwrap()
             .not_as("10.1.0.3/32".into())
@@ -223,7 +222,7 @@ mod std_tests {
                 .keys()
                 .filter(|k| k.protocol == NextHeader::TCP)
                 .count(),
-            3
+            2
         );
         assert_eq!(
             allocator
@@ -232,7 +231,7 @@ mod std_tests {
                 .keys()
                 .filter(|k| k.protocol == NextHeader::UDP)
                 .count(),
-            3
+            2
         );
 
         assert_eq!(allocator.pools_src66.0.len(), 0);


### PR DESCRIPTION
Allow users to pass overlapping prefixes in expose blocks configuration, for example 10.0.0.0/23 and 10.0.1.0/24, rather than rejecting them at validation time.

Refer to individual commits for details.
