### PR TITLE
(11) feat(acl): crate scaffolding + software reference backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dataplane-acl"
+version = "0.21.0"
+dependencies = [
+ "arrayvec",
+ "dataplane-concurrency",
+ "dataplane-lookup",
+ "dataplane-match-action",
+ "dataplane-net",
+ "thiserror",
+]
+
+[[package]]
 name = "dataplane-args"
 version = "0.22.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "acl",
     "args",
     "cli",
     "common",
@@ -64,6 +65,7 @@ repository = "https://github.com/githedgehog/dataplane/"
 # justifying why it is workspace-wide.
 
 # Internal
+acl = { path = "./acl", package = "dataplane-acl", features = [] }
 args = { path = "./args", package = "dataplane-args", features = [] }
 cli = { path = "./cli", package = "dataplane-cli", features = [] }
 common = { path = "./common", package = "dataplane-common", features = [] }
@@ -260,6 +262,15 @@ overflow-checks = true
 #        modified to use conditional compilation to work in wasm/miri.
 # miss: packages that are not logically hopeless, or pointless in wasm/miri, but which currently just happen to contain
 #       logic which can and should eventually be factored out or abstracted into something suitable for wasm/miri.
+[workspace.metadata.package.acl]
+package = "dataplane-acl"
+# Default features enable the DPDK `rte_acl` backend, which pulls in
+# `dpdk-sys` (bindgen against the system DPDK headers).  miri can't
+# build that path on the cross target, and the reference backend's
+# unit tests run fine outside the miri profile.
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
 [workspace.metadata.package.args]
 package = "dataplane-args"
 miri = true

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dataplane-acl"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+version.workspace = true
+
+[dependencies]
+arrayvec = { workspace = true, default-features = true }
+concurrency = { workspace = true, features = [] }
+lookup = { workspace = true, features = [] }
+match-action = { workspace = true, features = ["derive"] }
+net = { workspace = true, features = [] }
+thiserror = { workspace = true }

--- a/acl/src/lib.rs
+++ b/acl/src/lib.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+#![allow(missing_docs)] // shape settling; doc once stable
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
+//! Match-action classifier backends for [`match_action::MatchKey`]
+//! tables, behind the [`lookup::Lookup`] interface.
+//!
+//! - [`reference`](mod@reference): linear-scan software classifier;
+//!   differential oracle and a mutable cascade front.  Always built.
+//!
+//! The production `rte_acl` backend lands behind a follow-up `dpdk`
+//! feature gate.
+//!
+//! [`lookup::Lookup`]: lookup::Lookup
+//! [`match_action::MatchKey`]: match_action::MatchKey
+
+pub mod reference;

