### PR TITLE
(3) fix: fixup for glibc-ism

### DIFF
--- a/nix/pkgs/dplane-plugin/default.nix
+++ b/nix/pkgs/dplane-plugin/default.nix
@@ -20,15 +20,6 @@ stdenv.mkDerivation (finalAttrs: {
   version = sources.dplane-plugin.revision;
   src = sources.dplane-plugin.outPath;
 
-  # workaround: src/hh_dp_msg.c reaches into a glibc-internal anonymous
-  # union name (`.__in6_u.__u6_addr8`) on struct in6_addr.  musl exposes
-  # the POSIX-standard `.s6_addr` member directly without that wrapping
-  # union, so the access fails to compile.
-  # remove once fixed upstream in githedgehog/dplane-plugin.
-  postPatch = ''
-    sed -i 's/\.__in6_u\.__u6_addr8/.s6_addr/g' src/hh_dp_msg.c
-  '';
-
   doCheck = false;
   doFixup = false;
   enableParallelBuilding = true;

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -54,9 +54,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "ef3e718651d59fd4da5787a9c05e06a594c0136c",
-      "url": "https://github.com/githedgehog/dplane-plugin/archive/ef3e718651d59fd4da5787a9c05e06a594c0136c.tar.gz",
-      "hash": "sha256-CRsHKk50XnV23uVJxjN9ZtsIFH/BwZYlW27UL4V0D6E="
+      "revision": "f3517e68ef53955f107993b45c64222576e2e42d",
+      "url": "https://github.com/githedgehog/dplane-plugin/archive/f3517e68ef53955f107993b45c64222576e2e42d.tar.gz",
+      "hash": "sha256-C5Hn5L7TVwmh4q4EGKHs5fxx6DX9lTqSGHfQTz6lVuM="
     },
     "dplane-rpc": {
       "type": "Git",


### PR DESCRIPTION
Remove hack to protect us from glibc specific impl now that upstream has patched