### PR TITLE
(8) feat(dpdk): test EAL harness (with_eal macro + const fn)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-lookup"
+version = "0.21.0"
+
+[[package]]
 name = "dataplane-lpm"
 version = "0.21.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ name = "dataplane-match-action"
 version = "0.21.0"
 dependencies = [
  "arrayvec",
+ "bolero",
  "dataplane-fixed-size",
  "dataplane-match-action-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-fixed-size"
+version = "0.21.0"
+
+[[package]]
 name = "dataplane-flow-entry"
 version = "0.21.0"
 dependencies = [
@@ -1563,6 +1567,7 @@ dependencies = [
  "bytecheck",
  "dataplane-common",
  "dataplane-concurrency",
+ "dataplane-fixed-size",
  "dataplane-id",
  "derive_builder",
  "downcast-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-match-action"
+version = "0.21.0"
+dependencies = [
+ "arrayvec",
+ "dataplane-fixed-size",
+ "dataplane-match-action-derive",
+]
+
+[[package]]
+name = "dataplane-match-action-derive"
+version = "0.21.0"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dataplane-mgmt"
 version = "0.21.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,8 +1243,10 @@ version = "0.21.0"
 dependencies = [
  "bolero",
  "dataplane-concurrency",
+ "dataplane-dpdk",
  "dataplane-dpdk-sys",
  "dataplane-dpdk-sysroot-helper",
+ "dataplane-dpdk-test-macros",
  "dataplane-errno",
  "dataplane-id",
  "dataplane-net",
@@ -1266,6 +1268,16 @@ dependencies = [
 [[package]]
 name = "dataplane-dpdk-sysroot-helper"
 version = "0.21.0"
+
+[[package]]
+name = "dataplane-dpdk-test-macros"
+version = "0.21.0"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dataplane-errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "dpdk",
     "dpdk-sys",
     "dpdk-sysroot-helper",
+    "dpdk-test-macros",
     "errno",
     "flow-entry",
     "flow-filter",
@@ -68,6 +69,7 @@ config = { path = "./config", package = "dataplane-config", features = [] }
 dpdk = { path = "./dpdk", package = "dataplane-dpdk", features = [] }
 dpdk-sys = { path = "./dpdk-sys", package = "dataplane-dpdk-sys", features = [] }
 dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpdk-sysroot-helper", features = [] }
+dpdk-test-macros = { path = "./dpdk-test-macros", package = "dataplane-dpdk-test-macros", features = [] }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", branch = "pr/daniel-noland/bumps", features = [] }
 errno = { path = "./errno", package = "dataplane-errno", features = [] }
 flow-entry = { path = "./flow-entry", package = "dataplane-flow-entry", features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "dpdk-sysroot-helper",
     "dpdk-test-macros",
     "errno",
+    "fixed-size",
     "flow-entry",
     "flow-filter",
     "hardware",
@@ -72,6 +73,7 @@ dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpd
 dpdk-test-macros = { path = "./dpdk-test-macros", package = "dataplane-dpdk-test-macros", features = [] }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", branch = "pr/daniel-noland/bumps", features = [] }
 errno = { path = "./errno", package = "dataplane-errno", features = [] }
+fixed-size = { path = "./fixed-size", package = "dataplane-fixed-size", features = [] }
 flow-entry = { path = "./flow-entry", package = "dataplane-flow-entry", features = [] }
 flow-filter = { path = "./flow-filter", package = "dataplane-flow-filter", features = [] }
 hardware = { path = "./hardware", package = "dataplane-hardware", features = [] }
@@ -282,6 +284,11 @@ wasm = false # hopeless + pointless
 package = "dataplane-dpdk-sys"
 miri = false # hopeless + pointless
 wasm = false # hopeless + pointless
+
+[workspace.metadata.package.fixed-size]
+package = "dataplane-fixed-size"
+miri = true
+wasm = true
 
 [workspace.metadata.package.flow-entry]
 package = "dataplane-flow-entry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "lifecycle",
     "lookup",
     "lpm",
+    "match-action",
+    "match-action-derive",
     "mgmt",
     "nat",
     "net",
@@ -87,6 +89,8 @@ left-right-tlcache = { path = "./left-right-tlcache", package = "dataplane-left-
 lifecycle = { path = "./lifecycle", package = "dataplane-lifecycle", features = [] }
 lookup = { path = "./lookup", package = "dataplane-lookup", features = [] }
 lpm = { path = "./lpm", package = "dataplane-lpm", features = [] }
+match-action = { path = "./match-action", package = "dataplane-match-action", features = [] }
+match-action-derive = { path = "./match-action-derive", package = "dataplane-match-action-derive", features = [] }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt", features = [] }
 nat = { path = "./nat", package = "dataplane-nat", features = [] }
 net = { path = "./net", package = "dataplane-net", features = [] }
@@ -331,6 +335,18 @@ wasm = false # split
 package = "dataplane-lookup"
 miri = true
 wasm = false # split (std collections)
+
+[workspace.metadata.package.match-action]
+package = "dataplane-match-action"
+miri = true
+wasm = true
+
+[workspace.metadata.package.match-action-derive]
+package = "dataplane-match-action-derive"
+# Proc-macro crate: runs at the host toolchain, not the miri target.
+# Excluded from miri to keep the target dep graph clean.
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
 
 [workspace.metadata.package.mgmt]
 package = "dataplane-mgmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "k8s-less",
     "left-right-tlcache",
     "lifecycle",
+    "lookup",
     "lpm",
     "mgmt",
     "nat",
@@ -84,6 +85,7 @@ k8s-intf = { path = "./k8s-intf", package = "dataplane-k8s-intf", default-featur
 k8s-less = { path = "./k8s-less", package = "dataplane-k8s-less", features = [] }
 left-right-tlcache = { path = "./left-right-tlcache", package = "dataplane-left-right-tlcache", features = [] }
 lifecycle = { path = "./lifecycle", package = "dataplane-lifecycle", features = [] }
+lookup = { path = "./lookup", package = "dataplane-lookup", features = [] }
 lpm = { path = "./lpm", package = "dataplane-lpm", features = [] }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt", features = [] }
 nat = { path = "./nat", package = "dataplane-nat", features = [] }
@@ -324,6 +326,11 @@ wasm = false # split
 package = "dataplane-k8s-less"
 miri = true
 wasm = false # split
+
+[workspace.metadata.package.lookup]
+package = "dataplane-lookup"
+miri = true
+wasm = false # split (std collections)
 
 [workspace.metadata.package.mgmt]
 package = "dataplane-mgmt"

--- a/dpdk-test-macros/Cargo.toml
+++ b/dpdk-test-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dataplane-dpdk-test-macros"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-crate = { workspace = true, default-features = true }
+proc-macro2 = { workspace = true, default-features = true }
+quote = { workspace = true, default-features = true }
+syn = { workspace = true, default-features = true, features = ["full"] }

--- a/dpdk-test-macros/src/lib.rs
+++ b/dpdk-test-macros/src/lib.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{Ident, ItemFn, parse_macro_input, parse_quote};
+fn dpdk_crate_path() -> TokenStream2 {
+    match crate_name("dataplane-dpdk") {
+        Ok(FoundCrate::Itself) => quote! { crate },
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote! { ::#ident }
+        }
+        Err(_) => {
+            let ident = Ident::new("dataplane_dpdk", Span::call_site());
+            quote! { ::#ident }
+        }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn with_eal(args: TokenStream, input: TokenStream) -> TokenStream {
+    if !args.is_empty() {
+        let err: TokenStream2 =
+            syn::Error::new(Span::call_site(), "#[with_eal] takes no arguments").to_compile_error();
+        return err.into();
+    }
+
+    let mut input_fn = parse_macro_input!(input as ItemFn);
+    let dpdk = dpdk_crate_path();
+    let init_stmt: syn::Stmt = parse_quote! {
+        let _eal = #dpdk::test_support::start_eal();
+    };
+    input_fn.block.stmts.insert(0, init_stmt);
+
+    quote! { #input_fn }.into()
+}

--- a/dpdk/Cargo.toml
+++ b/dpdk/Cargo.toml
@@ -8,13 +8,17 @@ version.workspace = true
 [features]
 default = ["serde"]
 serde = ["dep:serde"]
+test = ["dep:id", "dep:nix", "dep:dpdk-test-macros"]
 
 [dependencies]
 
 concurrency = { workspace = true }
 dpdk-sys = { workspace = true }
+dpdk-test-macros = { workspace = true, optional = true }
 errno = { workspace = true }
+id = { workspace = true, optional = true }
 net = { workspace = true }
+nix = { workspace = true, optional = true, features = ["sched"] }
 
 serde = { workspace = true, optional = true, features = ["std"] }
 thiserror = { workspace = true }
@@ -24,7 +28,5 @@ tracing = { workspace = true, features = ["attributes"] }
 dpdk-sysroot-helper = { workspace = true }
 
 [dev-dependencies]
-id = { workspace = true }
-
 bolero = { workspace = true, default-features = false, features = ["std"] }
-nix = { workspace = true, features = ["sched"] }
+dataplane-dpdk = { path = ".", features = ["test"] }

--- a/dpdk/src/acl/config.rs
+++ b/dpdk/src/acl/config.rs
@@ -46,7 +46,7 @@ use super::rule::Rule;
 /// while DPDK strides through rules at `rule_size = size_of::<Rule<5>>()` over
 /// `Rule<3>`-sized slots -- the exact OOB read the const generic is meant to
 /// rule out.  Keeping `N` on the type closes that gap statically and is
-/// consistent with how [`AclBuildConfig<N>`] is parameterised.
+/// consistent with how [`AclBuildConfig<N>`] is parameterized.
 ///
 /// # Construction
 ///
@@ -905,34 +905,30 @@ impl<const N: usize> AclBuildConfig<N> {
         })
     }
 
-    /// Compute the buffer-size requirement at construction time.
+    /// Compute DPDK's minimum input buffer size.
     ///
-    /// See [`min_input_size`][AclBuildConfig::min_input_size] for the
-    /// formula and rationale.  Factored out so that `new` can call it
-    /// once and cache the result; the public accessor returns the cached
-    /// value.
-    ///
-    /// Precondition: all fields' `offset + 4` fit in `u32`.  This is
-    /// guaranteed by the `FieldExtentOverflow` check in
-    /// [`new`][AclBuildConfig::new], so the plain `+` below cannot
-    /// overflow.
-    fn compute_min_input_size(field_defs: &[FieldDef; N]) -> usize {
+    /// `offset + 4` must fit in `u32`; [`AclBuildConfig::new`] validates this.
+    #[must_use]
+    pub const fn compute_min_input_size(field_defs: &[FieldDef; N]) -> usize {
         let mut max_load_end: u32 = 0;
-        for def in field_defs {
+        let mut i = 0;
+        while i < N {
+            let def = &field_defs[i];
             let ii = def.input_index();
             let mut group_offset = def.offset();
-            for other in field_defs {
+            let mut j = 0;
+            while j < N {
+                let other = &field_defs[j];
                 if other.input_index() == ii && other.offset() < group_offset {
                     group_offset = other.offset();
                 }
+                j += 1;
             }
-            // No saturation: `new`'s FieldExtentOverflow check has
-            // already verified `def.offset() + 4 <= u32::MAX` for every
-            // def, and `group_offset <= def.offset()`.
             let load_end = group_offset + 4;
             if load_end > max_load_end {
                 max_load_end = load_end;
             }
+            i += 1;
         }
         max_load_end as usize
     }
@@ -1423,6 +1419,19 @@ mod tests {
             104,
             "DPDK loads 4 bytes from group_offset = 100, so min_input_size = 104"
         );
+    }
+
+    #[test]
+    fn compute_min_input_size_works_in_const_context() {
+        const DEFS: [FieldDef; 2] = [
+            FieldDef::new(FieldType::Bitmask, FieldSize::One, 0, 0, 0),
+            FieldDef::new(FieldType::Mask, FieldSize::Four, 1, 9, 100),
+        ];
+        const MIN_INPUT_SIZE: usize = AclBuildConfig::compute_min_input_size(&DEFS);
+        assert_eq!(MIN_INPUT_SIZE, 104);
+
+        let cfg = AclBuildConfig::new(1, DEFS, 0).expect("config should validate");
+        assert_eq!(cfg.min_input_size(), MIN_INPUT_SIZE);
     }
 
     /// Property: `AclCreateParams::new` accepts a name iff it is non-empty

--- a/dpdk/src/acl/mod.rs
+++ b/dpdk/src/acl/mod.rs
@@ -85,7 +85,7 @@
 //!     NonZero::new(1024).unwrap(),
 //! )?;
 //! let build_cfg = AclBuildConfig::new(1, field_defs, 0)?;
-//! let mut ctx = AclContext::<NUM_FIELDS>::new(params, build_cfg)?;
+//! let mut ctx = AclContext::new(params, build_cfg)?;
 //!
 //! // 2. Add rules -- Rule<5> is enforced by the type system.
 //! let rule = Rule::new(
@@ -169,147 +169,23 @@ pub use error::{
 // Module-level utilities
 pub use context::dump_all_contexts;
 
-/// End-to-end integration tests for the ACL wrapper, exercising real
-/// `rte_acl_*` calls against a live EAL.
-///
-/// # EAL configuration (shared by every test in this module)
-///
-/// All tests initialize EAL via [`start_eal`][self::tests::start_eal], which
-/// passes a fixed set of flags plus two dynamic values:
-///
-/// - `--no-huge --in-memory` -- back EAL with anonymous memory instead of
-///   hugetlbfs.  Keeps the tests runnable on any host without manual hugepage
-///   configuration.
-/// - `--lcores 0@({allowed_cpus})` -- a single logical lcore (the main),
-///   floated across whatever physical CPUs `sched_getaffinity` reports as
-///   available to the process.  No workers means
-///   `rte_eal_mp_remote_launch` has no per-worker readiness flag to read, so
-///   we sidestep a benign-but-flagged data race that ThreadSanitizer reports
-///   against DPDK's lcore startup, and we also avoid spawning unused worker
-///   threads.  Floating (instead of pinning to physical CPU 0) keeps the
-///   tests honest about cgroups, taskset, and container CPU restrictions.
-/// - `--file-prefix <unique-id>` -- a per-init unique identifier so that
-///   concurrent forked test processes do not fight over the EAL runtime
-///   configuration namespace.  Necessary alongside `--in-memory` because EAL
-///   still creates per-process control state in the runtime dir.
-/// - `--no-pci --no-telemetry --no-shconf --no-hpet` -- disable everything we
-///   do not need so the tests start quickly and have no shared-config files
-///   to clean up.
-///
-/// # Running once per process
-///
-/// `eal::init` may only be called once per process.  Every test in this
-/// module funnels through the [`EAL`][self::tests::EAL] `OnceLock`, so
-/// the init happens exactly once regardless of how the harness schedules
-/// tests: nextest's per-test process fork (the workspace default) runs
-/// the lazy init once per fork; a single-process runner (`cargo test
-/// --test-threads=1` or an in-process parallel harness) runs it once for
-/// the lifetime of the process.
-///
-/// # Running locally
-///
-/// ```text
-/// just setup-roots             # rebuild DPDK + wrapper
-/// # re-enter `nix-shell` so DATAPLANE_SYSROOT picks up the new sysroot
-/// cargo nextest run -p dataplane-dpdk acl::tests
-/// ```
 #[cfg(test)]
 mod tests {
     use core::num::NonZero;
 
-    use concurrency::sync::OnceLock;
-
     use crate::acl::*;
-    use crate::eal::Eal;
     use crate::socket::SocketId;
+    use crate::with_eal;
 
-    /// Number of fields used by all lifecycle tests in this module.
     const NUM_FIELDS: usize = 2;
 
-    /// Process-wide EAL initialized on first use, shared by every test.
-    ///
-    /// `eal::init` may only be called once per process.  Nextest's default
-    /// per-test process forking makes a per-test `init` trivially safe
-    /// (each forked process re-initializes EAL exactly once), but a
-    /// single-process test runner -- `cargo test --test-threads=1`, an
-    /// in-process parallel harness, or any future configuration that drops
-    /// the fork -- would call init twice and fail.  Funneling every test
-    /// through this lazy [`OnceLock`] makes the tests correct under both
-    /// modes: per-process forking initializes once per fork (cheap),
-    /// in-process initializes once for the lifetime of the process.
-    ///
-    /// The `Eal` value is intentionally leaked into the static for the
-    /// lifetime of the process; DPDK has no clean teardown path, and the
-    /// `Eal` Drop would (per [`crate::eal::init`]) be unable to free DPDK
-    /// allocations through the system allocator after the allocator swap.
-    static EAL: OnceLock<Eal> = OnceLock::new();
-
-    /// Lazily initialize EAL on first call.
-    ///
-    /// Each test calls this in place of `eal::init`; subsequent calls
-    /// return the shared `&'static Eal` without re-initializing DPDK.
-    fn start_eal() -> &'static Eal {
-        // DPDK pins lcores, but that is generally not what we actually want in a test environment.
-        // Instead, we need to allocate just lcore 0 (main) and pin it to "everything we legally have access to."
-        fn allowed_cpus() -> String {
-            use nix::sched::{CpuSet, sched_getaffinity};
-            use nix::unistd::Pid;
-            let set = sched_getaffinity(Pid::from_raw(0)).expect("sched_getaffinity");
-            (0..CpuSet::count())
-                .filter(|&i| set.is_set(i).unwrap_or(false))
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        }
-        // concurrent executions of DPDK EAL can fight over allocations and file resources.
-        // You can prevent that with a unique prefix on the hugepage files it allocates (if any).
-        let eal_id = format!("{}", id::Id::<Eal>::new());
-        let core_pinning = format!("0@({})", allowed_cpus());
-        // EAL arguments used the first time EAL is initialized in this process.
-        let args: &[&str] = &[
-            "--no-huge",
-            "--no-pci",
-            "--in-memory",
-            "--no-telemetry",
-            "--no-shconf",
-            "--no-hpet",
-            "--iova-mode=va",
-            "--file-prefix",
-            &eal_id,
-            // Restrict EAL to a single lcore (the main).  Without workers,
-            // rte_eal_mp_remote_launch has no readiness flags to read and there is
-            // no DPDK-internal init race for ThreadSanitizer to flag.  Also avoids
-            // spawning unused worker threads.
-            //
-            // The `0@(<cpu-list>)` form means "logical lcore 0, floated across
-            // the listed physical CPUs": DPDK schedules lcore 0 onto any of
-            // them rather than pinning to a single CPU.  Floating instead of
-            // pinning keeps the tests honest about cgroups, taskset, and
-            // container affinity restrictions.
-            "--lcores",
-            &core_pinning,
-        ];
-
-        EAL.get_or_init(|| super::super::eal::init(args.iter().copied()))
-    }
-
-    /// Standard field layout used by the lifecycle tests.
-    ///
-    /// DPDK ACL requires the first field in the rule definition to be one byte
-    /// long (it is consumed during trie setup).  All subsequent fields must be
-    /// grouped into sets of 4 consecutive bytes via `input_index`.
     fn standard_field_defs() -> [FieldDef; NUM_FIELDS] {
         [
-            // Field 0: 1-byte entry at offset 0 (required by DPDK to be 1 byte).
             FieldDef::new(FieldType::Bitmask, FieldSize::One, 0, 0, 0),
-            // Field 1: 4-byte Mask field at offset 4, input_index 1.
             FieldDef::new(FieldType::Mask, FieldSize::Four, 1, 1, 4),
         ]
     }
 
-    /// Build a rule that exact-matches the given 32-bit value in field 1.
-    ///
-    /// `userdata` becomes the classify result for matching inputs.
     fn exact_match_rule(value: u32, userdata: u32) -> Rule<NUM_FIELDS> {
         Rule::new(
             RuleData {
@@ -317,50 +193,30 @@ mod tests {
                 priority: Priority::new(1).unwrap(),
                 userdata: NonZero::new(userdata).expect("userdata must be non-zero"),
             },
-            [
-                // Wildcard entry byte: field 0 is FieldType::Bitmask
-                // (per standard_field_defs).  mask = 0 makes the
-                // predicate `(input & 0) == 0`, which is trivially true
-                // for any input -- so this field matches any byte at
-                // offset 0.
-                AclField::from_u8(0, 0),
-                // Field 1 is FieldType::Mask; mask_range is interpreted
-                // as a prefix length, so 32 means "compare all 32 bits".
-                AclField::from_u32(value, 32),
-            ],
+            [AclField::from_u8(0, 0), AclField::from_u32(value, 32)],
         )
     }
 
-    /// Build an 8-byte input buffer carrying `value` at offset 4 in network byte
-    /// order, suitable for the field layout returned by [`standard_field_defs`].
     fn input_buffer(value: u32) -> [u8; 8] {
         let mut buf = [0u8; 8];
         buf[4..8].copy_from_slice(&value.to_be_bytes());
         buf
     }
 
-    /// Build the default `AclBuildConfig` used across the lifecycle tests
-    /// (`num_categories = 1`, the standard 2-field layout, no max_size).
     fn standard_build_config() -> AclBuildConfig<NUM_FIELDS> {
         AclBuildConfig::new(1, standard_field_defs(), 0).expect("build config")
     }
 
-    /// End-to-end classify smoke test: build a tiny ACL context, run a real
-    /// `rte_acl_classify` call, and verify the match / no-match outcomes.
-    /// See the [module-level docs](self) for the EAL setup that applies to
-    /// every test here.
+    #[with_eal]
     #[test]
     fn classify_smoke() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "test_acl",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
 
         ctx.add_rules(&[exact_match_rule(0xDEAD_BEEF, 1)])
             .expect("add rules");
@@ -381,14 +237,9 @@ mod tests {
         assert_eq!(results[1], 0, "expected no match for 0x00000000");
     }
 
-    /// Reset round-trip: build, classify, reset back to Configuring, swap
-    /// in a new rule, rebuild (no config supplied -- it lives on the
-    /// context), and verify the new rule's userdata wins.  Also asserts
-    /// that the build config survives the reset.
+    #[with_eal]
     #[test]
     fn reset_round_trip() {
-        let _eal = start_eal();
-
         let original_cfg = standard_build_config();
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "reset_round_trip",
@@ -396,10 +247,8 @@ mod tests {
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, original_cfg.clone()).expect("new context");
+        let mut ctx = AclContext::new(params, original_cfg.clone()).expect("new context");
 
-        // First build cycle: match 0xAAAAAAAA -> userdata 1.
         ctx.add_rules(&[exact_match_rule(0xAAAA_AAAA, 1)])
             .expect("add rules (first)");
         let ctx = ctx.build().map_err(|f| f.error).expect("build (first)");
@@ -416,8 +265,6 @@ mod tests {
         unsafe { ctx.classify(&data_ptrs, &mut results, 1) }.expect("classify (first)");
         assert_eq!(results[0], 1, "first build should match 0xAAAAAAAA");
 
-        // Reset back to Configuring (config carries through) and load a
-        // different rule.
         let mut ctx = ctx.reset();
         assert_eq!(
             ctx.build_config(),
@@ -441,25 +288,17 @@ mod tests {
         assert_eq!(results[1], 0, "second build must not retain the first rule");
     }
 
-    /// `add_rules` rejects a rule whose [`FieldType::Mask`] field carries a
-    /// prefix length larger than the field's bit width.  Without this
-    /// wrapper-side check, DPDK's `RTE_ACL_MASKLEN_TO_BITMASK` would
-    /// perform a C shift by an out-of-range amount (UB).
+    #[with_eal]
     #[test]
     fn add_rules_rejects_out_of_range_prefix_length() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "prefix_len_validate",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
 
-        // Field 1 in standard_field_defs is a 4-byte Mask field, so the
-        // maximum legal prefix length is 32.  33 is out of range.
         let bad_rule: Rule<NUM_FIELDS> = Rule::new(
             RuleData {
                 category_mask: CategoryMask::new(1).unwrap(),
@@ -490,25 +329,20 @@ mod tests {
         );
     }
 
-    /// `set_default_algorithm` happy path: build, switch to a specific
-    /// algorithm, and classify.  Uses `Default` which is always supported.
+    #[with_eal]
     #[test]
     fn set_default_algorithm_then_classify() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "set_algo",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
         ctx.add_rules(&[exact_match_rule(0xCAFE_BABE, 7)])
             .expect("add rules");
         let mut ctx = ctx.build().map_err(|f| f.error).expect("build");
 
-        // `Default` is always available on any CPU DPDK runs on.
         ctx.set_default_algorithm(ClassifyAlgorithm::Default)
             .expect("set_default_algorithm");
 
@@ -520,22 +354,16 @@ mod tests {
         assert_eq!(results[0], 7);
     }
 
-    /// `classify` must reject `categories` values that would overflow DPDK's
-    /// per-thread runtime arrays sized to `RTE_ACL_MAX_CATEGORIES`, even when
-    /// the user's `results` slice is generous enough to satisfy the
-    /// per-element length check.
+    #[with_eal]
     #[test]
     fn classify_categories_validated_before_ffi() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "cat_validation",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
         ctx.add_rules(&[exact_match_rule(0xAAAA_AAAA, 1)])
             .expect("add rules");
         let ctx = ctx.build().map_err(|f| f.error).expect("build");
@@ -543,42 +371,31 @@ mod tests {
         let buf = input_buffer(0xAAAA_AAAA);
         let data_ptrs: Vec<*const u8> = vec![buf.as_ptr()];
 
-        // results slice large enough to pass the length check, but categories
-        // out of range -- must still be rejected.
         let mut results = vec![0u32; 64];
 
-        // categories = 0
         // SAFETY: see classify_smoke.
         let r = unsafe { ctx.classify(&data_ptrs, &mut results, 0) };
         assert!(matches!(r, Err(AclClassifyError::InvalidArgs)));
 
-        // categories > MAX_CATEGORIES (= 16)
         // SAFETY: see classify_smoke.
         let r = unsafe { ctx.classify(&data_ptrs, &mut results, MAX_CATEGORIES + 1) };
         assert!(matches!(r, Err(AclClassifyError::InvalidArgs)));
 
-        // categories > 1 but not a multiple of RESULTS_MULTIPLIER (= 4)
         // SAFETY: see classify_smoke.
         let r = unsafe { ctx.classify(&data_ptrs, &mut results, 3) };
         assert!(matches!(r, Err(AclClassifyError::InvalidArgs)));
     }
 
-    /// Creating a second [`AclContext`] with a name already registered in
-    /// DPDK's global ACL list must fail with [`AclCreateError::AlreadyExists`]
-    /// rather than silently aliasing the first context (which would
-    /// double-free on drop).
+    #[with_eal]
     #[test]
     fn duplicate_name_rejected() {
-        let _eal = start_eal();
-
         let params_a = AclCreateParams::<NUM_FIELDS>::new(
             "dup_name",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let _ctx_a =
-            AclContext::<NUM_FIELDS>::new(params_a, standard_build_config()).expect("first new");
+        let _ctx_a = AclContext::new(params_a, standard_build_config()).expect("first new");
 
         let params_b = AclCreateParams::<NUM_FIELDS>::new(
             "dup_name",
@@ -586,7 +403,7 @@ mod tests {
             NonZero::new(16).unwrap(),
         )
         .expect("create params (dup)");
-        let err = AclContext::<NUM_FIELDS>::new(params_b, standard_build_config())
+        let err = AclContext::new(params_b, standard_build_config())
             .expect_err("second new with same name must fail");
         assert!(
             matches!(err, AclCreateError::AlreadyExists { ref name } if name == "dup_name"),
@@ -594,33 +411,20 @@ mod tests {
         );
     }
 
-    /// Recovery after `add_rules` overflows `max_rule_num`: the context must
-    /// remain usable.  We submit one rule successfully, then submit more rules
-    /// than the remaining capacity allows, expect the error, and finally build
-    /// and classify against the first rule.
+    #[with_eal]
     #[test]
     fn add_rules_after_overflow_failure() {
-        let _eal = start_eal();
-
-        // `max_rule_num` of 1: a second add_rules call with any rule will
-        // overflow.
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "overflow_recover",
             SocketId::ANY,
             NonZero::new(1).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
 
         ctx.add_rules(&[exact_match_rule(0x1111_1111, 1)])
             .expect("first add_rules should succeed");
 
-        // Attempting to add another rule must fail: capacity is exhausted.
-        // DPDK signals "no room left in the rule list" with -ENOMEM, which
-        // the wrapper maps to AclAddRulesError::OutOfMemory.  Pin the variant
-        // so a future change in mapping or DPDK's behaviour surfaces as a
-        // test failure rather than silently passing through.
         let extra = exact_match_rule(0x2222_2222, 2);
         let err = ctx
             .add_rules(&[extra])
@@ -630,7 +434,6 @@ mod tests {
             "expected OutOfMemory from capacity exhaustion, got {err:?}",
         );
 
-        // Context must still be usable: build + classify against the first rule.
         let ctx = ctx
             .build()
             .map_err(|f| f.error)
@@ -644,25 +447,17 @@ mod tests {
         assert_eq!(results[0], 1);
     }
 
-    /// Build failure recovery: when `build()` fails, the wrapper returns
-    /// the original `Configuring` context inside `AclBuildFailure`.  The
-    /// caller must be able to keep using it (add rules, retry).  We force
-    /// the failure by calling `build()` with no rules added (DPDK rejects
-    /// `num_rules == 0` with `-EINVAL`).
+    #[with_eal]
     #[test]
     fn build_failure_returns_usable_context() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "build_failure_recovery",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let ctx = AclContext::new(params, standard_build_config()).expect("new context");
 
-        // First build with zero rules must fail.
         let failure = ctx.build().expect_err("build() with no rules must fail");
         assert!(
             matches!(failure.error, AclBuildError::InvalidConfig),
@@ -670,7 +465,6 @@ mod tests {
             failure.error,
         );
 
-        // Recover the context, add a rule, build again -- must succeed.
         let mut ctx = failure.context;
         ctx.add_rules(&[exact_match_rule(0xDEAD_BEEF, 1)])
             .expect("add rules after recovery");
@@ -687,24 +481,16 @@ mod tests {
         assert_eq!(results[0], 1);
     }
 
-    /// `add_rules` rejects a rule whose `category_mask` has bits set at
-    /// positions `>= config.num_categories()`.  DPDK would silently mask
-    /// off those bits at build time, narrowing the rule's intended
-    /// category set; we surface this at `add_rules` time instead.
+    #[with_eal]
     #[test]
     fn add_rules_rejects_category_mask_beyond_num_categories() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "cat_mask_validate",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        // standard_build_config uses num_categories = 1, so only bit 0 is
-        // legal.  Build a rule with bit 1 also set.
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
 
         let bad_rule: Rule<NUM_FIELDS> = Rule::new(
             RuleData {
@@ -733,20 +519,11 @@ mod tests {
         );
     }
 
-    /// Concurrent classify under `Arc<AclContext<N, Built<N>>>`: spawns
-    /// several worker threads, each calling
-    /// [`AclContext::classify`][crate::acl::AclContext::classify] in a
-    /// tight loop, and verifies every thread sees the correct match.
-    /// Exercises the per-state `Sync` impl on [`Built<N>`] and ensures
-    /// the wrapper's "share across classification threads" claim isn't
-    /// vacuous.  Test runs with N=4 workers and M=1000 iterations each
-    /// to give the OS scheduler a chance to interleave.
+    #[with_eal]
     #[test]
     fn classify_concurrent_arc_shared() {
         use concurrency::sync::Arc;
         use concurrency::thread;
-
-        let _eal = start_eal();
 
         const WORKERS: usize = 4;
         const ITERS_PER_WORKER: usize = 1000;
@@ -757,8 +534,7 @@ mod tests {
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
         ctx.add_rules(&[exact_match_rule(0xDEAD_BEEF, 1)])
             .expect("add rules");
         let ctx: Arc<AclContext<NUM_FIELDS, Built<NUM_FIELDS>>> =
@@ -768,8 +544,6 @@ mod tests {
             .map(|worker| {
                 let ctx = Arc::clone(&ctx);
                 thread::spawn(move || {
-                    // Each worker owns its own buffers; classify is the
-                    // only place we share state across threads.
                     let matching = input_buffer(0xDEAD_BEEF);
                     let non_matching = input_buffer(0);
                     for _ in 0..ITERS_PER_WORKER {
@@ -793,22 +567,16 @@ mod tests {
         }
     }
 
-    /// `classify_with_algorithm` with a non-`Default` algorithm: locks in
-    /// the special-casing in [`AclContext::classify_with_algorithm`] by
-    /// dispatching through the `Scalar` variant (always available on every
-    /// CPU DPDK runs on) and verifying classification still works.
+    #[with_eal]
     #[test]
     fn classify_with_algorithm_scalar() {
-        let _eal = start_eal();
-
         let params = AclCreateParams::<NUM_FIELDS>::new(
             "classify_alg_scalar",
             SocketId::ANY,
             NonZero::new(16).unwrap(),
         )
         .expect("create params");
-        let mut ctx =
-            AclContext::<NUM_FIELDS>::new(params, standard_build_config()).expect("new context");
+        let mut ctx = AclContext::new(params, standard_build_config()).expect("new context");
         ctx.add_rules(&[exact_match_rule(0xFEED_FACE, 9)])
             .expect("add rules");
         let ctx = ctx.build().map_err(|f| f.error).expect("build");

--- a/dpdk/src/lib.rs
+++ b/dpdk/src/lib.rs
@@ -42,3 +42,9 @@ pub mod mem;
 pub mod queue;
 pub mod ring;
 pub mod socket;
+
+#[cfg(any(test, feature = "test"))]
+pub mod test_support;
+
+#[cfg(feature = "test")]
+pub use dpdk_test_macros::with_eal;

--- a/dpdk/src/test_support.rs
+++ b/dpdk/src/test_support.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use concurrency::sync::OnceLock;
+
+use crate::eal::Eal;
+
+static EAL: OnceLock<Eal> = OnceLock::new();
+#[must_use]
+pub fn start_eal() -> &'static Eal {
+    EAL.get_or_init(|| {
+        let cpus = allowed_cpus();
+        let eal_id = format!("{}", id::Id::<Eal>::new());
+        let core_pinning = format!("0@({cpus})");
+        let args: &[&str] = &[
+            "--no-huge",
+            "--no-pci",
+            "--in-memory",
+            "--no-telemetry",
+            "--no-shconf",
+            "--no-hpet",
+            "--iova-mode=va",
+            "--file-prefix",
+            &eal_id,
+            "--lcores",
+            &core_pinning,
+        ];
+        crate::eal::init(args.iter().copied())
+    })
+}
+#[allow(clippy::expect_used)]
+fn allowed_cpus() -> String {
+    use nix::sched::{CpuSet, sched_getaffinity};
+    use nix::unistd::Pid;
+    let set = sched_getaffinity(Pid::from_raw(0)).expect("sched_getaffinity");
+    (0..CpuSet::count())
+        .filter(|&i| set.is_set(i).unwrap_or(false))
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}

--- a/fixed-size/Cargo.toml
+++ b/fixed-size/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dataplane-fixed-size"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/fixed-size/src/lib.rs
+++ b/fixed-size/src/lib.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![no_std]
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+use core::net::{Ipv4Addr, Ipv6Addr};
+pub trait FixedSize: Copy {
+    const SIZE: usize;
+    fn write_be(&self, out: &mut [u8]);
+}
+
+impl FixedSize for u8 {
+    const SIZE: usize = 1;
+    fn write_be(&self, out: &mut [u8]) {
+        out[0] = *self;
+    }
+}
+
+impl FixedSize for u16 {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u32 {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u64 {
+    const SIZE: usize = 8;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u128 {
+    const SIZE: usize = 16;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for Ipv4Addr {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.octets());
+    }
+}
+
+impl FixedSize for Ipv6Addr {
+    const SIZE: usize = 16;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.octets());
+    }
+}

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dataplane-lookup"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+#![allow(missing_docs)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+pub trait Projection<T> {
+    fn project(self) -> T;
+}
+impl<K> Projection<Option<K>> for Option<K> {
+    fn project(self) -> Option<K> {
+        self
+    }
+}
+pub trait Lookup<K, A> {
+    fn lookup(&self, key: &K) -> Option<&A>;
+    fn classify<S>(&self, source: S) -> Option<&A>
+    where
+        S: Projection<K>,
+    {
+        self.lookup(&source.project())
+    }
+    fn classify_opt<S>(&self, source: S) -> Option<&A>
+    where
+        S: Projection<Option<K>>,
+    {
+        source.project().and_then(|key| self.lookup(&key))
+    }
+}
+
+impl<K: Ord, V> Lookup<K, V> for BTreeMap<K, V> {
+    fn lookup(&self, key: &K) -> Option<&V> {
+        BTreeMap::get(self, key)
+    }
+}
+
+impl<K: Eq + Hash, V, S: std::hash::BuildHasher> Lookup<K, V> for HashMap<K, V, S> {
+    fn lookup(&self, key: &K) -> Option<&V> {
+        HashMap::get(self, key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Pkt {
+        src: u32,
+        dst: u32,
+        sport: u16,
+        dport: u16,
+    }
+
+    impl Projection<(u32, u32)> for &Pkt {
+        fn project(self) -> (u32, u32) {
+            (self.src, self.dst)
+        }
+    }
+
+    impl Projection<(u32, u32, u16, u16)> for &Pkt {
+        fn project(self) -> (u32, u32, u16, u16) {
+            (self.src, self.dst, self.sport, self.dport)
+        }
+    }
+
+    impl<'a> Projection<(&'a u32, &'a u32)> for &'a Pkt {
+        fn project(self) -> (&'a u32, &'a u32) {
+            (&self.src, &self.dst)
+        }
+    }
+    impl Projection<Option<(u32, u32)>> for &Pkt {
+        fn project(self) -> Option<(u32, u32)> {
+            (self.src != 0).then_some((self.src, self.dst))
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Action {
+        Allow,
+        Drop,
+    }
+
+    #[test]
+    fn classify_picks_the_two_tuple_projection_from_the_table_type() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 22,
+            dport: 80,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Drop));
+    }
+
+    #[test]
+    fn classify_picks_the_four_tuple_projection_from_the_table_type() {
+        let mut table: BTreeMap<(u32, u32, u16, u16), Action> = BTreeMap::new();
+        table.insert((10, 20, 22, 80), Action::Allow);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 22,
+            dport: 80,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Allow));
+    }
+
+    #[test]
+    fn borrowed_tuple_projection_threads_lifetime() {
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        let (src, dst): (&u32, &u32) = (&pkt).project();
+        assert_eq!(*src, 10);
+        assert_eq!(*dst, 20);
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        let pkt = Pkt {
+            src: 1,
+            dst: 2,
+            sport: 3,
+            dport: 4,
+        };
+        assert_eq!(table.classify(&pkt), None);
+    }
+
+    #[test]
+    fn classify_opt_looks_up_when_projection_yields_some() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify_opt(&pkt), Some(&Action::Drop));
+    }
+
+    #[test]
+    fn classify_opt_short_circuits_when_projection_yields_none() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((0, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 0,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify_opt(&pkt), None);
+    }
+
+    #[test]
+    fn classify_opt_accepts_a_computed_option_via_identity() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let built: Option<(u32, u32)> = Some((10, 20));
+        assert_eq!(table.classify_opt(built), Some(&Action::Drop));
+        assert_eq!(table.classify_opt(None::<(u32, u32)>), None);
+    }
+
+    #[test]
+    fn hashmap_backend_works_the_same_way() {
+        let mut table: HashMap<(u32, u32), Action> = HashMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Drop));
+    }
+}

--- a/match-action-derive/Cargo.toml
+++ b/match-action-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dataplane-match-action-derive"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+# The derive emits paths relative to the consumer's `dataplane-match-action`
+# import.  `proc-macro-crate` resolves whatever alias the consumer
+# chose (typical workspace alias is `match-action` / `match_action`).
+proc-macro-crate = { workspace = true, default-features = true }
+proc-macro2 = { workspace = true, default-features = true }
+quote = { workspace = true, default-features = true }
+syn = { workspace = true, default-features = true, features = ["full"] }

--- a/match-action-derive/Cargo.toml
+++ b/match-action-derive/Cargo.toml
@@ -9,10 +9,10 @@ version.workspace = true
 proc-macro = true
 
 [dependencies]
-# The derive emits paths relative to the consumer's `dataplane-match-action`
-# import.  `proc-macro-crate` resolves whatever alias the consumer
-# chose (typical workspace alias is `match-action` / `match_action`).
 proc-macro-crate = { workspace = true, default-features = true }
 proc-macro2 = { workspace = true, default-features = true }
 quote = { workspace = true, default-features = true }
 syn = { workspace = true, default-features = true, features = ["full"] }
+
+[features]
+bolero = []

--- a/match-action-derive/src/lib.rs
+++ b/match-action-derive/src/lib.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{
+    Attribute, Data, DeriveInput, Field, Fields, GenericParam, Ident, TypeParamBound,
+    parse_macro_input, parse_quote, spanned::Spanned,
+};
+fn match_action_crate_path() -> TokenStream2 {
+    match crate_name("dataplane-match-action") {
+        Ok(FoundCrate::Itself) => {
+            let ident = Ident::new("dataplane_match_action", Span::call_site());
+            quote! { ::#ident }
+        }
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote! { ::#ident }
+        }
+        Err(_) => {
+            let ident = Ident::new("dataplane_match_action", Span::call_site());
+            quote! { ::#ident }
+        }
+    }
+}
+#[derive(Debug, Copy, Clone)]
+enum Kind {
+    Prefix,
+    Mask,
+    Range,
+    Exact,
+}
+
+impl Kind {
+    fn variant_ident(self) -> Ident {
+        let name = match self {
+            Self::Prefix => "Prefix",
+            Self::Mask => "Mask",
+            Self::Range => "Range",
+            Self::Exact => "Exact",
+        };
+        Ident::new(name, Span::call_site())
+    }
+    fn spec_ident(self) -> Ident {
+        let name = match self {
+            Self::Prefix => "PrefixSpec",
+            Self::Mask => "MaskSpec",
+            Self::Range => "RangeSpec",
+            Self::Exact => "ExactSpec",
+        };
+        Ident::new(name, Span::call_site())
+    }
+}
+
+#[proc_macro_derive(MatchKey, attributes(prefix, mask, range, exact))]
+pub fn derive_match_key(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match expand(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let crate_path = match_action_crate_path();
+    let key_ident = &input.ident;
+    let key_vis = &input.vis;
+    let mut generics = input.generics.clone();
+    let fixed_size_bound: TypeParamBound = parse_quote!(#crate_path::FixedSize);
+    for param in &mut generics.params {
+        if let GenericParam::Type(tp) = param {
+            tp.bounds.push(fixed_size_bound.clone());
+        }
+    }
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let is_generic = input
+        .generics
+        .params
+        .iter()
+        .any(|p| matches!(p, GenericParam::Type(_) | GenericParam::Const(_)));
+
+    let fields = match &input.data {
+        Data::Struct(s) => match &s.fields {
+            Fields::Named(named) => &named.named,
+            Fields::Unnamed(_) => {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "MatchKey derive requires named fields",
+                ));
+            }
+            Fields::Unit => {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "MatchKey derive requires at least one field",
+                ));
+            }
+        },
+        _ => {
+            return Err(syn::Error::new(
+                input.span(),
+                "MatchKey derive only supports structs",
+            ));
+        }
+    };
+
+    if fields.is_empty() {
+        return Err(syn::Error::new(
+            input.span(),
+            "MatchKey derive requires at least one field",
+        ));
+    }
+    let kinds: Vec<Kind> = fields
+        .iter()
+        .map(parse_field_kind)
+        .collect::<syn::Result<_>>()?;
+
+    let n = fields.len();
+    let n_literal = syn::Index::from(n);
+    let size_exprs: Vec<TokenStream2> = fields
+        .iter()
+        .map(|f| {
+            let ty = &f.ty;
+            quote! { <#ty as #crate_path::FixedSize>::SIZE }
+        })
+        .collect();
+    let mut boundaries: Vec<TokenStream2> = Vec::with_capacity(n + 1);
+    boundaries.push(quote! { 0usize });
+    let mut acc: Vec<TokenStream2> = Vec::new();
+    for size in &size_exprs {
+        acc.push(size.clone());
+        boundaries.push(quote! { #(#acc)+* });
+    }
+    let key_size_expr = &boundaries[n];
+    let mut spec_entries: Vec<TokenStream2> = Vec::with_capacity(n);
+    for (i, field) in fields.iter().enumerate() {
+        let name = field
+            .ident
+            .as_ref()
+            .ok_or_else(|| syn::Error::new(field.span(), "unnamed field"))?;
+        let name_str = name.to_string();
+        let off = &boundaries[i];
+        let size = &size_exprs[i];
+        let kind_variant = kinds[i].variant_ident();
+        spec_entries.push(quote! {
+            #crate_path::FieldSpec {
+                name: #name_str,
+                kind: #crate_path::FieldKind::#kind_variant,
+                size: #size,
+                offset: #off,
+            }
+        });
+    }
+    let mut writers: Vec<TokenStream2> = Vec::with_capacity(n);
+    for (i, field) in fields.iter().enumerate() {
+        let name = field
+            .ident
+            .as_ref()
+            .ok_or_else(|| syn::Error::new(field.span(), "unnamed field"))?;
+        let ty = &field.ty;
+        let start = &boundaries[i];
+        let end = &boundaries[i + 1];
+        writers.push(quote! {
+            <#ty as #crate_path::FixedSize>::write_be(
+                &self.#name,
+                &mut out[#start..#end],
+            );
+        });
+    }
+    let rule_ident = Ident::new(&format!("{key_ident}Rule"), key_ident.span());
+    let mut rule_fields: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_bounds: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_converts: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_accepts: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_universal: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_accept_bounds: Vec<TokenStream2> = Vec::with_capacity(n);
+    let mut rule_field_universal_bounds: Vec<TokenStream2> = Vec::with_capacity(n);
+    for (i, field) in fields.iter().enumerate() {
+        let name = field
+            .ident
+            .as_ref()
+            .ok_or_else(|| syn::Error::new(field.span(), "unnamed field"))?;
+        let ty = &field.ty;
+        let spec = kinds[i].spec_ident();
+        rule_fields.push(quote! {
+            pub #name: #crate_path::#spec<#ty>
+        });
+        rule_field_bounds.push(quote! {
+            #crate_path::#spec<#ty>: #crate_path::IntoBackendField<__MaB>
+        });
+        rule_field_converts.push(quote! {
+            <#crate_path::#spec<#ty> as #crate_path::IntoBackendField<__MaB>>::into_backend_field(self.#name)
+        });
+        rule_field_accepts.push(quote! {
+            <#crate_path::#spec<#ty> as #crate_path::Accepts<#ty>>::accepts(&self.#name, &key.#name)
+        });
+        rule_field_universal.push(quote! {
+            <#crate_path::#spec<#ty> as #crate_path::IsUniversal>::is_universal(&self.#name)
+        });
+        rule_field_accept_bounds.push(quote! {
+            #crate_path::#spec<#ty>: #crate_path::Accepts<#ty>
+        });
+        rule_field_universal_bounds.push(quote! {
+            #crate_path::#spec<#ty>: #crate_path::IsUniversal
+        });
+    }
+    let as_key_impl = if is_generic {
+        quote! {}
+    } else {
+        quote! {
+            impl #impl_generics #key_ident #ty_generics #where_clause {
+                #[must_use]
+                pub fn as_key(&self) -> [u8; <Self as #crate_path::MatchKey>::KEY_SIZE] {
+                    let mut buf = [0u8; <Self as #crate_path::MatchKey>::KEY_SIZE];
+                    <Self as #crate_path::MatchKey>::as_key_into(self, &mut buf);
+                    buf
+                }
+            }
+        }
+    };
+    let existing_predicates: Vec<_> = where_clause
+        .map(|wc| wc.predicates.iter().collect())
+        .unwrap_or_default();
+    let merged_where_accepts = quote! {
+        where
+            #(#existing_predicates,)*
+            #(#rule_field_accept_bounds,)*
+    };
+    let merged_where_universal = quote! {
+        where
+            #(#existing_predicates,)*
+            #(#rule_field_universal_bounds,)*
+    };
+
+    let expanded = quote! {
+        const _: () = {
+            impl #impl_generics #key_ident #ty_generics #where_clause {
+                pub const FIELD_SPECS: &'static [#crate_path::FieldSpec] = &[
+                    #(#spec_entries),*
+                ];
+            }
+
+            impl #impl_generics #crate_path::MatchKey for #key_ident #ty_generics #where_clause {
+                const N: usize = #n_literal;
+                const KEY_SIZE: usize = #key_size_expr;
+
+                fn field_specs() -> &'static [#crate_path::FieldSpec] {
+                    Self::FIELD_SPECS
+                }
+
+                fn as_key_into(&self, out: &mut [u8]) {
+                    assert!(
+                        out.len() >= Self::KEY_SIZE,
+                        "as_key_into: output buffer shorter than KEY_SIZE",
+                    );
+                    #(#writers)*
+                }
+            }
+
+            #as_key_impl
+        };
+        #[derive(::core::marker::Copy, ::core::clone::Clone, ::core::fmt::Debug)]
+        #key_vis struct #rule_ident #generics {
+            #(#rule_fields),*
+        }
+        impl #impl_generics #rule_ident #ty_generics #where_clause {
+            pub fn into_backend_fields<__MaB>(self) -> ::std::vec::Vec<<__MaB as #crate_path::Backend>::Field>
+            where
+                __MaB: #crate_path::Backend,
+                #(#rule_field_bounds),*
+            {
+                ::std::vec![
+                    #(#rule_field_converts),*
+                ]
+            }
+        }
+        impl #impl_generics #rule_ident #ty_generics
+        #merged_where_accepts
+        {
+            #[must_use]
+            pub fn accepts(&self, key: &#key_ident #ty_generics) -> bool {
+                #(#rule_field_accepts) && *
+            }
+        }
+        impl #impl_generics #rule_ident #ty_generics
+        #merged_where_universal
+        {
+            #[must_use]
+            pub fn is_universal(&self) -> bool {
+                #(#rule_field_universal) && *
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+fn parse_field_kind(field: &Field) -> syn::Result<Kind> {
+    let mut found: Option<(Kind, &Attribute)> = None;
+    for attr in &field.attrs {
+        let kind = if attr.path().is_ident("prefix") {
+            Some(Kind::Prefix)
+        } else if attr.path().is_ident("mask") {
+            Some(Kind::Mask)
+        } else if attr.path().is_ident("range") {
+            Some(Kind::Range)
+        } else if attr.path().is_ident("exact") {
+            Some(Kind::Exact)
+        } else {
+            None
+        };
+        if let Some(k) = kind {
+            if found.is_some() {
+                return Err(syn::Error::new(
+                    attr.span(),
+                    "multiple match-flavor attributes on a single field; \
+                     expected at most one of #[prefix], #[mask], #[range], #[exact]",
+                ));
+            }
+            found = Some((k, attr));
+        }
+    }
+    Ok(found.map_or(Kind::Exact, |(k, _)| k))
+}

--- a/match-action/Cargo.toml
+++ b/match-action/Cargo.toml
@@ -7,10 +7,11 @@ version.workspace = true
 
 [dependencies]
 arrayvec = { workspace = true, default-features = true }
+bolero = { workspace = true, optional = true }
 fixed-size = { workspace = true, features = [] }
 match-action-derive = { workspace = true, optional = true }
 
 [features]
 default = ["derive"]
-# Re-export the `MatchKey` derive macro from `dataplane-match-action-derive`.
 derive = ["dep:match-action-derive"]
+bolero = ["dep:bolero", "match-action-derive?/bolero"]

--- a/match-action/Cargo.toml
+++ b/match-action/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dataplane-match-action"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+arrayvec = { workspace = true, default-features = true }
+fixed-size = { workspace = true, features = [] }
+match-action-derive = { workspace = true, optional = true }
+
+[features]
+default = ["derive"]
+# Re-export the `MatchKey` derive macro from `dataplane-match-action-derive`.
+derive = ["dep:match-action-derive"]

--- a/match-action/src/field.rs
+++ b/match-action/src/field.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+pub use fixed_size::FixedSize;

--- a/match-action/src/generator.rs
+++ b/match-action/src/generator.rs
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use core::net::{Ipv4Addr, Ipv6Addr};
+
+use bolero::{Driver, ValueGenerator, generator::constant};
+
+use crate::IsUniversal;
+use crate::rule::{ExactSpec, MaskSpec, PrefixSpec, RangeSpec};
+pub struct GuardedMisses<G> {
+    inner: G,
+    universal: bool,
+}
+
+impl<G: ValueGenerator> ValueGenerator for GuardedMisses<G> {
+    type Output = G::Output;
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<G::Output> {
+        if self.universal {
+            return None;
+        }
+        self.inner.generate(d)
+    }
+}
+pub trait FieldHit<T: 'static> {
+    fn hits(&self) -> impl ValueGenerator<Output = T>;
+}
+pub trait FieldMiss<T: 'static> {
+    fn misses(&self) -> impl ValueGenerator<Output = T>;
+}
+macro_rules! high_mask_fn {
+    ($name:ident, $i:ty, $bits:expr) => {
+        #[inline]
+        fn $name(len: u32) -> $i {
+            if len == 0 {
+                0
+            } else if len >= $bits {
+                <$i>::MAX
+            } else {
+                !((1 as $i) << ($bits - len)).wrapping_sub(1)
+            }
+        }
+    };
+}
+high_mask_fn!(high_mask_u8, u8, 8);
+high_mask_fn!(high_mask_u16, u16, 16);
+high_mask_fn!(high_mask_u32, u32, 32);
+high_mask_fn!(high_mask_u64, u64, 64);
+high_mask_fn!(high_mask_u128, u128, 128);
+macro_rules! impl_specs_for {
+    ($t:ty, $i:ty, $high_mask:ident) => {
+        impl FieldHit<$t> for ExactSpec<$t> {
+            fn hits(&self) -> impl ValueGenerator<Output = $t> {
+                constant(self.value)
+            }
+        }
+        impl FieldMiss<$t> for ExactSpec<$t> {
+            fn misses(&self) -> impl ValueGenerator<Output = $t> {
+                let target: $i = self.value.into();
+                GuardedMisses {
+                    inner: bolero::produce::<$i>()
+                        .filter_gen(move |x| *x != target)
+                        .map_gen(<$t>::from),
+                    universal: IsUniversal::is_universal(self),
+                }
+            }
+        }
+
+        impl FieldHit<$t> for PrefixSpec<$t> {
+            fn hits(&self) -> impl ValueGenerator<Output = $t> {
+                let value: $i = self.value.into();
+                let len = u32::from(self.len);
+                bolero::produce::<$i>().map_gen(move |rand| {
+                    let high = $high_mask(len);
+                    <$t>::from((value & high) | (rand & !high))
+                })
+            }
+        }
+        impl FieldMiss<$t> for PrefixSpec<$t> {
+            fn misses(&self) -> impl ValueGenerator<Output = $t> {
+                let value: $i = self.value.into();
+                let len = u32::from(self.len);
+                GuardedMisses {
+                    inner: bolero::produce::<$i>().filter_map_gen(move |rand| {
+                        let high = $high_mask(len);
+                        ((rand & high) != (value & high)).then(|| <$t>::from(rand))
+                    }),
+                    universal: IsUniversal::is_universal(self),
+                }
+            }
+        }
+
+        impl FieldHit<$t> for MaskSpec<$t> {
+            fn hits(&self) -> impl ValueGenerator<Output = $t> {
+                let v: $i = self.value.into();
+                let m: $i = self.mask.into();
+                bolero::produce::<$i>().map_gen(move |rand| <$t>::from((v & m) | (rand & !m)))
+            }
+        }
+        impl FieldMiss<$t> for MaskSpec<$t> {
+            fn misses(&self) -> impl ValueGenerator<Output = $t> {
+                let v: $i = self.value.into();
+                let m: $i = self.mask.into();
+                GuardedMisses {
+                    inner: bolero::produce::<$i>().filter_map_gen(move |rand| {
+                        ((rand & m) != (v & m)).then(|| <$t>::from(rand))
+                    }),
+                    universal: IsUniversal::is_universal(self),
+                }
+            }
+        }
+
+        impl FieldHit<$t> for RangeSpec<$t> {
+            fn hits(&self) -> impl ValueGenerator<Output = $t> {
+                let min: $i = self.min.into();
+                let max: $i = self.max.into();
+                (min..=max).map_gen(<$t>::from)
+            }
+        }
+        impl FieldMiss<$t> for RangeSpec<$t> {
+            fn misses(&self) -> impl ValueGenerator<Output = $t> {
+                let lo: $i = self.min.into();
+                let hi: $i = self.max.into();
+                GuardedMisses {
+                    inner: bolero::produce::<$i>().filter_map_gen(move |rand| {
+                        (rand < lo || rand > hi).then(|| <$t>::from(rand))
+                    }),
+                    universal: IsUniversal::is_universal(self),
+                }
+            }
+        }
+    };
+}
+
+impl_specs_for!(u8, u8, high_mask_u8);
+impl_specs_for!(u16, u16, high_mask_u16);
+impl_specs_for!(u32, u32, high_mask_u32);
+impl_specs_for!(u64, u64, high_mask_u64);
+impl_specs_for!(u128, u128, high_mask_u128);
+impl_specs_for!(Ipv4Addr, u32, high_mask_u32);
+impl_specs_for!(Ipv6Addr, u128, high_mask_u128);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Accepts, IsUniversal};
+
+    #[test]
+    fn exact_spec_hits_accepts() {
+        let spec = ExactSpec::new(42u16);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert!(spec.accepts(v)));
+    }
+
+    #[test]
+    fn exact_spec_misses_rejected() {
+        let spec = ExactSpec::new(42u16);
+        bolero::check!()
+            .with_generator(spec.misses())
+            .for_each(|v| assert!(!spec.accepts(v)));
+    }
+
+    #[test]
+    fn prefix_spec_u32_hits() {
+        let spec = PrefixSpec::new(0x0A00_0000u32, 8);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert_eq!(*v & 0xFF00_0000, 0x0A00_0000, "got {v:08x}"));
+    }
+
+    #[test]
+    fn prefix_spec_u32_misses() {
+        let spec = PrefixSpec::new(0x0A00_0000u32, 8);
+        bolero::check!()
+            .with_generator(spec.misses())
+            .for_each(|v| assert_ne!(*v & 0xFF00_0000, 0x0A00_0000, "got {v:08x}"));
+    }
+
+    #[test]
+    fn prefix_spec_zero_len_is_universal() {
+        assert!(PrefixSpec::new(0xDEAD_BEEF_u32, 0).is_universal());
+    }
+
+    #[test]
+    fn mask_spec_u16_hits_match_under_mask() {
+        let spec = MaskSpec::new(0xABCDu16, 0xFF00u16);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert_eq!(*v & 0xFF00, 0xAB00, "got {v:04x}"));
+    }
+
+    #[test]
+    fn mask_spec_u16_misses_disagree_under_mask() {
+        let spec = MaskSpec::new(0xABCDu16, 0xFF00u16);
+        bolero::check!()
+            .with_generator(spec.misses())
+            .for_each(|v| assert_ne!(*v & 0xFF00, 0xAB00, "got {v:04x}"));
+    }
+
+    #[test]
+    fn mask_spec_zero_mask_is_universal() {
+        assert!(MaskSpec::new(0xDEADu16, 0u16).is_universal());
+    }
+
+    #[test]
+    fn range_spec_u16_hits_in_range() {
+        let spec = RangeSpec::new(100u16, 200u16);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert!((100..=200).contains(v)));
+    }
+
+    #[test]
+    fn range_spec_u16_misses_outside_range() {
+        let spec = RangeSpec::new(100u16, 200u16);
+        bolero::check!()
+            .with_generator(spec.misses())
+            .for_each(|v| assert!(!(100..=200).contains(v)));
+    }
+
+    #[test]
+    fn range_spec_full_domain_is_universal() {
+        assert!(RangeSpec::new(0u16, u16::MAX).is_universal());
+    }
+
+    #[test]
+    fn ipv4_prefix_hits() {
+        let spec = PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert_eq!(v.octets()[0], 10, "got {v}"));
+    }
+
+    #[test]
+    fn ipv4_prefix_misses() {
+        let spec = PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8);
+        bolero::check!()
+            .with_generator(spec.misses())
+            .for_each(|v| assert_ne!(v.octets()[0], 10));
+    }
+
+    #[test]
+    fn ipv6_prefix_hits_on_high_chunk() {
+        let spec = PrefixSpec::new("2001:db8::".parse::<Ipv6Addr>().unwrap(), 32);
+        bolero::check!()
+            .with_generator(spec.hits())
+            .for_each(|v| assert_eq!(&v.octets()[0..4], &[0x20, 0x01, 0x0d, 0xb8], "got {v}"));
+    }
+}
+
+use crate::FieldPredicate;
+use crate::predicate::mask_matches;
+use core::ops::Bound;
+#[must_use]
+pub fn predicate_is_universal(pred: &FieldPredicate) -> bool {
+    if let Some((_, len)) = pred.as_prefix() {
+        len == 0
+    } else if let Some((_, mask)) = pred.as_mask() {
+        mask.iter().all(|&b| b == 0)
+    } else if let Some((min, max)) = pred.as_range() {
+        min.iter().all(|&b| b == 0) && max.iter().all(|&b| b == u8::MAX)
+    } else {
+        false
+    }
+}
+#[must_use]
+pub fn predicate_hits_bytes(pred: FieldPredicate) -> PredicateHitsBytes {
+    PredicateHitsBytes { pred }
+}
+#[must_use]
+pub fn predicate_misses_bytes(pred: FieldPredicate) -> PredicateMissesBytes {
+    let universal = predicate_is_universal(&pred);
+    PredicateMissesBytes { pred, universal }
+}
+
+pub struct PredicateHitsBytes {
+    pred: FieldPredicate,
+}
+
+impl ValueGenerator for PredicateHitsBytes {
+    type Output = Vec<u8>;
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Vec<u8>> {
+        if let Some(value) = self.pred.as_exact() {
+            Some(value.to_vec())
+        } else if let Some((value, prefix_len)) = self.pred.as_prefix() {
+            let mut buf = draw_bytes(d, value.len())?;
+            splat_prefix(&mut buf, value, prefix_len);
+            Some(buf)
+        } else if let Some((value, mask)) = self.pred.as_mask() {
+            let mut buf = draw_bytes(d, value.len())?;
+            splat_under_mask(&mut buf, value, mask);
+            Some(buf)
+        } else if let Some((min, max)) = self.pred.as_range() {
+            let lo = be_to_u32(min);
+            let hi = be_to_u32(max);
+            let v = (lo..=hi).generate(d)?;
+            Some(u32_to_be(v, min.len()))
+        } else {
+            None
+        }
+    }
+}
+
+pub struct PredicateMissesBytes {
+    pred: FieldPredicate,
+    universal: bool,
+}
+
+impl ValueGenerator for PredicateMissesBytes {
+    type Output = Vec<u8>;
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<Vec<u8>> {
+        if self.universal {
+            return None;
+        }
+        if let Some(value) = self.pred.as_exact() {
+            let buf = draw_bytes(d, value.len())?;
+            (buf.as_slice() != value).then_some(buf)
+        } else if let Some((value, prefix_len)) = self.pred.as_prefix() {
+            let buf = draw_bytes(d, value.len())?;
+            (!prefix_matches(&buf, value, prefix_len)).then_some(buf)
+        } else if let Some((value, mask)) = self.pred.as_mask() {
+            let buf = draw_bytes(d, value.len())?;
+            (!mask_matches(&buf, value, mask)).then_some(buf)
+        } else if let Some((min, max)) = self.pred.as_range() {
+            let buf = draw_bytes(d, min.len())?;
+            (buf.as_slice() < min || buf.as_slice() > max).then_some(buf)
+        } else {
+            None
+        }
+    }
+}
+
+fn draw_bytes<D: Driver>(d: &mut D, width: usize) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; width];
+    for byte in &mut buf {
+        *byte = d.gen_u8(Bound::Unbounded, Bound::Unbounded)?;
+    }
+    Some(buf)
+}
+fn splat_prefix(buf: &mut [u8], value: &[u8], len: u8) {
+    debug_assert_eq!(buf.len(), value.len());
+    let full_bytes = usize::from(len / 8);
+    let trailing_bits = u32::from(len % 8);
+    buf[..full_bytes].copy_from_slice(&value[..full_bytes]);
+    if trailing_bits > 0 && full_bytes < buf.len() {
+        let mask: u8 = !((1u8 << (8 - trailing_bits)) - 1);
+        buf[full_bytes] = (value[full_bytes] & mask) | (buf[full_bytes] & !mask);
+    }
+}
+fn splat_under_mask(buf: &mut [u8], value: &[u8], mask: &[u8]) {
+    debug_assert_eq!(buf.len(), value.len());
+    debug_assert_eq!(buf.len(), mask.len());
+    for ((b, &v), &m) in buf.iter_mut().zip(value).zip(mask) {
+        *b = (*b & !m) | (v & m);
+    }
+}
+fn prefix_matches(field: &[u8], value: &[u8], len: u8) -> bool {
+    let full_bytes = usize::from(len / 8);
+    if field[..full_bytes] != value[..full_bytes] {
+        return false;
+    }
+    let trailing_bits = u32::from(len % 8);
+    if trailing_bits == 0 {
+        return true;
+    }
+    let mask: u8 = !((1u8 << (8 - trailing_bits)) - 1);
+    (field[full_bytes] & mask) == (value[full_bytes] & mask)
+}
+fn be_to_u32(bytes: &[u8]) -> u32 {
+    assert!(
+        bytes.len() <= 4,
+        "be_to_u32: width {} exceeds 4 bytes",
+        bytes.len(),
+    );
+    let mut buf = [0u8; 4];
+    let off = 4 - bytes.len();
+    buf[off..].copy_from_slice(bytes);
+    u32::from_be_bytes(buf)
+}
+fn u32_to_be(value: u32, width: usize) -> Vec<u8> {
+    assert!(width <= 4, "u32_to_be: width {width} exceeds 4 bytes");
+    let buf = value.to_be_bytes();
+    buf[4 - width..].to_vec()
+}
+
+#[cfg(test)]
+mod byte_tests {
+    use super::*;
+    use crate::predicate::{Exact, FieldBytes, Mask, Prefix, Range};
+
+    fn fb(bytes: &[u8]) -> FieldBytes {
+        bytes.iter().copied().collect()
+    }
+
+    #[test]
+    fn is_universal_classifies_each_kind() {
+        assert!(!predicate_is_universal(&FieldPredicate::Exact(Exact::new(
+            fb(&[0])
+        ))));
+        assert!(predicate_is_universal(&FieldPredicate::Prefix(
+            Prefix::new(fb(&[0xAB, 0xCD]), 0)
+        )));
+        assert!(!predicate_is_universal(&FieldPredicate::Prefix(
+            Prefix::new(fb(&[0xAB, 0xCD]), 4)
+        )));
+        assert!(predicate_is_universal(&FieldPredicate::Mask(Mask::new(
+            fb(&[0xAB, 0xCD]),
+            fb(&[0, 0])
+        ))));
+        assert!(!predicate_is_universal(&FieldPredicate::Mask(Mask::new(
+            fb(&[0xAB, 0xCD]),
+            fb(&[0xFF, 0])
+        ))));
+        assert!(predicate_is_universal(&FieldPredicate::Range(Range::new(
+            fb(&[0, 0]),
+            fb(&[0xFF, 0xFF])
+        ))));
+        assert!(!predicate_is_universal(&FieldPredicate::Range(Range::new(
+            fb(&[0, 1]),
+            fb(&[0xFF, 0xFF])
+        ))));
+    }
+
+    #[test]
+    fn exact_hits_returns_value_bytes() {
+        let pred = FieldPredicate::Exact(Exact::new(fb(&[1, 2, 3, 4])));
+        bolero::check!()
+            .with_generator(predicate_hits_bytes(pred.clone()))
+            .for_each(|v| assert_eq!(v.as_slice(), &[1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn exact_misses_avoid_value() {
+        let pred = FieldPredicate::Exact(Exact::new(fb(&[1, 2])));
+        bolero::check!()
+            .with_generator(predicate_misses_bytes(pred.clone()))
+            .for_each(|v| assert_ne!(v.as_slice(), &[1, 2]));
+    }
+
+    #[test]
+    fn prefix_hits_preserve_top_bits() {
+        let pred = FieldPredicate::Prefix(Prefix::new(fb(&[0xAB, 0xCD]), 12));
+        bolero::check!()
+            .with_generator(predicate_hits_bytes(pred.clone()))
+            .for_each(|v| {
+                assert_eq!(v[0], 0xAB);
+                assert_eq!(v[1] & 0xF0, 0xC0);
+            });
+    }
+
+    #[test]
+    fn prefix_misses_differ_in_top_bits() {
+        let pred = FieldPredicate::Prefix(Prefix::new(fb(&[0xAB, 0xCD]), 12));
+        bolero::check!()
+            .with_generator(predicate_misses_bytes(pred.clone()))
+            .for_each(|v| {
+                let top_matches = v[0] == 0xAB && (v[1] & 0xF0) == 0xC0;
+                assert!(!top_matches);
+            });
+    }
+
+    #[test]
+    fn mask_hits_match_under_mask() {
+        let pred = FieldPredicate::Mask(Mask::new(fb(&[0xAB, 0xCD]), fb(&[0xFF, 0x00])));
+        bolero::check!()
+            .with_generator(predicate_hits_bytes(pred.clone()))
+            .for_each(|v| {
+                assert_eq!(v[0], 0xAB);
+            });
+    }
+
+    #[test]
+    fn mask_misses_disagree_under_mask() {
+        let pred = FieldPredicate::Mask(Mask::new(fb(&[0xAB, 0xCD]), fb(&[0xFF, 0x00])));
+        bolero::check!()
+            .with_generator(predicate_misses_bytes(pred.clone()))
+            .for_each(|v| {
+                assert_ne!(v[0], 0xAB);
+            });
+    }
+
+    #[test]
+    fn range_hits_in_range() {
+        let pred = FieldPredicate::Range(Range::new(
+            fb(&100u16.to_be_bytes()),
+            fb(&200u16.to_be_bytes()),
+        ));
+        bolero::check!()
+            .with_generator(predicate_hits_bytes(pred.clone()))
+            .for_each(|v| {
+                let x = u16::from_be_bytes([v[0], v[1]]);
+                assert!((100..=200).contains(&x));
+            });
+    }
+
+    #[test]
+    fn range_misses_outside_range() {
+        let pred = FieldPredicate::Range(Range::new(
+            fb(&100u16.to_be_bytes()),
+            fb(&200u16.to_be_bytes()),
+        ));
+        bolero::check!()
+            .with_generator(predicate_misses_bytes(pred.clone()))
+            .for_each(|v| {
+                let x = u16::from_be_bytes([v[0], v[1]]);
+                assert!(!(100..=200).contains(&x));
+            });
+    }
+}

--- a/match-action/src/lib.rs
+++ b/match-action/src/lib.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+#![allow(missing_docs)] // shape settling; doc once stable
+
+//! Backend-agnostic match-action key vocabulary.
+//!
+//! Struct fields annotated with `#[prefix]` / `#[mask]` / `#[range]` /
+//! `#[exact]`; `#[derive(MatchKey)]` emits the [`MatchKey`] impl and
+//! a parallel `<Name>Rule` struct of kind-typed `*Spec`s.
+//!
+//! ```ignore
+//! #[derive(MatchKey)]
+//! struct FiveTuple {
+//!     #[exact]  proto: u8,
+//!     #[prefix] src_ip: Ipv4Addr,
+//!     #[range]  dst_port: u16,
+//! }
+//! ```
+//!
+//! Backends consume via [`MatchKey::field_specs`] (structural view)
+//! and [`MatchKey::as_key_into`] (byte packer).  Rule wrappers and
+//! backend lowering live in [`rule`]; the type-erased
+//! [`FieldPredicate`] lives in [`predicate`].
+
+pub mod field;
+pub mod predicate;
+pub mod rule;
+
+pub use field::FixedSize;
+pub use predicate::{Erased, FieldBytes, FieldPredicate, MAX_FIELD_BYTES};
+pub use rule::{
+    Accepts, Backend, ExactSpec, IntoBackendField, IsUniversal, MaskSpec, PrefixSpec, RangeSpec,
+    RuleField,
+};
+
+#[cfg(feature = "derive")]
+pub use match_action_derive::MatchKey;
+
+/// One of the four predicate flavors.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum FieldKind {
+    Prefix,
+    Mask,
+    Range,
+    Exact,
+}
+
+/// Static layout of one field within a [`MatchKey`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FieldSpec {
+    pub name: &'static str,
+    pub kind: FieldKind,
+    pub size: usize,
+    pub offset: usize,
+}
+
+/// A match-action lookup key.
+///
+/// Emitted by `#[derive(MatchKey)]`, which also adds an inherent
+/// `FIELD_SPECS` const and (for non-generic structs) an `as_key() ->
+/// [u8; KEY_SIZE]` for ergonomics.
+///
+/// Trait methods take slices instead of `Self::N`-sized arrays
+/// because `Self::N` in a trait fn needs unstable
+/// `generic_const_exprs`; sized inherents sidestep that.
+pub trait MatchKey: Sized {
+    const N: usize;
+    const KEY_SIZE: usize;
+    fn field_specs() -> &'static [FieldSpec];
+    /// `out.len() >= KEY_SIZE`; the derive emits a length check.
+    fn as_key_into(&self, out: &mut [u8]);
+}

--- a/match-action/src/lib.rs
+++ b/match-action/src/lib.rs
@@ -9,31 +9,15 @@
     clippy::expect_used,
     clippy::panic
 )]
-#![allow(missing_docs)] // shape settling; doc once stable
-
-//! Backend-agnostic match-action key vocabulary.
-//!
-//! Struct fields annotated with `#[prefix]` / `#[mask]` / `#[range]` /
-//! `#[exact]`; `#[derive(MatchKey)]` emits the [`MatchKey`] impl and
-//! a parallel `<Name>Rule` struct of kind-typed `*Spec`s.
-//!
-//! ```ignore
-//! #[derive(MatchKey)]
-//! struct FiveTuple {
-//!     #[exact]  proto: u8,
-//!     #[prefix] src_ip: Ipv4Addr,
-//!     #[range]  dst_port: u16,
-//! }
-//! ```
-//!
-//! Backends consume via [`MatchKey::field_specs`] (structural view)
-//! and [`MatchKey::as_key_into`] (byte packer).  Rule wrappers and
-//! backend lowering live in [`rule`]; the type-erased
-//! [`FieldPredicate`] lives in [`predicate`].
+#![allow(missing_docs)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 pub mod field;
 pub mod predicate;
 pub mod rule;
+
+#[cfg(feature = "bolero")]
+pub mod generator;
 
 pub use field::FixedSize;
 pub use predicate::{Erased, FieldBytes, FieldPredicate, MAX_FIELD_BYTES};
@@ -42,10 +26,11 @@ pub use rule::{
     RuleField,
 };
 
+#[cfg(feature = "bolero")]
+pub use generator::{FieldHit, FieldMiss};
+
 #[cfg(feature = "derive")]
 pub use match_action_derive::MatchKey;
-
-/// One of the four predicate flavors.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FieldKind {
     Prefix,
@@ -53,8 +38,6 @@ pub enum FieldKind {
     Range,
     Exact,
 }
-
-/// Static layout of one field within a [`MatchKey`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FieldSpec {
     pub name: &'static str,
@@ -62,20 +45,9 @@ pub struct FieldSpec {
     pub size: usize,
     pub offset: usize,
 }
-
-/// A match-action lookup key.
-///
-/// Emitted by `#[derive(MatchKey)]`, which also adds an inherent
-/// `FIELD_SPECS` const and (for non-generic structs) an `as_key() ->
-/// [u8; KEY_SIZE]` for ergonomics.
-///
-/// Trait methods take slices instead of `Self::N`-sized arrays
-/// because `Self::N` in a trait fn needs unstable
-/// `generic_const_exprs`; sized inherents sidestep that.
 pub trait MatchKey: Sized {
     const N: usize;
     const KEY_SIZE: usize;
     fn field_specs() -> &'static [FieldSpec];
-    /// `out.len() >= KEY_SIZE`; the derive emits a length check.
     fn as_key_into(&self, out: &mut [u8]);
 }

--- a/match-action/src/predicate.rs
+++ b/match-action/src/predicate.rs
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use arrayvec::ArrayVec;
+
+use crate::field::FixedSize;
+use crate::rule::{
+    Accepts, Backend, ExactSpec, IntoBackendField, IsUniversal, MaskSpec, PrefixSpec, RangeSpec,
+};
+pub const MAX_FIELD_BYTES: usize = 16;
+pub type FieldBytes = ArrayVec<u8, MAX_FIELD_BYTES>;
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Erased;
+
+impl Backend for Erased {
+    type Field = FieldPredicate;
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Exact {
+    value: FieldBytes,
+}
+
+impl Exact {
+    #[must_use]
+    pub fn new(value: FieldBytes) -> Self {
+        Self { value }
+    }
+
+    fn matches(&self, field: &[u8]) -> bool {
+        assert_eq!(field.len(), self.value.len(), "field width mismatch");
+        field == self.value.as_slice()
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Prefix {
+    value: FieldBytes,
+    len: u8,
+}
+
+impl Prefix {
+    #[must_use]
+    pub fn new(value: FieldBytes, len: u8) -> Self {
+        assert!(
+            usize::from(len) <= value.len() * 8,
+            "prefix length {len} exceeds field width of {} bits",
+            value.len() * 8,
+        );
+        Self { value, len }
+    }
+    fn matches(&self, field: &[u8]) -> bool {
+        assert_eq!(field.len(), self.value.len(), "field width mismatch");
+        mask_matches(field, &self.value, &prefix_mask(field.len(), self.len))
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Mask {
+    value: FieldBytes,
+    mask: FieldBytes,
+}
+
+impl Mask {
+    #[must_use]
+    pub fn new(value: FieldBytes, mask: FieldBytes) -> Self {
+        assert_eq!(value.len(), mask.len(), "mask width must equal value width");
+        Self { value, mask }
+    }
+    fn matches(&self, field: &[u8]) -> bool {
+        assert_eq!(field.len(), self.value.len(), "field width mismatch");
+        mask_matches(field, &self.value, &self.mask)
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Range {
+    min: FieldBytes,
+    max: FieldBytes,
+}
+
+impl Range {
+    #[must_use]
+    pub fn new(min: FieldBytes, max: FieldBytes) -> Self {
+        assert_eq!(min.len(), max.len(), "range bounds must be equal width");
+        Self { min, max }
+    }
+    fn matches(&self, field: &[u8]) -> bool {
+        assert_eq!(field.len(), self.min.len(), "field width mismatch");
+        field >= self.min.as_slice() && field <= self.max.as_slice()
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FieldPredicate {
+    Exact(Exact),
+    Prefix(Prefix),
+    Mask(Mask),
+    Range(Range),
+}
+
+impl From<Exact> for FieldPredicate {
+    fn from(p: Exact) -> Self {
+        Self::Exact(p)
+    }
+}
+
+impl From<Prefix> for FieldPredicate {
+    fn from(p: Prefix) -> Self {
+        Self::Prefix(p)
+    }
+}
+
+impl From<Mask> for FieldPredicate {
+    fn from(p: Mask) -> Self {
+        Self::Mask(p)
+    }
+}
+
+impl From<Range> for FieldPredicate {
+    fn from(p: Range) -> Self {
+        Self::Range(p)
+    }
+}
+
+impl FieldPredicate {
+    #[must_use]
+    pub fn matches(&self, field: &[u8]) -> bool {
+        match self {
+            FieldPredicate::Exact(p) => p.matches(field),
+            FieldPredicate::Prefix(p) => p.matches(field),
+            FieldPredicate::Mask(p) => p.matches(field),
+            FieldPredicate::Range(p) => p.matches(field),
+        }
+    }
+    #[must_use]
+    pub fn width(&self) -> usize {
+        match self {
+            FieldPredicate::Exact(p) => p.value.len(),
+            FieldPredicate::Prefix(p) => p.value.len(),
+            FieldPredicate::Mask(p) => p.value.len(),
+            FieldPredicate::Range(p) => p.min.len(),
+        }
+    }
+
+    #[must_use]
+    pub fn as_exact(&self) -> Option<&[u8]> {
+        match self {
+            FieldPredicate::Exact(p) => Some(&p.value),
+            _ => None,
+        }
+    }
+    #[must_use]
+    pub fn as_prefix(&self) -> Option<(&[u8], u8)> {
+        match self {
+            FieldPredicate::Prefix(p) => Some((&p.value, p.len)),
+            _ => None,
+        }
+    }
+    #[must_use]
+    pub fn as_mask(&self) -> Option<(&[u8], &[u8])> {
+        match self {
+            FieldPredicate::Mask(p) => Some((&p.value, &p.mask)),
+            _ => None,
+        }
+    }
+    #[must_use]
+    pub fn as_range(&self) -> Option<(&[u8], &[u8])> {
+        match self {
+            FieldPredicate::Range(p) => Some((&p.min, &p.max)),
+            _ => None,
+        }
+    }
+}
+fn be_bytes<T: FixedSize>(value: &T) -> FieldBytes {
+    let mut buf = [0u8; MAX_FIELD_BYTES];
+    value.write_be(&mut buf);
+    buf[..T::SIZE].iter().copied().collect()
+}
+
+impl<T: FixedSize> IntoBackendField<Erased> for ExactSpec<T> {
+    fn into_backend_field(self) -> FieldPredicate {
+        FieldPredicate::Exact(Exact::new(be_bytes(&self.value)))
+    }
+}
+
+impl<T: FixedSize> IntoBackendField<Erased> for PrefixSpec<T> {
+    fn into_backend_field(self) -> FieldPredicate {
+        FieldPredicate::Prefix(Prefix::new(be_bytes(&self.value), self.len))
+    }
+}
+
+impl<T: FixedSize> IntoBackendField<Erased> for MaskSpec<T> {
+    fn into_backend_field(self) -> FieldPredicate {
+        FieldPredicate::Mask(Mask::new(be_bytes(&self.value), be_bytes(&self.mask)))
+    }
+}
+
+impl<T: FixedSize> IntoBackendField<Erased> for RangeSpec<T> {
+    fn into_backend_field(self) -> FieldPredicate {
+        FieldPredicate::Range(Range::new(be_bytes(&self.min), be_bytes(&self.max)))
+    }
+}
+impl<T: FixedSize> Accepts<T> for ExactSpec<T> {
+    fn accepts(&self, value: &T) -> bool {
+        Exact::new(be_bytes(&self.value)).matches(&be_bytes(value))
+    }
+}
+
+impl<T: FixedSize> Accepts<T> for PrefixSpec<T> {
+    fn accepts(&self, value: &T) -> bool {
+        Prefix::new(be_bytes(&self.value), self.len).matches(&be_bytes(value))
+    }
+}
+
+impl<T: FixedSize> Accepts<T> for MaskSpec<T> {
+    fn accepts(&self, value: &T) -> bool {
+        Mask::new(be_bytes(&self.value), be_bytes(&self.mask)).matches(&be_bytes(value))
+    }
+}
+
+impl<T: FixedSize> Accepts<T> for RangeSpec<T> {
+    fn accepts(&self, value: &T) -> bool {
+        Range::new(be_bytes(&self.min), be_bytes(&self.max)).matches(&be_bytes(value))
+    }
+}
+impl<T: FixedSize> IsUniversal for MaskSpec<T> {
+    fn is_universal(&self) -> bool {
+        be_bytes(&self.mask).iter().all(|b| *b == 0)
+    }
+}
+
+impl<T: FixedSize> IsUniversal for RangeSpec<T> {
+    fn is_universal(&self) -> bool {
+        let lo = be_bytes(&self.min);
+        let hi = be_bytes(&self.max);
+        lo.iter().all(|b| *b == 0) && hi.iter().all(|b| *b == u8::MAX)
+    }
+}
+#[inline]
+pub(crate) fn mask_matches(field: &[u8], value: &[u8], mask: &[u8]) -> bool {
+    assert_eq!(field.len(), value.len());
+    assert_eq!(field.len(), mask.len());
+    field
+        .iter()
+        .zip(value)
+        .zip(mask)
+        .all(|((f, v), m)| (f & m) == (v & m))
+}
+#[inline]
+fn prefix_mask(nbytes: usize, len: u8) -> FieldBytes {
+    assert!(
+        nbytes <= MAX_FIELD_BYTES,
+        "field width {nbytes} exceeds MAX_FIELD_BYTES {MAX_FIELD_BYTES}",
+    );
+    assert!(
+        usize::from(len) <= nbytes * 8,
+        "prefix length {len} exceeds {nbytes}-byte field",
+    );
+    let mut out = FieldBytes::new();
+    let mut remaining = usize::from(len);
+    for _ in 0..nbytes {
+        let bits = remaining.min(8);
+        let byte = if bits == 0 { 0 } else { 0xFFu8 << (8 - bits) };
+        out.push(byte);
+        remaining -= bits;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::net::Ipv4Addr;
+
+    fn bytes(slice: &[u8]) -> FieldBytes {
+        slice.iter().copied().collect()
+    }
+
+    #[test]
+    fn exact_matches_only_equal_bytes() {
+        let f = ExactSpec::new(6u8).into_backend_field();
+        assert!(f.matches(&[6]));
+        assert!(!f.matches(&[7]));
+    }
+
+    #[test]
+    fn prefix_mask_sets_top_bits() {
+        assert_eq!(prefix_mask(4, 24).as_slice(), &[0xFF, 0xFF, 0xFF, 0x00]);
+        assert_eq!(prefix_mask(4, 20).as_slice(), &[0xFF, 0xFF, 0xF0, 0x00]);
+        assert_eq!(prefix_mask(4, 0).as_slice(), &[0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(prefix_mask(4, 32).as_slice(), &[0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix length")]
+    fn prefix_mask_panics_on_over_long_len() {
+        let _ = prefix_mask(4, 33);
+    }
+
+    #[test]
+    #[should_panic(expected = "MAX_FIELD_BYTES")]
+    fn prefix_mask_panics_on_oversized_field() {
+        let _ = prefix_mask(MAX_FIELD_BYTES + 1, 8);
+    }
+
+    #[test]
+    fn prefix_matches_on_high_bits_only() {
+        let f = PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8).into_backend_field();
+        assert!(f.matches(&Ipv4Addr::new(10, 1, 2, 3).octets()));
+        assert!(f.matches(&Ipv4Addr::new(10, 255, 255, 255).octets()));
+        assert!(!f.matches(&Ipv4Addr::new(11, 0, 0, 0).octets()));
+    }
+
+    #[test]
+    fn prefix_len_zero_is_wildcard() {
+        let f = PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 0).into_backend_field();
+        assert!(f.matches(&Ipv4Addr::new(1, 2, 3, 4).octets()));
+        assert!(f.matches(&Ipv4Addr::UNSPECIFIED.octets()));
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix length")]
+    fn over_long_prefix_len_panics() {
+        let _ = Prefix::new(bytes(&[10, 0, 0, 1]), 200);
+    }
+
+    #[test]
+    fn mask_matches_required_bits() {
+        let f = MaskSpec::new(0xABu8, 0xF0u8).into_backend_field();
+        assert!(f.matches(&[0xA0]));
+        assert!(f.matches(&[0xAF]));
+        assert!(!f.matches(&[0xB0]));
+    }
+
+    #[test]
+    fn range_is_inclusive_both_ends() {
+        let f = RangeSpec::new(80u16, 8080u16).into_backend_field();
+        assert!(f.matches(&80u16.to_be_bytes()));
+        assert!(f.matches(&8080u16.to_be_bytes()));
+        assert!(f.matches(&443u16.to_be_bytes()));
+        assert!(!f.matches(&79u16.to_be_bytes()));
+        assert!(!f.matches(&8081u16.to_be_bytes()));
+    }
+
+    #[test]
+    #[should_panic(expected = "field width")]
+    fn exact_field_width_mismatch_panics() {
+        let f = FieldPredicate::Exact(Exact::new(bytes(&[1, 2, 3, 4])));
+        let _ = f.matches(&[1, 2]);
+    }
+
+    #[test]
+    #[should_panic(expected = "field width")]
+    fn range_field_width_mismatch_panics() {
+        let r = FieldPredicate::Range(Range::new(bytes(&[0, 0]), bytes(&[255, 255])));
+        let _ = r.matches(&[0, 0, 0]);
+    }
+}

--- a/match-action/src/rule.rs
+++ b/match-action/src/rule.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use crate::{FieldKind, FixedSize};
+pub trait RuleField {
+    const KIND: FieldKind;
+    type Value: FixedSize;
+}
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ExactSpec<T: FixedSize> {
+    pub value: T,
+}
+
+impl<T: FixedSize> ExactSpec<T> {
+    #[must_use]
+    pub const fn new(value: T) -> Self {
+        Self { value }
+    }
+}
+
+impl<T: FixedSize> RuleField for ExactSpec<T> {
+    const KIND: FieldKind = FieldKind::Exact;
+    type Value = T;
+}
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PrefixSpec<T: FixedSize> {
+    pub value: T,
+    pub len: u8,
+}
+
+impl<T: FixedSize> PrefixSpec<T> {
+    #[must_use]
+    pub fn new(value: T, len: u8) -> Self {
+        let bits = T::SIZE
+            .checked_mul(8)
+            .and_then(|b| u8::try_from(b).ok())
+            .unwrap_or(u8::MAX);
+        assert!(
+            len <= bits,
+            "prefix length {len} exceeds field width of {bits} bits",
+        );
+        Self { value, len }
+    }
+}
+
+impl<T: FixedSize> RuleField for PrefixSpec<T> {
+    const KIND: FieldKind = FieldKind::Prefix;
+    type Value = T;
+}
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MaskSpec<T: FixedSize> {
+    pub value: T,
+    pub mask: T,
+}
+
+impl<T: FixedSize> MaskSpec<T> {
+    #[must_use]
+    pub const fn new(value: T, mask: T) -> Self {
+        Self { value, mask }
+    }
+}
+
+impl<T: FixedSize> RuleField for MaskSpec<T> {
+    const KIND: FieldKind = FieldKind::Mask;
+    type Value = T;
+}
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RangeSpec<T: FixedSize> {
+    pub min: T,
+    pub max: T,
+}
+
+impl<T: FixedSize> RangeSpec<T> {
+    #[must_use]
+    pub const fn new(min: T, max: T) -> Self {
+        Self { min, max }
+    }
+    #[must_use]
+    pub const fn exact(value: T) -> Self {
+        Self {
+            min: value,
+            max: value,
+        }
+    }
+}
+
+impl<T: FixedSize> RuleField for RangeSpec<T> {
+    const KIND: FieldKind = FieldKind::Range;
+    type Value = T;
+}
+impl<T: FixedSize> From<core::ops::RangeInclusive<T>> for RangeSpec<T> {
+    fn from(range: core::ops::RangeInclusive<T>) -> Self {
+        let (min, max) = range.into_inner();
+        Self { min, max }
+    }
+}
+pub trait Backend {
+    type Field;
+}
+pub trait IntoBackendField<B: Backend> {
+    fn into_backend_field(self) -> B::Field;
+}
+pub trait Accepts<T> {
+    fn accepts(&self, value: &T) -> bool;
+}
+pub trait IsUniversal {
+    fn is_universal(&self) -> bool;
+}
+
+impl<T: FixedSize> IsUniversal for ExactSpec<T> {
+    fn is_universal(&self) -> bool {
+        false
+    }
+}
+
+impl<T: FixedSize> IsUniversal for PrefixSpec<T> {
+    fn is_universal(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn prefix_spec_accepts_max_v4_length() {
+        let _ = PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 32);
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix length 33 exceeds field width of 32 bits")]
+    fn prefix_spec_rejects_v4_over_32() {
+        let _ = PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 33);
+    }
+
+    #[test]
+    fn prefix_spec_accepts_max_v6_length() {
+        let _ = PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 128);
+    }
+
+    #[test]
+    #[should_panic(expected = "prefix length 129 exceeds field width of 128 bits")]
+    fn prefix_spec_rejects_v6_over_128() {
+        let _ = PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 129);
+    }
+}

--- a/match-action/tests/derive_roundtrip.rs
+++ b/match-action/tests/derive_roundtrip.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use core::net::Ipv4Addr;
+
+use dataplane_match_action::{
+    ExactSpec, FieldKind, FixedSize, MatchKey, PrefixSpec, RangeSpec, RuleField,
+};
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct IpProto(u8);
+
+impl FixedSize for IpProto {
+    const SIZE: usize = 1;
+    fn write_be(&self, out: &mut [u8]) {
+        out[0] = self.0;
+    }
+}
+
+#[derive(MatchKey)]
+struct FiveTuple {
+    #[exact]
+    proto: IpProto,
+    #[prefix]
+    src_ip: Ipv4Addr,
+    #[prefix]
+    dst_ip: Ipv4Addr,
+    #[range]
+    src_port: u16,
+    #[range]
+    dst_port: u16,
+}
+
+#[test]
+fn n_and_key_size_match_field_layout() {
+    assert_eq!(FiveTuple::N, 5);
+    assert_eq!(FiveTuple::KEY_SIZE, 13);
+}
+
+#[test]
+fn field_specs_match_declaration_order() {
+    let specs = FiveTuple::field_specs();
+    assert_eq!(specs.len(), 5);
+
+    assert_eq!(specs[0].name, "proto");
+    assert_eq!(specs[0].kind, FieldKind::Exact);
+    assert_eq!(specs[0].size, 1);
+    assert_eq!(specs[0].offset, 0);
+
+    assert_eq!(specs[1].name, "src_ip");
+    assert_eq!(specs[1].kind, FieldKind::Prefix);
+    assert_eq!(specs[1].size, 4);
+    assert_eq!(specs[1].offset, 1);
+
+    assert_eq!(specs[2].name, "dst_ip");
+    assert_eq!(specs[2].kind, FieldKind::Prefix);
+    assert_eq!(specs[2].size, 4);
+    assert_eq!(specs[2].offset, 5);
+
+    assert_eq!(specs[3].name, "src_port");
+    assert_eq!(specs[3].kind, FieldKind::Range);
+    assert_eq!(specs[3].size, 2);
+    assert_eq!(specs[3].offset, 9);
+
+    assert_eq!(specs[4].name, "dst_port");
+    assert_eq!(specs[4].kind, FieldKind::Range);
+    assert_eq!(specs[4].size, 2);
+    assert_eq!(specs[4].offset, 11);
+}
+
+#[test]
+fn key_packs_big_endian_at_field_offsets() {
+    let key = FiveTuple {
+        proto: IpProto(6),
+        src_ip: Ipv4Addr::new(10, 0, 1, 2),
+        dst_ip: Ipv4Addr::new(192, 168, 5, 7),
+        src_port: 54321,
+        dst_port: 22,
+    };
+    let arr: [u8; FiveTuple::KEY_SIZE] = key.as_key();
+    let mut buf = [0u8; FiveTuple::KEY_SIZE];
+    key.as_key_into(&mut buf);
+    assert_eq!(arr, buf);
+
+    assert_eq!(arr[0], 6);
+    assert_eq!(&arr[1..5], &[10, 0, 1, 2]);
+    assert_eq!(&arr[5..9], &[192, 168, 5, 7]);
+    assert_eq!(&arr[9..11], &54321u16.to_be_bytes());
+    assert_eq!(&arr[11..13], &22u16.to_be_bytes());
+}
+
+#[test]
+fn as_key_into_does_not_touch_bytes_past_the_key() {
+    let key = FiveTuple {
+        proto: IpProto(17),
+        src_ip: Ipv4Addr::UNSPECIFIED,
+        dst_ip: Ipv4Addr::UNSPECIFIED,
+        src_port: 0,
+        dst_port: 0,
+    };
+    let mut buf = [0xFFu8; 64];
+    key.as_key_into(&mut buf);
+    assert_eq!(buf[0], 17);
+    assert_eq!(buf[FiveTuple::KEY_SIZE], 0xFF);
+    assert_eq!(buf[63], 0xFF);
+}
+
+#[test]
+fn derive_emits_parallel_rule_struct() {
+    let rule = FiveTupleRule {
+        proto: ExactSpec::new(IpProto(6)),
+        src_ip: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 24),
+        dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+        src_port: RangeSpec::new(0, u16::MAX),
+        dst_port: RangeSpec::exact(80),
+    };
+
+    assert_eq!(rule.proto.value, IpProto(6));
+    assert_eq!(rule.src_ip.len, 24);
+    assert_eq!(rule.dst_ip.len, 0);
+    assert_eq!(rule.src_port.min, 0);
+    assert_eq!(rule.src_port.max, u16::MAX);
+    assert_eq!(rule.dst_port.min, 80);
+    assert_eq!(rule.dst_port.max, 80);
+}
+
+#[test]
+fn rule_field_kinds_match_match_key_attrs() {
+    assert_eq!(<ExactSpec<IpProto> as RuleField>::KIND, FieldKind::Exact);
+    assert_eq!(<PrefixSpec<Ipv4Addr> as RuleField>::KIND, FieldKind::Prefix);
+    assert_eq!(<RangeSpec<u16> as RuleField>::KIND, FieldKind::Range);
+}
+
+#[test]
+fn single_field_key_works() {
+    #[derive(MatchKey)]
+    #[allow(dead_code)]
+    struct Mono {
+        #[exact]
+        only: u32,
+    }
+
+    assert_eq!(Mono::N, 1);
+    assert_eq!(Mono::KEY_SIZE, 4);
+    let specs = Mono::field_specs();
+    assert_eq!(specs[0].name, "only");
+    assert_eq!(specs[0].offset, 0);
+    assert_eq!(specs[0].kind, FieldKind::Exact);
+
+    let m = Mono { only: 0xDEAD_BEEF };
+    let arr = m.as_key();
+    assert_eq!(arr, 0xDEAD_BEEFu32.to_be_bytes());
+}
+
+#[test]
+fn range_spec_from_inclusive_range() {
+    let r: RangeSpec<u16> = (80..=8080).into();
+    assert_eq!(r.min, 80);
+    assert_eq!(r.max, 8080);
+
+    let single: RangeSpec<u16> = (22..=22).into();
+    assert_eq!(single, RangeSpec::exact(22));
+}
+
+#[test]
+fn fields_without_attribute_default_to_exact() {
+    #[derive(MatchKey)]
+    #[allow(dead_code)]
+    struct AllExact {
+        a: u8,
+        b: u32,
+    }
+
+    let specs = AllExact::field_specs();
+    assert_eq!(specs.len(), 2);
+    assert_eq!(specs[0].kind, FieldKind::Exact);
+    assert_eq!(specs[1].kind, FieldKind::Exact);
+    assert_eq!(AllExact::KEY_SIZE, 5);
+    let _rule = AllExactRule {
+        a: ExactSpec::new(6u8),
+        b: ExactSpec::new(0x0A00_0001u32),
+    };
+
+    let key = AllExact {
+        a: 6,
+        b: 0x0A00_0001,
+    };
+    let bytes = key.as_key();
+    assert_eq!(bytes[0], 6);
+    assert_eq!(&bytes[1..5], &0x0A00_0001u32.to_be_bytes());
+}
+
+#[test]
+fn generic_match_key_instantiates_for_v4_and_v6() {
+    use core::net::Ipv6Addr;
+    #[derive(MatchKey)]
+    #[allow(dead_code)]
+    struct TwoTuple<Addr: FixedSize> {
+        #[prefix]
+        src: Addr,
+        #[prefix]
+        dst: Addr,
+    }
+    assert_eq!(<TwoTuple<Ipv4Addr>>::N, 2);
+    assert_eq!(<TwoTuple<Ipv4Addr>>::KEY_SIZE, 8);
+    let v4_specs = <TwoTuple<Ipv4Addr>>::field_specs();
+    assert_eq!(v4_specs[0].size, 4);
+    assert_eq!(v4_specs[1].offset, 4);
+    assert_eq!(v4_specs[0].kind, FieldKind::Prefix);
+    assert_eq!(<TwoTuple<Ipv6Addr>>::N, 2);
+    assert_eq!(<TwoTuple<Ipv6Addr>>::KEY_SIZE, 32);
+    let v6_specs = <TwoTuple<Ipv6Addr>>::field_specs();
+    assert_eq!(v6_specs[0].size, 16);
+    assert_eq!(v6_specs[1].offset, 16);
+    let _v4_rule = TwoTupleRule::<Ipv4Addr> {
+        src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+        dst: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+    };
+    let v4 = TwoTuple::<Ipv4Addr> {
+        src: Ipv4Addr::new(10, 0, 1, 2),
+        dst: Ipv4Addr::new(192, 168, 5, 7),
+    };
+    let mut buf = [0u8; 8];
+    v4.as_key_into(&mut buf);
+    assert_eq!(&buf[0..4], &[10, 0, 1, 2]);
+    assert_eq!(&buf[4..8], &[192, 168, 5, 7]);
+}
+#[test]
+fn derive_accepts_explicit_where_clause() {
+    #[derive(MatchKey)]
+    #[allow(dead_code)]
+    struct WithWhere<Addr>
+    where
+        Addr: FixedSize,
+    {
+        #[prefix]
+        src: Addr,
+    }
+
+    assert_eq!(<WithWhere<Ipv4Addr>>::N, 1);
+    assert_eq!(<WithWhere<Ipv4Addr>>::KEY_SIZE, 4);
+
+    let _rule = WithWhereRule::<Ipv4Addr> {
+        src: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+    };
+}

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -27,6 +27,7 @@ concurrency = { workspace = true }
 derive_builder = { workspace = true, features = ["alloc"] }
 downcast-rs = { workspace = true, features = ["sync"] }
 etherparse = { workspace = true, features = ["std"] }
+fixed-size = { workspace = true, features = [] }
 id = { workspace = true }
 multi_index_map = { workspace = true, default-features = false, features = ["serde"] }
 rapidhash = { workspace = true }

--- a/net/src/fixed_size.rs
+++ b/net/src/fixed_size.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use fixed_size::FixedSize;
+
+use crate::ipv4::UnicastIpv4Addr;
+use crate::tcp::TcpPort;
+use crate::udp::UdpPort;
+use crate::vxlan::Vni;
+
+impl FixedSize for TcpPort {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u16().write_be(out);
+    }
+}
+
+impl FixedSize for UdpPort {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u16().write_be(out);
+    }
+}
+
+impl FixedSize for UnicastIpv4Addr {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        self.inner().write_be(out);
+    }
+}
+
+impl FixedSize for Vni {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u32().write_be(out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn ports_write_two_big_endian_bytes() {
+        assert_eq!(<TcpPort as FixedSize>::SIZE, 2);
+        assert_eq!(<UdpPort as FixedSize>::SIZE, 2);
+        let mut buf = [0u8; 2];
+        TcpPort::new_checked(443).unwrap().write_be(&mut buf);
+        assert_eq!(buf, 443u16.to_be_bytes());
+        UdpPort::new_checked(4789).unwrap().write_be(&mut buf);
+        assert_eq!(buf, 4789u16.to_be_bytes());
+    }
+
+    #[test]
+    fn unicast_v4_writes_four_octets() {
+        assert_eq!(<UnicastIpv4Addr as FixedSize>::SIZE, 4);
+        let mut buf = [0u8; 4];
+        UnicastIpv4Addr::new(Ipv4Addr::new(10, 0, 1, 2))
+            .unwrap()
+            .write_be(&mut buf);
+        assert_eq!(buf, [10, 0, 1, 2]);
+    }
+
+    #[test]
+    fn vni_writes_four_bytes_with_zero_high_byte() {
+        assert_eq!(<Vni as FixedSize>::SIZE, 4);
+        let mut buf = [0u8; 4];
+        Vni::new_checked(0x00AB_CDEF).unwrap().write_be(&mut buf);
+        assert_eq!(buf, [0x00, 0xAB, 0xCD, 0xEF]);
+    }
+}

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -19,6 +19,8 @@ pub mod addr_parse_error;
 pub mod buffer;
 pub mod checksum;
 pub mod eth;
+/// `FixedSize` impls bridging `net` field types into match-action keys.
+mod fixed_size;
 #[cfg(unix)]
 pub mod flows;
 pub mod headers;


### PR DESCRIPTION
Stack (8). Base: `pr/daniel-noland/threading-rewrite`.

DPDK test plumbing that the rest of the ACL stack relies on, kept separate so it
reviews on its own:

- `refactor(dpdk/acl)`: make `compute_min_input_size` a `const fn`.
- `feat(dpdk)`: `test_support::start_eal` + `#[with_eal]` attribute macro
  (`dpdk-test-macros`), so EAL-dependent tests can opt in declaratively.

No new abstractions, no behavior change to shipping code.
---

**Review stack** (merge bottom -> top):
- (7) #1555 threading rewrite
- (8) #1572 dpdk test EAL harness
- (9) #1573 fixed-size + lookup
- (10) #1574 match-action
- (11) #1575 acl reference backend
- (12) #1576 acl rte_acl backend
- (13) #1567 cascade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds DPDK test harnessing and supporting workspace crates, plus a refactor to make an ACL helper const-evaluable. Key changes:

- refactor(dpdk/acl): make compute_min_input_size const
  - Converted AclBuildConfig::compute_min_input_size to pub const fn (rewritten to be const-friendly).
  - Preserved runtime call-path and FieldExtentOverflow validation.
  - Added a unit test that evaluates the function in a const context and verifies parity with the runtime result.

- feat(dpdk): EAL test harness and #[with_eal] macro
  - New proc-macro crate dataplane-dpdk-test-macros providing #[with_eal] which injects a call to crate::test_support::start_eal() at the start of test functions.
  - Added dpdk::test_support::start_eal() using a OnceLock-backed cached Eal. It configures EAL with --no-huge, --no-pci, --in-memory, derives --lcores from the process CPU affinity, and generates a unique --file-prefix. Designed to be once-per-process and safe to use with nextest.
  - dpdk crate now conditionally exposes test_support and re-exports with_eal behind a new `test` feature; dpdk tests were updated to use #[with_eal] (removing inline per-test start_eal and module-scoped OnceLock).

- workspace & crate additions / Cargo wiring
  - Added workspace members: dpdk-test-macros, fixed-size, lookup, match-action, match-action-derive.
  - Added workspace dependencies and workspace metadata entries for the new crates.
  - dpdk/Cargo.toml: added a `test` feature that wires optional deps (id, nix with sched feature, dpdk-test-macros) and replaced prior dev-only id/nix usage with a self-referencing dev-dependency using the new `test` feature so test-only helpers/macros are available to dpdk tests.

- New crates and notable APIs
  - fixed-size: new no_std crate providing a FixedSize trait (const SIZE and write_be) with impls for unsigned integer primitives and Ipv4/Ipv6.
  - lookup: new crate with Projection and Lookup traits and impls for BTreeMap and HashMap (unit-tested).
  - match-action and match-action-derive:
    - match-action: new crate defining FieldKind, FieldSpec, MatchKey trait, predicate and rule modules, and (behind feature flags) a generator module for bolero-based value generation.
    - match-action-derive: proc-macro derive(MatchKey) that generates FIELD_SPECS, MatchKey impls, a parallel Rule struct, and helper methods; supports attributes (prefix/mask/range/exact) and generic bounds on FixedSize.
    - match-action modules added: predicate (Exact/Prefix/Mask/Range predicates, matching helpers), rule (ExactSpec/PrefixSpec/MaskSpec/RangeSpec, RuleField traits, Accepts/IsUniversal), generator (bolero-based hits/misses generators) and tests including a derive_roundtrip integration test.
  - net: added fixed_size bridge implementations (TcpPort, UdpPort, UnicastIpv4Addr, Vni) and depends on fixed-size.

- Tests and usage
  - dpdk ACL integration tests now use #[with_eal] and type-inferred AclContext::new(...).
  - New unit and integration tests were added across the new crates (const-eval test for dpdk/acl, lookup tests, fixed-size tests, match-action derive/unit tests, predicate/generator tests).

## Scope & compatibility
- No production runtime behavior changes beyond test-only helpers and the addition of new workspace crates and public traits/types used by those crates.
- The ACL helper change is backward compatible at runtime; it exposes a const-capable API to callers that may now compute buffer sizes at compile time.
- This PR is part of a stacked review (merge order noted in the PR description).

## Review notes
- Reviewer qmonnet: "Sign-off tag missing" (needs address before merge).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->