### PR TITLE
(12) feat(acl): rte_acl backend + differential-vs-reference + benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,15 +153,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -720,9 +720,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2059,18 +2059,18 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2657,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -2996,9 +2996,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -3010,9 +3010,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3031,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4586,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
 dependencies = [
  "rustversion",
 ]
@@ -5294,9 +5294,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
 dependencies = [
  "lock_api",
 ]
@@ -5399,9 +5399,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "symbolic-common"
-version = "13.3.1"
+version = "13.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737b2b9897b9da03ec679ed4b4ae7e798fa340f36f6b2ff70781aa9f2ea042e1"
+checksum = "ba98c95b1ff25ce40400d286f5dec838097ee42ad1bbd64242cce24c2baace8c"
 dependencies = [
  "debugid",
  "memmap2",
@@ -5411,9 +5411,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "13.3.1"
+version = "13.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f3e43b297ac61e59cdca822c7cae395ac85beb39702142953337899e833a8b"
+checksum = "1c547b0231d1794aec8e4795dbb04c1d395ff774954f18e37d46d5a70f0ce4b2"
 dependencies = [
  "rustc-demangle",
  "symbolic-common",
@@ -6013,9 +6013,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6087,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6100,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6110,9 +6110,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6120,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6133,18 +6133,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +88,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
@@ -668,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbindgen"
 version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +760,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -964,6 +1012,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1086,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1165,6 +1252,7 @@ version = "0.22.0"
 dependencies = [
  "arrayvec",
  "bolero",
+ "criterion",
  "dataplane-concurrency",
  "dataplane-dpdk",
  "dataplane-lookup",
@@ -2518,6 +2606,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3978,6 +4077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4117,16 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"
@@ -4902,6 +5017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,6 +5696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6064,6 +6198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6167,6 +6311,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ version = "0.22.0"
 dependencies = [
  "arrayvec",
  "dataplane-concurrency",
+ "dataplane-dpdk",
  "dataplane-lookup",
  "dataplane-match-action",
  "dataplane-net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ name = "dataplane-acl"
 version = "0.22.0"
 dependencies = [
  "arrayvec",
+ "bolero",
  "dataplane-concurrency",
  "dataplane-dpdk",
  "dataplane-lookup",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,6 +287,16 @@ miri = true # must ALWAYS work
 # NOTE: concurrency should likely be dependency gated as `cfg(unix)` or `cfg(not(target_arch = "wasm32"))`
 wasm = false # hopeless + pointless
 
+[workspace.metadata.package.concurrency-macros]
+package = "dataplane-concurrency-macros"
+# Proc-macro crate: runs at the host toolchain, not the miri target.
+# Excluded from miri to keep the target dep graph clean.  Without this,
+# `cargo miri nextest` builds the host test binary and then tries to run
+# it through the cargo-miri runner, which fails with a misleading
+# "outdated or invalid JSON; try `cargo clean`".
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
 [workspace.metadata.package.dataplane]
 package = "dataplane"
 miri = false # hopeless + pointless
@@ -299,6 +309,16 @@ wasm = false # hopeless + pointless
 
 [workspace.metadata.package.dpdk-sys]
 package = "dataplane-dpdk-sys"
+miri = false # hopeless + pointless
+wasm = false # hopeless + pointless
+
+[workspace.metadata.package.dpdk-test-macros]
+package = "dataplane-dpdk-test-macros"
+# Proc-macro crate: runs at the host toolchain, not the miri target.
+# Excluded from miri to keep the target dep graph clean.  Without this,
+# `cargo miri nextest` builds the host test binary and then tries to run
+# it through the cargo-miri runner, which fails with a misleading
+# "outdated or invalid JSON; try `cargo clean`".
 miri = false # hopeless + pointless
 wasm = false # hopeless + pointless
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ chrono = { version = "0.4.45", default-features = false, features = [] }
 clap = { version = "4.6.1", default-features = true, features = [] }
 color-eyre = { version = "0.6.5", default-features = false, features = [] }
 colored = { version = "3.1.1", default-features = false, features = [] }
+criterion = { version = "0.8.2", default-features = false, features = [] }
 crossbeam-utils = { version = "0.8.21", default-features = false, features = [] }
 dashmap = { version = "6.2.1", default-features = false, features = [] }
 derive_builder = { version = "0.20.2", default-features = false, features = [] }

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -25,7 +25,8 @@ net = { workspace = true, features = [] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-# Property-test draws for the shape-fuzz oracle.
+# Differential oracle harness: random rulesets + packets compared
+# between the reference and DPDK backends.
 bolero = { workspace = true, features = ["std"] }
 # Override the regular `dpdk` dep to enable its `test` feature
 # (exposes `dpdk::test_support::start_eal` and `dpdk::with_eal`).
@@ -33,3 +34,4 @@ dpdk = { workspace = true, features = ["test"] }
 # Override match-action to also enable `bolero` for property-test
 # generators (`FieldHit` / `FieldMiss`).
 match-action = { workspace = true, features = ["derive", "bolero"] }
+net = { workspace = true, features = ["test_buffer", "builder"] }

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -5,9 +5,20 @@ license.workspace = true
 publish.workspace = true
 version.workspace = true
 
+[features]
+default = []
+# Enables the DPDK `rte_acl` backend for `cascade::Lookup`.  Pulls in
+# the `dpdk` crate (and transitively `dpdk-sys`), so off by default;
+# only the production binary / DPDK-bound consumers turn it on.  The
+# reference backend (always built) carries its own `thiserror`-derived
+# error types, so `thiserror` is unconditional rather than feature-gated
+# under `dpdk`.
+dpdk = ["dep:dpdk"]
+
 [dependencies]
 arrayvec = { workspace = true, default-features = true }
 concurrency = { workspace = true, features = [] }
+dpdk = { workspace = true, optional = true }
 lookup = { workspace = true, features = [] }
 match-action = { workspace = true, features = ["derive"] }
 net = { workspace = true, features = [] }

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -7,12 +7,6 @@ version.workspace = true
 
 [features]
 default = []
-# Enables the DPDK `rte_acl` backend for `cascade::Lookup`.  Pulls in
-# the `dpdk` crate (and transitively `dpdk-sys`), so off by default;
-# only the production binary / DPDK-bound consumers turn it on.  The
-# reference backend (always built) carries its own `thiserror`-derived
-# error types, so `thiserror` is unconditional rather than feature-gated
-# under `dpdk`.
 dpdk = ["dep:dpdk"]
 
 [dependencies]
@@ -25,13 +19,20 @@ net = { workspace = true, features = [] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-# Differential oracle harness: random rulesets + packets compared
-# between the reference and DPDK backends.
 bolero = { workspace = true, features = ["std"] }
-# Override the regular `dpdk` dep to enable its `test` feature
-# (exposes `dpdk::test_support::start_eal` and `dpdk::with_eal`).
+criterion = { workspace = true, features = ["cargo_bench_support"] }
 dpdk = { workspace = true, features = ["test"] }
-# Override match-action to also enable `bolero` for property-test
-# generators (`FieldHit` / `FieldMiss`).
 match-action = { workspace = true, features = ["derive", "bolero"] }
 net = { workspace = true, features = ["test_buffer", "builder"] }
+
+[[bench]]
+name = "reference_five_tuple"
+harness = false
+
+[[bench]]
+name = "dpdk_five_tuple"
+harness = false
+
+[[bench]]
+name = "table_build"
+harness = false

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -23,3 +23,8 @@ lookup = { workspace = true, features = [] }
 match-action = { workspace = true, features = ["derive"] }
 net = { workspace = true, features = [] }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+# Override the regular `dpdk` dep to enable its `test` feature
+# (exposes `dpdk::test_support::start_eal` and `dpdk::with_eal`).
+dpdk = { workspace = true, features = ["test"] }

--- a/acl/Cargo.toml
+++ b/acl/Cargo.toml
@@ -25,6 +25,11 @@ net = { workspace = true, features = [] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+# Property-test draws for the shape-fuzz oracle.
+bolero = { workspace = true, features = ["std"] }
 # Override the regular `dpdk` dep to enable its `test` feature
 # (exposes `dpdk::test_support::start_eal` and `dpdk::with_eal`).
 dpdk = { workspace = true, features = ["test"] }
+# Override match-action to also enable `bolero` for property-test
+# generators (`FieldHit` / `FieldMiss`).
+match-action = { workspace = true, features = ["derive", "bolero"] }

--- a/acl/benches/dpdk_five_tuple.rs
+++ b/acl/benches/dpdk_five_tuple.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+#[cfg(feature = "dpdk")]
+mod bench {
+    use core::net::{Ipv4Addr, Ipv6Addr};
+    use core::num::NonZero;
+
+    use std::hint::black_box;
+
+    use criterion::measurement::WallTime;
+    use criterion::{BenchmarkGroup, BenchmarkId, Criterion, Throughput};
+
+    use dataplane_acl::dpdk::install::install_table;
+    use dataplane_acl::dpdk::lookup::DpdkAclLookup;
+    use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+    use dataplane_acl::dpdk_table_alias;
+    use dpdk::acl::{CategoryMask, Priority};
+    use lookup::Lookup;
+    use match_action::{ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+
+    #[derive(MatchKey)]
+    struct FiveTuple {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src: Ipv4Addr,
+        #[prefix]
+        dst: Ipv4Addr,
+        #[range]
+        sport: u16,
+        #[range]
+        dport: u16,
+    }
+
+    #[derive(MatchKey)]
+    struct FiveTuple6 {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src: Ipv6Addr,
+        #[prefix]
+        dst: Ipv6Addr,
+        #[range]
+        sport: u16,
+        #[range]
+        dport: u16,
+    }
+
+    dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
+    dpdk_table_alias!(type FiveTuple6Table<A> = FiveTuple6);
+    const RULE_COUNTS: [usize; 15] = [
+        1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+    ];
+    const BATCH: usize = 32;
+    fn build_table_v4(n: usize) -> FiveTupleTable<u32> {
+        let specs: Vec<RuleSpec<FiveTuple, u32>> = (0..n)
+            .map(|i| {
+                let prio = i32::try_from(i + 1).unwrap_or(i32::MAX);
+                let dport = u16::try_from(i).unwrap_or(u16::MAX);
+                let action = u32::try_from(i).unwrap_or(u32::MAX);
+                RuleSpec::new(
+                    Priority::new(prio).expect("nonzero priority"),
+                    CategoryMask::new(1).expect("nonzero mask"),
+                    FiveTupleRule {
+                        proto: ExactSpec::new(6),
+                        src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+                        dst: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                        sport: RangeSpec::new(0, u16::MAX),
+                        dport: RangeSpec::exact(dport),
+                    }
+                    .into_backend_fields::<Dpdk>(),
+                    action,
+                )
+                .expect("valid RuleSpec")
+            })
+            .collect();
+        let max_rules = NonZero::new(u32::try_from(n).unwrap_or(u32::MAX)).expect("n >= 1");
+        install_table(&format!("bench_dpdk_v4_{n}"), max_rules, specs).expect("install_table")
+    }
+    fn build_table_v6(n: usize) -> FiveTuple6Table<u32> {
+        let src: Ipv6Addr = "2001:db8::".parse().expect("v6 literal");
+        let specs: Vec<RuleSpec<FiveTuple6, u32>> = (0..n)
+            .map(|i| {
+                let prio = i32::try_from(i + 1).unwrap_or(i32::MAX);
+                let dport = u16::try_from(i).unwrap_or(u16::MAX);
+                let action = u32::try_from(i).unwrap_or(u32::MAX);
+                RuleSpec::new(
+                    Priority::new(prio).expect("nonzero priority"),
+                    CategoryMask::new(1).expect("nonzero mask"),
+                    FiveTuple6Rule {
+                        proto: ExactSpec::new(6),
+                        src: PrefixSpec::new(src, 32),
+                        dst: PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 0),
+                        sport: RangeSpec::new(0, u16::MAX),
+                        dport: RangeSpec::exact(dport),
+                    }
+                    .into_backend_fields::<Dpdk>(),
+                    action,
+                )
+                .expect("valid RuleSpec")
+            })
+            .collect();
+        let max_rules = NonZero::new(u32::try_from(n).unwrap_or(u32::MAX)).expect("n >= 1");
+        install_table(&format!("bench_dpdk_v6_{n}"), max_rules, specs).expect("install_table")
+    }
+    fn run_lookups<K, const N: usize, const STRIDE: usize>(
+        group: &mut BenchmarkGroup<'_, WallTime>,
+        n: usize,
+        table: &DpdkAclLookup<K, N, STRIDE, u32>,
+        miss: &K,
+        hit: &K,
+        batch: &[K],
+    ) where
+        K: MatchKey,
+    {
+        group.throughput(Throughput::Elements(1));
+        group.bench_function(BenchmarkId::new("single_miss", n), |b| {
+            b.iter(|| black_box(table.lookup(black_box(miss))));
+        });
+        group.bench_function(BenchmarkId::new("single_hit", n), |b| {
+            b.iter(|| black_box(table.lookup(black_box(hit))));
+        });
+        group.throughput(Throughput::Elements(
+            u64::try_from(batch.len()).unwrap_or(0),
+        ));
+        group.bench_function(BenchmarkId::new("batch", n), |b| {
+            let mut out: [Option<&u32>; BATCH] = [None; BATCH];
+            b.iter(|| {
+                table
+                    .lookup_batch(black_box(batch), &mut out)
+                    .expect("batch");
+                black_box(&out);
+            });
+        });
+    }
+
+    fn bench_v4(c: &mut Criterion) {
+        let batch: Vec<FiveTuple> = (0..BATCH)
+            .map(|j| FiveTuple {
+                proto: 6,
+                src: Ipv4Addr::new(10, 0, 0, 1),
+                dst: Ipv4Addr::new(192, 0, 2, 1),
+                sport: 1234,
+                dport: u16::try_from(j).unwrap_or(0),
+            })
+            .collect();
+
+        let mut group = c.benchmark_group("dpdk_five_tuple_v4");
+        for n in RULE_COUNTS {
+            let table = build_table_v4(n);
+            let miss = FiveTuple {
+                proto: 6,
+                src: Ipv4Addr::new(10, 0, 0, 1),
+                dst: Ipv4Addr::new(192, 0, 2, 1),
+                sport: 1234,
+                dport: u16::MAX,
+            };
+            let hit = FiveTuple { dport: 0, ..miss };
+            run_lookups(&mut group, n, &table, &miss, &hit, &batch);
+        }
+        group.finish();
+    }
+
+    fn bench_v6(c: &mut Criterion) {
+        let in_prefix: Ipv6Addr = "2001:db8::1".parse().expect("v6 literal");
+        let dst: Ipv6Addr = "::1".parse().expect("v6 literal");
+        let batch: Vec<FiveTuple6> = (0..BATCH)
+            .map(|j| FiveTuple6 {
+                proto: 6,
+                src: in_prefix,
+                dst,
+                sport: 1234,
+                dport: u16::try_from(j).unwrap_or(0),
+            })
+            .collect();
+
+        let mut group = c.benchmark_group("dpdk_five_tuple_v6");
+        for n in RULE_COUNTS {
+            let table = build_table_v6(n);
+            let miss = FiveTuple6 {
+                proto: 6,
+                src: in_prefix,
+                dst,
+                sport: 1234,
+                dport: u16::MAX,
+            };
+            let hit = FiveTuple6 { dport: 0, ..miss };
+            run_lookups(&mut group, n, &table, &miss, &hit, &batch);
+        }
+        group.finish();
+    }
+
+    pub fn benches(c: &mut Criterion) {
+        let _eal = dpdk::test_support::start_eal();
+        bench_v4(c);
+        bench_v6(c);
+    }
+}
+
+#[cfg(feature = "dpdk")]
+criterion::criterion_group!(benchmarks, bench::benches);
+#[cfg(feature = "dpdk")]
+criterion::criterion_main!(benchmarks);
+#[cfg(not(feature = "dpdk"))]
+fn main() {}

--- a/acl/benches/dpdk_five_tuple.rs
+++ b/acl/benches/dpdk_five_tuple.rs
@@ -106,10 +106,10 @@ mod bench {
         let max_rules = NonZero::new(u32::try_from(n).unwrap_or(u32::MAX)).expect("n >= 1");
         install_table(&format!("bench_dpdk_v6_{n}"), max_rules, specs).expect("install_table")
     }
-    fn run_lookups<K, const N: usize, const STRIDE: usize>(
+    fn run_lookups<K>(
         group: &mut BenchmarkGroup<'_, WallTime>,
         n: usize,
-        table: &DpdkAclLookup<K, N, STRIDE, u32>,
+        table: &DpdkAclLookup<K, u32>,
         miss: &K,
         hit: &K,
         batch: &[K],

--- a/acl/benches/reference_five_tuple.rs
+++ b/acl/benches/reference_five_tuple.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![allow(clippy::unwrap_used)]
+
+use core::net::{Ipv4Addr, Ipv6Addr};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use dataplane_acl::reference::{Erased, RefRule, ReferenceTable};
+use lookup::Lookup;
+use match_action::{ExactSpec, FixedSize, MatchKey, PrefixSpec, RangeSpec};
+
+mod sealed {
+    use core::net::{Ipv4Addr, Ipv6Addr};
+    pub trait Sealed {}
+    impl Sealed for Ipv4Addr {}
+    impl Sealed for Ipv6Addr {}
+}
+
+trait IpAddress: FixedSize + sealed::Sealed {
+    const UNSPECIFIED: Self;
+}
+impl IpAddress for Ipv4Addr {
+    const UNSPECIFIED: Self = Ipv4Addr::UNSPECIFIED;
+}
+impl IpAddress for Ipv6Addr {
+    const UNSPECIFIED: Self = Ipv6Addr::UNSPECIFIED;
+}
+const RULE_COUNTS: [usize; 15] = [
+    1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+];
+
+#[derive(MatchKey)]
+struct FiveTuple<A: IpAddress> {
+    #[exact]
+    proto: u8,
+    #[prefix]
+    src: A,
+    #[prefix]
+    dst: A,
+    #[range]
+    sport: u16,
+    #[range]
+    dport: u16,
+}
+fn deep_scan_table<A: IpAddress>(
+    n: usize,
+    src: A,
+    src_len: u8,
+) -> ReferenceTable<FiveTuple<A>, u32> {
+    let rules = (0..n)
+        .map(|i| {
+            RefRule::new(
+                FiveTupleRule::<A> {
+                    proto: ExactSpec::new(6),
+                    src: PrefixSpec::new(src, src_len),
+                    dst: PrefixSpec::new(A::UNSPECIFIED, 0),
+                    sport: RangeSpec::new(0, u16::MAX),
+                    dport: RangeSpec::exact(u16::try_from(i).unwrap_or(u16::MAX)),
+                }
+                .into_backend_fields::<Erased>(),
+                u32::try_from(i).unwrap_or(u32::MAX),
+            )
+        })
+        .collect();
+    ReferenceTable::new(rules)
+}
+fn bench_width<A: IpAddress>(
+    c: &mut Criterion,
+    name: &str,
+    prefix: A,
+    prefix_len: u8,
+    in_prefix: A,
+    dst: A,
+) {
+    let mut group = c.benchmark_group(name);
+    for n in RULE_COUNTS {
+        let table = deep_scan_table(n, prefix, prefix_len);
+        let miss = FiveTuple {
+            proto: 6,
+            src: in_prefix,
+            dst,
+            sport: 1234,
+            dport: u16::MAX,
+        };
+        let hit = FiveTuple {
+            proto: 6,
+            src: in_prefix,
+            dst,
+            sport: 1234,
+            dport: 0,
+        };
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::new("deep_miss", n), &miss, |b, pkt| {
+            b.iter(|| black_box(table.lookup(black_box(pkt))));
+        });
+        group.bench_with_input(BenchmarkId::new("hit_first", n), &hit, |b, pkt| {
+            b.iter(|| black_box(table.lookup(black_box(pkt))));
+        });
+    }
+    group.finish();
+}
+
+fn benches(c: &mut Criterion) {
+    bench_width::<Ipv4Addr>(
+        c,
+        "reference_five_tuple_v4",
+        Ipv4Addr::new(10, 0, 0, 0),
+        8,
+        Ipv4Addr::new(10, 0, 0, 1),
+        Ipv4Addr::new(192, 0, 2, 1),
+    );
+    bench_width::<Ipv6Addr>(
+        c,
+        "reference_five_tuple_v6",
+        "2001:db8::".parse().unwrap(),
+        32,
+        "2001:db8::1".parse().unwrap(),
+        "::1".parse().unwrap(),
+    );
+}
+
+criterion_group!(benchmarks, benches);
+criterion_main!(benchmarks);

--- a/acl/benches/table_build.rs
+++ b/acl/benches/table_build.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+#[cfg(feature = "dpdk")]
+mod bench {
+    use std::hint::black_box;
+
+    use concurrency::sync::atomic::{AtomicU32, Ordering};
+    use core::net::{Ipv4Addr, Ipv6Addr};
+    use core::num::NonZero;
+
+    use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+
+    use dataplane_acl::dpdk::install::install_table;
+    use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+    use dataplane_acl::dpdk_table_alias;
+    use dataplane_acl::reference::{Erased, RefRule, ReferenceTable};
+    use dpdk::acl::{CategoryMask, Priority};
+    use match_action::{ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+
+    #[derive(MatchKey)]
+    struct FiveTuple {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src: Ipv4Addr,
+        #[prefix]
+        dst: Ipv4Addr,
+        #[range]
+        sport: u16,
+        #[range]
+        dport: u16,
+    }
+
+    #[derive(MatchKey)]
+    struct FiveTuple6 {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src: Ipv6Addr,
+        #[prefix]
+        dst: Ipv6Addr,
+        #[range]
+        sport: u16,
+        #[range]
+        dport: u16,
+    }
+
+    dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
+    dpdk_table_alias!(type FiveTuple6Table<A> = FiveTuple6);
+    const RULE_COUNTS: [usize; 15] = [
+        1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+    ];
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_name(prefix: &str) -> String {
+        format!("{prefix}_{}", SEQ.fetch_add(1, Ordering::Relaxed))
+    }
+    fn rule_v4(i: usize) -> FiveTupleRule {
+        FiveTupleRule {
+            proto: ExactSpec::new(6),
+            src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+            dst: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+            sport: RangeSpec::new(0, u16::MAX),
+            dport: RangeSpec::exact(u16::try_from(i).unwrap_or(u16::MAX)),
+        }
+    }
+    fn rule_v6(i: usize) -> FiveTuple6Rule {
+        FiveTuple6Rule {
+            proto: ExactSpec::new(6),
+            src: PrefixSpec::new("2001:db8::".parse().expect("v6 literal"), 32),
+            dst: PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 0),
+            sport: RangeSpec::new(0, u16::MAX),
+            dport: RangeSpec::exact(u16::try_from(i).unwrap_or(u16::MAX)),
+        }
+    }
+    fn build_reference_v4(n: usize) -> ReferenceTable<FiveTuple, u32> {
+        let rules = (0..n)
+            .map(|i| {
+                let action = u32::try_from(i).unwrap_or(u32::MAX);
+                RefRule::new(rule_v4(i).into_backend_fields::<Erased>(), action)
+            })
+            .collect();
+        ReferenceTable::new(rules)
+    }
+
+    fn build_reference_v6(n: usize) -> ReferenceTable<FiveTuple6, u32> {
+        let rules = (0..n)
+            .map(|i| {
+                let action = u32::try_from(i).unwrap_or(u32::MAX);
+                RefRule::new(rule_v6(i).into_backend_fields::<Erased>(), action)
+            })
+            .collect();
+        ReferenceTable::new(rules)
+    }
+    fn build_dpdk_v4(n: usize) -> FiveTupleTable<u32> {
+        let specs: Vec<RuleSpec<FiveTuple, u32>> = (0..n)
+            .map(|i| make_spec(i, rule_v4(i).into_backend_fields::<Dpdk>()))
+            .collect();
+        let max = NonZero::new(u32::try_from(n).unwrap_or(u32::MAX)).expect("n >= 1");
+        install_table(&unique_name("table_build_v4"), max, specs).expect("install_table")
+    }
+
+    fn build_dpdk_v6(n: usize) -> FiveTuple6Table<u32> {
+        let specs: Vec<RuleSpec<FiveTuple6, u32>> = (0..n)
+            .map(|i| make_spec(i, rule_v6(i).into_backend_fields::<Dpdk>()))
+            .collect();
+        let max = NonZero::new(u32::try_from(n).unwrap_or(u32::MAX)).expect("n >= 1");
+        install_table(&unique_name("table_build_v6"), max, specs).expect("install_table")
+    }
+    fn make_spec<K: MatchKey>(
+        i: usize,
+        fields: Vec<dataplane_acl::dpdk::rule::AclFieldChunks>,
+    ) -> RuleSpec<K, u32> {
+        let prio = i32::try_from(i + 1).unwrap_or(i32::MAX);
+        let action = u32::try_from(i).unwrap_or(u32::MAX);
+        RuleSpec::new(
+            Priority::new(prio).expect("nonzero priority"),
+            CategoryMask::new(1).expect("nonzero mask"),
+            fields,
+            action,
+        )
+        .expect("valid RuleSpec")
+    }
+    fn bench_build_group<R, D>(
+        c: &mut Criterion,
+        name: &str,
+        build_reference: impl Fn(usize) -> R,
+        build_dpdk: impl Fn(usize) -> D,
+    ) {
+        let mut group = c.benchmark_group(name);
+        for n in RULE_COUNTS {
+            group.throughput(Throughput::Elements(u64::try_from(n).unwrap_or(0)));
+            group.bench_function(BenchmarkId::new("reference", n), |b| {
+                b.iter_batched(
+                    || (),
+                    |()| black_box(build_reference(n)),
+                    BatchSize::PerIteration,
+                );
+            });
+            group.bench_function(BenchmarkId::new("dpdk", n), |b| {
+                b.iter_batched(
+                    || (),
+                    |()| black_box(build_dpdk(n)),
+                    BatchSize::PerIteration,
+                );
+            });
+        }
+        group.finish();
+    }
+
+    pub fn benches(c: &mut Criterion) {
+        let _eal = dpdk::test_support::start_eal();
+        bench_build_group(c, "table_build_v4", build_reference_v4, build_dpdk_v4);
+        bench_build_group(c, "table_build_v6", build_reference_v6, build_dpdk_v6);
+    }
+}
+
+#[cfg(feature = "dpdk")]
+criterion::criterion_group!(benchmarks, bench::benches);
+#[cfg(feature = "dpdk")]
+criterion::criterion_main!(benchmarks);
+#[cfg(not(feature = "dpdk"))]
+fn main() {}

--- a/acl/src/dpdk/dyn_table.rs
+++ b/acl/src/dpdk/dyn_table.rs
@@ -1,0 +1,611 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+#![allow(unsafe_code)]
+
+use core::num::NonZero;
+
+use dpdk::acl::{
+    AclAddRulesError, AclBuildConfig, AclBuildFailure, AclContext, AclCreateError, AclCreateParams,
+    AclField, Built, FieldDef, InvalidAclBuildConfig, InvalidAclName, Rule, RuleData,
+};
+use dpdk::socket::SocketId;
+use match_action::{FieldPredicate, FieldSpec};
+
+use crate::dpdk::layout::{DpdkLayout, LayoutError, plan_layout};
+use crate::dpdk::rule::{
+    AclFieldChunks, AclSize, SpliceError, acl_size_for, exact_field, mask_field, padding_field,
+    prefix_field, range_field, splice_user_fields_to_dpdk,
+};
+pub const MAX_DYN_N: usize = 16;
+pub struct DynRuleSpec<A> {
+    pub priority: dpdk::acl::Priority,
+    pub category_mask: dpdk::acl::CategoryMask,
+    pub user_fields: Vec<AclFieldChunks>,
+    pub action: A,
+}
+
+impl<A> DynRuleSpec<A> {
+    #[must_use]
+    pub fn new(
+        priority: dpdk::acl::Priority,
+        category_mask: dpdk::acl::CategoryMask,
+        user_fields: Vec<AclFieldChunks>,
+        action: A,
+    ) -> Self {
+        Self {
+            priority,
+            category_mask,
+            user_fields,
+            action,
+        }
+    }
+}
+#[must_use]
+pub fn predicate_to_chunks(pred: &FieldPredicate, size_bytes: usize) -> AclFieldChunks {
+    assert_eq!(
+        pred.width(),
+        size_bytes,
+        "predicate width must equal FieldSpec::size",
+    );
+    debug_assert!(
+        size_bytes == 1 || size_bytes == 2 || size_bytes.is_multiple_of(4),
+        "predicate_to_chunks: size_bytes ({size_bytes}) must be 1, 2, or a multiple of 4",
+    );
+    let acl = acl_size_for(size_bytes);
+    let mut group = AclFieldChunks::new();
+    if let Some(value) = pred.as_exact() {
+        for chunk in pack_chunks(value, acl) {
+            group.push(exact_field(acl, chunk));
+        }
+    } else if let Some((value, prefix_len)) = pred.as_prefix() {
+        let bits_per_chunk = acl.bits();
+        let mut remaining = prefix_len;
+        for chunk in pack_chunks(value, acl) {
+            let chunk_len = remaining.min(bits_per_chunk);
+            group.push(prefix_field(acl, chunk, chunk_len));
+            remaining = remaining.saturating_sub(chunk_len);
+        }
+    } else if let Some((value, mask)) = pred.as_mask() {
+        let values = pack_chunks(value, acl);
+        let masks = pack_chunks(mask, acl);
+        for (v, m) in values.iter().zip(masks.iter()) {
+            group.push(mask_field(acl, *v & *m, *m));
+        }
+    } else if let Some((min, max)) = pred.as_range() {
+        assert!(
+            size_bytes <= 4,
+            "range match is unsupported on fields wider than 4 bytes",
+        );
+        let mins = pack_chunks(min, acl);
+        let maxs = pack_chunks(max, acl);
+        group.push(range_field(acl, mins[0], maxs[0]));
+    } else {
+        unreachable!("FieldPredicate has no variant inspector");
+    }
+    group
+}
+fn pack_chunks(bytes: &[u8], chunk_size: AclSize) -> Vec<u32> {
+    let csz = chunk_size.bytes();
+    debug_assert!(!bytes.is_empty());
+    if bytes.len() <= csz {
+        let mut buf = [0u8; 4];
+        let off = 4 - bytes.len();
+        buf[off..].copy_from_slice(bytes);
+        vec![u32::from_be_bytes(buf)]
+    } else {
+        debug_assert!(bytes.len().is_multiple_of(csz));
+        bytes
+            .chunks_exact(csz)
+            .map(|c| {
+                let mut buf = [0u8; 4];
+                let off = 4 - c.len();
+                buf[off..].copy_from_slice(c);
+                u32::from_be_bytes(buf)
+            })
+            .collect()
+    }
+}
+pub trait DynClassifier: Send + Sync {
+    /// Classify a single packed key, returning the matching rule's userdata (`0` on no match).
+    ///
+    /// # Safety
+    ///
+    /// `key` must be at least [`min_input_size`](DynClassifier::min_input_size) bytes long.
+    /// `rte_acl` reads that many bytes from the key pointer regardless of `key.len()`, so a
+    /// shorter slice is an out-of-bounds read.
+    unsafe fn classify_one(&self, key: &[u8]) -> Result<u32, dpdk::acl::AclClassifyError>;
+
+    fn min_input_size(&self) -> usize;
+}
+
+impl<const N: usize> DynClassifier for AclContext<N, Built<N>> {
+    unsafe fn classify_one(&self, key: &[u8]) -> Result<u32, dpdk::acl::AclClassifyError> {
+        let ptrs = [key.as_ptr()];
+        let mut results = [0u32; 1];
+        // SAFETY: per trait contract.
+        unsafe {
+            self.classify(&ptrs, &mut results, 1)?;
+        }
+        Ok(results[0])
+    }
+
+    fn min_input_size(&self) -> usize {
+        self.build_config().min_input_size()
+    }
+}
+pub fn install_table_dynamic<A>(
+    name: &str,
+    specs: &[FieldSpec],
+    rules: Vec<DynRuleSpec<A>>,
+    max_rules: NonZero<u32>,
+) -> Result<DynDpdkLookup<A>, DynInstallError> {
+    if specs.is_empty() {
+        return Err(DynInstallError::EmptySpecs);
+    }
+    let mut cursor = 0usize;
+    for (idx, spec) in specs.iter().enumerate() {
+        if spec.size == 0 {
+            return Err(DynInstallError::ZeroSizeSpec { idx });
+        }
+        if spec.offset != cursor {
+            return Err(DynInstallError::OffsetMismatch {
+                idx,
+                offset: spec.offset,
+                expected: cursor,
+            });
+        }
+        cursor += spec.size;
+    }
+    let layout = plan_layout(specs)?;
+    let n = layout.field_defs.len();
+    if n > MAX_DYN_N {
+        return Err(DynInstallError::UnsupportedFieldCount { n, max: MAX_DYN_N });
+    }
+    let user_field_sizes: Vec<usize> = specs.iter().map(|s| s.size).collect();
+    dispatch_install(n, name, layout, rules, max_rules, user_field_sizes)
+}
+#[derive(Debug, thiserror::Error)]
+pub enum DynInstallError {
+    #[error("layout planning failed: {0}")]
+    Layout(#[from] LayoutError),
+    #[error("field-def count {n} exceeds dynamic-install dispatch ceiling {max}")]
+    UnsupportedFieldCount { n: usize, max: usize },
+    #[error("specs are empty")]
+    EmptySpecs,
+    #[error("spec {idx} has zero size")]
+    ZeroSizeSpec { idx: usize },
+    #[error(
+        "spec {idx} offset {offset} disagrees with cumulative size {expected} of fields 0..{idx}"
+    )]
+    OffsetMismatch {
+        idx: usize,
+        offset: usize,
+        expected: usize,
+    },
+    #[error("too many rules: userdata would overflow at rule {count}")]
+    TooManyRules { count: usize },
+    #[error("splicing rule fields failed: {0}")]
+    Splice(#[from] SpliceError),
+    #[error("invalid ACL build config: {0}")]
+    InvalidConfig(#[from] InvalidAclBuildConfig),
+    #[error("invalid ACL context name: {0}")]
+    InvalidName(#[from] InvalidAclName),
+    #[error("failed to create ACL context: {0}")]
+    AclCreate(#[from] AclCreateError),
+    #[error("failed to add rules: {0}")]
+    AclAddRules(#[from] AclAddRulesError),
+    // String deviation (see development/code/error-handling.md): the underlying
+    // `AclBuildFailure<N>` is generic over the const field count `N`, which cannot be
+    // stored in this non-generic enum without erasing it. We capture its `Debug` rendering
+    // for diagnostics; build failure is terminal here and is not matched on.
+    #[error("ACL build failed: {0}")]
+    AclBuild(String),
+    #[error("layout stride {stride} < context min_input_size {required}")]
+    StrideTooSmall { stride: usize, required: usize },
+}
+macro_rules! dispatch_match {
+    ($n:expr, $name:expr, $layout:expr, $rules:expr, $max_rules:expr, $sizes:expr,
+     [ $($k:literal),+ $(,)? ]) => {
+        match $n {
+            $(
+                $k => do_install_n::<$k, _>($name, $layout, $rules, $max_rules, $sizes),
+            )+
+            _ => Err(DynInstallError::UnsupportedFieldCount {
+                n: $n,
+                max: MAX_DYN_N,
+            }),
+        }
+    };
+}
+
+fn dispatch_install<A>(
+    n: usize,
+    name: &str,
+    layout: DpdkLayout,
+    rules: Vec<DynRuleSpec<A>>,
+    max_rules: NonZero<u32>,
+    user_field_sizes: Vec<usize>,
+) -> Result<DynDpdkLookup<A>, DynInstallError> {
+    const _: () = assert!(
+        MAX_DYN_N == 16,
+        "MAX_DYN_N changed; extend the dispatch_match literal list",
+    );
+    dispatch_match!(
+        n,
+        name,
+        layout,
+        rules,
+        max_rules,
+        user_field_sizes,
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    )
+}
+fn do_install_n<const N: usize, A>(
+    name: &str,
+    layout: DpdkLayout,
+    rules: Vec<DynRuleSpec<A>>,
+    max_rules: NonZero<u32>,
+    user_field_sizes: Vec<usize>,
+) -> Result<DynDpdkLookup<A>, DynInstallError> {
+    debug_assert_eq!(N, layout.field_defs.len());
+    let field_defs: [FieldDef; N] = core::array::from_fn(|i| layout.field_defs[i]);
+    let build_cfg = AclBuildConfig::<N>::new(1, field_defs, 0)?;
+    let params = AclCreateParams::<N>::new(name, SocketId::ANY, max_rules)?;
+    let mut ctx = AclContext::<N>::new(params, build_cfg)?;
+
+    let mut actions: Vec<A> = Vec::with_capacity(rules.len());
+    let mut dpdk_rules: Vec<Rule<N>> = Vec::with_capacity(rules.len());
+    for (i, spec) in rules.into_iter().enumerate() {
+        let one_based =
+            u32::try_from(i + 1).map_err(|_| DynInstallError::TooManyRules { count: i })?;
+        let userdata = NonZero::new(one_based).ok_or(DynInstallError::TooManyRules { count: i })?;
+        let data = RuleData {
+            priority: spec.priority,
+            category_mask: spec.category_mask,
+            userdata,
+        };
+        let dpdk_fields: [AclField; N] = splice_user_fields_to_dpdk(&layout, &spec.user_fields)?;
+        dpdk_rules.push(Rule::<N>::new(data, dpdk_fields));
+        actions.push(spec.action);
+    }
+
+    ctx.add_rules(&dpdk_rules)?;
+    let built = ctx
+        .build()
+        .map_err(|f: AclBuildFailure<N>| DynInstallError::AclBuild(format!("{:?}", f.error)))?;
+
+    let min_input = built.build_config().min_input_size();
+    if layout.stride < min_input {
+        return Err(DynInstallError::StrideTooSmall {
+            stride: layout.stride,
+            required: min_input,
+        });
+    }
+
+    let classifier: Box<dyn DynClassifier> = Box::new(built);
+    Ok(DynDpdkLookup {
+        classifier,
+        actions,
+        layout,
+        user_field_sizes,
+    })
+}
+#[allow(dead_code)]
+const _PAD: fn() -> AclField = padding_field;
+pub struct DynDpdkLookup<A> {
+    classifier: Box<dyn DynClassifier>,
+    actions: Vec<A>,
+    layout: DpdkLayout,
+    user_field_sizes: Vec<usize>,
+}
+
+impl<A> DynDpdkLookup<A> {
+    #[must_use]
+    pub fn user_key_size(&self) -> usize {
+        self.user_field_sizes.iter().sum()
+    }
+
+    #[must_use]
+    pub fn layout(&self) -> &DpdkLayout {
+        &self.layout
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.actions.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+    /// Classify a key already packed in user-field order.
+    ///
+    /// `None` means "no rule matched" -- a table miss, not an error. A wrong-length key is a
+    /// caller contract violation, not a miss, so it panics rather than silently returning
+    /// `None` (conflating the two would violate "Option is not a good error"; see
+    /// development/code/error-handling.md). This mirrors the reference backend's
+    /// `DynReferenceTable::lookup_bytes`. The typed [`Lookup`](lookup::Lookup) path builds
+    /// the key from `K` and so cannot reach this panic.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key.len()` differs from [`user_key_size`](DynDpdkLookup::user_key_size).
+    #[must_use]
+    pub fn lookup_bytes(&self, key: &[u8]) -> Option<&A> {
+        let expected = self.user_key_size();
+        assert_eq!(key.len(), expected, "key length must equal user_key_size");
+        let mut dpdk_buf = [0u8; crate::dpdk::lookup::MAX_USER_KEY_BYTES];
+        let stride = self.layout.stride;
+        assert!(
+            stride <= dpdk_buf.len(),
+            "layout stride {stride} exceeds MAX_USER_KEY_BYTES {}",
+            dpdk_buf.len(),
+        );
+        let mut user_cursor = 0;
+        for (user_idx, &user_size) in self.user_field_sizes.iter().enumerate() {
+            let first_slot = self.layout.user_to_dpdk[user_idx];
+            let off = self.layout.field_defs[first_slot].offset() as usize;
+            dpdk_buf[off..off + user_size]
+                .copy_from_slice(&key[user_cursor..user_cursor + user_size]);
+            user_cursor += user_size;
+        }
+        // SAFETY: stride >= min_input_size (checked in `do_install_n`).
+        let user_data = unsafe {
+            match self.classifier.classify_one(&dpdk_buf[..stride]) {
+                Ok(ud) => ud,
+                Err(_) => return None,
+            }
+        };
+        if user_data == 0 {
+            return None;
+        }
+        let idx = usize::try_from(user_data).ok()?.checked_sub(1)?;
+        self.actions.get(idx)
+    }
+}
+
+#[cfg(all(test, feature = "dpdk"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_pass_by_value
+)]
+mod failing_repros {
+
+    use super::*;
+    use match_action::FieldKind;
+    use match_action::predicate::{Exact, FieldBytes, Mask, Range};
+
+    fn fb(bytes: &[u8]) -> FieldBytes {
+        bytes.iter().copied().collect()
+    }
+    fn spec(kind: FieldKind, size: usize, offset: usize) -> FieldSpec {
+        FieldSpec {
+            name: "f",
+            kind,
+            size,
+            offset,
+        }
+    }
+    use concurrency::sync::atomic::{AtomicU32, Ordering};
+
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    fn uname(p: &str) -> String {
+        format!("{p}_{}", SEQ.fetch_add(1, Ordering::Relaxed))
+    }
+    fn install_single<A>(
+        prefix: &str,
+        specs: Vec<FieldSpec>,
+        preds: Vec<FieldPredicate>,
+        action: A,
+    ) -> DynDpdkLookup<A> {
+        let chunks: Vec<_> = preds
+            .iter()
+            .zip(&specs)
+            .map(|(p, s)| predicate_to_chunks(p, s.size))
+            .collect();
+        install_table_dynamic::<A>(
+            &uname(prefix),
+            &specs,
+            vec![DynRuleSpec::new(
+                dpdk::acl::Priority::new(1).unwrap(),
+                dpdk::acl::CategoryMask::new(1).unwrap(),
+                chunks,
+                action,
+            )],
+            NonZero::new(2).unwrap(),
+        )
+        .expect("install_table_dynamic")
+    }
+    #[test]
+    #[dpdk::with_eal]
+    fn exact_then_range_then_mask_agrees() {
+        let specs = vec![
+            spec(FieldKind::Exact, 1, 0),
+            spec(FieldKind::Range, 2, 1),
+            spec(FieldKind::Mask, 1, 3),
+        ];
+        let preds = vec![
+            FieldPredicate::Exact(Exact::new(fb(&[198]))),
+            FieldPredicate::Range(Range::new(fb(&[63, 196]), fb(&[116, 68]))),
+            FieldPredicate::Mask(Mask::new(fb(&[75]), fb(&[2]))),
+        ];
+        let dpdk = install_single("repro_emr", specs, preds, 0xAAu32);
+        assert_eq!(dpdk.lookup_bytes(&[198, 111, 75, 39]), Some(&0xAA));
+    }
+}
+
+#[cfg(all(test, feature = "dpdk"))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::dpdk::install::install_table;
+    use crate::dpdk_table_alias;
+    use core::net::Ipv4Addr;
+    use dpdk::acl::{CategoryMask, Priority};
+    use lookup::Lookup;
+    use match_action::{Erased, ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+
+    #[derive(MatchKey, Debug, Clone, Copy)]
+    struct FiveTuple {
+        #[exact]
+        proto: u8,
+        #[prefix]
+        src: Ipv4Addr,
+        #[range]
+        dport: u16,
+    }
+
+    dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
+
+    use concurrency::sync::atomic::{AtomicU32, Ordering};
+
+    static CTX_SEQ: AtomicU32 = AtomicU32::new(0);
+    fn unique_name(prefix: &str) -> String {
+        format!("{prefix}_{}", CTX_SEQ.fetch_add(1, Ordering::Relaxed))
+    }
+    #[test]
+    #[dpdk::with_eal]
+    fn dyn_dpdk_agrees_with_typed_dpdk() {
+        let typed_rule = FiveTupleRule {
+            proto: ExactSpec::new(6),
+            src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+            dport: RangeSpec::exact(22),
+        };
+        let typed: FiveTupleTable<u32> = install_table(
+            &unique_name("dyn_typed"),
+            NonZero::new(2).unwrap(),
+            vec![
+                crate::dpdk::rule::RuleSpec::<FiveTuple, u32>::new(
+                    Priority::new(1).unwrap(),
+                    CategoryMask::new(1).unwrap(),
+                    typed_rule.into_backend_fields::<crate::dpdk::rule::Dpdk>(),
+                    0xAA,
+                )
+                .unwrap(),
+            ],
+        )
+        .expect("install_table");
+        let erased: Vec<FieldPredicate> = FiveTupleRule {
+            proto: ExactSpec::new(6),
+            src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+            dport: RangeSpec::exact(22),
+        }
+        .into_backend_fields::<Erased>();
+        let specs = FiveTuple::field_specs();
+        let chunks: Vec<AclFieldChunks> = erased
+            .iter()
+            .zip(specs)
+            .map(|(p, s)| predicate_to_chunks(p, s.size))
+            .collect();
+        let dyn_table = install_table_dynamic::<u32>(
+            &unique_name("dyn_dyn"),
+            specs,
+            vec![DynRuleSpec::new(
+                Priority::new(1).unwrap(),
+                CategoryMask::new(1).unwrap(),
+                chunks,
+                0xAA,
+            )],
+            NonZero::new(2).unwrap(),
+        )
+        .expect("install_table_dynamic");
+
+        for (key, label) in &[
+            (
+                FiveTuple {
+                    proto: 6,
+                    src: "10.1.2.3".parse().unwrap(),
+                    dport: 22,
+                },
+                "hit",
+            ),
+            (
+                FiveTuple {
+                    proto: 6,
+                    src: "11.0.0.0".parse().unwrap(),
+                    dport: 22,
+                },
+                "src miss",
+            ),
+            (
+                FiveTuple {
+                    proto: 17,
+                    src: "10.1.2.3".parse().unwrap(),
+                    dport: 22,
+                },
+                "proto miss",
+            ),
+        ] {
+            let bytes = key.as_key();
+            assert_eq!(
+                typed.lookup(key).copied(),
+                dyn_table.lookup_bytes(&bytes).copied(),
+                "typed vs dynamic disagree on {label}",
+            );
+        }
+    }
+    #[test]
+    fn rejects_offset_gap() {
+        let specs = vec![
+            FieldSpec {
+                name: "a",
+                kind: match_action::FieldKind::Exact,
+                size: 1,
+                offset: 0,
+            },
+            FieldSpec {
+                name: "b",
+                kind: match_action::FieldKind::Exact,
+                size: 1,
+                offset: 2,
+            },
+        ];
+        match install_table_dynamic::<u32>(
+            "rejects_offset_gap",
+            &specs,
+            Vec::new(),
+            NonZero::new(2).unwrap(),
+        ) {
+            Err(DynInstallError::OffsetMismatch {
+                idx: 1,
+                offset: 2,
+                expected: 1,
+            }) => {}
+            other => panic!("expected OffsetMismatch, got {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn rejects_zero_size_spec() {
+        let specs = vec![FieldSpec {
+            name: "x",
+            kind: match_action::FieldKind::Exact,
+            size: 0,
+            offset: 0,
+        }];
+        match install_table_dynamic::<u32>(
+            "rejects_zero_size",
+            &specs,
+            Vec::new(),
+            NonZero::new(2).unwrap(),
+        ) {
+            Err(DynInstallError::ZeroSizeSpec { idx: 0 }) => {}
+            other => panic!("expected ZeroSizeSpec, got {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn rejects_empty_specs() {
+        match install_table_dynamic::<u32>(
+            "rejects_empty",
+            &[],
+            Vec::new(),
+            NonZero::new(2).unwrap(),
+        ) {
+            Err(DynInstallError::EmptySpecs) => {}
+            other => panic!("expected EmptySpecs, got {:?}", other.err()),
+        }
+    }
+}

--- a/acl/src/dpdk/dyn_table.rs
+++ b/acl/src/dpdk/dyn_table.rs
@@ -11,12 +11,13 @@ use dpdk::acl::{
 use dpdk::socket::SocketId;
 use match_action::{FieldPredicate, FieldSpec};
 
+use dpdk::acl::MAX_FIELDS;
+
 use crate::dpdk::layout::{DpdkLayout, LayoutError, plan_layout};
 use crate::dpdk::rule::{
     AclFieldChunks, AclSize, SpliceError, acl_size_for, exact_field, mask_field, padding_field,
     prefix_field, range_field, splice_user_fields_to_dpdk,
 };
-pub const MAX_DYN_N: usize = 16;
 pub struct DynRuleSpec<A> {
     pub priority: dpdk::acl::Priority,
     pub category_mask: dpdk::acl::CategoryMask,
@@ -115,6 +116,21 @@ pub trait DynClassifier: Send + Sync {
     /// shorter slice is an out-of-bounds read.
     unsafe fn classify_one(&self, key: &[u8]) -> Result<u32, dpdk::acl::AclClassifyError>;
 
+    /// Classifies a batch of pre-packed keys in a single `rte_acl` call.
+    ///
+    /// # Safety
+    ///
+    /// Every pointer in `data` must address at least
+    /// [`min_input_size`](Self::min_input_size) bytes of valid, initialized
+    /// memory laid out according to the ACL context's field definitions (the
+    /// same per-pointer contract as [`classify_one`](Self::classify_one)).
+    /// `results.len()` must be at least `data.len()`.
+    unsafe fn classify_batch(
+        &self,
+        data: &[*const u8],
+        results: &mut [u32],
+    ) -> Result<(), dpdk::acl::AclClassifyError>;
+
     fn min_input_size(&self) -> usize;
 }
 
@@ -127,6 +143,15 @@ impl<const N: usize> DynClassifier for AclContext<N, Built<N>> {
             self.classify(&ptrs, &mut results, 1)?;
         }
         Ok(results[0])
+    }
+
+    unsafe fn classify_batch(
+        &self,
+        data: &[*const u8],
+        results: &mut [u32],
+    ) -> Result<(), dpdk::acl::AclClassifyError> {
+        // SAFETY: per trait contract.
+        unsafe { self.classify(data, results, 1) }
     }
 
     fn min_input_size(&self) -> usize {
@@ -158,17 +183,23 @@ pub fn install_table_dynamic<A>(
     }
     let layout = plan_layout(specs)?;
     let n = layout.field_defs.len();
-    if n > MAX_DYN_N {
-        return Err(DynInstallError::UnsupportedFieldCount { n, max: MAX_DYN_N });
+    if n > MAX_FIELDS {
+        return Err(DynInstallError::UnsupportedFieldCount { n, max: MAX_FIELDS });
     }
     let user_field_sizes: Vec<usize> = specs.iter().map(|s| s.size).collect();
-    dispatch_install(n, name, layout, rules, max_rules, user_field_sizes)
+    let (classifier, actions) = dispatch_build_classifier(n, name, &layout, rules, max_rules)?;
+    Ok(DynDpdkLookup {
+        classifier,
+        actions,
+        layout,
+        user_field_sizes,
+    })
 }
 #[derive(Debug, thiserror::Error)]
 pub enum DynInstallError {
     #[error("layout planning failed: {0}")]
     Layout(#[from] LayoutError),
-    #[error("field-def count {n} exceeds dynamic-install dispatch ceiling {max}")]
+    #[error("field-def count {n} exceeds rte_acl field ceiling {max}")]
     UnsupportedFieldCount { n: usize, max: usize },
     #[error("specs are empty")]
     EmptySpecs,
@@ -204,31 +235,34 @@ pub enum DynInstallError {
     StrideTooSmall { stride: usize, required: usize },
 }
 macro_rules! dispatch_match {
-    ($n:expr, $name:expr, $layout:expr, $rules:expr, $max_rules:expr, $sizes:expr,
+    ($n:expr, $name:expr, $layout:expr, $rules:expr, $max_rules:expr,
      [ $($k:literal),+ $(,)? ]) => {
         match $n {
             $(
-                $k => do_install_n::<$k, _>($name, $layout, $rules, $max_rules, $sizes),
+                $k => build_classifier_n::<$k, _>($name, $layout, $rules, $max_rules),
             )+
             _ => Err(DynInstallError::UnsupportedFieldCount {
                 n: $n,
-                max: MAX_DYN_N,
+                max: MAX_FIELDS,
             }),
         }
     };
 }
 
-fn dispatch_install<A>(
+/// Dispatch the runtime field-def count `n` to the const-`N`
+/// [`build_classifier_n`], which is monomorphized for every `N` up to the
+/// `rte_acl` ceiling. `plan_layout` already guarantees `n <= MAX_FIELDS`, so the
+/// fallthrough arm is unreachable for any valid layout.
+pub(crate) fn dispatch_build_classifier<A>(
     n: usize,
     name: &str,
-    layout: DpdkLayout,
+    layout: &DpdkLayout,
     rules: Vec<DynRuleSpec<A>>,
     max_rules: NonZero<u32>,
-    user_field_sizes: Vec<usize>,
-) -> Result<DynDpdkLookup<A>, DynInstallError> {
+) -> Result<(Box<dyn DynClassifier>, Vec<A>), DynInstallError> {
     const _: () = assert!(
-        MAX_DYN_N == 16,
-        "MAX_DYN_N changed; extend the dispatch_match literal list",
+        MAX_FIELDS == 64,
+        "MAX_FIELDS changed; regenerate the dispatch_match literal list",
     );
     dispatch_match!(
         n,
@@ -236,17 +270,28 @@ fn dispatch_install<A>(
         layout,
         rules,
         max_rules,
-        user_field_sizes,
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+            47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
+        ]
     )
 }
-fn do_install_n<const N: usize, A>(
+
+/// Build a boxed, type-erased classifier for a layout with exactly `N` DPDK
+/// field defs. Shared by the dynamic ([`install_table_dynamic`]) and typed
+/// (`install_table`) install paths: both reduce to a `Vec<DynRuleSpec<A>>`
+/// over a planned [`DpdkLayout`]. Generic only over `<N, A>` (not the key
+/// type), so the 64-way dispatch monomorphizes a bounded amount of code.
+///
+/// Validates that `layout.stride >= min_input_size` so callers can pack into a
+/// `stride`-sized buffer and classify soundly.
+fn build_classifier_n<const N: usize, A>(
     name: &str,
-    layout: DpdkLayout,
+    layout: &DpdkLayout,
     rules: Vec<DynRuleSpec<A>>,
     max_rules: NonZero<u32>,
-    user_field_sizes: Vec<usize>,
-) -> Result<DynDpdkLookup<A>, DynInstallError> {
+) -> Result<(Box<dyn DynClassifier>, Vec<A>), DynInstallError> {
     debug_assert_eq!(N, layout.field_defs.len());
     let field_defs: [FieldDef; N] = core::array::from_fn(|i| layout.field_defs[i]);
     let build_cfg = AclBuildConfig::<N>::new(1, field_defs, 0)?;
@@ -264,7 +309,7 @@ fn do_install_n<const N: usize, A>(
             category_mask: spec.category_mask,
             userdata,
         };
-        let dpdk_fields: [AclField; N] = splice_user_fields_to_dpdk(&layout, &spec.user_fields)?;
+        let dpdk_fields: [AclField; N] = splice_user_fields_to_dpdk(layout, &spec.user_fields)?;
         dpdk_rules.push(Rule::<N>::new(data, dpdk_fields));
         actions.push(spec.action);
     }
@@ -282,13 +327,7 @@ fn do_install_n<const N: usize, A>(
         });
     }
 
-    let classifier: Box<dyn DynClassifier> = Box::new(built);
-    Ok(DynDpdkLookup {
-        classifier,
-        actions,
-        layout,
-        user_field_sizes,
-    })
+    Ok((Box::new(built), actions))
 }
 #[allow(dead_code)]
 const _PAD: fn() -> AclField = padding_field;

--- a/acl/src/dpdk/install.rs
+++ b/acl/src/dpdk/install.rs
@@ -3,101 +3,59 @@
 
 use core::num::NonZero;
 
-use dpdk::acl::{
-    AclAddRulesError, AclBuildConfig, AclBuildFailure, AclContext, AclCreateError, AclCreateParams,
-    FieldDef, InvalidAclBuildConfig, InvalidAclName, Rule, RuleData,
-};
-use dpdk::socket::SocketId;
 use match_action::MatchKey;
 
+use crate::dpdk::dyn_table::{DynInstallError, DynRuleSpec, dispatch_build_classifier};
 use crate::dpdk::layout::{LayoutError, plan_layout};
 use crate::dpdk::lookup::{DpdkAclLookup, MAX_USER_KEY_BYTES, StrideTooSmall};
-use crate::dpdk::rule::{RuleSpec, SpliceError, splice_user_fields_to_dpdk};
-pub fn install_table<K, A, const N: usize, const STRIDE: usize>(
+use crate::dpdk::rule::RuleSpec;
+
+/// Install a typed ACL table.
+///
+/// The `rte_acl` field count is computed from `K`'s layout at runtime and
+/// dispatched to the const-`N` builder shared with the dynamic install path
+/// (see [`dispatch_build_classifier`]). The resulting `DpdkAclLookup<K, A>`
+/// carries no field-count or stride const generics, so one type covers every
+/// monomorphization of a generic key.
+pub fn install_table<K, A>(
     name: &str,
     max_rules: NonZero<u32>,
     rules: Vec<RuleSpec<K, A>>,
-) -> Result<DpdkAclLookup<K, N, STRIDE, A>, InstallError>
+) -> Result<DpdkAclLookup<K, A>, InstallError>
 where
     K: MatchKey,
 {
     let layout = plan_layout(K::field_specs())?;
-    if N != layout.field_defs.len() {
-        return Err(InstallError::WrongN {
-            expected: layout.field_defs.len(),
-            got: N,
-        });
-    }
-    if STRIDE != layout.stride {
-        return Err(InstallError::WrongStride {
-            expected: layout.stride,
-            got: STRIDE,
-        });
-    }
     if K::KEY_SIZE > MAX_USER_KEY_BYTES {
         return Err(InstallError::UserKeyTooLarge {
             key_size: K::KEY_SIZE,
             limit: MAX_USER_KEY_BYTES,
         });
     }
-    let field_defs: [FieldDef; N] = core::array::from_fn(|i| layout.field_defs[i]);
-    let build_cfg = AclBuildConfig::<N>::new(1, field_defs, 0)?;
-
-    let params = AclCreateParams::<N>::new(name, SocketId::ANY, max_rules)?;
-    let mut ctx = AclContext::<N>::new(params, build_cfg)?;
-
-    let mut actions: Vec<A> = Vec::with_capacity(rules.len());
-    let mut dpdk_rules: Vec<Rule<N>> = Vec::with_capacity(rules.len());
-    for (i, spec) in rules.into_iter().enumerate() {
-        let one_based =
-            u32::try_from(i + 1).map_err(|_| InstallError::TooManyRules { count: i })?;
-        let userdata = NonZero::new(one_based).ok_or(InstallError::TooManyRules { count: i })?;
-        let data = RuleData {
-            priority: spec.priority,
-            category_mask: spec.category_mask,
-            userdata,
-        };
-        let dpdk_fields: [dpdk::acl::AclField; N] =
-            splice_user_fields_to_dpdk(&layout, &spec.user_fields)?;
-        dpdk_rules.push(Rule::<N>::new(data, dpdk_fields));
-        actions.push(spec.action);
-    }
-
-    ctx.add_rules(&dpdk_rules)?;
-    let ctx = ctx
-        .build()
-        .map_err(|f: AclBuildFailure<N>| InstallError::AclBuild(format!("{:?}", f.error)))?;
-
-    DpdkAclLookup::<K, N, STRIDE, A>::new(ctx, actions, layout).map_err(InstallError::Stride)
+    let n = layout.field_defs.len();
+    let dyn_rules: Vec<DynRuleSpec<A>> = rules
+        .into_iter()
+        .map(|spec| {
+            DynRuleSpec::new(
+                spec.priority,
+                spec.category_mask,
+                spec.user_fields,
+                spec.action,
+            )
+        })
+        .collect();
+    let (classifier, actions) = dispatch_build_classifier(n, name, &layout, dyn_rules, max_rules)?;
+    DpdkAclLookup::<K, A>::new(classifier, actions, layout).map_err(InstallError::Stride)
 }
+
 #[derive(Debug, thiserror::Error)]
 pub enum InstallError {
     #[error("layout planning failed: {0}")]
     Layout(#[from] LayoutError),
-    #[error("const generic N: expected {expected}, got {got}")]
-    WrongN { expected: usize, got: usize },
-    #[error("const generic STRIDE: expected {expected}, got {got}")]
-    WrongStride { expected: usize, got: usize },
     #[error("MatchKey::KEY_SIZE ({key_size}) exceeds MAX_USER_KEY_BYTES ({limit})")]
     UserKeyTooLarge { key_size: usize, limit: usize },
-    #[error("too many rules: userdata would overflow at rule {count}")]
-    TooManyRules { count: usize },
-    #[error("splicing rule fields failed: {0}")]
-    Splice(#[from] SpliceError),
-    #[error("invalid ACL build config: {0}")]
-    InvalidConfig(#[from] InvalidAclBuildConfig),
-    #[error("invalid ACL context name: {0}")]
-    InvalidName(#[from] InvalidAclName),
-    #[error("failed to create ACL context: {0}")]
-    AclCreate(#[from] AclCreateError),
-    #[error("failed to add rules: {0}")]
-    AclAddRules(#[from] AclAddRulesError),
-    // String deviation (see development/code/error-handling.md): the underlying
-    // `AclBuildFailure<N>` is generic over the const field count `N`, which cannot be
-    // stored in this non-generic enum without erasing it. We capture its `Debug` rendering
-    // for diagnostics; build failure is terminal here and is not matched on.
-    #[error("ACL build failed: {0}")]
-    AclBuild(String),
+    #[error(transparent)]
+    Build(#[from] DynInstallError),
     #[error(transparent)]
     Stride(#[from] StrideTooSmall),
 }

--- a/acl/src/dpdk/install.rs
+++ b/acl/src/dpdk/install.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use core::num::NonZero;
+
+use dpdk::acl::{
+    AclAddRulesError, AclBuildConfig, AclBuildFailure, AclContext, AclCreateError, AclCreateParams,
+    FieldDef, InvalidAclBuildConfig, InvalidAclName, Rule, RuleData,
+};
+use dpdk::socket::SocketId;
+use match_action::MatchKey;
+
+use crate::dpdk::layout::{LayoutError, plan_layout};
+use crate::dpdk::lookup::{DpdkAclLookup, MAX_USER_KEY_BYTES, StrideTooSmall};
+use crate::dpdk::rule::{RuleSpec, SpliceError, splice_user_fields_to_dpdk};
+pub fn install_table<K, A, const N: usize, const STRIDE: usize>(
+    name: &str,
+    max_rules: NonZero<u32>,
+    rules: Vec<RuleSpec<K, A>>,
+) -> Result<DpdkAclLookup<K, N, STRIDE, A>, InstallError>
+where
+    K: MatchKey,
+{
+    let layout = plan_layout(K::field_specs())?;
+    if N != layout.field_defs.len() {
+        return Err(InstallError::WrongN {
+            expected: layout.field_defs.len(),
+            got: N,
+        });
+    }
+    if STRIDE != layout.stride {
+        return Err(InstallError::WrongStride {
+            expected: layout.stride,
+            got: STRIDE,
+        });
+    }
+    if K::KEY_SIZE > MAX_USER_KEY_BYTES {
+        return Err(InstallError::UserKeyTooLarge {
+            key_size: K::KEY_SIZE,
+            limit: MAX_USER_KEY_BYTES,
+        });
+    }
+    let field_defs: [FieldDef; N] = core::array::from_fn(|i| layout.field_defs[i]);
+    let build_cfg = AclBuildConfig::<N>::new(1, field_defs, 0)?;
+
+    let params = AclCreateParams::<N>::new(name, SocketId::ANY, max_rules)?;
+    let mut ctx = AclContext::<N>::new(params, build_cfg)?;
+
+    let mut actions: Vec<A> = Vec::with_capacity(rules.len());
+    let mut dpdk_rules: Vec<Rule<N>> = Vec::with_capacity(rules.len());
+    for (i, spec) in rules.into_iter().enumerate() {
+        let one_based =
+            u32::try_from(i + 1).map_err(|_| InstallError::TooManyRules { count: i })?;
+        let userdata = NonZero::new(one_based).ok_or(InstallError::TooManyRules { count: i })?;
+        let data = RuleData {
+            priority: spec.priority,
+            category_mask: spec.category_mask,
+            userdata,
+        };
+        let dpdk_fields: [dpdk::acl::AclField; N] =
+            splice_user_fields_to_dpdk(&layout, &spec.user_fields)?;
+        dpdk_rules.push(Rule::<N>::new(data, dpdk_fields));
+        actions.push(spec.action);
+    }
+
+    ctx.add_rules(&dpdk_rules)?;
+    let ctx = ctx
+        .build()
+        .map_err(|f: AclBuildFailure<N>| InstallError::AclBuild(format!("{:?}", f.error)))?;
+
+    DpdkAclLookup::<K, N, STRIDE, A>::new(ctx, actions, layout).map_err(InstallError::Stride)
+}
+#[derive(Debug, thiserror::Error)]
+pub enum InstallError {
+    #[error("layout planning failed: {0}")]
+    Layout(#[from] LayoutError),
+    #[error("const generic N: expected {expected}, got {got}")]
+    WrongN { expected: usize, got: usize },
+    #[error("const generic STRIDE: expected {expected}, got {got}")]
+    WrongStride { expected: usize, got: usize },
+    #[error("MatchKey::KEY_SIZE ({key_size}) exceeds MAX_USER_KEY_BYTES ({limit})")]
+    UserKeyTooLarge { key_size: usize, limit: usize },
+    #[error("too many rules: userdata would overflow at rule {count}")]
+    TooManyRules { count: usize },
+    #[error("splicing rule fields failed: {0}")]
+    Splice(#[from] SpliceError),
+    #[error("invalid ACL build config: {0}")]
+    InvalidConfig(#[from] InvalidAclBuildConfig),
+    #[error("invalid ACL context name: {0}")]
+    InvalidName(#[from] InvalidAclName),
+    #[error("failed to create ACL context: {0}")]
+    AclCreate(#[from] AclCreateError),
+    #[error("failed to add rules: {0}")]
+    AclAddRules(#[from] AclAddRulesError),
+    // String deviation (see development/code/error-handling.md): the underlying
+    // `AclBuildFailure<N>` is generic over the const field count `N`, which cannot be
+    // stored in this non-generic enum without erasing it. We capture its `Debug` rendering
+    // for diagnostics; build failure is terminal here and is not matched on.
+    #[error("ACL build failed: {0}")]
+    AclBuild(String),
+    #[error(transparent)]
+    Stride(#[from] StrideTooSmall),
+}

--- a/acl/src/dpdk/layout.rs
+++ b/acl/src/dpdk/layout.rs
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use arrayvec::ArrayVec;
+use dpdk::acl::{FieldDef, FieldSize, FieldType, MAX_FIELDS};
+use match_action::{FieldKind, FieldSpec};
+pub const MAX_FIELD_CHUNKS: usize = 4;
+const fn chunk_shape(size: usize) -> (usize, usize) {
+    if size <= 4 {
+        assert!(
+            size == 1 || size == 2 || size == 4,
+            "field size must be 1, 2, or 4 bytes (or a multiple of 4 for split wide fields)",
+        );
+        (size, 1)
+    } else {
+        assert!(
+            size.is_multiple_of(4),
+            "wide field size must be a multiple of 4 bytes",
+        );
+        let n = size / 4;
+        assert!(
+            n <= MAX_FIELD_CHUNKS,
+            "wide field too large; at most 16 bytes (4 chunks)",
+        );
+        (4, n)
+    }
+}
+#[must_use]
+pub const fn const_extents(specs: &[FieldSpec]) -> (usize, usize) {
+    assert!(!specs.is_empty(), "MatchKey has zero fields");
+    assert!(specs[0].size == 1, "first field must be 1 byte for rte_acl");
+
+    let mut n: usize = 1;
+    let mut offset: usize = 4;
+    let mut group_used: usize = 0;
+
+    let mut i = 1;
+    while i < specs.len() {
+        let (chunk_size, n_chunks) = chunk_shape(specs[i].size);
+        assert!(
+            !(n_chunks > 1 && matches!(specs[i].kind, FieldKind::Range)),
+            "range match is unsupported on fields wider than 4 bytes",
+        );
+
+        let mut c = 0;
+        while c < n_chunks {
+            let starts_new_group =
+                group_used > 0 && (chunk_size == 4 || group_used + chunk_size > 4);
+            if starts_new_group {
+                while group_used < 4 {
+                    n += 1;
+                    offset += 1;
+                    group_used += 1;
+                }
+                group_used = 0;
+            }
+
+            n += 1;
+            offset += chunk_size;
+            group_used += chunk_size;
+
+            c += 1;
+        }
+
+        i += 1;
+    }
+
+    while group_used > 0 && group_used < 4 {
+        n += 1;
+        offset += 1;
+        group_used += 1;
+    }
+
+    (n, offset)
+}
+#[derive(Debug, Clone)]
+pub struct DpdkLayout {
+    pub(crate) field_defs: ArrayVec<FieldDef, MAX_FIELDS>,
+    pub(crate) stride: usize,
+    pub(crate) user_to_dpdk: ArrayVec<usize, MAX_FIELDS>,
+    pub(crate) user_chunk_counts: ArrayVec<usize, MAX_FIELDS>,
+}
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LayoutError {
+    #[error("MatchKey has zero fields; rte_acl needs at least one")]
+    EmptyKey,
+    #[error("first field must be 1 byte for rte_acl, got {actual_size}")]
+    FirstFieldNotOneByte { actual_size: usize },
+    #[error(
+        "field {user_index} has size {size}; rte_acl fields must be 1, 2, or 4 bytes, \
+         or a multiple of 4 up to 16 for split wide fields"
+    )]
+    InvalidFieldSize { user_index: usize, size: usize },
+    #[error("field {user_index} is a {size}-byte range; rte_acl range match is limited to 4 bytes")]
+    RangeFieldTooWide { user_index: usize, size: usize },
+    #[error("too many field defs: {total} exceeds rte_acl's field limit")]
+    TooManyFieldDefs { total: usize },
+}
+pub fn plan_layout(specs: &[FieldSpec]) -> Result<DpdkLayout, LayoutError> {
+    if specs.is_empty() {
+        return Err(LayoutError::EmptyKey);
+    }
+    if specs.len() > MAX_FIELDS {
+        return Err(LayoutError::TooManyFieldDefs { total: specs.len() });
+    }
+    if specs[0].size != 1 {
+        return Err(LayoutError::FirstFieldNotOneByte {
+            actual_size: specs[0].size,
+        });
+    }
+
+    let mut defs: ArrayVec<FieldDef, MAX_FIELDS> = ArrayVec::new();
+    let mut user_to_dpdk: ArrayVec<usize, MAX_FIELDS> =
+        std::iter::repeat_n(0, specs.len()).collect();
+    let mut user_chunk_counts: ArrayVec<usize, MAX_FIELDS> =
+        std::iter::repeat_n(0, specs.len()).collect();
+    // note: the DPDK ACL library hard requires the first field to be a single byte exact match.
+    // We need to handle that specially.  If the user doesn't want to match on any 1 byte exact match fields then
+    // we need to implicitly wildcard it.
+    user_chunk_counts[0] = 1;
+    push_def(
+        &mut defs,
+        FieldDef::new(field_type_of(specs[0].kind), FieldSize::One, 0, 0, 0),
+    )?;
+
+    let mut offset: u32 = 4;
+    let mut input_index: u8 = 1;
+    let mut group_used: u32 = 0;
+
+    for (user_idx, spec) in specs.iter().enumerate().skip(1) {
+        let (chunk_size, n_chunks) = chunk_shape_checked(spec.size, user_idx)?;
+        if n_chunks > 1 && spec.kind == FieldKind::Range {
+            return Err(LayoutError::RangeFieldTooWide {
+                user_index: user_idx,
+                size: spec.size,
+            });
+        }
+        user_chunk_counts[user_idx] = n_chunks;
+
+        for chunk in 0..n_chunks {
+            let starts_new_group =
+                group_used > 0 && (chunk_size == 4 || group_used + chunk_size > 4);
+
+            if starts_new_group {
+                pad_group(&mut defs, &mut offset, &mut group_used, input_index)?;
+                input_index = input_index
+                    .checked_add(1)
+                    .ok_or(LayoutError::TooManyFieldDefs {
+                        total: defs.len() + 1,
+                    })?;
+                group_used = 0;
+            }
+
+            let slot = defs.len();
+            let field_index =
+                u8::try_from(slot).map_err(|_| LayoutError::TooManyFieldDefs { total: slot })?;
+            if chunk == 0 {
+                user_to_dpdk[user_idx] = slot;
+            }
+            push_def(
+                &mut defs,
+                FieldDef::new(
+                    field_type_of(spec.kind),
+                    field_size_of(chunk_size),
+                    field_index,
+                    input_index,
+                    offset,
+                ),
+            )?;
+            offset += chunk_size;
+            group_used += chunk_size;
+        }
+    }
+    pad_group(&mut defs, &mut offset, &mut group_used, input_index)?;
+
+    let stride =
+        usize::try_from(offset).map_err(|_| LayoutError::TooManyFieldDefs { total: defs.len() })?;
+
+    Ok(DpdkLayout {
+        field_defs: defs,
+        stride,
+        user_to_dpdk,
+        user_chunk_counts,
+    })
+}
+
+fn push_def(defs: &mut ArrayVec<FieldDef, MAX_FIELDS>, def: FieldDef) -> Result<(), LayoutError> {
+    let current = defs.len();
+    defs.try_push(def)
+        .map_err(|_| LayoutError::TooManyFieldDefs { total: current + 1 })
+}
+fn pad_group(
+    defs: &mut ArrayVec<FieldDef, MAX_FIELDS>,
+    offset: &mut u32,
+    group_used: &mut u32,
+    input_index: u8,
+) -> Result<(), LayoutError> {
+    while *group_used < 4 && *group_used > 0 {
+        let field_index = u8::try_from(defs.len())
+            .map_err(|_| LayoutError::TooManyFieldDefs { total: defs.len() })?;
+        push_def(
+            defs,
+            FieldDef::new(
+                FieldType::Bitmask,
+                FieldSize::One,
+                field_index,
+                input_index,
+                *offset,
+            ),
+        )?;
+        *offset += 1;
+        *group_used += 1;
+    }
+    Ok(())
+}
+
+fn field_type_of(kind: FieldKind) -> FieldType {
+    match kind {
+        FieldKind::Prefix => FieldType::Mask,
+        FieldKind::Mask | FieldKind::Exact => FieldType::Bitmask,
+        FieldKind::Range => FieldType::Range,
+    }
+}
+
+fn field_size_of(size: u32) -> FieldSize {
+    match size {
+        1 => FieldSize::One,
+        2 => FieldSize::Two,
+        4 => FieldSize::Four,
+        other => unreachable!("plan_layout validated size in {{1,2,4}}, got {other}"),
+    }
+}
+fn chunk_shape_checked(size: usize, user_index: usize) -> Result<(u32, usize), LayoutError> {
+    let invalid = || LayoutError::InvalidFieldSize { user_index, size };
+    if size <= 4 {
+        if size != 1 && size != 2 && size != 4 {
+            return Err(invalid());
+        }
+        Ok((u32::try_from(size).map_err(|_| invalid())?, 1))
+    } else {
+        if !size.is_multiple_of(4) {
+            return Err(invalid());
+        }
+        let n = size / 4;
+        if n > MAX_FIELD_CHUNKS {
+            return Err(invalid());
+        }
+        Ok((4, n))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpdk::acl::AclBuildConfig;
+
+    fn spec(name: &'static str, kind: FieldKind, size: usize, offset: usize) -> FieldSpec {
+        FieldSpec {
+            name,
+            kind,
+            size,
+            offset,
+        }
+    }
+    fn assert_dpdk_accepts<const N: usize>(layout: &DpdkLayout) {
+        assert_eq!(
+            layout.field_defs.len(),
+            N,
+            "expected {N} field defs, got {}",
+            layout.field_defs.len()
+        );
+        let arr: [FieldDef; N] = core::array::from_fn(|i| layout.field_defs[i]);
+        let cfg = AclBuildConfig::new(1, arr, 0);
+        assert!(
+            cfg.is_ok(),
+            "AclBuildConfig rejected the planned layout: {:?}",
+            cfg.err()
+        );
+    }
+
+    #[test]
+    fn rejects_empty_specs() {
+        assert_eq!(plan_layout(&[]).unwrap_err(), LayoutError::EmptyKey);
+    }
+
+    #[test]
+    fn rejects_non_one_byte_first_field() {
+        let specs = [spec("ip", FieldKind::Prefix, 4, 0)];
+        assert_eq!(
+            plan_layout(&specs).unwrap_err(),
+            LayoutError::FirstFieldNotOneByte { actual_size: 4 }
+        );
+    }
+
+    #[test]
+    fn rejects_three_byte_field() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("weird", FieldKind::Exact, 3, 1),
+        ];
+        assert_eq!(
+            plan_layout(&specs).unwrap_err(),
+            LayoutError::InvalidFieldSize {
+                user_index: 1,
+                size: 3
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_multiple_of_four_wide_field() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("weird", FieldKind::Exact, 6, 1),
+        ];
+        assert_eq!(
+            plan_layout(&specs).unwrap_err(),
+            LayoutError::InvalidFieldSize {
+                user_index: 1,
+                size: 6
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_field_wider_than_sixteen_bytes() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("huge", FieldKind::Prefix, 20, 1),
+        ];
+        assert_eq!(
+            plan_layout(&specs).unwrap_err(),
+            LayoutError::InvalidFieldSize {
+                user_index: 1,
+                size: 20
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_wide_range_field() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("addr_range", FieldKind::Range, 16, 0),
+        ];
+        assert_eq!(
+            plan_layout(&specs).unwrap_err(),
+            LayoutError::RangeFieldTooWide {
+                user_index: 1,
+                size: 16
+            }
+        );
+    }
+
+    #[test]
+    fn five_tuple_plans_without_padding() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("src_ip", FieldKind::Prefix, 4, 0),
+            spec("dst_ip", FieldKind::Prefix, 4, 0),
+            spec("src_port", FieldKind::Range, 2, 0),
+            spec("dst_port", FieldKind::Range, 2, 0),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        assert_eq!(layout.field_defs.len(), 5);
+        assert_eq!(layout.stride, 16);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0, 1, 2, 3, 4]);
+
+        assert_eq!(layout.field_defs[0].input_index(), 0);
+        assert_eq!(layout.field_defs[0].offset(), 0);
+        assert_eq!(layout.field_defs[1].input_index(), 1);
+        assert_eq!(layout.field_defs[1].offset(), 4);
+        assert_eq!(layout.field_defs[2].input_index(), 2);
+        assert_eq!(layout.field_defs[2].offset(), 8);
+        assert_eq!(layout.field_defs[3].input_index(), 3);
+        assert_eq!(layout.field_defs[3].offset(), 12);
+        assert_eq!(layout.field_defs[4].input_index(), 3);
+        assert_eq!(layout.field_defs[4].offset(), 14);
+
+        assert_dpdk_accepts::<5>(&layout);
+    }
+
+    #[test]
+    fn ipv6_five_tuple_splits_each_address_into_four_u32_subfields() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("src", FieldKind::Prefix, 16, 0),
+            spec("dst", FieldKind::Prefix, 16, 0),
+            spec("sport", FieldKind::Range, 2, 0),
+            spec("dport", FieldKind::Range, 2, 0),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        assert_eq!(layout.field_defs.len(), 11);
+        assert_eq!(layout.stride, 40);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0, 1, 5, 9, 10]);
+        for (k, slot) in (1..=4).enumerate() {
+            let off = u32::try_from(4 + k * 4).unwrap();
+            assert_eq!(
+                layout.field_defs[slot].input_index(),
+                u8::try_from(slot).unwrap()
+            );
+            assert_eq!(layout.field_defs[slot].offset(), off);
+            assert_eq!(layout.field_defs[slot].size(), FieldSize::Four);
+            assert_eq!(layout.field_defs[slot].field_type(), FieldType::Mask);
+        }
+        for (k, slot) in (5..=8).enumerate() {
+            let off = u32::try_from(20 + k * 4).unwrap();
+            assert_eq!(
+                layout.field_defs[slot].input_index(),
+                u8::try_from(slot).unwrap()
+            );
+            assert_eq!(layout.field_defs[slot].offset(), off);
+        }
+        assert_eq!(layout.field_defs[9].input_index(), 9);
+        assert_eq!(layout.field_defs[9].offset(), 36);
+        assert_eq!(layout.field_defs[10].input_index(), 9);
+        assert_eq!(layout.field_defs[10].offset(), 38);
+
+        assert_dpdk_accepts::<11>(&layout);
+    }
+
+    #[test]
+    fn all_four_byte_layout_after_proto_needs_no_padding() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("a", FieldKind::Prefix, 4, 0),
+            spec("b", FieldKind::Prefix, 4, 0),
+            spec("c", FieldKind::Prefix, 4, 0),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        assert_eq!(layout.field_defs.len(), 4);
+        assert_eq!(layout.stride, 16);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0, 1, 2, 3]);
+
+        assert_dpdk_accepts::<4>(&layout);
+    }
+
+    #[test]
+    fn three_two_byte_fields_pack_with_one_padding_in_final_group() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("a", FieldKind::Range, 2, 0),
+            spec("b", FieldKind::Range, 2, 0),
+            spec("c", FieldKind::Range, 2, 0),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        assert_eq!(layout.field_defs.len(), 6);
+        assert_eq!(layout.stride, 12);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0, 1, 2, 3]);
+
+        assert_eq!(layout.field_defs[3].input_index(), 2);
+        assert_eq!(layout.field_defs[4].input_index(), 2);
+        assert_eq!(layout.field_defs[5].input_index(), 2);
+
+        assert_dpdk_accepts::<6>(&layout);
+    }
+
+    #[test]
+    fn final_group_gets_padded_when_short() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1, 0),
+            spec("port", FieldKind::Range, 2, 0),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        assert_eq!(layout.field_defs.len(), 4);
+        assert_eq!(layout.stride, 8);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0, 1]);
+
+        assert_eq!(layout.field_defs[0].input_index(), 0);
+        assert_eq!(layout.field_defs[1].input_index(), 1);
+        assert_eq!(layout.field_defs[1].offset(), 4);
+        assert_eq!(layout.field_defs[2].input_index(), 1);
+        assert_eq!(layout.field_defs[3].input_index(), 1);
+
+        assert_dpdk_accepts::<4>(&layout);
+    }
+
+    #[test]
+    fn single_one_byte_field_emits_just_that_field() {
+        let specs = [spec("proto", FieldKind::Exact, 1, 0)];
+        let layout = plan_layout(&specs).expect("plan");
+        assert_eq!(layout.field_defs.len(), 1);
+        assert_eq!(layout.stride, 4);
+        assert_eq!(layout.user_to_dpdk.as_slice(), [0]);
+
+        assert_dpdk_accepts::<1>(&layout);
+    }
+
+    #[test]
+    fn const_extents_agrees_with_plan_layout() {
+        let cases: [&[FieldSpec]; 3] = [
+            &[
+                spec("proto", FieldKind::Exact, 1, 0),
+                spec("src_ip", FieldKind::Prefix, 4, 0),
+                spec("dst_ip", FieldKind::Prefix, 4, 0),
+                spec("src_port", FieldKind::Range, 2, 0),
+                spec("dst_port", FieldKind::Range, 2, 0),
+            ],
+            &[
+                spec("proto", FieldKind::Exact, 1, 0),
+                spec("a", FieldKind::Range, 2, 0),
+                spec("b", FieldKind::Range, 2, 0),
+                spec("c", FieldKind::Range, 2, 0),
+            ],
+            &[
+                spec("proto", FieldKind::Exact, 1, 0),
+                spec("src", FieldKind::Prefix, 16, 0),
+                spec("dst", FieldKind::Prefix, 16, 0),
+                spec("sport", FieldKind::Range, 2, 0),
+                spec("dport", FieldKind::Range, 2, 0),
+            ],
+        ];
+        for specs in cases {
+            let layout = plan_layout(specs).expect("plan");
+            let extents = const_extents(specs);
+            assert_eq!(extents.0, layout.field_defs.len(), "n disagreement");
+            assert_eq!(extents.1, layout.stride, "stride disagreement");
+        }
+        assert_eq!(const_extents(cases[2]), (11, 40));
+    }
+    #[test]
+    fn const_extents_works_in_const_context() {
+        const SPECS: &[FieldSpec] = &[
+            FieldSpec {
+                name: "proto",
+                kind: FieldKind::Exact,
+                size: 1,
+                offset: 0,
+            },
+            FieldSpec {
+                name: "src_ip",
+                kind: FieldKind::Prefix,
+                size: 4,
+                offset: 0,
+            },
+            FieldSpec {
+                name: "dst_ip",
+                kind: FieldKind::Prefix,
+                size: 4,
+                offset: 0,
+            },
+            FieldSpec {
+                name: "src_port",
+                kind: FieldKind::Range,
+                size: 2,
+                offset: 0,
+            },
+            FieldSpec {
+                name: "dst_port",
+                kind: FieldKind::Range,
+                size: 2,
+                offset: 0,
+            },
+        ];
+        const EXTENTS: (usize, usize) = const_extents(SPECS);
+        assert_eq!(EXTENTS, (5, 16));
+    }
+}

--- a/acl/src/dpdk/lookup.rs
+++ b/acl/src/dpdk/lookup.rs
@@ -4,43 +4,65 @@
 
 use core::marker::PhantomData;
 
-use dpdk::acl::{AclContext, Built};
+use arrayvec::ArrayVec;
 use lookup::Lookup;
 use match_action::MatchKey;
 
-use arrayvec::ArrayVec;
-
-use crate::dpdk::layout::{DpdkLayout, LayoutError, plan_layout};
+use crate::dpdk::dyn_table::DynClassifier;
+use crate::dpdk::layout::DpdkLayout;
 pub const MAX_USER_KEY_BYTES: usize = 256;
 pub const MAX_BATCH: usize = 32;
-pub struct DpdkAclLookup<K, const N_FIELDS: usize, const STRIDE: usize, A>
+
+/// Rodata zero source so packing can clear a slot without a stack-resident
+/// `[0u8; MAX_USER_KEY_BYTES]` initializer touching memory the lookup never
+/// actually uses.
+const ZEROS: [u8; MAX_USER_KEY_BYTES] = [0u8; MAX_USER_KEY_BYTES];
+
+/// A typed DPDK ACL lookup table.
+///
+/// `K` is a phantom marker that gives the typed `lookup` / `lookup_batch` API;
+/// the underlying classifier is held as a `Box<dyn DynClassifier>` so the
+/// `rte_acl` field count does not leak into this type's signature. Keys are
+/// packed at the runtime `layout.stride`, so a single `DpdkAclLookup<K, A>`
+/// covers any key shape -- including generic keys such as
+/// `DpdkAclLookup<MyKey<Ip, Port>, A>`.
+pub struct DpdkAclLookup<K, A>
 where
     K: MatchKey,
 {
-    ctx: AclContext<N_FIELDS, Built<N_FIELDS>>,
+    classifier: Box<dyn DynClassifier>,
     actions: Vec<A>,
     layout: DpdkLayout,
     _key: PhantomData<fn(K)>,
 }
 
-impl<K, const N_FIELDS: usize, const STRIDE: usize, A> DpdkAclLookup<K, N_FIELDS, STRIDE, A>
+impl<K, A> DpdkAclLookup<K, A>
 where
     K: MatchKey,
 {
+    /// Construct a lookup table from a built classifier, its action table, and
+    /// the planned layout.
+    ///
+    /// Returns [`StrideTooSmall`] if `layout.stride` is smaller than the
+    /// classifier's `min_input_size`. This is the keystone invariant: once it
+    /// holds, packing a key into a `stride`-sized buffer always yields at least
+    /// `min_input_size` valid bytes, which is what makes the `unsafe` classify
+    /// calls below sound (see `development/code/unsafe-code.md` -- `unsafe` used
+    /// only to build a safe abstraction with local reasoning).
     pub fn new(
-        ctx: AclContext<N_FIELDS, Built<N_FIELDS>>,
+        classifier: Box<dyn DynClassifier>,
         actions: Vec<A>,
         layout: DpdkLayout,
     ) -> Result<Self, StrideTooSmall> {
-        let required = ctx.build_config().min_input_size();
-        if STRIDE < required {
+        let required = classifier.min_input_size();
+        if layout.stride < required {
             return Err(StrideTooSmall {
-                stride: STRIDE,
+                stride: layout.stride,
                 required,
             });
         }
         Ok(Self {
-            ctx,
+            classifier,
             actions,
             layout,
             _key: PhantomData,
@@ -48,42 +70,20 @@ where
     }
 
     #[must_use]
-    pub fn ctx(&self) -> &AclContext<N_FIELDS, Built<N_FIELDS>> {
-        &self.ctx
-    }
-    #[must_use]
     pub fn actions(&self) -> &[A] {
         &self.actions
     }
+
     #[must_use]
     pub fn layout(&self) -> &DpdkLayout {
         &self.layout
     }
-}
 
-impl<K, const N_FIELDS: usize, const STRIDE: usize, A> Lookup<K, A>
-    for DpdkAclLookup<K, N_FIELDS, STRIDE, A>
-where
-    K: MatchKey,
-{
-    fn lookup(&self, key: &K) -> Option<&A> {
-        let dpdk_buf = pack_user_to_dpdk_stack::<K, STRIDE>(key, &self.layout);
-        // SAFETY: STRIDE >= min_input_size (checked in `new`).
-        let user_data = unsafe { classify_one(&self.ctx, dpdk_buf.as_ptr())? };
-        action_for(&self.actions, user_data)
-    }
-}
-
-impl<K, const N_FIELDS: usize, const STRIDE: usize, A> DpdkAclLookup<K, N_FIELDS, STRIDE, A>
-where
-    K: MatchKey,
-{
-    #[must_use]
-    pub fn lookup_via_bytes(&self, key: &[u8; STRIDE]) -> Option<&A> {
-        // SAFETY: STRIDE >= min_input_size (checked in `new`).
-        let user_data = unsafe { classify_one(&self.ctx, key.as_ptr())? };
-        action_for(&self.actions, user_data)
-    }
+    /// Classify a batch of up to [`MAX_BATCH`] keys in a single `rte_acl` call.
+    ///
+    /// Keys are packed contiguously at `layout.stride` into one arena, so the
+    /// classify gather walks a single dense run -- the arena's worst-case
+    /// capacity is never touched beyond `stride * keys.len()`.
     pub fn lookup_batch<'a>(
         &'a self,
         keys: &[K],
@@ -102,22 +102,26 @@ where
             });
         }
 
-        let mut bufs: ArrayVec<[u8; STRIDE], MAX_BATCH> = ArrayVec::new();
-        for key in keys {
-            let buf = pack_user_to_dpdk_stack::<K, STRIDE>(key, &self.layout);
-            bufs.try_push(buf).map_err(|_| BatchError::TooLarge {
-                size: keys.len(),
-                limit: MAX_BATCH,
-            })?;
+        let stride = self.layout.stride;
+        let mut arena: ArrayVec<u8, { MAX_USER_KEY_BYTES * MAX_BATCH }> = ArrayVec::new();
+        for _ in 0..keys.len() {
+            let _ = arena.try_extend_from_slice(&ZEROS[..stride]);
         }
-        // `bufs.len() == keys.len() <= MAX_BATCH` (guarded above), so neither collect can
-        // overflow the ArrayVec capacity; on overflow `collect` panics loudly rather than
-        // silently producing a short pointer list.
-        let ptrs: ArrayVec<*const u8, MAX_BATCH> = bufs.iter().map(|buf| buf.as_ptr()).collect();
-        let mut results: ArrayVec<u32, MAX_BATCH> = bufs.iter().map(|_| 0u32).collect();
+        for (i, key) in keys.iter().enumerate() {
+            pack_user_to_dpdk(key, &self.layout, &mut arena[i * stride..(i + 1) * stride]);
+        }
+        let mut ptrs: ArrayVec<*const u8, MAX_BATCH> = ArrayVec::new();
+        for i in 0..keys.len() {
+            let _ = ptrs.try_push(arena[i * stride..].as_ptr());
+        }
+        let mut results: ArrayVec<u32, MAX_BATCH> = ArrayVec::new();
+        let mut results: ArrayVec<u32, MAX_BATCH> =
+            std::std::iter::repeat_n(0, keys.len()).collect();
+        // SAFETY: every pointer addresses `stride >= min_input_size` valid
+        // bytes (invariant established in `new`), packed contiguously above.
         unsafe {
-            self.ctx
-                .classify(&ptrs, &mut results, 1)
+            self.classifier
+                .classify_batch(&ptrs, &mut results)
                 .map_err(BatchError::Classify)?;
         }
 
@@ -127,6 +131,24 @@ where
         Ok(())
     }
 }
+
+impl<K, A> Lookup<K, A> for DpdkAclLookup<K, A>
+where
+    K: MatchKey,
+{
+    fn lookup(&self, key: &K) -> Option<&A> {
+        let stride = self.layout.stride;
+        let mut buf: ArrayVec<u8, MAX_USER_KEY_BYTES> = ArrayVec::new();
+        // Touch only `stride` bytes, zeroed from rodata.
+        let _ = buf.try_extend_from_slice(&ZEROS[..stride]);
+        pack_user_to_dpdk(key, &self.layout, &mut buf);
+        // SAFETY: `buf` holds `stride >= min_input_size` valid bytes (invariant
+        // established in `new`).
+        let user_data = unsafe { self.classifier.classify_one(&buf).ok()? };
+        action_for(&self.actions, user_data)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum BatchError {
     #[error("batch size mismatch: {keys} keys but {out} output slots")]
@@ -136,18 +158,6 @@ pub enum BatchError {
     #[error("rte_acl_classify failed: {0}")]
     Classify(#[from] dpdk::acl::AclClassifyError),
 }
-unsafe fn classify_one<const N_FIELDS: usize>(
-    ctx: &AclContext<N_FIELDS, Built<N_FIELDS>>,
-    ptr: *const u8,
-) -> Option<u32> {
-    let ptrs = [ptr];
-    let mut results = [0u32; 1];
-    // SAFETY: per the fn contract.
-    unsafe {
-        ctx.classify(&ptrs, &mut results, 1).ok()?;
-    }
-    Some(results[0])
-}
 
 fn action_for<A>(actions: &[A], user_data: u32) -> Option<&A> {
     if user_data == 0 {
@@ -156,7 +166,12 @@ fn action_for<A>(actions: &[A], user_data: u32) -> Option<&A> {
     let idx = usize::try_from(user_data).ok()?.checked_sub(1)?;
     actions.get(idx)
 }
-fn pack_user_to_dpdk_stack<K, const STRIDE: usize>(key: &K, layout: &DpdkLayout) -> [u8; STRIDE]
+
+/// Pack a typed key into `dst` (`dst.len() == layout.stride`) using the layout's
+/// user-field -> DPDK-field-offset mapping. The per-field copies are
+/// runtime-length (`user_spec.size`); the resulting byte layout is what
+/// `rte_acl` classifies against.
+fn pack_user_to_dpdk<K>(key: &K, layout: &DpdkLayout, dst: &mut [u8])
 where
     K: MatchKey,
 {
@@ -167,55 +182,30 @@ where
         MAX_USER_KEY_BYTES,
     );
     debug_assert_eq!(
-        layout.stride, STRIDE,
-        "STRIDE ({STRIDE}) != layout.stride ({})",
+        dst.len(),
+        layout.stride,
+        "dst.len() ({}) != layout.stride ({})",
+        dst.len(),
         layout.stride,
     );
     let mut user_buf = [0u8; MAX_USER_KEY_BYTES];
     key.as_key_into(&mut user_buf[..K::KEY_SIZE]);
 
-    let mut dpdk_buf = [0u8; STRIDE];
     for (user_idx, &dpdk_idx) in layout.user_to_dpdk.iter().enumerate() {
         let user_spec = &K::field_specs()[user_idx];
         let dpdk_def = &layout.field_defs[dpdk_idx];
         let src_off = user_spec.offset;
         let dst_off = dpdk_def.offset() as usize;
         let size = user_spec.size;
-        dpdk_buf[dst_off..dst_off + size].copy_from_slice(&user_buf[src_off..src_off + size]);
+        dst[dst_off..dst_off + size].copy_from_slice(&user_buf[src_off..src_off + size]);
     }
-    dpdk_buf
 }
+
 #[derive(Debug, thiserror::Error)]
-#[error("DpdkAclLookup STRIDE={stride} is smaller than the context's min_input_size={required}")]
+#[error(
+    "DpdkAclLookup layout stride={stride} is smaller than the context's min_input_size={required}"
+)]
 pub struct StrideTooSmall {
     pub stride: usize,
     pub required: usize,
-}
-pub fn dpdk_key_bytes<K, const STRIDE: usize>(key: &K) -> Result<[u8; STRIDE], DpdkKeyError>
-where
-    K: MatchKey,
-{
-    let layout = plan_layout(K::field_specs())?;
-    if layout.stride != STRIDE {
-        return Err(DpdkKeyError::WrongStride {
-            expected: layout.stride,
-            got: STRIDE,
-        });
-    }
-    if K::KEY_SIZE > MAX_USER_KEY_BYTES {
-        return Err(DpdkKeyError::UserKeyTooLarge {
-            key_size: K::KEY_SIZE,
-            limit: MAX_USER_KEY_BYTES,
-        });
-    }
-    Ok(pack_user_to_dpdk_stack::<K, STRIDE>(key, &layout))
-}
-#[derive(Debug, thiserror::Error)]
-pub enum DpdkKeyError {
-    #[error("layout planning failed: {0}")]
-    Layout(#[from] LayoutError),
-    #[error("STRIDE mismatch: expected {expected}, got {got}")]
-    WrongStride { expected: usize, got: usize },
-    #[error("MatchKey::KEY_SIZE {key_size} exceeds MAX_USER_KEY_BYTES {limit}")]
-    UserKeyTooLarge { key_size: usize, limit: usize },
 }

--- a/acl/src/dpdk/lookup.rs
+++ b/acl/src/dpdk/lookup.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+#![allow(unsafe_code)]
+
+use core::marker::PhantomData;
+
+use dpdk::acl::{AclContext, Built};
+use lookup::Lookup;
+use match_action::MatchKey;
+
+use arrayvec::ArrayVec;
+
+use crate::dpdk::layout::{DpdkLayout, LayoutError, plan_layout};
+pub const MAX_USER_KEY_BYTES: usize = 256;
+pub const MAX_BATCH: usize = 32;
+pub struct DpdkAclLookup<K, const N_FIELDS: usize, const STRIDE: usize, A>
+where
+    K: MatchKey,
+{
+    ctx: AclContext<N_FIELDS, Built<N_FIELDS>>,
+    actions: Vec<A>,
+    layout: DpdkLayout,
+    _key: PhantomData<fn(K)>,
+}
+
+impl<K, const N_FIELDS: usize, const STRIDE: usize, A> DpdkAclLookup<K, N_FIELDS, STRIDE, A>
+where
+    K: MatchKey,
+{
+    pub fn new(
+        ctx: AclContext<N_FIELDS, Built<N_FIELDS>>,
+        actions: Vec<A>,
+        layout: DpdkLayout,
+    ) -> Result<Self, StrideTooSmall> {
+        let required = ctx.build_config().min_input_size();
+        if STRIDE < required {
+            return Err(StrideTooSmall {
+                stride: STRIDE,
+                required,
+            });
+        }
+        Ok(Self {
+            ctx,
+            actions,
+            layout,
+            _key: PhantomData,
+        })
+    }
+
+    #[must_use]
+    pub fn ctx(&self) -> &AclContext<N_FIELDS, Built<N_FIELDS>> {
+        &self.ctx
+    }
+    #[must_use]
+    pub fn actions(&self) -> &[A] {
+        &self.actions
+    }
+    #[must_use]
+    pub fn layout(&self) -> &DpdkLayout {
+        &self.layout
+    }
+}
+
+impl<K, const N_FIELDS: usize, const STRIDE: usize, A> Lookup<K, A>
+    for DpdkAclLookup<K, N_FIELDS, STRIDE, A>
+where
+    K: MatchKey,
+{
+    fn lookup(&self, key: &K) -> Option<&A> {
+        let dpdk_buf = pack_user_to_dpdk_stack::<K, STRIDE>(key, &self.layout);
+        // SAFETY: STRIDE >= min_input_size (checked in `new`).
+        let user_data = unsafe { classify_one(&self.ctx, dpdk_buf.as_ptr())? };
+        action_for(&self.actions, user_data)
+    }
+}
+
+impl<K, const N_FIELDS: usize, const STRIDE: usize, A> DpdkAclLookup<K, N_FIELDS, STRIDE, A>
+where
+    K: MatchKey,
+{
+    #[must_use]
+    pub fn lookup_via_bytes(&self, key: &[u8; STRIDE]) -> Option<&A> {
+        // SAFETY: STRIDE >= min_input_size (checked in `new`).
+        let user_data = unsafe { classify_one(&self.ctx, key.as_ptr())? };
+        action_for(&self.actions, user_data)
+    }
+    pub fn lookup_batch<'a>(
+        &'a self,
+        keys: &[K],
+        out: &mut [Option<&'a A>],
+    ) -> Result<(), BatchError> {
+        if keys.len() != out.len() {
+            return Err(BatchError::OutputLenMismatch {
+                keys: keys.len(),
+                out: out.len(),
+            });
+        }
+        if keys.len() > MAX_BATCH {
+            return Err(BatchError::TooLarge {
+                size: keys.len(),
+                limit: MAX_BATCH,
+            });
+        }
+
+        let mut bufs: ArrayVec<[u8; STRIDE], MAX_BATCH> = ArrayVec::new();
+        for key in keys {
+            let buf = pack_user_to_dpdk_stack::<K, STRIDE>(key, &self.layout);
+            bufs.try_push(buf).map_err(|_| BatchError::TooLarge {
+                size: keys.len(),
+                limit: MAX_BATCH,
+            })?;
+        }
+        // `bufs.len() == keys.len() <= MAX_BATCH` (guarded above), so neither collect can
+        // overflow the ArrayVec capacity; on overflow `collect` panics loudly rather than
+        // silently producing a short pointer list.
+        let ptrs: ArrayVec<*const u8, MAX_BATCH> = bufs.iter().map(|buf| buf.as_ptr()).collect();
+        let mut results: ArrayVec<u32, MAX_BATCH> = bufs.iter().map(|_| 0u32).collect();
+        unsafe {
+            self.ctx
+                .classify(&ptrs, &mut results, 1)
+                .map_err(BatchError::Classify)?;
+        }
+
+        for (i, &user_data) in results.iter().enumerate() {
+            out[i] = action_for(&self.actions, user_data);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug, thiserror::Error)]
+pub enum BatchError {
+    #[error("batch size mismatch: {keys} keys but {out} output slots")]
+    OutputLenMismatch { keys: usize, out: usize },
+    #[error("batch size {size} exceeds MAX_BATCH {limit}")]
+    TooLarge { size: usize, limit: usize },
+    #[error("rte_acl_classify failed: {0}")]
+    Classify(#[from] dpdk::acl::AclClassifyError),
+}
+unsafe fn classify_one<const N_FIELDS: usize>(
+    ctx: &AclContext<N_FIELDS, Built<N_FIELDS>>,
+    ptr: *const u8,
+) -> Option<u32> {
+    let ptrs = [ptr];
+    let mut results = [0u32; 1];
+    // SAFETY: per the fn contract.
+    unsafe {
+        ctx.classify(&ptrs, &mut results, 1).ok()?;
+    }
+    Some(results[0])
+}
+
+fn action_for<A>(actions: &[A], user_data: u32) -> Option<&A> {
+    if user_data == 0 {
+        return None;
+    }
+    let idx = usize::try_from(user_data).ok()?.checked_sub(1)?;
+    actions.get(idx)
+}
+fn pack_user_to_dpdk_stack<K, const STRIDE: usize>(key: &K, layout: &DpdkLayout) -> [u8; STRIDE]
+where
+    K: MatchKey,
+{
+    debug_assert!(
+        K::KEY_SIZE <= MAX_USER_KEY_BYTES,
+        "K::KEY_SIZE ({}) > MAX_USER_KEY_BYTES ({})",
+        K::KEY_SIZE,
+        MAX_USER_KEY_BYTES,
+    );
+    debug_assert_eq!(
+        layout.stride, STRIDE,
+        "STRIDE ({STRIDE}) != layout.stride ({})",
+        layout.stride,
+    );
+    let mut user_buf = [0u8; MAX_USER_KEY_BYTES];
+    key.as_key_into(&mut user_buf[..K::KEY_SIZE]);
+
+    let mut dpdk_buf = [0u8; STRIDE];
+    for (user_idx, &dpdk_idx) in layout.user_to_dpdk.iter().enumerate() {
+        let user_spec = &K::field_specs()[user_idx];
+        let dpdk_def = &layout.field_defs[dpdk_idx];
+        let src_off = user_spec.offset;
+        let dst_off = dpdk_def.offset() as usize;
+        let size = user_spec.size;
+        dpdk_buf[dst_off..dst_off + size].copy_from_slice(&user_buf[src_off..src_off + size]);
+    }
+    dpdk_buf
+}
+#[derive(Debug, thiserror::Error)]
+#[error("DpdkAclLookup STRIDE={stride} is smaller than the context's min_input_size={required}")]
+pub struct StrideTooSmall {
+    pub stride: usize,
+    pub required: usize,
+}
+pub fn dpdk_key_bytes<K, const STRIDE: usize>(key: &K) -> Result<[u8; STRIDE], DpdkKeyError>
+where
+    K: MatchKey,
+{
+    let layout = plan_layout(K::field_specs())?;
+    if layout.stride != STRIDE {
+        return Err(DpdkKeyError::WrongStride {
+            expected: layout.stride,
+            got: STRIDE,
+        });
+    }
+    if K::KEY_SIZE > MAX_USER_KEY_BYTES {
+        return Err(DpdkKeyError::UserKeyTooLarge {
+            key_size: K::KEY_SIZE,
+            limit: MAX_USER_KEY_BYTES,
+        });
+    }
+    Ok(pack_user_to_dpdk_stack::<K, STRIDE>(key, &layout))
+}
+#[derive(Debug, thiserror::Error)]
+pub enum DpdkKeyError {
+    #[error("layout planning failed: {0}")]
+    Layout(#[from] LayoutError),
+    #[error("STRIDE mismatch: expected {expected}, got {got}")]
+    WrongStride { expected: usize, got: usize },
+    #[error("MatchKey::KEY_SIZE {key_size} exceeds MAX_USER_KEY_BYTES {limit}")]
+    UserKeyTooLarge { key_size: usize, limit: usize },
+}

--- a/acl/src/dpdk/mod.rs
+++ b/acl/src/dpdk/mod.rs
@@ -1,25 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-//! DPDK `rte_acl` backend for [`match_action::MatchKey`] tables.
-//!
-//! Translates a user `MatchKey` struct into a built
-//! [`dpdk::acl::AclContext`] wrapped in [`self::lookup::DpdkAclLookup`]
-//! (a `lookup::Lookup` backend; the trait link is unlinked here because
-//! this module has a child `lookup` that shadows the extern crate in
-//! doc-link resolution).  Submodules:
-//!
-//! - [`layout`] -- plan the `rte_acl` field layout from `FieldSpec`s
-//!   (group bucketing, padding, packed stride).
-//! - [`rule`] -- [`Dpdk`](rule::Dpdk) marker, [`AclWord`](rule::AclWord)
-//!   trait, `IntoBackendField` impls, rule-field splicing.
-//! - [`install`] -- build an `AclContext` from a `MatchKey` + rules.
-//! - [`mod@self::lookup`] -- the backend itself + the batch
-//!   `rte_acl_classify` path.
-//!
-//! [`match_action::MatchKey`]: match_action::MatchKey
-//! [`dpdk::acl::AclContext`]: dpdk::acl::AclContext
-
+pub mod dyn_table;
 pub mod install;
 pub mod layout;
 pub mod lookup;

--- a/acl/src/dpdk/mod.rs
+++ b/acl/src/dpdk/mod.rs
@@ -3,21 +3,24 @@
 
 //! DPDK `rte_acl` backend for [`match_action::MatchKey`] tables.
 //!
-//! This PR lands the static type machinery only:
+//! Translates a user `MatchKey` struct into a built
+//! [`dpdk::acl::AclContext`] wrapped in [`self::lookup::DpdkAclLookup`]
+//! (a `lookup::Lookup` backend; the trait link is unlinked here because
+//! this module has a child `lookup` that shadows the extern crate in
+//! doc-link resolution).  Submodules:
 //!
 //! - [`layout`] -- plan the `rte_acl` field layout from `FieldSpec`s
 //!   (group bucketing, padding, packed stride).
 //! - [`rule`] -- [`Dpdk`](rule::Dpdk) marker, [`AclWord`](rule::AclWord)
 //!   trait, `IntoBackendField` impls, rule-field splicing.
-//!
-//! The runtime backend (`install`, `lookup`) and the
-//! `dpdk_table_alias!` macro land in a follow-up PR.
+//! - [`install`] -- build an `AclContext` from a `MatchKey` + rules.
+//! - [`mod@self::lookup`] -- the backend itself + the batch
+//!   `rte_acl_classify` path.
 //!
 //! [`match_action::MatchKey`]: match_action::MatchKey
+//! [`dpdk::acl::AclContext`]: dpdk::acl::AclContext
 
-// `RuleSpec` and `DpdkLayout::stride` are wired up by `install` /
-// `lookup` in the next PR; until then they read as dead code.
-#![allow(dead_code)]
-
+pub mod install;
 pub mod layout;
+pub mod lookup;
 pub mod rule;

--- a/acl/src/dpdk/mod.rs
+++ b/acl/src/dpdk/mod.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! DPDK `rte_acl` backend for [`match_action::MatchKey`] tables.
+//!
+//! This PR lands the static type machinery only:
+//!
+//! - [`layout`] -- plan the `rte_acl` field layout from `FieldSpec`s
+//!   (group bucketing, padding, packed stride).
+//! - [`rule`] -- [`Dpdk`](rule::Dpdk) marker, [`AclWord`](rule::AclWord)
+//!   trait, `IntoBackendField` impls, rule-field splicing.
+//!
+//! The runtime backend (`install`, `lookup`) and the
+//! `dpdk_table_alias!` macro land in a follow-up PR.
+//!
+//! [`match_action::MatchKey`]: match_action::MatchKey
+
+// `RuleSpec` and `DpdkLayout::stride` are wired up by `install` /
+// `lookup` in the next PR; until then they read as dead code.
+#![allow(dead_code)]
+
+pub mod layout;
+pub mod rule;

--- a/acl/src/dpdk/rule.rs
+++ b/acl/src/dpdk/rule.rs
@@ -1,0 +1,613 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use core::marker::PhantomData;
+
+use arrayvec::ArrayVec;
+use dpdk::acl::{AclField, CategoryMask, Priority};
+use match_action::{
+    Backend, ExactSpec, FixedSize, IntoBackendField, MaskSpec, MatchKey, PrefixSpec, RangeSpec,
+};
+
+use crate::dpdk::layout::{DpdkLayout, MAX_FIELD_CHUNKS};
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Dpdk;
+
+impl Backend for Dpdk {
+    type Field = AclFieldChunks;
+}
+pub type AclFieldChunks = ArrayVec<AclField, MAX_FIELD_CHUNKS>;
+pub type WordChunks = ArrayVec<u32, MAX_FIELD_CHUNKS>;
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AclSize {
+    One,
+    Two,
+    Four,
+}
+
+impl AclSize {
+    pub(crate) const fn bytes(self) -> usize {
+        match self {
+            AclSize::One => 1,
+            AclSize::Two => 2,
+            AclSize::Four => 4,
+        }
+    }
+    pub(crate) const fn bits(self) -> u8 {
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            (self.bytes() * 8) as u8
+        }
+    }
+}
+pub trait AclWord: FixedSize {
+    const CHUNK_SIZE: AclSize;
+    fn chunks(self) -> WordChunks {
+        let size = <Self as FixedSize>::SIZE;
+        let chunk_bytes = Self::CHUNK_SIZE.bytes();
+        let mut bytes = [0u8; 4 * MAX_FIELD_CHUNKS];
+        self.write_be(&mut bytes[..size]);
+        bytes[..size]
+            .chunks_exact(chunk_bytes)
+            .map(|chunk| chunk.iter().fold(0u32, |acc, &b| (acc << 8) | u32::from(b)))
+            .collect()
+    }
+}
+pub(crate) const fn acl_size_for(size_bytes: usize) -> AclSize {
+    match size_bytes {
+        1 => AclSize::One,
+        2 => AclSize::Two,
+        _ => AclSize::Four,
+    }
+}
+
+impl<T: FixedSize> AclWord for T {
+    const CHUNK_SIZE: AclSize = {
+        let size = <T as FixedSize>::SIZE;
+        assert!(
+            size == 1 || size == 2 || size.is_multiple_of(4),
+            "AclWord: FixedSize::SIZE must be 1, 2, or a multiple of 4",
+        );
+        assert!(
+            size <= 4 * MAX_FIELD_CHUNKS,
+            "AclWord: FixedSize::SIZE exceeds RTE_ACL_MAX_FIELDS * 4 chunk-bytes",
+        );
+        acl_size_for(size)
+    };
+}
+
+impl<T: AclWord> IntoBackendField<Dpdk> for ExactSpec<T> {
+    fn into_backend_field(self) -> AclFieldChunks {
+        self.value
+            .chunks()
+            .into_iter()
+            .map(|chunk| exact_field(T::CHUNK_SIZE, chunk))
+            .collect()
+    }
+}
+
+impl<T: AclWord> IntoBackendField<Dpdk> for PrefixSpec<T> {
+    fn into_backend_field(self) -> AclFieldChunks {
+        let bits = T::CHUNK_SIZE.bits();
+        let mut remaining = self.len;
+        let mut group = AclFieldChunks::new();
+        for chunk in self.value.chunks() {
+            let chunk_len = remaining.min(bits);
+            group.push(prefix_field(T::CHUNK_SIZE, chunk, chunk_len));
+            remaining = remaining.saturating_sub(chunk_len);
+        }
+        debug_assert_eq!(
+            remaining, 0,
+            "PrefixSpec lowered with leftover len -- bypassed PrefixSpec::new?",
+        );
+        group
+    }
+}
+
+impl<T: AclWord> IntoBackendField<Dpdk> for MaskSpec<T> {
+    fn into_backend_field(self) -> AclFieldChunks {
+        let values = self.value.chunks();
+        let masks = self.mask.chunks();
+        values
+            .into_iter()
+            .zip(masks)
+            .map(|(value, mask)| mask_field(T::CHUNK_SIZE, value & mask, mask))
+            .collect()
+    }
+}
+
+impl<T: AclWord> IntoBackendField<Dpdk> for RangeSpec<T> {
+    fn into_backend_field(self) -> AclFieldChunks {
+        const {
+            assert!(
+                <T as FixedSize>::SIZE <= 4,
+                "RangeSpec<T> on the DPDK backend requires T::SIZE <= 4",
+            );
+        };
+        let mins = self.min.chunks();
+        let maxs = self.max.chunks();
+        let mut group = AclFieldChunks::new();
+        group.push(range_field(T::CHUNK_SIZE, mins[0], maxs[0]));
+        group
+    }
+}
+pub struct RuleSpec<K: MatchKey, A> {
+    pub(crate) priority: Priority,
+    pub(crate) category_mask: CategoryMask,
+    pub(crate) user_fields: Vec<AclFieldChunks>,
+    pub(crate) action: A,
+    _phantom: PhantomData<fn() -> K>,
+}
+
+impl<K: MatchKey, A> RuleSpec<K, A> {
+    pub fn new(
+        priority: Priority,
+        category_mask: CategoryMask,
+        user_fields: Vec<AclFieldChunks>,
+        action: A,
+    ) -> Result<Self, SpliceError> {
+        if user_fields.len() != K::N {
+            return Err(SpliceError::UserFieldCount {
+                expected: K::N,
+                actual: user_fields.len(),
+            });
+        }
+        Ok(Self {
+            priority,
+            category_mask,
+            user_fields,
+            action,
+            _phantom: PhantomData,
+        })
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SpliceError {
+    #[error("expected {expected} user fields, got {actual}")]
+    UserFieldCount { expected: usize, actual: usize },
+    #[error("const generic N={expected_n} disagrees with planned field-def count {actual_n}")]
+    DpdkFieldCount { expected_n: usize, actual_n: usize },
+    #[error("user field {user_index}: expected {expected} chunks, rule lowered to {actual}")]
+    ChunkCountMismatch {
+        user_index: usize,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("user field {user_index} lowered to {chunks} sub-fields, overflowing dpdk slot {slot}")]
+    ChunkOverflow {
+        user_index: usize,
+        chunks: usize,
+        slot: usize,
+    },
+}
+#[must_use]
+pub fn padding_field() -> AclField {
+    AclField::from_u8(0, 0)
+}
+
+#[must_use]
+pub fn exact_u8(value: u8) -> AclField {
+    AclField::from_u8(value, u8::MAX)
+}
+
+#[must_use]
+pub fn exact_u16(value: u16) -> AclField {
+    AclField::from_u16(value, u16::MAX)
+}
+
+#[must_use]
+pub fn exact_u32(value: u32) -> AclField {
+    AclField::from_u32(value, u32::MAX)
+}
+#[must_use]
+pub fn prefix_u8(value: u8, len: u8) -> AclField {
+    AclField::from_u8(value, len)
+}
+
+#[must_use]
+pub fn prefix_u16(value: u16, len: u8) -> AclField {
+    AclField::from_u16(value, u16::from(len))
+}
+
+#[must_use]
+pub fn prefix_u32(value: u32, len: u8) -> AclField {
+    AclField::from_u32(value, u32::from(len))
+}
+
+#[must_use]
+pub fn mask_u8(value: u8, mask: u8) -> AclField {
+    AclField::from_u8(value, mask)
+}
+
+#[must_use]
+pub fn mask_u16(value: u16, mask: u16) -> AclField {
+    AclField::from_u16(value, mask)
+}
+
+#[must_use]
+pub fn mask_u32(value: u32, mask: u32) -> AclField {
+    AclField::from_u32(value, mask)
+}
+#[must_use]
+pub fn range_u8(min: u8, max: u8) -> AclField {
+    AclField::from_u8(min, max)
+}
+
+#[must_use]
+pub fn range_u16(min: u16, max: u16) -> AclField {
+    AclField::from_u16(min, max)
+}
+
+#[must_use]
+pub fn range_u32(min: u32, max: u32) -> AclField {
+    AclField::from_u32(min, max)
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn exact_field(size: AclSize, value: u32) -> AclField {
+    match size {
+        AclSize::One => exact_u8(value as u8),
+        AclSize::Two => exact_u16(value as u16),
+        AclSize::Four => exact_u32(value),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn prefix_field(size: AclSize, value: u32, len: u8) -> AclField {
+    match size {
+        AclSize::One => prefix_u8(value as u8, len),
+        AclSize::Two => prefix_u16(value as u16, len),
+        AclSize::Four => prefix_u32(value, len),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn mask_field(size: AclSize, value: u32, mask: u32) -> AclField {
+    match size {
+        AclSize::One => mask_u8(value as u8, mask as u8),
+        AclSize::Two => mask_u16(value as u16, mask as u16),
+        AclSize::Four => mask_u32(value, mask),
+    }
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn range_field(size: AclSize, min: u32, max: u32) -> AclField {
+    match size {
+        AclSize::One => range_u8(min as u8, max as u8),
+        AclSize::Two => range_u16(min as u16, max as u16),
+        AclSize::Four => range_u32(min, max),
+    }
+}
+pub fn splice_user_fields_to_dpdk<const N: usize>(
+    layout: &DpdkLayout,
+    user_fields: &[AclFieldChunks],
+) -> Result<[AclField; N], SpliceError> {
+    if N != layout.field_defs.len() {
+        return Err(SpliceError::DpdkFieldCount {
+            expected_n: N,
+            actual_n: layout.field_defs.len(),
+        });
+    }
+    if user_fields.len() != layout.user_to_dpdk.len() {
+        return Err(SpliceError::UserFieldCount {
+            expected: layout.user_to_dpdk.len(),
+            actual: user_fields.len(),
+        });
+    }
+
+    let mut dpdk_fields: [AclField; N] = core::array::from_fn(|_| padding_field());
+    for (user_idx, (&first_slot, group)) in layout.user_to_dpdk.iter().zip(user_fields).enumerate()
+    {
+        let expected = layout.user_chunk_counts[user_idx];
+        if group.len() != expected {
+            return Err(SpliceError::ChunkCountMismatch {
+                user_index: user_idx,
+                expected,
+                actual: group.len(),
+            });
+        }
+        for (chunk_idx, &field) in group.iter().enumerate() {
+            let slot = first_slot + chunk_idx;
+            *dpdk_fields
+                .get_mut(slot)
+                .ok_or(SpliceError::ChunkOverflow {
+                    user_index: user_idx,
+                    chunks: group.len(),
+                    slot,
+                })? = field;
+        }
+    }
+    Ok(dpdk_fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+    use crate::dpdk::layout::plan_layout;
+    use match_action::{FieldKind, FieldSpec};
+
+    fn spec(name: &'static str, kind: FieldKind, size: usize) -> FieldSpec {
+        FieldSpec {
+            name,
+            kind,
+            size,
+            offset: 0,
+        }
+    }
+    fn assert_field_eq(actual: &AclField, expected: &AclField) {
+        assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+    }
+
+    fn group(field: AclField) -> AclFieldChunks {
+        let mut chunks = AclFieldChunks::new();
+        chunks.push(field);
+        chunks
+    }
+
+    #[test]
+    fn rejects_user_field_count_mismatch_in_new() {
+        struct Five;
+        impl MatchKey for Five {
+            const N: usize = 5;
+            const KEY_SIZE: usize = 13;
+            fn field_specs() -> &'static [FieldSpec] {
+                &[]
+            }
+            fn as_key_into(&self, _: &mut [u8]) {}
+        }
+
+        let result = RuleSpec::<Five, ()>::new(
+            Priority::new(1).unwrap(),
+            CategoryMask::new(1).unwrap(),
+            vec![group(AclField::from_u8(0, 0)); 4],
+            (),
+        );
+        assert!(matches!(
+            result.err(),
+            Some(SpliceError::UserFieldCount {
+                expected: 5,
+                actual: 4
+            }),
+        ));
+    }
+
+    #[test]
+    fn five_tuple_splice_matches_layout_positions() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1),
+            spec("src_ip", FieldKind::Prefix, 4),
+            spec("dst_ip", FieldKind::Prefix, 4),
+            spec("src_port", FieldKind::Range, 2),
+            spec("dst_port", FieldKind::Range, 2),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+
+        let proto = AclField::from_u8(6, 0xFF);
+        let src_ip = AclField::from_u32(0x0A00_0001, 24);
+        let dst_ip = AclField::from_u32(0xC0A8_0101, 24);
+        let src_port = AclField::from_u16(0, u16::MAX);
+        let dst_port = AclField::from_u16(80, 80);
+
+        let user = vec![
+            group(proto),
+            group(src_ip),
+            group(dst_ip),
+            group(src_port),
+            group(dst_port),
+        ];
+        let dpdk: [AclField; 5] = splice_user_fields_to_dpdk(&layout, &user).expect("splice");
+
+        assert_field_eq(&dpdk[0], &proto);
+        assert_field_eq(&dpdk[1], &src_ip);
+        assert_field_eq(&dpdk[2], &dst_ip);
+        assert_field_eq(&dpdk[3], &src_port);
+        assert_field_eq(&dpdk[4], &dst_port);
+    }
+
+    #[test]
+    fn padded_layout_splice_inserts_wildcards_at_padding_slots() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1),
+            spec("a", FieldKind::Range, 2),
+            spec("b", FieldKind::Range, 2),
+            spec("c", FieldKind::Range, 2),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+        assert_eq!(layout.field_defs.len(), 6);
+        assert_eq!(layout.user_to_dpdk.len(), 4);
+
+        let proto = AclField::from_u8(17, 0xFF);
+        let a = AclField::from_u16(0, u16::MAX);
+        let b = AclField::from_u16(0, u16::MAX);
+        let c = AclField::from_u16(0, u16::MAX);
+
+        let user = vec![group(proto), group(a), group(b), group(c)];
+        let dpdk: [AclField; 6] = splice_user_fields_to_dpdk(&layout, &user).expect("splice");
+        assert_field_eq(&dpdk[0], &proto);
+        assert_field_eq(&dpdk[1], &a);
+        assert_field_eq(&dpdk[2], &b);
+        assert_field_eq(&dpdk[3], &c);
+        let pad = padding_field();
+        assert_field_eq(&dpdk[4], &pad);
+        assert_field_eq(&dpdk[5], &pad);
+    }
+
+    #[test]
+    fn rejects_wrong_n_const_generic() {
+        let specs = [spec("proto", FieldKind::Exact, 1)];
+        let layout = plan_layout(&specs).expect("plan");
+        let user = vec![group(AclField::from_u8(6, 0xFF))];
+        let err = splice_user_fields_to_dpdk::<3>(&layout, &user).unwrap_err();
+        assert_eq!(
+            err,
+            SpliceError::DpdkFieldCount {
+                expected_n: 3,
+                actual_n: 1
+            }
+        );
+    }
+
+    #[test]
+    fn exact_helpers_set_full_mask() {
+        assert_field_eq(&exact_u8(6), &AclField::from_u8(6, u8::MAX));
+        assert_field_eq(&exact_u16(1234), &AclField::from_u16(1234, u16::MAX));
+        assert_field_eq(
+            &exact_u32(0xDEAD_BEEF),
+            &AclField::from_u32(0xDEAD_BEEF, u32::MAX),
+        );
+    }
+
+    #[test]
+    fn prefix_helpers_store_length_in_mask_slot() {
+        assert_field_eq(&prefix_u8(0xAB, 4), &AclField::from_u8(0xAB, 4));
+        assert_field_eq(&prefix_u16(0x1234, 12), &AclField::from_u16(0x1234, 12));
+        assert_field_eq(
+            &prefix_u32(0x0A00_0000, 24),
+            &AclField::from_u32(0x0A00_0000, 24),
+        );
+    }
+
+    #[test]
+    fn mask_helpers_pass_value_and_mask_through() {
+        assert_field_eq(&mask_u8(0xAB, 0xF0), &AclField::from_u8(0xAB, 0xF0));
+        assert_field_eq(
+            &mask_u16(0xABCD, 0xFF00),
+            &AclField::from_u16(0xABCD, 0xFF00),
+        );
+        assert_field_eq(
+            &mask_u32(0xABCD_1234, 0xFFFF_FF00),
+            &AclField::from_u32(0xABCD_1234, 0xFFFF_FF00),
+        );
+    }
+
+    #[test]
+    fn range_helpers_store_min_and_max() {
+        assert_field_eq(&range_u8(10, 20), &AclField::from_u8(10, 20));
+        assert_field_eq(&range_u16(80, 8080), &AclField::from_u16(80, 8080));
+        assert_field_eq(&range_u32(1024, 65535), &AclField::from_u32(1024, 65535));
+    }
+
+    #[test]
+    fn rejects_wrong_user_field_count_in_splice() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1),
+            spec("a", FieldKind::Range, 2),
+            spec("b", FieldKind::Range, 2),
+            spec("c", FieldKind::Range, 2),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+        let user = vec![group(AclField::from_u8(0, 0)); 3];
+        let err = splice_user_fields_to_dpdk::<6>(&layout, &user).unwrap_err();
+        assert_eq!(
+            err,
+            SpliceError::UserFieldCount {
+                expected: 4,
+                actual: 3
+            }
+        );
+    }
+    fn lower<S: IntoBackendField<Dpdk>>(spec: S) -> AclFieldChunks {
+        IntoBackendField::<Dpdk>::into_backend_field(spec)
+    }
+
+    #[test]
+    fn ipv6_prefix_lowers_to_four_chunks_with_distributed_length() {
+        let addr: Ipv6Addr = "2001:db8::".parse().unwrap();
+        let chunks = lower(PrefixSpec::new(addr, 48));
+
+        assert_eq!(chunks.len(), 4);
+        assert_field_eq(&chunks[0], &AclField::from_u32(0x2001_0db8, 32));
+        assert_field_eq(&chunks[1], &AclField::from_u32(0x0000_0000, 16));
+        assert_field_eq(&chunks[2], &AclField::from_u32(0x0000_0000, 0));
+        assert_field_eq(&chunks[3], &AclField::from_u32(0x0000_0000, 0));
+    }
+
+    #[test]
+    fn ipv6_prefix_zero_is_all_wildcard_chunks() {
+        let chunks = lower(PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 0));
+        assert_eq!(chunks.len(), 4);
+        for chunk in &chunks {
+            assert_field_eq(chunk, &AclField::from_u32(0, 0));
+        }
+    }
+
+    #[test]
+    fn ipv6_full_prefix_keeps_every_chunk_at_full_length() {
+        let addr: Ipv6Addr = "2001:db8:abcd:1234:5678:9abc:def0:1111".parse().unwrap();
+        let chunks = lower(PrefixSpec::new(addr, 128));
+        assert_eq!(chunks.len(), 4);
+        assert_field_eq(&chunks[0], &AclField::from_u32(0x2001_0db8, 32));
+        assert_field_eq(&chunks[1], &AclField::from_u32(0xabcd_1234, 32));
+        assert_field_eq(&chunks[2], &AclField::from_u32(0x5678_9abc, 32));
+        assert_field_eq(&chunks[3], &AclField::from_u32(0xdef0_1111, 32));
+    }
+
+    #[test]
+    fn ipv6_exact_lowers_to_four_full_mask_chunks() {
+        let addr: Ipv6Addr = "::1".parse().unwrap();
+        let chunks = lower(ExactSpec::new(addr));
+        assert_eq!(chunks.len(), 4);
+        assert_field_eq(&chunks[0], &AclField::from_u32(0, u32::MAX));
+        assert_field_eq(&chunks[1], &AclField::from_u32(0, u32::MAX));
+        assert_field_eq(&chunks[2], &AclField::from_u32(0, u32::MAX));
+        assert_field_eq(&chunks[3], &AclField::from_u32(1, u32::MAX));
+    }
+
+    #[test]
+    fn ipv6_mask_lowers_per_chunk() {
+        let value: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        let mask: Ipv6Addr = "ffff:ffff::ffff".parse().unwrap();
+        let chunks = lower(MaskSpec::new(value, mask));
+        assert_eq!(chunks.len(), 4);
+        assert_field_eq(&chunks[0], &AclField::from_u32(0x2001_0db8, 0xffff_ffff));
+        assert_field_eq(&chunks[1], &AclField::from_u32(0, 0));
+        assert_field_eq(&chunks[2], &AclField::from_u32(0, 0));
+        assert_field_eq(&chunks[3], &AclField::from_u32(1, 0x0000_ffff));
+    }
+
+    #[test]
+    fn scalar_fields_lower_to_single_chunk() {
+        assert_eq!(lower(ExactSpec::new(6u8)).len(), 1);
+        assert_eq!(
+            lower(PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8)).len(),
+            1
+        );
+        assert_eq!(lower(RangeSpec::new(0u16, 1024u16)).len(), 1);
+    }
+
+    #[test]
+    fn ipv6_five_tuple_splice_places_chunks_contiguously() {
+        let specs = [
+            spec("proto", FieldKind::Exact, 1),
+            spec("src", FieldKind::Prefix, 16),
+            spec("dst", FieldKind::Prefix, 16),
+            spec("sport", FieldKind::Range, 2),
+            spec("dport", FieldKind::Range, 2),
+        ];
+        let layout = plan_layout(&specs).expect("plan");
+        assert_eq!(layout.field_defs.len(), 11);
+
+        let src: Ipv6Addr = "2001:db8::".parse().unwrap();
+        let user = vec![
+            lower(ExactSpec::new(6u8)),
+            lower(PrefixSpec::new(src, 48)),
+            lower(PrefixSpec::new(Ipv6Addr::UNSPECIFIED, 0)),
+            lower(RangeSpec::new(0u16, u16::MAX)),
+            lower(RangeSpec::exact(443u16)),
+        ];
+        let dpdk: [AclField; 11] = splice_user_fields_to_dpdk(&layout, &user).expect("splice");
+
+        assert_field_eq(&dpdk[0], &AclField::from_u8(6, u8::MAX));
+        assert_field_eq(&dpdk[1], &AclField::from_u32(0x2001_0db8, 32));
+        assert_field_eq(&dpdk[2], &AclField::from_u32(0, 16));
+        assert_field_eq(&dpdk[3], &AclField::from_u32(0, 0));
+        assert_field_eq(&dpdk[4], &AclField::from_u32(0, 0));
+        for chunk in &dpdk[5..=8] {
+            assert_field_eq(chunk, &AclField::from_u32(0, 0));
+        }
+        assert_field_eq(&dpdk[9], &AclField::from_u16(0, u16::MAX));
+        assert_field_eq(&dpdk[10], &AclField::from_u16(443, 443));
+    }
+}

--- a/acl/src/lib.rs
+++ b/acl/src/lib.rs
@@ -36,12 +36,7 @@ macro_rules! dpdk_table_alias {
                 <= $crate::dpdk::lookup::MAX_USER_KEY_BYTES,
             "MatchKey::KEY_SIZE exceeds MAX_USER_KEY_BYTES",
         );
-        $vis type $alias<$action> = $crate::dpdk::lookup::DpdkAclLookup<
-            $key,
-            { $crate::dpdk::layout::const_extents(<$key>::FIELD_SPECS).0 },
-            { $crate::dpdk::layout::const_extents(<$key>::FIELD_SPECS).1 },
-            $action,
-        >;
+        $vis type $alias<$action> = $crate::dpdk::lookup::DpdkAclLookup<$key, $action>;
     };
 }
 #[doc(hidden)]

--- a/acl/src/lib.rs
+++ b/acl/src/lib.rs
@@ -9,17 +9,17 @@
     clippy::expect_used,
     clippy::panic
 )]
-#![allow(missing_docs)] // shape settling; doc once stable
+#![allow(missing_docs)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
 //! Match-action classifier backends for [`match_action::MatchKey`]
 //! tables, behind the [`lookup::Lookup`] interface.
 //!
-//! - [`dpdk`] (`dpdk` feature): production `rte_acl` backend; in this
-//!   PR the static type machinery (layout planner + rule lowering).
-//!   The runtime install / classify path lands next.
+//! - `dpdk` module (`dpdk` feature): production `rte_acl` backend --
+//!   layout planner, rule lowering, install, and the single-shot /
+//!   batched classify path.
 //! - [`reference`](mod@reference): linear-scan software classifier;
-//!   differential oracle and a mutable cascade front.  Always built.
+//!   differential oracle for the `dpdk` backend.  Always built.
 //!
 //! [`lookup::Lookup`]: lookup::Lookup
 //! [`match_action::MatchKey`]: match_action::MatchKey
@@ -27,3 +27,25 @@
 #[cfg(feature = "dpdk")]
 pub mod dpdk;
 pub mod reference;
+#[cfg(feature = "dpdk")]
+#[macro_export]
+macro_rules! dpdk_table_alias {
+    ($vis:vis type $alias:ident < $action:ident > = $key:ty) => {
+        const _: () = assert!(
+            <$key as $crate::__match_action::MatchKey>::KEY_SIZE
+                <= $crate::dpdk::lookup::MAX_USER_KEY_BYTES,
+            "MatchKey::KEY_SIZE exceeds MAX_USER_KEY_BYTES",
+        );
+        $vis type $alias<$action> = $crate::dpdk::lookup::DpdkAclLookup<
+            $key,
+            { $crate::dpdk::layout::const_extents(<$key>::FIELD_SPECS).0 },
+            { $crate::dpdk::layout::const_extents(<$key>::FIELD_SPECS).1 },
+            $action,
+        >;
+    };
+}
+#[doc(hidden)]
+#[cfg(feature = "dpdk")]
+pub mod __match_action {
+    pub use ::match_action::MatchKey;
+}

--- a/acl/src/lib.rs
+++ b/acl/src/lib.rs
@@ -15,13 +15,15 @@
 //! Match-action classifier backends for [`match_action::MatchKey`]
 //! tables, behind the [`lookup::Lookup`] interface.
 //!
+//! - [`dpdk`] (`dpdk` feature): production `rte_acl` backend; in this
+//!   PR the static type machinery (layout planner + rule lowering).
+//!   The runtime install / classify path lands next.
 //! - [`reference`](mod@reference): linear-scan software classifier;
 //!   differential oracle and a mutable cascade front.  Always built.
-//!
-//! The production `rte_acl` backend lands behind a follow-up `dpdk`
-//! feature gate.
 //!
 //! [`lookup::Lookup`]: lookup::Lookup
 //! [`match_action::MatchKey`]: match_action::MatchKey
 
+#[cfg(feature = "dpdk")]
+pub mod dpdk;
 pub mod reference;

--- a/acl/tests/eal_classify_via_projection.rs
+++ b/acl/tests/eal_classify_via_projection.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core::net::Ipv4Addr;
+use core::num::NonZero;
+
+use dataplane_acl::dpdk::install::install_table;
+use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+use dataplane_acl::dpdk_table_alias;
+use dpdk::acl::{CategoryMask, Priority};
+use lookup::{Lookup, Projection};
+use match_action::{ExactSpec, FixedSize, MatchKey, PrefixSpec, RangeSpec};
+use net::eth::Eth;
+use net::headers::builder::HeaderStack;
+use net::headers::{HeadersView, Look};
+use net::ipv4::{Ipv4, UnicastIpv4Addr};
+use net::tcp::{Tcp, TcpPort};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct IpProto(u8);
+
+impl FixedSize for IpProto {
+    const SIZE: usize = 1;
+    fn write_be(&self, out: &mut [u8]) {
+        out[0] = self.0;
+    }
+}
+
+#[derive(MatchKey)]
+#[allow(dead_code)]
+struct FiveTuple {
+    #[exact]
+    proto: IpProto,
+    #[prefix]
+    src_ip: Ipv4Addr,
+    #[prefix]
+    dst_ip: Ipv4Addr,
+    #[range]
+    src_port: u16,
+    #[range]
+    dst_port: u16,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+enum Verdict {
+    Allow,
+    Drop,
+}
+
+dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
+struct V4TcpSource<'a>(&'a HeadersView<(&'a Eth, &'a Ipv4, &'a Tcp)>);
+
+impl Projection<FiveTuple> for &V4TcpSource<'_> {
+    fn project(self) -> FiveTuple {
+        let (_eth, ipv4, tcp) = self.0.look();
+        FiveTuple {
+            proto: IpProto(6),
+            src_ip: ipv4.source().inner(),
+            dst_ip: ipv4.destination(),
+            src_port: u16::from(tcp.source()),
+            dst_port: u16::from(tcp.destination()),
+        }
+    }
+}
+
+fn build_packet(src: Ipv4Addr, dst: Ipv4Addr, sport: u16, dport: u16) -> net::headers::Headers {
+    HeaderStack::new()
+        .eth(|_| {})
+        .ipv4(|ip| {
+            ip.set_source(UnicastIpv4Addr::new(src).unwrap());
+            ip.set_destination(dst);
+        })
+        .tcp(|tcp| {
+            tcp.set_source(TcpPort::try_from(sport).unwrap());
+            tcp.set_destination(TcpPort::try_from(dport).unwrap());
+        })
+        .build_headers()
+        .unwrap()
+}
+
+#[dpdk::with_eal]
+#[test]
+fn classify_real_packet_via_projection() {
+    let rule = FiveTupleRule {
+        proto: ExactSpec::new(IpProto(6)),
+        src_ip: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+        dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+        src_port: RangeSpec::new(0, u16::MAX),
+        dst_port: RangeSpec::exact(22),
+    };
+    let rule_spec = RuleSpec::<FiveTuple, Verdict>::new(
+        Priority::new(100).expect("priority"),
+        CategoryMask::new(1).expect("category mask"),
+        rule.into_backend_fields::<Dpdk>(),
+        Verdict::Drop,
+    )
+    .expect("RuleSpec");
+
+    let table: FiveTupleTable<Verdict> = install_table(
+        "eal_classify_via_projection",
+        NonZero::new(16).expect("max rules"),
+        vec![rule_spec],
+    )
+    .expect("install_table");
+    let hit = build_packet(
+        Ipv4Addr::new(10, 0, 1, 5),
+        Ipv4Addr::new(192, 168, 1, 1),
+        54321,
+        22,
+    );
+    let view = hit.as_view::<(&Eth, &Ipv4, &Tcp)>().expect("v4 tcp shape");
+    let src = V4TcpSource(view);
+    assert_eq!(table.classify(&src), Some(&Verdict::Drop));
+    let miss = build_packet(
+        Ipv4Addr::new(192, 168, 1, 5),
+        Ipv4Addr::new(192, 168, 1, 1),
+        54321,
+        22,
+    );
+    let miss_view = miss.as_view::<(&Eth, &Ipv4, &Tcp)>().unwrap();
+    assert_eq!(table.classify(&V4TcpSource(miss_view)), None);
+}
+
+#[test]
+fn non_tcp_packet_cannot_be_projected_to_five_tuple() {
+    let udp = HeaderStack::new()
+        .eth(|_| {})
+        .ipv4(|_| {})
+        .udp(|_| {})
+        .build_headers()
+        .unwrap();
+    assert!(udp.as_view::<(&Eth, &Ipv4, &Tcp)>().is_none());
+}

--- a/acl/tests/eal_install_classify.rs
+++ b/acl/tests/eal_install_classify.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core::net::Ipv4Addr;
+use core::num::NonZero;
+use std::error::Error;
+
+use dataplane_acl::dpdk::install::install_table;
+use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+use dataplane_acl::dpdk_table_alias;
+use dpdk::acl::{CategoryMask, Priority};
+use lookup::Lookup;
+use match_action::{ExactSpec, FixedSize, MatchKey, PrefixSpec, RangeSpec};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct IpProto(u8);
+
+impl IpProto {
+    const TCP: Self = IpProto(6);
+}
+
+impl FixedSize for IpProto {
+    const SIZE: usize = 1;
+    fn write_be(&self, out: &mut [u8]) {
+        out[0] = self.0;
+    }
+}
+
+#[derive(MatchKey)]
+struct FiveTuple {
+    #[exact]
+    proto: IpProto,
+    #[prefix]
+    src_ip: Ipv4Addr,
+    #[prefix]
+    dst_ip: Ipv4Addr,
+    #[range]
+    src_port: u16,
+    #[range]
+    dst_port: u16,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Verdict {
+    Allow,
+    Drop,
+}
+
+dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
+
+#[test]
+#[dpdk::with_eal]
+fn install_one_rule_and_classify() -> Result<(), Box<dyn Error>> {
+    let rule_spec = vec![
+        RuleSpec::<FiveTuple, Verdict>::new(
+            Priority::new(100)?,
+            CategoryMask::new(1)?,
+            FiveTupleRule {
+                proto: ExactSpec::new(IpProto::TCP),
+                src_ip: PrefixSpec::new("10.0.0.0".parse()?, 8),
+                dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                src_port: RangeSpec::new(0, u16::MAX),
+                dst_port: RangeSpec::exact(22),
+            }
+            .into_backend_fields::<Dpdk>(),
+            Verdict::Drop,
+        )
+        .expect("invalid RuleSpec"),
+        RuleSpec::<FiveTuple, Verdict>::new(
+            Priority::new(500)?,
+            CategoryMask::new(1)?,
+            FiveTupleRule {
+                proto: ExactSpec::new(IpProto::TCP),
+                src_ip: PrefixSpec::new("10.0.0.0".parse()?, 30),
+                dst_ip: PrefixSpec::new(Ipv4Addr::UNSPECIFIED, 0),
+                src_port: RangeSpec::new(0, u16::MAX),
+                dst_port: RangeSpec::exact(22),
+            }
+            .into_backend_fields::<Dpdk>(),
+            Verdict::Allow,
+        )
+        .expect("invalid RuleSpec"),
+    ];
+
+    let table: FiveTupleTable<Verdict> = install_table(
+        "eal_install_classify_smoke",
+        NonZero::new(16).expect("max rules"),
+        rule_spec,
+    )
+    .expect("install_table");
+    assert_eq!(
+        table.lookup(&FiveTuple {
+            proto: IpProto::TCP,
+            src_ip: "10.0.1.5".parse()?,
+            dst_ip: "192.168.1.1".parse()?,
+            src_port: 54321,
+            dst_port: 22,
+        }),
+        Some(&Verdict::Drop),
+    );
+    let batch = [
+        FiveTuple {
+            proto: IpProto::TCP,
+            src_ip: "10.0.0.1".parse()?,
+            dst_ip: "192.168.1.1".parse()?,
+            src_port: 54321,
+            dst_port: 22,
+        },
+        FiveTuple {
+            proto: IpProto::TCP,
+            src_ip: "10.0.1.5".parse()?,
+            dst_ip: "192.168.1.1".parse()?,
+            src_port: 54321,
+            dst_port: 22,
+        },
+        FiveTuple {
+            proto: IpProto::TCP,
+            src_ip: "192.168.1.5".parse()?,
+            dst_ip: "192.168.1.1".parse()?,
+            src_port: 54321,
+            dst_port: 22,
+        },
+        FiveTuple {
+            proto: IpProto::TCP,
+            src_ip: "10.0.1.5".parse()?,
+            dst_ip: "192.168.1.1".parse()?,
+            src_port: 54321,
+            dst_port: 80,
+        },
+    ];
+    let mut out: [Option<&Verdict>; 4] = [None; 4];
+    table.lookup_batch(&batch, &mut out).expect("lookup_batch");
+    assert_eq!(
+        out,
+        [Some(&Verdict::Allow), Some(&Verdict::Drop), None, None]
+    );
+    Ok(())
+}

--- a/acl/tests/metadata_projection.rs
+++ b/acl/tests/metadata_projection.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core::net::Ipv4Addr;
+use core::num::NonZero;
+
+use dataplane_acl::dpdk::install::install_table;
+use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+use dataplane_acl::dpdk_table_alias;
+use dataplane_acl::reference::{Erased, RefRule, ReferenceTable};
+use dpdk::acl::{CategoryMask, Priority};
+use lookup::{Lookup, Projection};
+use match_action::{ExactSpec, MatchKey, PrefixSpec, RangeSpec};
+use net::eth::Eth;
+use net::headers::builder::HeaderStack;
+use net::headers::{HeadersView, Look};
+use net::ipv4::{Ipv4, UnicastIpv4Addr};
+use net::packet::{PacketMeta, VpcDiscriminant, VrfId};
+use net::tcp::{Tcp, TcpPort};
+use net::vxlan::Vni;
+#[derive(MatchKey, Debug, Clone, Copy)]
+struct OverlayFlowKey {
+    #[exact]
+    proto: u8,
+    #[prefix]
+    src: Ipv4Addr,
+    #[range]
+    dport: u16,
+    #[exact]
+    vrf: VrfId,
+    #[exact]
+    vni: Vni,
+}
+
+dpdk_table_alias!(type OverlayFlowTable<A> = OverlayFlowKey);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Verdict {
+    Drop,
+}
+struct PacketSource<'a> {
+    view: &'a HeadersView<(&'a Eth, &'a Ipv4, &'a Tcp)>,
+    meta: &'a PacketMeta,
+}
+
+impl Projection<Option<OverlayFlowKey>> for &PacketSource<'_> {
+    fn project(self) -> Option<OverlayFlowKey> {
+        let (_eth, ipv4, tcp) = self.view.look();
+        Some(OverlayFlowKey {
+            proto: 6,
+            src: ipv4.source().inner(),
+            dport: tcp.destination().as_u16(),
+            vrf: self.meta.vrf?,
+            vni: Vni::try_from(self.meta.src_vpcd?).ok()?,
+        })
+    }
+}
+
+fn rule() -> OverlayFlowKeyRule {
+    OverlayFlowKeyRule {
+        proto: ExactSpec::new(6),
+        src: PrefixSpec::new(Ipv4Addr::new(10, 0, 0, 0), 8),
+        dport: RangeSpec::exact(443),
+        vrf: ExactSpec::new(42),
+        vni: ExactSpec::new(Vni::new_checked(1000).unwrap()),
+    }
+}
+
+fn packet(src: Ipv4Addr, dport: u16) -> net::headers::Headers {
+    HeaderStack::new()
+        .eth(|_| {})
+        .ipv4(|ip| {
+            ip.set_source(UnicastIpv4Addr::new(src).unwrap());
+            ip.set_destination(Ipv4Addr::new(192, 0, 2, 1));
+        })
+        .tcp(|tcp| {
+            tcp.set_source(TcpPort::try_from(40000u16).unwrap());
+            tcp.set_destination(TcpPort::try_from(dport).unwrap());
+        })
+        .build_headers()
+        .unwrap()
+}
+#[allow(clippy::field_reassign_with_default)]
+fn meta_with(vrf: Option<VrfId>, vni: Option<Vni>) -> PacketMeta {
+    let mut meta = PacketMeta::default();
+    meta.vrf = vrf;
+    meta.src_vpcd = vni.map(VpcDiscriminant::from);
+    meta
+}
+
+#[test]
+#[dpdk::with_eal]
+fn classify_on_headers_plus_metadata() {
+    let dpdk: OverlayFlowTable<Verdict> = install_table(
+        "metadata_projection",
+        NonZero::new(8).unwrap(),
+        vec![
+            RuleSpec::<OverlayFlowKey, Verdict>::new(
+                Priority::new(1).unwrap(),
+                CategoryMask::new(1).unwrap(),
+                rule().into_backend_fields::<Dpdk>(),
+                Verdict::Drop,
+            )
+            .unwrap(),
+        ],
+    )
+    .expect("install_table");
+    let reference = ReferenceTable::<OverlayFlowKey, Verdict>::new(vec![RefRule::new(
+        rule().into_backend_fields::<Erased>(),
+        Verdict::Drop,
+    )]);
+
+    let headers = packet(Ipv4Addr::new(10, 9, 9, 9), 443);
+    let view = headers
+        .as_view::<(&Eth, &Ipv4, &Tcp)>()
+        .expect("v4 tcp shape");
+    let vni = Vni::new_checked(1000).unwrap();
+    let full = meta_with(Some(42), Some(vni));
+    let src = PacketSource { view, meta: &full };
+    assert_eq!(dpdk.classify_opt(&src), Some(&Verdict::Drop));
+    assert_eq!(
+        reference.classify_opt(&PacketSource { view, meta: &full }),
+        Some(&Verdict::Drop)
+    );
+    let no_vrf = meta_with(None, Some(vni));
+    assert_eq!(
+        dpdk.classify_opt(&PacketSource {
+            view,
+            meta: &no_vrf
+        }),
+        None
+    );
+    assert_eq!(
+        reference.classify_opt(&PacketSource {
+            view,
+            meta: &no_vrf
+        }),
+        None
+    );
+    let wrong_vni = meta_with(Some(42), Some(Vni::new_checked(2000).unwrap()));
+    assert_eq!(
+        dpdk.classify_opt(&PacketSource {
+            view,
+            meta: &wrong_vni
+        }),
+        None
+    );
+    assert_eq!(
+        reference.classify_opt(&PacketSource {
+            view,
+            meta: &wrong_vni
+        }),
+        None
+    );
+}
+#[test]
+#[dpdk::with_eal]
+fn classify_opt_accepts_an_inline_key() {
+    let dpdk: OverlayFlowTable<Verdict> = install_table(
+        "metadata_projection_by",
+        NonZero::new(8).unwrap(),
+        vec![
+            RuleSpec::<OverlayFlowKey, Verdict>::new(
+                Priority::new(1).unwrap(),
+                CategoryMask::new(1).unwrap(),
+                rule().into_backend_fields::<Dpdk>(),
+                Verdict::Drop,
+            )
+            .unwrap(),
+        ],
+    )
+    .expect("install_table");
+
+    let headers = packet(Ipv4Addr::new(10, 9, 9, 9), 443);
+    let view = headers
+        .as_view::<(&Eth, &Ipv4, &Tcp)>()
+        .expect("v4 tcp shape");
+    let key_for = |meta: &PacketMeta| -> Option<OverlayFlowKey> {
+        let (_eth, ipv4, tcp) = view.look();
+        Some(OverlayFlowKey {
+            proto: 6,
+            src: ipv4.source().inner(),
+            dport: tcp.destination().as_u16(),
+            vrf: meta.vrf?,
+            vni: Vni::try_from(meta.src_vpcd?).ok()?,
+        })
+    };
+
+    let full = meta_with(Some(42), Some(Vni::new_checked(1000).unwrap()));
+    assert_eq!(dpdk.classify_opt(key_for(&full)), Some(&Verdict::Drop));
+    let no_vrf = meta_with(None, Some(Vni::new_checked(1000).unwrap()));
+    assert_eq!(dpdk.classify_opt(key_for(&no_vrf)), None);
+}

--- a/acl/tests/net_field_types.rs
+++ b/acl/tests/net_field_types.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core::net::Ipv4Addr;
+use core::num::NonZero;
+
+use dataplane_acl::dpdk::install::install_table;
+use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+use dataplane_acl::dpdk_table_alias;
+use dataplane_acl::reference::{Erased, RefRule, ReferenceTable};
+use dpdk::acl::{CategoryMask, Priority};
+use lookup::Lookup;
+use match_action::{ExactSpec, MatchKey, PrefixSpec};
+use net::ipv4::UnicastIpv4Addr;
+use net::tcp::TcpPort;
+use net::vxlan::Vni;
+#[derive(MatchKey, Debug, Clone, Copy)]
+struct OverlayKey {
+    #[exact]
+    proto: u8,
+    #[prefix]
+    src: UnicastIpv4Addr,
+    #[exact]
+    vni: Vni,
+    #[exact]
+    dport: TcpPort,
+}
+
+dpdk_table_alias!(type OverlayTable<A> = OverlayKey);
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Verdict {
+    Drop,
+}
+
+fn unicast(addr: &str) -> UnicastIpv4Addr {
+    UnicastIpv4Addr::new(addr.parse::<Ipv4Addr>().unwrap()).unwrap()
+}
+
+fn rule() -> OverlayKeyRule {
+    OverlayKeyRule {
+        proto: ExactSpec::new(6),
+        src: PrefixSpec::new(unicast("10.0.0.0"), 8),
+        vni: ExactSpec::new(Vni::new_checked(1000).unwrap()),
+        dport: ExactSpec::new(TcpPort::new_checked(443).unwrap()),
+    }
+}
+
+#[test]
+#[dpdk::with_eal]
+fn net_newtypes_classify_through_dpdk_and_reference() {
+    let spec = RuleSpec::<OverlayKey, Verdict>::new(
+        Priority::new(1).unwrap(),
+        CategoryMask::new(1).unwrap(),
+        rule().into_backend_fields::<Dpdk>(),
+        Verdict::Drop,
+    )
+    .unwrap();
+    let dpdk: OverlayTable<Verdict> =
+        install_table("net_field_types", NonZero::new(8).unwrap(), vec![spec])
+            .expect("install_table");
+    let reference = ReferenceTable::<OverlayKey, Verdict>::new(vec![RefRule::new(
+        rule().into_backend_fields::<Erased>(),
+        Verdict::Drop,
+    )]);
+
+    let hit = OverlayKey {
+        proto: 6,
+        src: unicast("10.9.9.9"),
+        vni: Vni::new_checked(1000).unwrap(),
+        dport: TcpPort::new_checked(443).unwrap(),
+    };
+    assert_eq!(dpdk.lookup(&hit), Some(&Verdict::Drop));
+    assert_eq!(reference.lookup(&hit), Some(&Verdict::Drop));
+    let wrong_vni = OverlayKey {
+        vni: Vni::new_checked(2000).unwrap(),
+        ..hit
+    };
+    assert_eq!(dpdk.lookup(&wrong_vni), None);
+    assert_eq!(reference.lookup(&wrong_vni), None);
+    let off_prefix = OverlayKey {
+        src: unicast("11.0.0.1"),
+        ..hit
+    };
+    assert_eq!(dpdk.lookup(&off_prefix), None);
+    assert_eq!(reference.lookup(&off_prefix), None);
+    let wrong_port = OverlayKey {
+        dport: TcpPort::new_checked(80).unwrap(),
+        ..hit
+    };
+    assert_eq!(dpdk.lookup(&wrong_port), None);
+    assert_eq!(reference.lookup(&wrong_port), None);
+}

--- a/acl/tests/property_dyn_shape.rs
+++ b/acl/tests/property_dyn_shape.rs
@@ -11,10 +11,10 @@ use bolero::TypeGenerator;
 use bolero::ValueGenerator;
 use bolero::generator::bolero_generator::driver::{ByteSliceDriver, Options};
 use dataplane_acl::dpdk::dyn_table::{
-    DynDpdkLookup, DynRuleSpec, MAX_DYN_N, install_table_dynamic, predicate_to_chunks,
+    DynDpdkLookup, DynRuleSpec, install_table_dynamic, predicate_to_chunks,
 };
 use dataplane_acl::reference::{DynReferenceTable, FieldPredicate, RefRule};
-use dpdk::acl::{CategoryMask, Priority};
+use dpdk::acl::{CategoryMask, MAX_FIELDS, Priority};
 use match_action::generator::{
     predicate_hits_bytes, predicate_is_universal, predicate_misses_bytes,
 };
@@ -72,7 +72,7 @@ fn build_shape(raw: &RawShape) -> Option<(Vec<FieldSpec>, Vec<FieldPredicate>)> 
             offset,
         };
         post_split += if size <= 4 { 1 } else { size / 4 };
-        if post_split > MAX_DYN_N {
+        if post_split > MAX_FIELDS {
             return None;
         }
         let pred = build_predicate(kind, size, f)?;

--- a/acl/tests/property_dyn_shape.rs
+++ b/acl/tests/property_dyn_shape.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use concurrency::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use core::num::NonZero;
+
+use bolero::TypeGenerator;
+use bolero::ValueGenerator;
+use bolero::generator::bolero_generator::driver::{ByteSliceDriver, Options};
+use dataplane_acl::dpdk::dyn_table::{
+    DynDpdkLookup, DynRuleSpec, MAX_DYN_N, install_table_dynamic, predicate_to_chunks,
+};
+use dataplane_acl::reference::{DynReferenceTable, FieldPredicate, RefRule};
+use dpdk::acl::{CategoryMask, Priority};
+use match_action::generator::{
+    predicate_hits_bytes, predicate_is_universal, predicate_misses_bytes,
+};
+use match_action::predicate::{Exact, FieldBytes, Mask, Prefix, Range};
+use match_action::{FieldKind, FieldSpec};
+
+#[derive(Debug, Clone, TypeGenerator)]
+struct RawShape {
+    n_choice: u8,
+    fields: [RawField; MAX_DYN_N_USER],
+}
+
+#[derive(Debug, Clone, TypeGenerator)]
+struct RawField {
+    kind_choice: u8,
+    size_choice: u8,
+    payload_a: [u8; 16],
+    payload_b: [u8; 16],
+    prefix_len_choice: u8,
+}
+const MAX_DYN_N_USER: usize = 4;
+const SIZE_TABLE: &[usize] = &[1, 2, 4, 8, 12, 16];
+
+fn pick_kind(choice: u8, size: usize) -> FieldKind {
+    let base = choice % 4;
+    let base = if size > 4 && base == 3 { 0 } else { base };
+    match base {
+        0 => FieldKind::Exact,
+        1 => FieldKind::Prefix,
+        2 => FieldKind::Mask,
+        _ => FieldKind::Range,
+    }
+}
+
+fn pick_size(choice: u8) -> usize {
+    SIZE_TABLE[(choice as usize) % SIZE_TABLE.len()]
+}
+fn build_shape(raw: &RawShape) -> Option<(Vec<FieldSpec>, Vec<FieldPredicate>)> {
+    let n = (raw.n_choice as usize) % MAX_DYN_N_USER + 1;
+    let mut specs: Vec<FieldSpec> = Vec::with_capacity(n);
+    let mut preds: Vec<FieldPredicate> = Vec::with_capacity(n);
+    let mut offset = 0usize;
+    let mut post_split = 0usize;
+    for (i, f) in raw.fields.iter().take(n).enumerate() {
+        let size = if i == 0 { 1 } else { pick_size(f.size_choice) };
+        let kind = if i == 0 {
+            FieldKind::Exact
+        } else {
+            pick_kind(f.kind_choice, size)
+        };
+        let spec = FieldSpec {
+            name: "f",
+            kind,
+            size,
+            offset,
+        };
+        post_split += if size <= 4 { 1 } else { size / 4 };
+        if post_split > MAX_DYN_N {
+            return None;
+        }
+        let pred = build_predicate(kind, size, f)?;
+        specs.push(spec);
+        preds.push(pred);
+        offset += size;
+    }
+    Some((specs, preds))
+}
+
+fn fb(bytes: &[u8]) -> FieldBytes {
+    bytes.iter().copied().collect()
+}
+
+fn build_predicate(kind: FieldKind, size: usize, f: &RawField) -> Option<FieldPredicate> {
+    let a = &f.payload_a[..size];
+    let b = &f.payload_b[..size];
+    Some(match kind {
+        FieldKind::Exact => FieldPredicate::Exact(Exact::new(fb(a))),
+        FieldKind::Prefix => {
+            let max_len = (size * 8) as u8;
+            let len = f.prefix_len_choice % (max_len.saturating_add(1));
+            FieldPredicate::Prefix(Prefix::new(fb(a), len))
+        }
+        FieldKind::Mask => FieldPredicate::Mask(Mask::new(fb(a), fb(b))),
+        FieldKind::Range => {
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            FieldPredicate::Range(Range::new(fb(lo), fb(hi)))
+        }
+    })
+}
+struct ShapeHits {
+    preds: Vec<FieldPredicate>,
+    key_size: usize,
+}
+
+impl ValueGenerator for ShapeHits {
+    type Output = Vec<u8>;
+    fn generate<D: bolero::Driver>(&self, d: &mut D) -> Option<Vec<u8>> {
+        let mut key = Vec::with_capacity(self.key_size);
+        for pred in &self.preds {
+            let chunk = predicate_hits_bytes(pred.clone()).generate(d)?;
+            key.extend_from_slice(&chunk);
+        }
+        Some(key)
+    }
+}
+struct ShapeMisses {
+    preds: Vec<FieldPredicate>,
+    non_universal: Vec<usize>,
+    key_size: usize,
+}
+
+impl ValueGenerator for ShapeMisses {
+    type Output = Vec<u8>;
+    fn generate<D: bolero::Driver>(&self, d: &mut D) -> Option<Vec<u8>> {
+        if self.non_universal.is_empty() {
+            return None;
+        }
+        let pick: u8 = d.gen_u8(core::ops::Bound::Unbounded, core::ops::Bound::Unbounded)?;
+        let target = self.non_universal[(pick as usize) % self.non_universal.len()];
+        let mut key = Vec::with_capacity(self.key_size);
+        for (i, pred) in self.preds.iter().enumerate() {
+            let chunk = if i == target {
+                predicate_misses_bytes(pred.clone()).generate(d)?
+            } else {
+                predicate_hits_bytes(pred.clone()).generate(d)?
+            };
+            key.extend_from_slice(&chunk);
+        }
+        Some(key)
+    }
+}
+
+static CTX_SEQ: AtomicU32 = AtomicU32::new(0);
+
+fn unique_name(prefix: &str) -> String {
+    format!("{prefix}_{}", CTX_SEQ.fetch_add(1, Ordering::Relaxed))
+}
+
+fn install_both(
+    specs: &[FieldSpec],
+    preds: &[FieldPredicate],
+) -> Option<(DynDpdkLookup<u32>, DynReferenceTable<u32>)> {
+    let dpdk_fields: Vec<_> = preds
+        .iter()
+        .zip(specs)
+        .map(|(p, s)| predicate_to_chunks(p, s.size))
+        .collect();
+    let dpdk = install_table_dynamic::<u32>(
+        &unique_name("prop_dyn"),
+        specs,
+        vec![DynRuleSpec::new(
+            Priority::new(1).expect("nonzero priority"),
+            CategoryMask::new(1).expect("nonzero mask"),
+            dpdk_fields,
+            0xAA,
+        )],
+        NonZero::new(2).expect("nonzero"),
+    )
+    .ok()?;
+    let reference =
+        DynReferenceTable::new(specs.to_vec(), vec![RefRule::new(preds.to_vec(), 0xAA)]).ok()?;
+    Some((dpdk, reference))
+}
+
+const INNER_DRAWS: usize = 16;
+const MIN_ASSERTED_HITS: u64 = 200;
+const MIN_ASSERTED_MISSES: u64 = 100;
+
+fn sweep<G, F>(g: &G, bytes: &[u8], pred: F) -> u64
+where
+    G: ValueGenerator,
+    F: Fn(&G::Output),
+{
+    let opts = Options::default()
+        .with_max_len(bytes.len())
+        .with_max_depth(64);
+    let mut driver = ByteSliceDriver::new(bytes, &opts);
+    let mut count = 0;
+    for _ in 0..INNER_DRAWS {
+        if driver.as_slice().is_empty() {
+            break;
+        }
+        if let Some(v) = g.generate(&mut driver) {
+            pred(&v);
+            count += 1;
+        }
+    }
+    count
+}
+
+#[test]
+#[dpdk::with_eal]
+fn dyn_dpdk_and_reference_agree_on_random_shapes() {
+    static ASSERTED_HITS: AtomicU64 = AtomicU64::new(0);
+    static ASSERTED_MISSES: AtomicU64 = AtomicU64::new(0);
+    static SHAPES_RUN: AtomicU64 = AtomicU64::new(0);
+
+    bolero::check!()
+        .with_type::<(RawShape, Box<[u8]>, Box<[u8]>)>()
+        .for_each(|(raw, hit_bytes, miss_bytes)| {
+            let Some((specs, preds)) = build_shape(raw) else {
+                return;
+            };
+            let Some((dpdk, reference)) = install_both(&specs, &preds) else {
+                return;
+            };
+            SHAPES_RUN.fetch_add(1, Ordering::Relaxed);
+
+            let key_size: usize = specs.iter().map(|s| s.size).sum();
+            let hits = ShapeHits {
+                preds: preds.clone(),
+                key_size,
+            };
+            let n_hits = sweep(&hits, hit_bytes, |key| {
+                assert_eq!(
+                    dpdk.lookup_bytes(key),
+                    Some(&0xAA),
+                    "dpdk missed hit on shape {specs:?} key {key:?} rule {preds:?}",
+                );
+                assert_eq!(
+                    reference.lookup_bytes(key),
+                    Some(&0xAA),
+                    "reference missed hit on shape {specs:?} key {key:?} rule {preds:?}",
+                );
+            });
+            ASSERTED_HITS.fetch_add(n_hits, Ordering::Relaxed);
+            let non_universal: Vec<usize> = preds
+                .iter()
+                .enumerate()
+                .filter_map(|(i, p)| (!predicate_is_universal(p)).then_some(i))
+                .collect();
+            if !non_universal.is_empty() {
+                let misses = ShapeMisses {
+                    preds: preds.clone(),
+                    non_universal,
+                    key_size,
+                };
+                let n_misses = sweep(&misses, miss_bytes, |key| {
+                    assert_eq!(
+                        dpdk.lookup_bytes(key),
+                        None,
+                        "dpdk unexpectedly hit on miss key {key:?} for shape {specs:?}",
+                    );
+                    assert_eq!(
+                        reference.lookup_bytes(key),
+                        None,
+                        "reference unexpectedly hit on miss key {key:?} for shape {specs:?}",
+                    );
+                });
+                ASSERTED_MISSES.fetch_add(n_misses, Ordering::Relaxed);
+            }
+        });
+
+    let shapes = SHAPES_RUN.load(Ordering::Relaxed);
+    let h = ASSERTED_HITS.load(Ordering::Relaxed);
+    let m = ASSERTED_MISSES.load(Ordering::Relaxed);
+    assert!(
+        shapes > 0,
+        "no shapes survived rejection -- shape generator may be over-restricting",
+    );
+    assert!(
+        h >= MIN_ASSERTED_HITS,
+        "asserted only {h} hits (< {MIN_ASSERTED_HITS}) across {shapes} shapes; \
+         harness may have gone inert",
+    );
+    assert!(
+        m >= MIN_ASSERTED_MISSES,
+        "asserted only {m} misses (< {MIN_ASSERTED_MISSES}) across {shapes} shapes; \
+         harness may have gone inert",
+    );
+}

--- a/acl/tests/property_predicate.rs
+++ b/acl/tests/property_predicate.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+#![cfg(feature = "dpdk")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use concurrency::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use core::net::{Ipv4Addr, Ipv6Addr};
+use core::num::NonZero;
+use core::ops::Bound;
+
+use arrayvec::ArrayVec;
+use bolero::generator::bolero_generator::driver::{ByteSliceDriver, Options};
+use bolero::{Driver, TypeGenerator, ValueGenerator};
+use dataplane_acl::dpdk::install::install_table;
+use dataplane_acl::dpdk::rule::{Dpdk, RuleSpec};
+use dataplane_acl::dpdk_table_alias;
+use dataplane_acl::reference::{Erased, RefRule, ReferenceTable};
+use dpdk::acl::{CategoryMask, Priority};
+use lookup::Lookup;
+use match_action::{
+    ExactSpec, FieldHit, FieldMiss, FixedSize, IsUniversal, MatchKey, PrefixSpec, RangeSpec,
+};
+
+mod sealed {
+    use core::net::{Ipv4Addr, Ipv6Addr};
+    pub trait Sealed {}
+    impl Sealed for Ipv4Addr {}
+    impl Sealed for Ipv6Addr {}
+}
+pub trait IpAddress:
+    FixedSize + sealed::Sealed + TypeGenerator + Copy + core::fmt::Debug + 'static + Send + Sync
+{
+    const BITS: u8;
+}
+
+impl IpAddress for Ipv4Addr {
+    const BITS: u8 = 32;
+}
+
+impl IpAddress for Ipv6Addr {
+    const BITS: u8 = 128;
+}
+
+#[derive(MatchKey, Debug, Clone, Copy)]
+struct FiveTuple<A: IpAddress> {
+    #[exact]
+    proto: u8,
+    #[prefix]
+    src: A,
+    #[prefix]
+    dst: A,
+    #[range]
+    sport: u16,
+    #[range]
+    dport: u16,
+}
+
+dpdk_table_alias!(type FiveTupleTableV4<A> = FiveTuple<Ipv4Addr>);
+dpdk_table_alias!(type FiveTupleTableV6<A> = FiveTuple<Ipv6Addr>);
+
+#[derive(Debug, Clone, Copy, TypeGenerator)]
+struct RawRule<A> {
+    proto: u8,
+    src: A,
+    src_len: u8,
+    dst: A,
+    dst_len: u8,
+    sport_a: u16,
+    sport_b: u16,
+    dport_a: u16,
+    dport_b: u16,
+}
+
+fn minmax<T: Ord>(a: T, b: T) -> (T, T) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+fn build_rule<A: IpAddress>(raw: &RawRule<A>) -> FiveTupleRule<A> {
+    let (sport_lo, sport_hi) = minmax(raw.sport_a, raw.sport_b);
+    let (dport_lo, dport_hi) = minmax(raw.dport_a, raw.dport_b);
+    let bits = u16::from(A::BITS) + 1;
+    let src_len = u8::try_from(u16::from(raw.src_len) % bits).unwrap_or(A::BITS);
+    let dst_len = u8::try_from(u16::from(raw.dst_len) % bits).unwrap_or(A::BITS);
+    FiveTupleRule {
+        proto: ExactSpec::new(raw.proto),
+        src: PrefixSpec::new(raw.src, src_len),
+        dst: PrefixSpec::new(raw.dst, dst_len),
+        sport: RangeSpec::new(sport_lo, sport_hi),
+        dport: RangeSpec::new(dport_lo, dport_hi),
+    }
+}
+
+struct HitsGen<A: IpAddress> {
+    rule: FiveTupleRule<A>,
+}
+
+impl<A: IpAddress> ValueGenerator for HitsGen<A>
+where
+    PrefixSpec<A>: FieldHit<A>,
+{
+    type Output = FiveTuple<A>;
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<FiveTuple<A>> {
+        let r = &self.rule;
+        Some(FiveTuple {
+            proto: FieldHit::hits(&r.proto).generate(d)?,
+            src: FieldHit::hits(&r.src).generate(d)?,
+            dst: FieldHit::hits(&r.dst).generate(d)?,
+            sport: FieldHit::hits(&r.sport).generate(d)?,
+            dport: FieldHit::hits(&r.dport).generate(d)?,
+        })
+    }
+}
+
+struct MissesGen<A: IpAddress> {
+    rule: FiveTupleRule<A>,
+}
+
+impl<A: IpAddress> ValueGenerator for MissesGen<A>
+where
+    PrefixSpec<A>: FieldHit<A> + FieldMiss<A> + IsUniversal,
+{
+    type Output = FiveTuple<A>;
+    fn generate<D: Driver>(&self, d: &mut D) -> Option<FiveTuple<A>> {
+        let r = &self.rule;
+        let mut nu: ArrayVec<u8, 5> = ArrayVec::new();
+        if !r.proto.is_universal() {
+            nu.push(0);
+        }
+        if !r.src.is_universal() {
+            nu.push(1);
+        }
+        if !r.dst.is_universal() {
+            nu.push(2);
+        }
+        if !r.sport.is_universal() {
+            nu.push(3);
+        }
+        if !r.dport.is_universal() {
+            nu.push(4);
+        }
+        if nu.is_empty() {
+            return None;
+        }
+        let pick: u8 = d.gen_u8(Bound::Unbounded, Bound::Unbounded)?;
+        let target = nu[(pick as usize) % nu.len()];
+        Some(FiveTuple {
+            proto: if target == 0 {
+                FieldMiss::misses(&r.proto).generate(d)?
+            } else {
+                FieldHit::hits(&r.proto).generate(d)?
+            },
+            src: if target == 1 {
+                FieldMiss::misses(&r.src).generate(d)?
+            } else {
+                FieldHit::hits(&r.src).generate(d)?
+            },
+            dst: if target == 2 {
+                FieldMiss::misses(&r.dst).generate(d)?
+            } else {
+                FieldHit::hits(&r.dst).generate(d)?
+            },
+            sport: if target == 3 {
+                FieldMiss::misses(&r.sport).generate(d)?
+            } else {
+                FieldHit::hits(&r.sport).generate(d)?
+            },
+            dport: if target == 4 {
+                FieldMiss::misses(&r.dport).generate(d)?
+            } else {
+                FieldHit::hits(&r.dport).generate(d)?
+            },
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Verdict {
+    Drop,
+}
+
+static CTX_SEQ: AtomicU32 = AtomicU32::new(0);
+
+fn unique_name(prefix: &str) -> String {
+    format!("{prefix}_{}", CTX_SEQ.fetch_add(1, Ordering::Relaxed))
+}
+const INNER_DRAWS: usize = 32;
+
+fn sweep<G, F>(g: &G, bytes: &[u8], pred: F) -> u64
+where
+    G: ValueGenerator,
+    F: Fn(&G::Output),
+{
+    let opts = Options::default()
+        .with_max_len(bytes.len())
+        .with_max_depth(64);
+    let mut driver = ByteSliceDriver::new(bytes, &opts);
+    let mut count = 0;
+    for _ in 0..INNER_DRAWS {
+        if driver.as_slice().is_empty() {
+            break;
+        }
+        if let Some(v) = g.generate(&mut driver) {
+            pred(&v);
+            count += 1;
+        }
+    }
+    count
+}
+const MIN_ASSERTED_HITS: u64 = 200;
+const MIN_ASSERTED_MISSES: u64 = 200;
+fn run_property<A, T>(
+    name_prefix: &str,
+    install_dpdk: impl Fn(String, &FiveTupleRule<A>) -> T + core::panic::RefUnwindSafe,
+) where
+    A: IpAddress,
+    PrefixSpec<A>: FieldHit<A> + FieldMiss<A> + IsUniversal,
+    T: Lookup<FiveTuple<A>, Verdict>,
+    RawRule<A>: TypeGenerator,
+{
+    let asserted_hits = AtomicU64::new(0);
+    let asserted_misses = AtomicU64::new(0);
+
+    bolero::check!()
+        .with_type::<(RawRule<A>, Box<[u8]>, Box<[u8]>)>()
+        .for_each(|(raw, hit_bytes, miss_bytes)| {
+            let rule = build_rule(raw);
+            let dpdk = install_dpdk(unique_name(name_prefix), &rule);
+            let reference = ReferenceTable::<FiveTuple<A>, Verdict>::new(vec![RefRule::new(
+                rule.into_backend_fields::<Erased>(),
+                Verdict::Drop,
+            )]);
+
+            let hits = HitsGen { rule };
+            let n_hits = sweep(&hits, hit_bytes, |k| {
+                assert!(rule.accepts(k), "hits gen produced a rejected key: {k:?}");
+                assert_eq!(reference.lookup(k), Some(&Verdict::Drop));
+                assert_eq!(dpdk.lookup(k), Some(&Verdict::Drop));
+            });
+            asserted_hits.fetch_add(n_hits, Ordering::Relaxed);
+
+            if !rule.is_universal() {
+                let misses = MissesGen { rule };
+                let n_misses = sweep(&misses, miss_bytes, |k| {
+                    assert!(
+                        !rule.accepts(k),
+                        "misses gen produced an accepted key: {k:?}",
+                    );
+                    assert_eq!(reference.lookup(k), None);
+                    assert_eq!(dpdk.lookup(k), None);
+                });
+                asserted_misses.fetch_add(n_misses, Ordering::Relaxed);
+            }
+        });
+
+    let h = asserted_hits.load(Ordering::Relaxed);
+    let m = asserted_misses.load(Ordering::Relaxed);
+    assert!(
+        h >= MIN_ASSERTED_HITS,
+        "asserted only {h} hits (< {MIN_ASSERTED_HITS}); generator may have gone inert",
+    );
+    assert!(
+        m >= MIN_ASSERTED_MISSES,
+        "asserted only {m} misses (< {MIN_ASSERTED_MISSES}); generator may have gone inert",
+    );
+}
+
+#[test]
+#[dpdk::with_eal]
+fn property_v4() {
+    run_property::<Ipv4Addr, FiveTupleTableV4<Verdict>>("prop_v4", |name, rule| {
+        install_table(
+            &name,
+            NonZero::new(2).expect("nonzero"),
+            vec![
+                RuleSpec::<FiveTuple<Ipv4Addr>, Verdict>::new(
+                    Priority::new(1).expect("nonzero priority"),
+                    CategoryMask::new(1).expect("nonzero mask"),
+                    rule.into_backend_fields::<Dpdk>(),
+                    Verdict::Drop,
+                )
+                .expect("RuleSpec"),
+            ],
+        )
+        .expect("install_table")
+    });
+}
+
+#[test]
+#[dpdk::with_eal]
+fn property_v6() {
+    run_property::<Ipv6Addr, FiveTupleTableV6<Verdict>>("prop_v6", |name, rule| {
+        install_table(
+            &name,
+            NonZero::new(2).expect("nonzero"),
+            vec![
+                RuleSpec::<FiveTuple<Ipv6Addr>, Verdict>::new(
+                    Priority::new(1).expect("nonzero priority"),
+                    CategoryMask::new(1).expect("nonzero mask"),
+                    rule.into_backend_fields::<Dpdk>(),
+                    Verdict::Drop,
+                )
+                .expect("RuleSpec"),
+            ],
+        )
+        .expect("install_table")
+    });
+}

--- a/default.nix
+++ b/default.nix
@@ -526,6 +526,44 @@ let
     ) package-list;
   };
 
+  # Build criterion bench binaries without running them.
+  bench-builder =
+    {
+      package ? null,
+      cargoArtifacts ? null,
+    }:
+    let
+      pname = if package != null then package else "all";
+    in
+    pkgs.callPackage invoke {
+      builder = craneLib.mkCargoDerivation;
+      profile = profile-tests';
+      args = {
+        inherit pname cargoArtifacts;
+        buildPhaseCargoCommand =
+          (builtins.concatStringsSep " " (
+            [
+              "mkdir -p $out/bin;"
+              "cargoBenchLog=$(mktemp cargoBenchLogXXXX.json);"
+              "cargo"
+              "bench"
+              "--no-run"
+              "--profile=${cargo-profile}"
+            ]
+            ++ (if package != null then [ "--package=${pname}" ] else [ ])
+            ++ cargo-cmd-prefix-tests
+            ++ [ "--message-format=json-render-diagnostics > $cargoBenchLog;" ]
+          ))
+          + ''
+            for exe in $(grep -E '"kind":\["bench"\]' "$cargoBenchLog" | grep -oE '"executable":"[^"]+"' | sed -E 's/"executable":"//; s/"$//'); do
+              cp "$exe" "$out/bin/$(basename "$exe" | sed -E 's/-[0-9a-f]{16}$//')"
+            done
+          '';
+      };
+    };
+
+  benches = bench-builder { };
+
   clippy-builder =
     {
       pname ? null,
@@ -963,6 +1001,7 @@ let
 in
 {
   inherit
+    benches
     check
     clippy
     containers

--- a/justfile
+++ b/justfile
@@ -160,6 +160,15 @@ test package="tests.all" *args: (build (if package == "tests.all" { "tests.all" 
     declare -r target="{{ if package == "tests.all" { "tests.all" } else { "tests.pkg." + package } }}"
     cargo nextest run --archive-file results/${target}/*.tar.zst --workspace-remap $(pwd) {{ filter }}
 
+# Build and run the criterion benches. The rte_acl benches are gated behind the
+# `dpdk` feature, so run `just features=dpdk bench` to exercise them; a plain
+# `just bench` builds them as empty `main()` and only runs the reference benches.
+[script]
+bench: (build "benches")
+    {{ _just_debuggable_ }}
+    shopt -s nullglob
+    for bench in ./results/benches/bin/*; do "$bench" --bench; done
+
 [script]
 build-each *args: (build "workspace" args)
     {{ _just_debuggable_ }}
@@ -415,5 +424,3 @@ shell:
       --argstr profile '{{ profile }}' \
       --argstr sanitize '{{ sanitize }}' \
       --argstr tag '{{version}}'
-
-

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ version_platform := if platform == "x86-64-v3" { "" } else { "-" + platform }
 version_profile := if profile == "release" { "" } else { "-" + profile }
 version_san := if sanitize == "" { "" } else { "-san." + replace(sanitize, ",", ".") }
 version_feat := if features == "" { "" } else { "-feat." + replace(features, ",", ".") }
-version := env("VERSION", "") || `git describe --tags --dirty --always` + version_platform + version_profile + version_san + version_feat + version_extra
+version := env("VERSION", `git describe --tags --dirty --always` + version_platform + version_profile + version_san + version_feat + version_extra)
 
 # Print version that will be used in the build
 version:

--- a/nix/overlays/dataplane.nix
+++ b/nix/overlays/dataplane.nix
@@ -146,6 +146,15 @@ in
         version = sources.rdma-core.branch;
         src = sources.rdma-core.outPath;
 
+        # nixpkgs carries the "cmake-allow-overriding-sysusers.d-install-directory" patch, which turns SYSUSERS_DIR
+        # into a CMake cache variable.  Our pinned fork already cherry-picked that exact upstream commit (see the
+        # SYSUSERS_DIR cmakeFlag note below), so applying the nixpkgs patch on top fails with "Reversed (or previously
+        # applied) patch detected" and aborts patchPhase.  Drop that one patch by name (rather than clearing the whole
+        # list) so any future nixpkgs patches we *do* want still apply.
+        patches = builtins.filter (
+          p: !final.lib.hasInfix "cmake-allow-overriding-sysusers.d-install-directory" (toString p)
+        ) (orig.patches or [ ]);
+
         # Patching the shebang lines in the perl scripts causes nixgraph to (incorrectly) think we depend on perl at
         # runtime.  We absolutely do not (we don't even ship a perl interpreter), so don't patch these shebang lines.
         # In fact, we don't use any of the scripts from this package.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -97,9 +97,9 @@
       },
       "branch": "stable/10.5",
       "submodules": false,
-      "revision": "824875605f33fb900adeb505dc83bb8fc74887c6",
-      "url": "https://github.com/FRRouting/frr/archive/824875605f33fb900adeb505dc83bb8fc74887c6.tar.gz",
-      "hash": "sha256-Gxo69vg/pUQwe4SmKuwCxs80tcNHwW0x2Nwc9xgvhLc="
+      "revision": "35803e560d5c16601744fc20698fc88c6d992b3b",
+      "url": "https://github.com/FRRouting/frr/archive/35803e560d5c16601744fc20698fc88c6d992b3b.tar.gz",
+      "hash": "sha256-SSyqimcf5/ievzRNVaCOqPTfn1f2QtekOa4HmADricE="
     },
     "frr-agent": {
       "type": "Git",
@@ -154,17 +154,17 @@
       "version_upper_bound": null,
       "release_prefix": "mermaid@",
       "submodules": false,
-      "version": "mermaid@11.15.0",
-      "revision": "7373a1ed5bd159e3f4f5b35b726cbc0f9fbf4c85",
-      "url": "https://api.github.com/repos/mermaid-js/mermaid/tarball/refs/tags/mermaid@11.15.0",
-      "hash": "sha256-nBuZGj7/OaXeIQX4fiLfMl34c88LDyacrWGiliaHB34="
+      "version": "mermaid@11.16.0",
+      "revision": "5e3c88ea6d937a89078a5e8f1b2a6fd0ea391a5c",
+      "url": "https://api.github.com/repos/mermaid-js/mermaid/tarball/refs/tags/mermaid@11.16.0",
+      "hash": "sha256-GyOf/BU6eBX9vEH+rYFg2Uz4DPMUQ47mOdheittEgDQ="
     },
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1017567.3e41b24abd26/nixexprs.tar.xz",
-      "hash": "sha256-eM+l4TVD26SNoEjcxRcpispqZi5Qrqj/G0ZY4LfqwfM="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1024311.9c4c05a947a9/nixexprs.tar.xz",
+      "hash": "sha256-OFj3VquPuOYklwLnj1kOaGC85aingEYsHk+UjdO4/oY="
     },
     "opengrep": {
       "type": "GitRelease",
@@ -233,9 +233,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "f59bc28dd0b89e9c0240d1b80195559fc79c2471",
-      "url": "https://github.com/oxalica/rust-overlay/archive/f59bc28dd0b89e9c0240d1b80195559fc79c2471.tar.gz",
-      "hash": "sha256-4XHdXp3MRa++XiGkltJChCtdbCmSlNTwQRfWQOhqbRw="
+      "revision": "067959ef838c440558ca519cf08ca87f43c3db3a",
+      "url": "https://github.com/oxalica/rust-overlay/archive/067959ef838c440558ca519cf08ca87f43c3db3a.tar.gz",
+      "hash": "sha256-CR55gKCChD9ffN1Ag5az20Z3RD4tylHlcM1SSohkMA8="
     }
   },
   "version": 8

--- a/scripts/doc/custom-header.html
+++ b/scripts/doc/custom-header.html
@@ -75,8 +75,8 @@ Fix with padding
 
 <script
     defer
-    src="https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.min.js"
-    integrity="sha384-yQ4mmBBT+vhTAwjFH0toJXNYJ6O4usWnt6EPIdWwrRvx2V/n5lXuDZQwQFeSFydF"
+    src="https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js"
+    integrity="sha384-T/0lMUdJpd2S1ZHtRiofG3htU3xPCrFVeAQ1UUE2TJwlEJSV5NUwn30kP28n238E"
     crossorigin="anonymous"
     onload="mermaidStuff();"
 ></script>


### PR DESCRIPTION
Stack (12). Base: `pr/daniel-noland/acl-reference`.

The `rte_acl` backend and everything proving it matches the reference oracle.
This is the largest PR -- the irreducible DPDK lowering complexity:

- `feat(acl/dpdk)`: layout planner + rule lowering.
- `feat(acl/dpdk)`: install + `DpdkAclLookup` + EAL smoke.
- `feat(acl/dpdk)`: `DynDpdkLookup` + shape-fuzz property test.
- `test(acl)`: differential property (reference vs DPDK) + Headers/metadata
  projection demos.
- `feat(acl)`: criterion benchmarks + nix bench-builder.
---

**Review stack** (merge bottom -> top):
- (7) #1555 threading rewrite
- (8) #1572 dpdk test EAL harness
- (9) #1573 fixed-size + lookup
- (10) #1574 match-action
- (11) #1575 acl reference backend
- (12) #1576 acl rte_acl backend
- (13) #1567 cascade