### PR TITLE
(9) feat: fixed-size + lookup foundation trait crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-lookup"
+version = "0.21.0"
+
+[[package]]
 name = "dataplane-lpm"
 version = "0.21.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-fixed-size"
+version = "0.21.0"
+
+[[package]]
 name = "dataplane-flow-entry"
 version = "0.21.0"
 dependencies = [
@@ -1563,6 +1567,7 @@ dependencies = [
  "bytecheck",
  "dataplane-common",
  "dataplane-concurrency",
+ "dataplane-fixed-size",
  "dataplane-id",
  "derive_builder",
  "downcast-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "dpdk-sysroot-helper",
     "dpdk-test-macros",
     "errno",
+    "fixed-size",
     "flow-entry",
     "flow-filter",
     "hardware",
@@ -72,6 +73,7 @@ dpdk-sysroot-helper = { path = "./dpdk-sysroot-helper", package = "dataplane-dpd
 dpdk-test-macros = { path = "./dpdk-test-macros", package = "dataplane-dpdk-test-macros", features = [] }
 dplane-rpc = { git = "https://github.com/githedgehog/dplane-rpc.git", branch = "pr/daniel-noland/bumps", features = [] }
 errno = { path = "./errno", package = "dataplane-errno", features = [] }
+fixed-size = { path = "./fixed-size", package = "dataplane-fixed-size", features = [] }
 flow-entry = { path = "./flow-entry", package = "dataplane-flow-entry", features = [] }
 flow-filter = { path = "./flow-filter", package = "dataplane-flow-filter", features = [] }
 hardware = { path = "./hardware", package = "dataplane-hardware", features = [] }
@@ -282,6 +284,11 @@ wasm = false # hopeless + pointless
 package = "dataplane-dpdk-sys"
 miri = false # hopeless + pointless
 wasm = false # hopeless + pointless
+
+[workspace.metadata.package.fixed-size]
+package = "dataplane-fixed-size"
+miri = true
+wasm = true
 
 [workspace.metadata.package.flow-entry]
 package = "dataplane-flow-entry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "k8s-less",
     "left-right-tlcache",
     "lifecycle",
+    "lookup",
     "lpm",
     "mgmt",
     "nat",
@@ -84,6 +85,7 @@ k8s-intf = { path = "./k8s-intf", package = "dataplane-k8s-intf", default-featur
 k8s-less = { path = "./k8s-less", package = "dataplane-k8s-less", features = [] }
 left-right-tlcache = { path = "./left-right-tlcache", package = "dataplane-left-right-tlcache", features = [] }
 lifecycle = { path = "./lifecycle", package = "dataplane-lifecycle", features = [] }
+lookup = { path = "./lookup", package = "dataplane-lookup", features = [] }
 lpm = { path = "./lpm", package = "dataplane-lpm", features = [] }
 mgmt = { path = "./mgmt", package = "dataplane-mgmt", features = [] }
 nat = { path = "./nat", package = "dataplane-nat", features = [] }
@@ -324,6 +326,11 @@ wasm = false # split
 package = "dataplane-k8s-less"
 miri = true
 wasm = false # split
+
+[workspace.metadata.package.lookup]
+package = "dataplane-lookup"
+miri = true
+wasm = false # split (std collections)
 
 [workspace.metadata.package.mgmt]
 package = "dataplane-mgmt"

--- a/fixed-size/Cargo.toml
+++ b/fixed-size/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dataplane-fixed-size"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/fixed-size/src/lib.rs
+++ b/fixed-size/src/lib.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![no_std]
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+use core::net::{Ipv4Addr, Ipv6Addr};
+pub trait FixedSize: Copy {
+    const SIZE: usize;
+    fn write_be(&self, out: &mut [u8]);
+}
+
+impl FixedSize for u8 {
+    const SIZE: usize = 1;
+    fn write_be(&self, out: &mut [u8]) {
+        out[0] = *self;
+    }
+}
+
+impl FixedSize for u16 {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u32 {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u64 {
+    const SIZE: usize = 8;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for u128 {
+    const SIZE: usize = 16;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.to_be_bytes());
+    }
+}
+
+impl FixedSize for Ipv4Addr {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.octets());
+    }
+}
+
+impl FixedSize for Ipv6Addr {
+    const SIZE: usize = 16;
+    fn write_be(&self, out: &mut [u8]) {
+        out[..Self::SIZE].copy_from_slice(&self.octets());
+    }
+}

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dataplane-lookup"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+#![allow(missing_docs)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+pub trait Projection<T> {
+    fn project(self) -> T;
+}
+impl<K> Projection<Option<K>> for Option<K> {
+    fn project(self) -> Option<K> {
+        self
+    }
+}
+pub trait Lookup<K, A> {
+    fn lookup(&self, key: &K) -> Option<&A>;
+    fn classify<S>(&self, source: S) -> Option<&A>
+    where
+        S: Projection<K>,
+    {
+        self.lookup(&source.project())
+    }
+    fn classify_opt<S>(&self, source: S) -> Option<&A>
+    where
+        S: Projection<Option<K>>,
+    {
+        source.project().and_then(|key| self.lookup(&key))
+    }
+}
+
+impl<K: Ord, V> Lookup<K, V> for BTreeMap<K, V> {
+    fn lookup(&self, key: &K) -> Option<&V> {
+        BTreeMap::get(self, key)
+    }
+}
+
+impl<K: Eq + Hash, V, S: std::hash::BuildHasher> Lookup<K, V> for HashMap<K, V, S> {
+    fn lookup(&self, key: &K) -> Option<&V> {
+        HashMap::get(self, key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Pkt {
+        src: u32,
+        dst: u32,
+        sport: u16,
+        dport: u16,
+    }
+
+    impl Projection<(u32, u32)> for &Pkt {
+        fn project(self) -> (u32, u32) {
+            (self.src, self.dst)
+        }
+    }
+
+    impl Projection<(u32, u32, u16, u16)> for &Pkt {
+        fn project(self) -> (u32, u32, u16, u16) {
+            (self.src, self.dst, self.sport, self.dport)
+        }
+    }
+
+    impl<'a> Projection<(&'a u32, &'a u32)> for &'a Pkt {
+        fn project(self) -> (&'a u32, &'a u32) {
+            (&self.src, &self.dst)
+        }
+    }
+    impl Projection<Option<(u32, u32)>> for &Pkt {
+        fn project(self) -> Option<(u32, u32)> {
+            (self.src != 0).then_some((self.src, self.dst))
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Action {
+        Allow,
+        Drop,
+    }
+
+    #[test]
+    fn classify_picks_the_two_tuple_projection_from_the_table_type() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 22,
+            dport: 80,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Drop));
+    }
+
+    #[test]
+    fn classify_picks_the_four_tuple_projection_from_the_table_type() {
+        let mut table: BTreeMap<(u32, u32, u16, u16), Action> = BTreeMap::new();
+        table.insert((10, 20, 22, 80), Action::Allow);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 22,
+            dport: 80,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Allow));
+    }
+
+    #[test]
+    fn borrowed_tuple_projection_threads_lifetime() {
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        let (src, dst): (&u32, &u32) = (&pkt).project();
+        assert_eq!(*src, 10);
+        assert_eq!(*dst, 20);
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        let pkt = Pkt {
+            src: 1,
+            dst: 2,
+            sport: 3,
+            dport: 4,
+        };
+        assert_eq!(table.classify(&pkt), None);
+    }
+
+    #[test]
+    fn classify_opt_looks_up_when_projection_yields_some() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify_opt(&pkt), Some(&Action::Drop));
+    }
+
+    #[test]
+    fn classify_opt_short_circuits_when_projection_yields_none() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((0, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 0,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify_opt(&pkt), None);
+    }
+
+    #[test]
+    fn classify_opt_accepts_a_computed_option_via_identity() {
+        let mut table: BTreeMap<(u32, u32), Action> = BTreeMap::new();
+        table.insert((10, 20), Action::Drop);
+        let built: Option<(u32, u32)> = Some((10, 20));
+        assert_eq!(table.classify_opt(built), Some(&Action::Drop));
+        assert_eq!(table.classify_opt(None::<(u32, u32)>), None);
+    }
+
+    #[test]
+    fn hashmap_backend_works_the_same_way() {
+        let mut table: HashMap<(u32, u32), Action> = HashMap::new();
+        table.insert((10, 20), Action::Drop);
+        let pkt = Pkt {
+            src: 10,
+            dst: 20,
+            sport: 0,
+            dport: 0,
+        };
+        assert_eq!(table.classify(&pkt), Some(&Action::Drop));
+    }
+}

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -27,6 +27,7 @@ concurrency = { workspace = true }
 derive_builder = { workspace = true, features = ["alloc"] }
 downcast-rs = { workspace = true, features = ["sync"] }
 etherparse = { workspace = true, features = ["std"] }
