### PR TITLE
perf(miri): trim heavy tests so the miri job finishes in reasonable time

### DIFF
--- a/config/src/utils/collapse.rs
+++ b/config/src/utils/collapse.rs
@@ -548,10 +548,21 @@ mod tests {
 
     #[test]
     fn test_bolero_collapse_prefix_lists() {
-        let generator = PrefixExcludeAddrsGenerator {
-            prefix_max: 100,
-            exclude_max: 100,
-            addr_count: 1000,
+        let generator = cfg_select! {
+           miri => {
+               PrefixExcludeAddrsGenerator {
+                    prefix_max: 10,
+                    exclude_max: 10,
+                    addr_count: 100,
+                }
+           }
+           _ => {
+               PrefixExcludeAddrsGenerator {
+                    prefix_max: 100,
+                    exclude_max: 100,
+                    addr_count: 1000,
+                }
+           }
         };
         bolero::check!()
             .with_generator(generator)

--- a/miri.just
+++ b/miri.just
@@ -19,7 +19,7 @@ export schedule_seed := choose('5', "0123456789")
 export seeds := "1"
 export stacked_borrow_check := "disabled"
 export preemption_rate := "0.10"
-export weak_failure_rate := "0.15"
+export weak_failure_rate := "0.05"
 export randomize_struct_layout := "enabled"
 export layout_seed := `printf '%u' "$((16#$(git rev-parse HEAD)))"`
 

--- a/nat/src/stateless/test.rs
+++ b/nat/src/stateless/test.rs
@@ -606,7 +606,7 @@ fn check_packet(
     packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
     set_addresses_v4(&mut packet, orig_src_ip, orig_dst_ip);
 
-    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let packets_out: Vec<_> = nat.process([packet].into_iter()).collect();
     let hdr_out = packets_out[0]
         .try_ipv4()
         .expect("Failed to get IPv4 header");
@@ -616,12 +616,13 @@ fn check_packet(
 }
 
 #[test]
-#[traced_test]
+#[cfg_attr(not(miri), traced_test)]
 #[allow(clippy::too_many_lines)]
 fn test_full_config() {
     let config = build_sample_config();
 
     let nat_tables = build_nat_configuration(config.external().overlay().vpc_table()).unwrap();
+    #[cfg(not(miri))]
     println!("Nat tables: {:#?}", &nat_tables);
 
     let (mut nat, mut tablesw) = StatelessNat::new("stateless-nat");


### PR DESCRIPTION
Three independent miri-only adjustments collected for the per-CI-run budget. All are no-ops outside `cfg(miri)`:

* `config/src/utils/collapse.rs`: the bolero generator for `test_bolero_collapse_prefix_lists` shrinks from (prefix_max=100, exclude_max=100, addr_count=1000) to (10, 10, 100) under miri. Miri's borrow-stack cost on prefix-trie traversal is ~100-1000x; the algorithmic coverage is largely the same with the smaller shape.
* `nat/src/stateless/test.rs`: `test_full_config` was dominated by `#[traced_test]` subscriber dispatch (formatting, TLS atomics, layer walk, capture mutex) on per-packet `debug!` calls; hundreds of events per run, each disproportionately expensive under miri. Skip the subscriber install under miri, gate out the `println!` debug dump, and use `[packet]` rather than `vec![packet]` to drop one per-call allocation.
* `miri.just`: weak_failure_rate 0.15 -> 0.05. The 0.15 value was inflating miri's weak-memory failure injection beyond what the protocol invariants are tuned for; 0.05 still exercises the path and gives shuttle headroom for other interleavings.  We should still (sometimes) run with higher weak failure rates, but no need to burn endless resources on it.