--- a/acl/src/reference/dyn_table.rs
+++ b/acl/src/reference/dyn_table.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use match_action::FieldSpec;
+
+use super::table::RefRule;
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum DynShapeError {
+    #[error("specs are empty")]
+    EmptySpecs,
+    #[error(
+        "spec {idx} offset {offset} disagrees with cumulative size {expected_offset} \
+         of fields 0..{idx}"
+    )]
+    OffsetMismatch {
+        idx: usize,
+        offset: usize,
+        expected_offset: usize,
+    },
+    #[error("spec {idx} has zero size")]
+    ZeroSize { idx: usize },
+    #[error("rule {rule} has {actual} predicates, specs has {expected}")]
+    FieldCountMismatch {
+        rule: usize,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("rule {rule} field {field}: predicate width {actual} != spec size {expected}")]
+    PredicateWidthMismatch {
+        rule: usize,
+        field: usize,
+        expected: usize,
+        actual: usize,
+    },
+}
+#[derive(Clone, Debug)]
+pub struct DynReferenceTable<A> {
+    specs: Vec<FieldSpec>,
+    key_size: usize,
+    rules: Vec<RefRule<A>>,
+}
+
+impl<A> DynReferenceTable<A> {
+    pub fn new(specs: Vec<FieldSpec>, rules: Vec<RefRule<A>>) -> Result<Self, DynShapeError> {
+        let key_size = validate_specs(&specs)?;
+        for (rule_idx, rule) in rules.iter().enumerate() {
+            if rule.fields().len() != specs.len() {
+                return Err(DynShapeError::FieldCountMismatch {
+                    rule: rule_idx,
+                    expected: specs.len(),
+                    actual: rule.fields().len(),
+                });
+            }
+            for (field_idx, (pred, spec)) in rule.fields().iter().zip(&specs).enumerate() {
+                if pred.width() != spec.size {
+                    return Err(DynShapeError::PredicateWidthMismatch {
+                        rule: rule_idx,
+                        field: field_idx,
+                        expected: spec.size,
+                        actual: pred.width(),
+                    });
+                }
+            }
+        }
+        Ok(Self {
+            specs,
+            key_size,
+            rules,
+        })
+    }
+    #[must_use]
+    pub fn key_size(&self) -> usize {
+        self.key_size
+    }
+    #[must_use]
+    pub fn specs(&self) -> &[FieldSpec] {
+        &self.specs
+    }
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+    #[must_use]
+    pub fn lookup_bytes(&self, key: &[u8]) -> Option<&A> {
+        assert_eq!(key.len(), self.key_size, "key length must equal key_size");
+        self.rules
+            .iter()
+            .find(|rule| rule.matches_packed(&self.specs, key))
+            .map(RefRule::action)
+    }
+    #[must_use]
+    pub fn matches_bytes(&self, key: &[u8]) -> Vec<&RefRule<A>> {
+        assert_eq!(key.len(), self.key_size, "key length must equal key_size");
+        self.rules
+            .iter()
+            .filter(|rule| rule.matches_packed(&self.specs, key))
+            .collect()
+    }
+}
+fn validate_specs(specs: &[FieldSpec]) -> Result<usize, DynShapeError> {
+    if specs.is_empty() {
+        return Err(DynShapeError::EmptySpecs);
+    }
+    let mut cursor = 0usize;
+    for (idx, spec) in specs.iter().enumerate() {
+        if spec.size == 0 {
+            return Err(DynShapeError::ZeroSize { idx });
+        }
+        if spec.offset != cursor {
+            return Err(DynShapeError::OffsetMismatch {
+                idx,
+                offset: spec.offset,
+                expected_offset: cursor,
+            });
+        }
+        cursor += spec.size;
+    }
+    Ok(cursor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use match_action::{FieldKind, FieldPredicate};
+
+    fn spec(name: &'static str, kind: FieldKind, size: usize, offset: usize) -> FieldSpec {
+        FieldSpec {
+            name,
+            kind,
+            size,
+            offset,
+        }
+    }
+
+    fn make_rule_5tuple(
+        proto: u8,
+        src: [u8; 4],
+        src_len: u8,
+        dport_lo: u16,
+        dport_hi: u16,
+        action: u32,
+    ) -> RefRule<u32> {
+        use match_action::predicate::{Exact, FieldBytes, Prefix, Range};
+        let proto_b: FieldBytes = [proto].iter().copied().collect();
+        let src_b: FieldBytes = src.iter().copied().collect();
+        let dlo: FieldBytes = dport_lo.to_be_bytes().iter().copied().collect();
+        let dhi: FieldBytes = dport_hi.to_be_bytes().iter().copied().collect();
+        RefRule::new(
+            vec![
+                FieldPredicate::Exact(Exact::new(proto_b)),
+                FieldPredicate::Prefix(Prefix::new(src_b, src_len)),
+                FieldPredicate::Range(Range::new(dlo, dhi)),
+            ],
+            action,
+        )
+    }
+
+    fn five_tuple_specs() -> Vec<FieldSpec> {
+        vec![
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("src", FieldKind::Prefix, 4, 1),
+            spec("dport", FieldKind::Range, 2, 5),
+        ]
+    }
+
+    #[test]
+    fn lookup_bytes_hits_and_misses() {
+        let table = DynReferenceTable::new(
+            five_tuple_specs(),
+            vec![make_rule_5tuple(6, [10, 0, 0, 0], 8, 22, 22, 0xAA)],
+        )
+        .expect("valid shape");
+        assert_eq!(table.key_size(), 1 + 4 + 2);
+
+        let mut key = vec![6u8];
+        key.extend_from_slice(&[10, 1, 2, 3]);
+        key.extend_from_slice(&22u16.to_be_bytes());
+        assert_eq!(table.lookup_bytes(&key), Some(&0xAA));
+        let mut key = vec![6u8];
+        key.extend_from_slice(&[11, 0, 0, 0]);
+        key.extend_from_slice(&22u16.to_be_bytes());
+        assert_eq!(table.lookup_bytes(&key), None);
+        let mut key = vec![6u8];
+        key.extend_from_slice(&[10, 1, 2, 3]);
+        key.extend_from_slice(&80u16.to_be_bytes());
+        assert_eq!(table.lookup_bytes(&key), None);
+    }
+
+    #[test]
+    fn matches_bytes_is_nonlossy() {
+        use match_action::predicate::{Exact, FieldBytes};
+        let broad = RefRule::new(
+            vec![
+                FieldPredicate::Exact(Exact::new([6u8].iter().copied().collect::<FieldBytes>())),
+                FieldPredicate::Prefix(match_action::predicate::Prefix::new(
+                    [0u8; 4].iter().copied().collect::<FieldBytes>(),
+                    0,
+                )),
+                FieldPredicate::Range(match_action::predicate::Range::new(
+                    0u16.to_be_bytes().iter().copied().collect::<FieldBytes>(),
+                    u16::MAX
+                        .to_be_bytes()
+                        .iter()
+                        .copied()
+                        .collect::<FieldBytes>(),
+                )),
+            ],
+            0xBB,
+        );
+        let narrow = make_rule_5tuple(6, [10, 0, 0, 0], 8, 22, 22, 0xCC);
+        let table =
+            DynReferenceTable::new(five_tuple_specs(), vec![broad, narrow]).expect("valid shape");
+
+        let mut key = vec![6u8];
+        key.extend_from_slice(&[10, 1, 2, 3]);
+        key.extend_from_slice(&22u16.to_be_bytes());
+        let m = table.matches_bytes(&key);
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[0].action(), &0xBB);
+        assert_eq!(m[1].action(), &0xCC);
+    }
+
+    #[test]
+    fn rejects_offset_mismatch() {
+        let bad = vec![
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("src", FieldKind::Prefix, 4, 0),
+        ];
+        let err = DynReferenceTable::<()>::new(bad, vec![]).unwrap_err();
+        assert!(matches!(
+            err,
+            DynShapeError::OffsetMismatch {
+                idx: 1,
+                offset: 0,
+                expected_offset: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_predicate_width_mismatch() {
+        use match_action::predicate::{Exact, FieldBytes};
+        let bad_proto: FieldBytes = [0u8, 0].iter().copied().collect();
+        let rule = RefRule::new(vec![FieldPredicate::Exact(Exact::new(bad_proto))], 0u32);
+        let specs = vec![spec("proto", FieldKind::Exact, 1, 0)];
+        let err = DynReferenceTable::new(specs, vec![rule]).unwrap_err();
+        assert!(matches!(
+            err,
+            DynShapeError::PredicateWidthMismatch {
+                rule: 0,
+                field: 0,
+                expected: 1,
+                actual: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_specs() {
+        let err = DynReferenceTable::<u32>::new(vec![], vec![]).unwrap_err();
+        assert_eq!(err, DynShapeError::EmptySpecs);
+    }
+
+    #[test]
+    fn rejects_zero_size_spec() {
+        let bad = vec![spec("x", FieldKind::Exact, 0, 0)];
+        let err = DynReferenceTable::<u32>::new(bad, vec![]).unwrap_err();
+        assert_eq!(err, DynShapeError::ZeroSize { idx: 0 });
+    }
+    #[test]
+    fn dyn_table_agrees_with_typed_table() {
+        use crate::reference::ReferenceTable;
+        use core::net::Ipv4Addr;
+        use lookup::Lookup;
+        use match_action::{ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+
+        #[derive(MatchKey)]
+        struct K {
+            #[exact]
+            proto: u8,
+            #[prefix]
+            src: Ipv4Addr,
+            #[range]
+            dport: u16,
+        }
+
+        let rule_fields = KRule {
+            proto: ExactSpec::new(6),
+            src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+            dport: RangeSpec::exact(22),
+        }
+        .into_backend_fields::<crate::reference::Erased>();
+
+        let typed = ReferenceTable::<K, u32>::new(vec![RefRule::new(rule_fields.clone(), 0xAA)]);
+        let dynamic = DynReferenceTable::new(
+            K::field_specs().to_vec(),
+            vec![RefRule::new(rule_fields, 0xAA)],
+        )
+        .expect("valid shape");
+
+        for (key, label) in &[
+            (
+                K {
+                    proto: 6,
+                    src: "10.1.2.3".parse().unwrap(),
+                    dport: 22,
+                },
+                "hit",
+            ),
+            (
+                K {
+                    proto: 6,
+                    src: "11.0.0.0".parse().unwrap(),
+                    dport: 22,
+                },
+                "src miss",
+            ),
+            (
+                K {
+                    proto: 17,
+                    src: "10.1.2.3".parse().unwrap(),
+                    dport: 22,
+                },
+                "proto miss",
+            ),
+        ] {
+            let bytes = key.as_key();
+            assert_eq!(
+                typed.lookup(key).copied(),
+                dynamic.lookup_bytes(&bytes).copied(),
+                "typed vs dynamic disagree on {label}",
+            );
+        }
+    }
+}

--- a/acl/src/reference/mod.rs
+++ b/acl/src/reference/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+pub mod dyn_table;
+pub mod table;
+
+pub use dyn_table::{DynReferenceTable, DynShapeError};
+pub use match_action::{Erased, FieldPredicate};
+pub use table::{RefRule, ReferenceTable};

--- a/acl/src/reference/table.rs
+++ b/acl/src/reference/table.rs
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use core::marker::PhantomData;
+
+use lookup::Lookup;
+use match_action::{FieldPredicate, FieldSpec, MatchKey};
+const MAX_KEY_BYTES: usize = 256;
+#[derive(Clone, Debug)]
+pub struct RefRule<A> {
+    fields: Vec<FieldPredicate>,
+    action: A,
+}
+
+impl<A> RefRule<A> {
+    #[must_use]
+    pub fn new(fields: Vec<FieldPredicate>, action: A) -> Self {
+        Self { fields, action }
+    }
+
+    pub fn action(&self) -> &A {
+        &self.action
+    }
+    #[must_use]
+    pub fn fields(&self) -> &[FieldPredicate] {
+        &self.fields
+    }
+
+    pub(crate) fn matches_packed(&self, specs: &[FieldSpec], buf: &[u8]) -> bool {
+        debug_assert_eq!(self.fields.len(), specs.len());
+        self.fields
+            .iter()
+            .zip(specs)
+            .all(|(pred, spec)| pred.matches(&buf[spec.offset..spec.offset + spec.size]))
+    }
+}
+#[derive(Clone, Debug)]
+pub struct ReferenceTable<K, A> {
+    rules: Vec<RefRule<A>>,
+    _key: PhantomData<fn() -> K>,
+}
+
+impl<K: MatchKey, A> ReferenceTable<K, A> {
+    #[must_use]
+    pub fn new(rules: Vec<RefRule<A>>) -> Self {
+        Self {
+            rules,
+            _key: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+    fn pack(key: &K) -> Option<[u8; MAX_KEY_BYTES]> {
+        if K::KEY_SIZE > MAX_KEY_BYTES {
+            return None;
+        }
+        let mut buf = [0u8; MAX_KEY_BYTES];
+        key.as_key_into(&mut buf[..K::KEY_SIZE]);
+        Some(buf)
+    }
+    #[must_use]
+    pub fn matches(&self, key: &K) -> Vec<&RefRule<A>> {
+        let Some(buf) = Self::pack(key) else {
+            return Vec::new();
+        };
+        let specs = K::field_specs();
+        self.rules
+            .iter()
+            .filter(|rule| rule.matches_packed(specs, &buf))
+            .collect()
+    }
+}
+
+impl<K: MatchKey, A> Lookup<K, A> for ReferenceTable<K, A> {
+    fn lookup(&self, key: &K) -> Option<&A> {
+        let buf = Self::pack(key)?;
+        let specs = K::field_specs();
+        self.rules
+            .iter()
+            .find(|rule| rule.matches_packed(specs, &buf))
+            .map(RefRule::action)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::net::Ipv4Addr;
+    use match_action::{Erased, ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    enum Verdict {
+        Allow,
+        Drop,
+    }
+
+    #[derive(MatchKey)]
+    struct FiveTuple {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src_ip: Ipv4Addr,
+        #[prefix]
+        dst_ip: Ipv4Addr,
+        #[range]
+        src_port: u16,
+        #[range]
+        dst_port: u16,
+    }
+
+    fn drop_10_8_to_22() -> RefRule<Verdict> {
+        RefRule::new(
+            FiveTupleRule {
+                proto: ExactSpec::new(6),
+                src_ip: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+                dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                src_port: RangeSpec::new(0, u16::MAX),
+                dst_port: RangeSpec::exact(22),
+            }
+            .into_backend_fields::<Erased>(),
+            Verdict::Drop,
+        )
+    }
+
+    #[test]
+    fn single_rule_hit_and_miss() {
+        let table = ReferenceTable::new(vec![drop_10_8_to_22()]);
+
+        assert_eq!(
+            table.lookup(&FiveTuple {
+                proto: 6,
+                src_ip: "10.1.2.3".parse().unwrap(),
+                dst_ip: "192.168.1.1".parse().unwrap(),
+                src_port: 54321,
+                dst_port: 22,
+            }),
+            Some(&Verdict::Drop),
+        );
+        assert_eq!(
+            table.lookup(&FiveTuple {
+                proto: 6,
+                src_ip: "11.0.0.1".parse().unwrap(),
+                dst_ip: "192.168.1.1".parse().unwrap(),
+                src_port: 54321,
+                dst_port: 22,
+            }),
+            None,
+        );
+        assert_eq!(
+            table.lookup(&FiveTuple {
+                proto: 6,
+                src_ip: "10.1.2.3".parse().unwrap(),
+                dst_ip: "192.168.1.1".parse().unwrap(),
+                src_port: 54321,
+                dst_port: 80,
+            }),
+            None,
+        );
+    }
+
+    #[test]
+    fn empty_table_always_misses() {
+        let table: ReferenceTable<FiveTuple, Verdict> = ReferenceTable::empty();
+        assert!(table.is_empty());
+        assert_eq!(
+            table.lookup(&FiveTuple {
+                proto: 6,
+                src_ip: Ipv4Addr::UNSPECIFIED,
+                dst_ip: Ipv4Addr::UNSPECIFIED,
+                src_port: 0,
+                dst_port: 0,
+            }),
+            None,
+        );
+    }
+    fn allow_all_tcp() -> RefRule<Verdict> {
+        RefRule::new(
+            FiveTupleRule {
+                proto: ExactSpec::new(6),
+                src_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                src_port: RangeSpec::new(0, u16::MAX),
+                dst_port: RangeSpec::new(0, u16::MAX),
+            }
+            .into_backend_fields::<Erased>(),
+            Verdict::Allow,
+        )
+    }
+
+    fn overlapping_packet() -> FiveTuple {
+        FiveTuple {
+            proto: 6,
+            src_ip: "10.1.2.3".parse().unwrap(),
+            dst_ip: "192.168.1.1".parse().unwrap(),
+            src_port: 54321,
+            dst_port: 22,
+        }
+    }
+
+    #[test]
+    fn positional_precedence_first_match_wins() {
+        let table = ReferenceTable::new(vec![allow_all_tcp(), drop_10_8_to_22()]);
+        assert_eq!(table.lookup(&overlapping_packet()), Some(&Verdict::Allow));
+    }
+
+    #[test]
+    fn matches_is_nonlossy_and_retains_shadowed_losers() {
+        let table = ReferenceTable::new(vec![allow_all_tcp(), drop_10_8_to_22()]);
+        let matched = table.matches(&overlapping_packet());
+
+        assert_eq!(matched.len(), 2);
+        assert_eq!(matched[0].action(), &Verdict::Allow);
+        assert_eq!(matched[1].action(), &Verdict::Drop);
+    }
+}


### PR DESCRIPTION
Stack (11). Base: `pr/daniel-noland/match-action`.

The ACL crate scaffolding and the **software reference backend** -- the readable
oracle that defines ACL semantics and the public API surface.

- `feat(acl)`: crate scaffolding + software reference backend.

The DPDK backend (proven equivalent to this oracle via a differential test)
lands in the next PR.
---

**Review stack** (merge bottom -> top):
- (7) #1555 threading rewrite
- (8) #1572 dpdk test EAL harness
- (9) #1573 fixed-size + lookup
- (10) #1574 match-action
- (11) #1575 acl reference backend
- (12) #1576 acl rte_acl backend
- (13) #1567 cascade