+fixed-size = { workspace = true, features = [] }
 id = { workspace = true }
 multi_index_map = { workspace = true, default-features = false, features = ["serde"] }
 rapidhash = { workspace = true }

--- a/net/src/fixed_size.rs
+++ b/net/src/fixed_size.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use fixed_size::FixedSize;
+
+use crate::ipv4::UnicastIpv4Addr;
+use crate::tcp::TcpPort;
+use crate::udp::UdpPort;
+use crate::vxlan::Vni;
+
+impl FixedSize for TcpPort {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u16().write_be(out);
+    }
+}
+
+impl FixedSize for UdpPort {
+    const SIZE: usize = 2;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u16().write_be(out);
+    }
+}
+
+impl FixedSize for UnicastIpv4Addr {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        self.inner().write_be(out);
+    }
+}
+
+impl FixedSize for Vni {
+    const SIZE: usize = 4;
+    fn write_be(&self, out: &mut [u8]) {
+        self.as_u32().write_be(out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn ports_write_two_big_endian_bytes() {
+        assert_eq!(<TcpPort as FixedSize>::SIZE, 2);
+        assert_eq!(<UdpPort as FixedSize>::SIZE, 2);
+        let mut buf = [0u8; 2];
+        TcpPort::new_checked(443).unwrap().write_be(&mut buf);
+        assert_eq!(buf, 443u16.to_be_bytes());
+        UdpPort::new_checked(4789).unwrap().write_be(&mut buf);
+        assert_eq!(buf, 4789u16.to_be_bytes());
+    }
+
+    #[test]
+    fn unicast_v4_writes_four_octets() {
+        assert_eq!(<UnicastIpv4Addr as FixedSize>::SIZE, 4);
+        let mut buf = [0u8; 4];
+        UnicastIpv4Addr::new(Ipv4Addr::new(10, 0, 1, 2))
+            .unwrap()
+            .write_be(&mut buf);
+        assert_eq!(buf, [10, 0, 1, 2]);
+    }
+
+    #[test]
+    fn vni_writes_four_bytes_with_zero_high_byte() {
+        assert_eq!(<Vni as FixedSize>::SIZE, 4);
+        let mut buf = [0u8; 4];
+        Vni::new_checked(0x00AB_CDEF).unwrap().write_be(&mut buf);
+        assert_eq!(buf, [0x00, 0xAB, 0xCD, 0xEF]);
+    }
+}

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -19,6 +19,8 @@ pub mod addr_parse_error;
 pub mod buffer;
 pub mod checksum;
 pub mod eth;
+/// `FixedSize` impls bridging `net` field types into match-action keys.
+mod fixed_size;
 #[cfg(unix)]
 pub mod flows;
 pub mod headers;


### PR DESCRIPTION
Stack (9). Base: `pr/daniel-noland/dpdk-test-eal`.

The two foundational leaf trait crates the match-action / ACL layers build on.
No DPDK, no `unsafe`:

- `feat(fixed-size)`: `FixedSize` trait crate + `impl`s for `net` wire newtypes.
- `feat(lookup)`: `Lookup<K, A>` + `Projection<T>` trait crate.
---

**Review stack** (merge bottom -> top):
- (7) #1555 threading rewrite
- (8) #1572 dpdk test EAL harness
- (9) #1573 fixed-size + lookup
- (10) #1574 match-action
- (11) #1575 acl reference backend
- (12) #1576 acl rte_acl backend
- (13) #1567 cascade