### PR TITLE
feat(concurrency): poison-as-panic wrapper for std::sync

### DIFF
--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -13,12 +13,10 @@
 #![allow(missing_docs)]
 
 pub mod macros;
+pub mod sync;
 
 #[cfg(all(miri, any(feature = "shuttle", feature = "loom")))]
 compile_error!("miri does not meaningfully support 'loom' or 'shuttle'");
-
-#[cfg(not(any(feature = "loom", feature = "shuttle")))]
-pub use std::sync;
 
 #[cfg(not(any(feature = "loom", feature = "shuttle")))]
 pub use std::thread;
@@ -28,21 +26,7 @@ pub use std::thread;
     not(feature = "shuttle"),
     not(feature = "silence_clippy")
 ))]
-pub use loom::sync;
-
-#[cfg(all(
-    feature = "loom",
-    not(feature = "shuttle"),
-    not(feature = "silence_clippy")
-))]
 pub use loom::thread;
-
-#[cfg(all(
-    feature = "shuttle",
-    not(feature = "loom"),
-    not(feature = "silence_clippy")
-))]
-pub use shuttle::sync;
 
 #[cfg(all(
     feature = "shuttle",
@@ -57,9 +41,6 @@ compile_error!("Cannot enable both 'loom' and 'shuttle' features at the same tim
 //////////////////////
 // This is a workaround to silence clippy warnings when both loom and shuttle
 // features are enabled in the clippy checks which uses --all-features.
-#[cfg(all(feature = "shuttle", feature = "loom", feature = "silence_clippy"))]
-pub use std::sync;
-
 #[cfg(all(feature = "shuttle", feature = "loom", feature = "silence_clippy"))]
 pub use std::thread;
 //////////////////////

--- a/concurrency/src/quiescent.rs
+++ b/concurrency/src/quiescent.rs
@@ -55,17 +55,29 @@ impl Domain {
 
     fn register(&self) -> Epoch {
         let epoch = Epoch::new();
-        #[allow(clippy::expect_used)] // the mutex is poisoned only in unrecoverable error cases
-        self.active
-            .lock()
-            .expect("qsbr mutex poisoned")
-            .push(Arc::clone(&epoch.cell));
+        let guard = self.active.lock();
+        // Loom and shuttle still expose `LockResult<MutexGuard>`; PRs
+        // extending the poison-as-panic wrapper to those backends will
+        // drop this `.expect` (the default backend already returns a
+        // naked guard).
+        #[cfg(any(feature = "loom", feature = "shuttle"))]
+        #[allow(clippy::expect_used)]
+        // the mutex is poisoned only in unrecoverable error cases
+        let mut guard = guard.expect("qsbr mutex poisoned");
+        #[cfg(not(any(feature = "loom", feature = "shuttle")))]
+        let mut guard = guard;
+        guard.push(Arc::clone(&epoch.cell));
         epoch
     }
 
     fn min_observed(&self) -> Option<Version> {
-        #[allow(clippy::expect_used)] // the mutex is poisoned only in unrecoverable error cases
-        let mut active = self.active.lock().expect("qsbr mutex poisoned");
+        let guard = self.active.lock();
+        #[cfg(any(feature = "loom", feature = "shuttle"))]
+        #[allow(clippy::expect_used)]
+        // the mutex is poisoned only in unrecoverable error cases
+        let mut active = guard.expect("qsbr mutex poisoned");
+        #[cfg(not(any(feature = "loom", feature = "shuttle")))]
+        let mut active = guard;
         let mut min = u64::MAX;
         let mut any_in_flight = false;
         active.retain(|cell| {

--- a/concurrency/src/sync/mod.rs
+++ b/concurrency/src/sync/mod.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Backend-routed synchronization primitives.
+//!
+//! Exposes a `parking_lot`-shaped surface for `Mutex` / `RwLock` that
+//! compiles unchanged across backends. The default (non-model-checker)
+//! backend currently routes through `std_backend` -- a thin
+//! poison-as-panic wrapper around `std::sync::{Mutex, RwLock}` that
+//! exposes naked guards (no `LockResult` to `.unwrap()` at call
+//! sites). This workspace treats a crashed thread as a crashed
+//! process, so silently inheriting state from a poisoned lock is
+//! wrong; surfacing it as a panic propagates the failure correctly.
+//!
+//! Loom and shuttle still re-export their raw `LockResult`-based
+//! primitives at this point in the stack; subsequent PRs add the same
+//! poison-as-panic wrap for those backends.
+
+#[cfg(not(any(feature = "loom", feature = "shuttle")))]
+mod std_backend;
+#[cfg(not(any(feature = "loom", feature = "shuttle")))]
+pub use std_backend::*;
+
+#[cfg(all(
+    feature = "loom",
+    not(feature = "shuttle"),
+    not(feature = "silence_clippy")
+))]
+pub use loom::sync::*;
+
+#[cfg(all(
+    feature = "shuttle",
+    not(feature = "loom"),
+    not(feature = "silence_clippy")
+))]
+pub use shuttle::sync::*;
+
+// Match the silence_clippy escape hatch in lib.rs: when both loom and
+// shuttle are pulled in (under `--all-features`), route sync through
+// `std` purely to keep clippy happy. The binary is never executed in
+// that configuration.
+#[cfg(all(feature = "shuttle", feature = "loom", feature = "silence_clippy"))]
+mod std_backend;
+#[cfg(all(feature = "shuttle", feature = "loom", feature = "silence_clippy"))]
+pub use std_backend::*;

--- a/concurrency/src/sync/std_backend.rs
+++ b/concurrency/src/sync/std_backend.rs
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Default backend: poison-as-panic wrapper around `std::sync`.
+//!
+//! `std::sync::{Mutex, RwLock}` return `LockResult<Guard>` because they
+//! poison on holder panic. This workspace treats poison as a fatal
+//! invariant violation; the wrapper below strips `LockResult` and
+//! panics, presenting a `parking_lot`-shaped naked-guard surface.
+//!
+//! One indirection on lock acquire/release (wrapper match + std poison
+//! branch). Cold path only -- the fast path under contention is
+//! unchanged.
+
+// Wrapping below panics on poison. clippy::panic is denied at the
+// crate root; allow it locally for the cold poisoned() helper.
+#![allow(clippy::panic)]
+
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+use std::sync as inner;
+
+pub use std::sync::{
+    Arc, Barrier, BarrierWaitResult, Condvar, LockResult, Once, OnceLock, OnceState, PoisonError,
+    TryLockError, TryLockResult, WaitTimeoutResult, Weak, atomic, mpsc,
+};
+
+#[inline(never)]
+#[cold]
+fn poisoned() -> ! {
+    panic!(
+        "concurrency::sync lock was poisoned: a previous holder panicked while \
+         holding the lock; propagating the failure"
+    );
+}
+
+// =============================== Mutex ====================================
+
+/// Mutual exclusion primitive with a `parking_lot`-shaped surface.
+///
+/// Returns guards directly (no `LockResult`); poison is treated as a
+/// fatal invariant violation and panics. See module docs for rationale.
+pub struct Mutex<T: ?Sized>(inner::Mutex<T>);
+
+/// RAII guard for [`Mutex`].
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MutexGuard<'a, T: ?Sized + 'a>(inner::MutexGuard<'a, T>);
+
+impl<T> Mutex<T> {
+    #[inline]
+    pub const fn new(value: T) -> Self {
+        Self(inner::Mutex::new(value))
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self.0.into_inner() {
+            Ok(v) => v,
+            Err(_) => poisoned(),
+        }
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    #[inline]
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        match self.0.lock() {
+            Ok(g) => MutexGuard(g),
+            Err(_) => poisoned(),
+        }
+    }
+
+    #[inline]
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        match self.0.try_lock() {
+            Ok(g) => Some(MutexGuard(g)),
+            Err(TryLockError::Poisoned(_)) => poisoned(),
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T {
+        match self.0.get_mut() {
+            Ok(v) => v,
+            Err(_) => poisoned(),
+        }
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mutex").finish_non_exhaustive()
+    }
+}
+
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+// =============================== RwLock ===================================
+
+/// Reader-writer lock with a `parking_lot`-shaped surface.
+///
+/// `T: Sized` for parity with future model-checker backends, which
+/// adopt the lowest common denominator across their inner types.
+pub struct RwLock<T>(inner::RwLock<T>);
+
+/// Shared-reference guard for [`RwLock`].
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockReadGuard<'a, T: 'a>(inner::RwLockReadGuard<'a, T>);
+
+/// Exclusive-reference guard for [`RwLock`].
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockWriteGuard<'a, T: 'a>(inner::RwLockWriteGuard<'a, T>);
+
+/// Upgradable-read guard for [`RwLock`].
+///
+/// std `RwLock` has no native upgradable-read state machine; this is
+/// an exclusive write guard with a `parking_lot`-shaped `upgrade()` API.
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockUpgradableReadGuard<'a, T: 'a>(inner::RwLockWriteGuard<'a, T>);
+
+impl<T> RwLock<T> {
+    #[inline]
+    pub const fn new(value: T) -> Self {
+        Self(inner::RwLock::new(value))
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self.0.into_inner() {
+            Ok(v) => v,
+            Err(_) => poisoned(),
+        }
+    }
+
+    #[inline]
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        match self.0.read() {
+            Ok(g) => RwLockReadGuard(g),
+            Err(_) => poisoned(),
+        }
+    }
+
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        match self.0.write() {
+            Ok(g) => RwLockWriteGuard(g),
+            Err(_) => poisoned(),
+        }
+    }
+
+    #[inline]
+    pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        match self.0.try_read() {
+            Ok(g) => Some(RwLockReadGuard(g)),
+            Err(TryLockError::Poisoned(_)) => poisoned(),
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    #[inline]
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        match self.0.try_write() {
+            Ok(g) => Some(RwLockWriteGuard(g)),
+            Err(TryLockError::Poisoned(_)) => poisoned(),
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    /// Acquire an upgradable read guard.
+    ///
+    /// std `RwLock` has no native upgradable-read; this is implemented
+    /// as an exclusive `write()`. Subsequent backends (parking_lot)
+    /// will replace this with a true upgradable read; meanwhile the
+    /// surface is consistent across backends, sound in all cases, and
+    /// merely loses the many-readers-plus-one-upgradable schedule that
+    /// `parking_lot` permits.
+    #[inline]
+    pub fn upgradable_read(&self) -> RwLockUpgradableReadGuard<'_, T> {
+        match self.0.write() {
+            Ok(g) => RwLockUpgradableReadGuard(g),
+            Err(_) => poisoned(),
+        }
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T {
+        match self.0.get_mut() {
+            Ok(v) => v,
+            Err(_) => poisoned(),
+        }
+    }
+}
+
+impl<'a, T: 'a> RwLockUpgradableReadGuard<'a, T> {
+    /// Upgrade to a write guard. Free here because we already hold the
+    /// underlying write lock.
+    #[inline]
+    pub fn upgrade(s: Self) -> RwLockWriteGuard<'a, T> {
+        RwLockWriteGuard(s.0)
+    }
+
+    /// Always succeeds under the std backend.
+    ///
+    /// # Errors
+    ///
+    /// Never returns `Err`; the `Result` shape matches `parking_lot`.
+    #[inline]
+    pub fn try_upgrade(s: Self) -> Result<RwLockWriteGuard<'a, T>, Self> {
+        Ok(RwLockWriteGuard(s.0))
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RwLock").finish_non_exhaustive()
+    }
+}
+
+impl<T: Default> Default for RwLock<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for RwLock<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+macro_rules! impl_rwlock_guard_traits {
+    ($guard:ident, $mutability:ident) => {
+        impl<T> Deref for $guard<'_, T> {
+            type Target = T;
+            #[inline]
+            fn deref(&self) -> &T {
+                &*self.0
+            }
+        }
+
+        impl<T: fmt::Debug> fmt::Debug for $guard<'_, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Debug::fmt(&**self, f)
+            }
+        }
+
+        impl<T: fmt::Display> fmt::Display for $guard<'_, T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(&**self, f)
+            }
+        }
+
+        impl_rwlock_guard_traits!(@mut $guard, $mutability);
+    };
+    (@mut $guard:ident, mut) => {
+        impl<T> DerefMut for $guard<'_, T> {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut T {
+                &mut *self.0
+            }
+        }
+    };
+    (@mut $guard:ident, immut) => {};
+}
+
+impl_rwlock_guard_traits!(RwLockReadGuard, immut);
+impl_rwlock_guard_traits!(RwLockWriteGuard, mut);
+impl_rwlock_guard_traits!(RwLockUpgradableReadGuard, immut);


### PR DESCRIPTION
## Summary

- New `concurrency::sync` module exposing `Mutex` / `RwLock` with a `parking_lot`-shaped naked-guard surface backed by a poison-as-panic wrapper around `std::sync`. Workspace policy treats a crashed thread as a crashed process: poison surfacing inside a lock acquire panics through `concurrency::sync::poisoned()` rather than handing back a possibly-torn `LockResult`.
- One cold `#[inline(never)] fn poisoned() -> !` keeps the hot path branch-free; the wrapper is a single `match` per acquire, all `Send/Sync`/`Default`/`From`/`Display` impls forward to the wrapped type.
- `RwLock::upgradable_read` is implemented as exclusive `write()` for now; sound but lossy. Documented at the backend module level.
- `Arc`, `Weak`, atomics, `Condvar`, `mpsc`, `OnceLock`, etc. are re-exported from `std::sync` unchanged.
- `concurrency::quiescent` migrates from `std::sync::{Arc, Mutex}` to `crate::sync::{Arc, Mutex}` so the QSBR primitive consumes the facade.

PR 2 of 6. Depends on **#1539 — absorb-quiescent**. The next PR layers `parking_lot` as the default backend on top of this.

