### PR TITLE
Flowtable concurrent fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2033,7 +2033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2966,13 +2966,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3766,7 +3765,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4773,7 +4772,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5417,7 +5416,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5427,7 +5426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6037,9 +6036,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6050,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6060,9 +6059,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6070,9 +6069,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6083,9 +6082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -6126,9 +6125,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -75,12 +75,18 @@ mod stress;
 pub mod sync;
 pub mod thread;
 
-// `stress` is `pub` so the expansion of `#[concurrency::test]` in
-// downstream crates can name it. It is not part of the recommended
-// public surface; the macro is. `#[doc(hidden)]` keeps the symbol
-// off rustdoc, leaving users to land on `#[concurrency::test]`.
-#[doc(hidden)]
+// `stress` runs a body under the active backend's model checker (the
+// full shuttle portfolio / `loom::model` / a single std call). It backs
+// the `#[concurrency::test]` expansion, and is *also* a supported entry
+// point in its own right: a bolero x shuttle suite can call it once per
+// generated shape to explore that shape under the standard portfolio.
+// See `stress` and `concurrency/tests/quiescent_shuttle.rs`.
 pub use stress::stress;
+
+// The standard shuttle `Config` (4 MiB stacks). Exposed for suites that
+// build their own `Runner` rather than going through `stress`.
+#[cfg(all(not(feature = "loom"), feature = "shuttle"))]
+pub use stress::shuttle_config;
 
 #[cfg(all(miri, any(feature = "shuttle", feature = "loom")))]
 compile_error!("miri does not meaningfully support 'loom' or 'shuttle'");

--- a/concurrency/src/stress.rs
+++ b/concurrency/src/stress.rs
@@ -10,7 +10,37 @@
 //! * `shuttle_dfs` (additive on top of `shuttle`) -- also adds
 //!   `DfsScheduler` to the portfolio.
 
+/// The workspace-standard shuttle [`Config`](shuttle::Config).
+///
+/// The only departure from shuttle's default is a 4 MiB stack (shuttle
+/// defaults to ~60 KiB, which is too small for the deep call stacks the
+/// dataplane primitives reach under the model checker). [`stress`] uses
+/// this for its `PortfolioRunner`; bolero x shuttle suites that drive a
+/// single schedule per generated shape should build their `Runner` with
+/// it too, so every shuttle run shares one stack-size story.
+#[cfg(all(not(feature = "loom"), feature = "shuttle"))]
+#[must_use]
+pub fn shuttle_config() -> shuttle::Config {
+    let mut config = shuttle::Config::default();
+    config.stack_size = 4 * 1024 * 1024;
+    config
+}
+
 /// Run `body` under the currently selected concurrency backend.
+///
+/// * default backend -- one direct call, no scheduling exploration.
+/// * `loom` -- `loom::model`.
+/// * `shuttle` -- the [`shuttle_config`]-configured `PortfolioRunner`
+///   (`RandomScheduler` + `PctScheduler`, plus `DfsScheduler` under
+///   `shuttle_dfs`).
+///
+/// Backs the `#[concurrency::test]` expansion, but is equally usable on
+/// its own. In particular a bolero x shuttle suite can call `stress`
+/// once per generated shape to explore that shape under the full
+/// portfolio -- the same config `#[concurrency::test]` uses -- instead of
+/// hand-wiring a `Runner`. Note that the shuttle portfolio includes PCT,
+/// which panics on a body that does not exercise real concurrency, so the
+/// caller must ensure every shape keeps at least two threads runnable.
 #[allow(unused_variables)]
 #[allow(clippy::expect_used)]
 pub fn stress<F>(body: F)
@@ -44,10 +74,7 @@ where
             use shuttle::PortfolioRunner;
             use shuttle::scheduler::{PctScheduler, RandomScheduler};
 
-            let mut config = shuttle::Config::default();
-            config.stack_size = 4 * 1024 * 1024;
-
-            let mut portfolio = PortfolioRunner::new(true, config);
+            let mut portfolio = PortfolioRunner::new(true, shuttle_config());
             portfolio.add(RandomScheduler::new(ITERATIONS));
             portfolio.add(PctScheduler::new(SCHEDULES, ITERATIONS));
             #[cfg(feature = "shuttle_dfs")]

--- a/concurrency/tests/quiescent_shuttle.rs
+++ b/concurrency/tests/quiescent_shuttle.rs
@@ -168,7 +168,13 @@ fn fuzz_test<Arg: Clone + TypeGenerator + RefUnwindSafe + std::fmt::Debug>(
 #[test]
 #[cfg(feature = "shuttle")]
 fn protocol_under_shuttle() {
-    fuzz_test(|plan: Plan| shuttle::check_random(move || run_plan(&plan), 1));
+    fuzz_test(|plan: Plan| {
+        let runner = shuttle::Runner::new(
+            shuttle::scheduler::RandomScheduler::new(1),
+            dataplane_concurrency::shuttle_config(),
+        );
+        runner.run(move || run_plan(&plan));
+    });
 }
 
 #[test]
@@ -191,7 +197,11 @@ fn protocol_under_shuttle_pct() {
         {
             return;
         }
-        shuttle::check_pct(move || run_plan(&plan), 16, 3);
+        let runner = shuttle::Runner::new(
+            shuttle::scheduler::PctScheduler::new(3, 16),
+            dataplane_concurrency::shuttle_config(),
+        );
+        runner.run(move || run_plan(&plan));
     });
 }
 

--- a/flow-entry/src/flow_table/concurrent_fuzz.rs
+++ b/flow-entry/src/flow_table/concurrent_fuzz.rs
@@ -3,350 +3,300 @@
 
 //! Concurrent fuzz tests for [`FlowTable`].
 //!
-//! Two complementary modules, both driven by the same operation universe
-//! (insert / lookup / invalidate / extend-expiry / drain-stale) over a small
-//! key set:
+//! A single test, [`stress_test_concurrency_model`], drives one
+//! bolero-generated [`Scenario`] through [`concurrency::stress`] on every
+//! backend — the same dispatch `#[concurrency::test]` uses. This mirrors
+//! the bolero x model-checker layout of the other concurrency primitives
+//! (see `concurrency/tests/quiescent_shuttle.rs`). bolero is the *outer*
+//! loop (it picks the shape: a key seed plus one op stream per worker
+//! thread); the backend is the *inner* loop (it explores interleavings of
+//! that fixed shape):
 //!
-//! * `sanitizer_fuzz` — compiled in the default (std) concurrency mode. Each
-//!   bolero iteration generates a [`FlowKey`], derives a tiny key set from
-//!   it, then spawns one real OS thread per operation. Built with
-//!   `just test sanitize=thread`, this surfaces data races inside the table.
+//! * **default (std) backend** — `concurrency::stress` runs the body once
+//!   on real OS threads. Build with `just test sanitize=thread` to surface
+//!   data races inside the table.
+//! * **`--features shuttle`** — the body runs under the full portfolio
+//!   (Random + PCT [+ DFS]) on the workspace-standard config.
 //!
-//! * `shuttle_fuzz` — compiled with `--features shuttle`. Bolero is *not*
-//!   used here: shuttle wants a deterministic initial state so it can
-//!   explore interleavings. The key set is hand-built (matching the
-//!   convention in `table.rs`'s existing shuttle suite) and we lean on
-//!   [`shuttle::check_random`] to produce schedule variety.
+//! Every generated [`Scenario`] is normalized at generation time (see the
+//! [`bolero::TypeGenerator`] impl) to keep at least two worker threads
+//! inserting, so the portfolio's PCT scheduler — which panics on a body
+//! that never has two threads simultaneously runnable — always sees real
+//! concurrency, without skipping any shape.
+//!
+//! # No loom
+//!
+//! The whole module is `#[cfg(not(feature = "loom"))]`. [`FlowTable`] is
+//! `DashMap`-backed, and `DashMap` synchronizes through its own `std`
+//! atomics/locks that loom cannot instrument (see `table.rs`'s
+//! shuttle-only `concurrency_tests` and the shim-limitation notes in the
+//! `concurrency` crate root). Compiling this against loom would
+//! type-check but not meaningfully model-check, so we exclude it. Loom
+//! coverage, if wanted, belongs on an isolated primitive
+//! (`AtomicFlowStatus`, `FlowInfoLocked`) with no `DashMap` in the picture.
 
 #![cfg(test)]
-#![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
+#![cfg(not(feature = "loom"))]
 
-use concurrency::concurrency_mode;
+use crate::flow_table::FlowTable;
+use concurrency::sync::Arc;
+use concurrency::sync::atomic::{AtomicU8, Ordering};
+use concurrency::thread;
+// `spawn_scoped` is inherent on std's `Builder`, but supplied by `BuilderExt` under shuttle
+#[cfg_attr(not(feature = "shuttle"), allow(unused_imports))]
+use concurrency::thread::BuilderExt;
+use net::FlowKey;
+use net::flows::{ExtractRef, FlowInfo};
+use std::fmt;
+use std::time::{Duration, Instant};
 
-#[concurrency_mode(std)]
-mod sanitizer_fuzz {
-    use crate::flow_table::FlowTable;
-    use net::FlowKey;
-    use net::flows::{ExtractRef, FlowInfo};
-    use std::fmt;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicU8, Ordering};
-    use std::time::{Duration, Instant};
+/// Stub [`FlowInfoItem`] payload: a single `Arc<AtomicU8>` that all flows
+/// share within one scenario. The blanket
+/// `impl<T> FlowInfoItem for T where T: Debug + Send + Sync + 'static + Display`
+/// picks this up automatically — no explicit trait impl needed.
+///
+/// Purpose: exercise the `RwLock`-guarded `FlowInfoLocked` + `Box<dyn
+/// FlowInfoItem>` plus `extract_ref` path. The shared inner atomic is a
+/// `concurrency::sync` atomic, so it is the one piece of state a model
+/// checker definitely sees regardless of which flow a worker hits — it
+/// concentrates the race signal.
+#[derive(Debug)]
+struct StubItem {
+    status: Arc<AtomicU8>,
+}
+impl fmt::Display for StubItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "stub({})", self.status.load(Ordering::Relaxed))
+    }
+}
 
-    /// Stub [`FlowInfoItem`] payload: a single `Arc<AtomicU8>` that all flows
-    /// share within one bolero iteration. The blanket
-    /// `impl<T> FlowInfoItem for T where T: Debug + Send + Sync + 'static + Display`
-    /// picks this up automatically — no explicit trait impl needed.
+/// A single table operation. bolero generates op *streams*, so the
+/// interleaving of ops across worker threads is the source of
+/// nondeterminism the backends explore.
+#[derive(Clone, Copy, Debug, bolero::TypeGenerator)]
+enum Op {
+    Insert,
+    Lookup,
+    Invalidate,
+    ExtendExpiry,
+    ReadStubStatus,
+    FlipStubStatus,
+}
+
+/// One bolero-generated test shape: a key seed plus an op stream for
+/// each of the three worker threads. Three workers is enough to expose
+/// inserter/mutator/reader contention without blowing up the
+/// interleaving space under the model checker.
+#[derive(Clone, Debug)]
+struct Scenario {
+    seed_key: FlowKey,
+    ops: [Vec<Op>; 3],
+}
+
+impl bolero::TypeGenerator for Scenario {
+    /// Generate a scenario, then normalize it so the run always exercises
+    /// real concurrency.
     ///
-    /// Purpose: exercise the RwLock-guarded `FlowInfoLocked` + `Box<dyn FlowInfoItem>`
-    /// + `extract_ref` path. The shared inner atomic concentrates the race
-    /// signal so the sanitizer flags contention regardless of which flow a
-    /// worker hits.
-    #[derive(Debug)]
-    struct StubItem {
-        status: Arc<AtomicU8>,
-    }
-    impl fmt::Display for StubItem {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "stub({})", self.status.load(Ordering::Relaxed))
+    /// shuttle's PCT scheduler panics ("test closure did not exercise any
+    /// concurrency") unless at least two threads are simultaneously
+    /// runnable at some scheduling point. Rather than skip degenerate
+    /// shapes, we guarantee at least two of the three op streams contain
+    /// an `Insert` — an `Insert` does model-visible work (writes
+    /// `FlowInfoLocked` + the atomic status) *and* creates a flow for any
+    /// `Read`/`Flip` ops to land on. Missing inserts are spliced in at a
+    /// driver-chosen offset, so the normalization stays a deterministic
+    /// function of the input and a failure still reproduces from its seed.
+    fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
+        let mut this = Self {
+            seed_key: driver.produce()?,
+            ops: driver.produce()?,
+        };
+        let has_insert = |s: &[Op]| s.iter().any(|op| matches!(op, Op::Insert));
+        let mut need = 2usize.saturating_sub(this.ops.iter().filter(|s| has_insert(s)).count());
+        for i in 0..this.ops.len() {
+            if need == 0 {
+                break;
+            }
+            if has_insert(&this.ops[i]) {
+                continue;
+            }
+            let pos = driver.produce::<usize>()? % (this.ops[i].len() + 1);
+            this.ops[i].insert(pos, Op::Insert);
+            need -= 1;
         }
+        Some(this)
     }
+}
 
-    /// Operation issued by one worker thread. Each worker is bound to one op
-    /// so the *interleaving* of ops across threads is the only source of
-    /// nondeterminism — handy when triaging a sanitizer report.
-    #[derive(Clone, Copy)]
-    enum Op {
-        Insert,
-        Lookup,
-        Invalidate,
-        ExtendExpiry,
-        DrainStale,
-        ReadStubStatus,
-        FlipStubStatus,
+/// Build a small key set out of the seed [`FlowKey`]: the base key and
+/// its reverse. Two distinct keys is enough to expose both same-key
+/// contention (workers racing on one `DashMap` shard) and cross-key
+/// races (different shards).
+fn key_set(base: FlowKey) -> Vec<FlowKey> {
+    let rev = base.reverse(None);
+    if rev == base {
+        vec![base]
+    } else {
+        vec![base, rev]
     }
+}
 
-    fn drive(table: &FlowTable, keys: &[FlowKey], stub_status: &Arc<AtomicU8>, op: Op) {
-        const OPS_PER_KEY: usize = 8;
-        for k in keys {
-            for i in 0..OPS_PER_KEY {
-                match op {
-                    Op::Insert => {
-                        // Far-future expiry so the per-flow timer never fires
-                        // inside the test window — we race the insert path,
-                        // not the expiry path.
-                        let fi = Arc::new(FlowInfo::new(
-                            *k,
-                            Instant::now() + Duration::from_secs(3600),
-                        ));
-                        // Stuff a stub item into the locked state so readers
-                        // and flippers have something to race on.
-                        {
-                            let mut guard = fi.locked.write();
-                            guard.nat_state = Some(Box::new(StubItem {
-                                status: stub_status.clone(),
-                            }));
-                        }
-                        let _ = table.insert_from_arc(&fi);
-                    }
-                    Op::Lookup => {
-                        let _ = table.lookup(k);
-                    }
-                    Op::Invalidate => {
-                        if let Some(fi) = table.lookup(k) {
-                            fi.invalidate();
-                        }
-                    }
-                    Op::ExtendExpiry => {
-                        if let Some(fi) = table.lookup(k) {
-                            let _ = fi.extend_expiry(Duration::from_secs(60));
-                        }
-                    }
-                    Op::DrainStale => {
-                        // Don't hammer drain_stale — once per key is plenty
-                        // and we want the race window to stay small enough
-                        // that the inserter usually wins.
-                        if i == 0 {
-                            table.drain_stale();
-                        }
-                    }
-                    Op::ReadStubStatus => {
-                        if let Some(fi) = table.lookup(k) {
-                            let guard = fi.locked.read();
-                            if let Some(stub) =
-                                guard.nat_state.as_ref().extract_ref::<StubItem>()
-                            {
-                                let _ = stub.status.load(Ordering::Relaxed);
-                            }
-                        }
-                    }
-                    Op::FlipStubStatus => {
-                        if let Some(fi) = table.lookup(k) {
-                            let guard = fi.locked.read();
-                            if let Some(stub) =
-                                guard.nat_state.as_ref().extract_ref::<StubItem>()
-                            {
-                                // Value is arbitrary; we only care that the store
-                                // races with concurrent loads on the same atomic.
-                                stub.status.store(0xA5, Ordering::Relaxed);
-                            }
-                        }
-                    }
+/// Apply one [`Op`] across the whole key set.
+fn apply_op(table: &FlowTable, keys: &[FlowKey], stub_status: &Arc<AtomicU8>, op: Op) {
+    for k in keys {
+        match op {
+            Op::Insert => {
+                // Far-future expiry so the per-flow timer never fires
+                // inside the test window — we race the insert path, not
+                // the expiry path. (The timer task is also cfg'd out
+                // entirely under shuttle.)
+                let fi = Arc::new(FlowInfo::new(*k, Instant::now() + Duration::from_hours(1)));
+                // Stuff a stub item into the locked state so readers and
+                // flippers have something to race on.
+                {
+                    let mut guard = fi.locked.write();
+                    guard.nat_state = Some(Box::new(StubItem {
+                        status: stub_status.clone(),
+                    }));
+                }
+                let _ = table.insert_from_arc(&fi);
+            }
+            Op::Lookup => {
+                // A returned entry must always carry a legal status;
+                // AtomicFlowStatus::load panics on a corrupt u8, so the
+                // load itself is the assertion against torn writes /
+                // use-after-free.
+                if let Some(fi) = table.lookup(k) {
+                    let _ = fi.status();
+                }
+            }
+            Op::Invalidate => {
+                if let Some(fi) = table.lookup(k) {
+                    fi.invalidate();
+                }
+            }
+            Op::ExtendExpiry => {
+                if let Some(fi) = table.lookup(k) {
+                    let _ = fi.extend_expiry(Duration::from_mins(1));
+                }
+            }
+            Op::ReadStubStatus => {
+                if let Some(fi) = table.lookup(k)
+                    && let Some(stub) = fi
+                        .locked
+                        .read()
+                        .nat_state
+                        .as_ref()
+                        .extract_ref::<StubItem>()
+                {
+                    let _ = stub.status.load(Ordering::Relaxed);
+                }
+            }
+            Op::FlipStubStatus => {
+                if let Some(fi) = table.lookup(k)
+                    && let Some(stub) = fi
+                        .locked
+                        .read()
+                        .nat_state
+                        .as_ref()
+                        .extract_ref::<StubItem>()
+                {
+                    // Value is arbitrary; we only care that the store
+                    // races with concurrent loads on the same atomic.
+                    stub.status.store(0xA5, Ordering::Relaxed);
                 }
             }
         }
     }
+}
 
-    /// Build a small key set out of one bolero-generated [`FlowKey`]: the
-    /// base key and its reverse. Two distinct keys is enough to expose both
-    /// same-key contention (workers racing on the same FlowKey, i.e. one
-    /// DashMap shard) and cross-key races (different shards).
-    fn key_set(base: FlowKey) -> Vec<FlowKey> {
-        let rev = base.reverse(None);
-        if rev == base { vec![base] } else { vec![base, rev] }
-    }
+impl Scenario {
+    /// Run the scenario to completion: spawn a worker per op stream, run the
+    /// streams concurrently, then sweep every surviving entry for a legal
+    /// status.
+    ///
+    /// `rt` is the tokio handle the std backend needs: `FlowTable::insert`
+    /// schedules a per-flow expiry timer via `tokio::task::spawn`, which
+    /// panics outside a runtime context. Each worker enters the handle so
+    /// the spawn succeeds; the queued timer tasks never run (far-future
+    /// expiry) and are dropped with the runtime. Under shuttle the timer
+    /// path is cfg'd out, so `rt` is `None`.
+    fn run(&self, handle: Option<&tokio::runtime::Handle>) {
+        let keys: Arc<Vec<FlowKey>> = Arc::new(key_set(self.seed_key));
+        let table = Arc::new(FlowTable::default());
+        // One atomic per scenario, cloned into every inserted stub. Every
+        // read/flip across all flows hits this same atomic, so a racing
+        // load/store is visible regardless of which flow a worker looks up.
+        let stub_status = Arc::new(AtomicU8::new(0));
 
-    #[test]
-    fn test_flow_table_concurrent_fuzz_sanitizer() {
-        // FlowTable::insert calls tokio::task::spawn to schedule the
-        // per-flow expiry timer; that call panics if invoked outside a
-        // runtime context. We never need the timer task to actually run —
-        // far-future expiries see to that — so a single-threaded runtime is
-        // enough. Each worker enters the runtime via Handle::enter() so the
-        // spawn succeeds; queued timer tasks accumulate and are dropped
-        // with the runtime at the end of the test.
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("build tokio runtime");
-        let handle = rt.handle().clone();
-
-        bolero::check!()
-            .with_type::<FlowKey>()
-            .with_test_time(std::time::Duration::from_secs(5))
-            .for_each(|base| {
-                let keys: Arc<Vec<FlowKey>> = Arc::new(key_set(*base));
-                let table = Arc::new(FlowTable::default());
-                // One atomic per iteration, cloned into every inserted stub.
-                // Every read/flip across all flows hits this same atomic, so
-                // the sanitizer sees the racing load/store regardless of which flow a
-                // worker happens to look up.
-                let stub_status = Arc::new(AtomicU8::new(0));
-                let ops = [
-                    Op::Insert,
-                    Op::Lookup,
-                    Op::Invalidate,
-                    Op::ExtendExpiry,
-                    Op::DrainStale,
-                    Op::ReadStubStatus,
-                    Op::FlipStubStatus,
-                ];
-
-                let handles: Vec<_> = ops
-                    .into_iter()
-                    .map(|op| {
-                        let keys = keys.clone();
-                        let table = table.clone();
-                        let stub_status = stub_status.clone();
-                        let handle = handle.clone();
-                        std::thread::spawn(move || {
-                            let _guard = handle.enter();
-                            drive(&table, &keys, &stub_status, op);
+        concurrency::thread::scope(|scope| {
+            let handles: Vec<_> = self
+                .ops
+                .iter()
+                .enumerate()
+                .map(|(i, ops)| {
+                    let keys = keys.clone();
+                    let table = table.clone();
+                    let stub_status = stub_status.clone();
+                    let ops = ops.clone();
+                    thread::Builder::new()
+                        .name(format!("worker-{i}"))
+                        .spawn_scoped(scope, move || {
+                            let _guard = handle.map(tokio::runtime::Handle::enter);
+                            for op in ops {
+                                apply_op(&table, &keys, &stub_status, op);
+                                // Give the model checker a preemption point
+                                // between ops; a cheap hint under std.
+                                thread::yield_now();
+                            }
                         })
-                    })
-                    .collect();
+                        .expect("spawn worker")
+                })
+                .collect();
+            for h in handles {
+                h.join().expect("worker panicked");
+            }
+        });
 
-                for h in handles {
-                    h.join().expect("worker panicked");
-                }
-
-                // Whatever survives must still be a valid FlowStatus value;
-                // AtomicFlowStatus::load panics on a corrupt u8, so touching
-                // .status() here catches use-after-free / torn writes that
-                // the sanitizer itself might not flag. Also touch the stub atomic via
-                // extract_ref to make sure the locked state isn't corrupted.
-                table.for_each_flow(|_k, v| {
-                    let _ = v.status();
-                    let guard = v.locked.read();
-                    if let Some(stub) = guard.nat_state.as_ref().extract_ref::<StubItem>() {
-                        let _ = stub.status.load(Ordering::Relaxed);
-                    }
-                });
-            });
+        // Whatever survives must still be a valid FlowStatus value;
+        // AtomicFlowStatus::load panics on a corrupt u8, so touching
+        // .status() here catches use-after-free / torn writes the sanitizer
+        // itself might not flag. Also touch the stub atomic via extract_ref
+        // to make sure the locked state isn't corrupted.
+        table.for_each_flow(|_k, v| {
+            let _ = v.status();
+            let guard = v.locked.read();
+            if let Some(stub) = guard.nat_state.as_ref().extract_ref::<StubItem>() {
+                let _ = stub.status.load(Ordering::Relaxed);
+            }
+        });
     }
 }
 
-#[concurrency_mode(shuttle)]
-mod shuttle_fuzz {
-    use crate::flow_table::FlowTable;
-    use concurrency::sync::Arc;
-    use concurrency::thread;
-    use net::flows::{FlowInfo, FlowStatus};
-    use net::packet::VpcDiscriminant;
-    use net::tcp::TcpPort;
-    use net::vxlan::Vni;
-    use net::{FlowKey, FlowKeyData, IpProtoKey, TcpProtoKey};
-    use std::net::IpAddr;
-    use std::time::{Duration, Instant};
-
-    fn make_keys() -> Vec<FlowKey> {
-        (1u16..=4u16)
-            .map(|i| {
-                FlowKey::Unidirectional(FlowKeyData::new(
-                    Some(VpcDiscriminant::VNI(
-                        Vni::new_checked(u32::from(i) + 10).unwrap(),
-                    )),
-                    format!("10.{i}.0.1").parse::<IpAddr>().unwrap(),
-                    format!("10.{i}.0.2").parse::<IpAddr>().unwrap(),
-                    IpProtoKey::Tcp(TcpProtoKey {
-                        src_port: TcpPort::new_checked(1000 + i).unwrap(),
-                        dst_port: TcpPort::new_checked(2000 + i).unwrap(),
-                    }),
-                ))
-            })
-            .collect()
-    }
-
-    /// Three workers (insert / flip-status / lookup) race over a 4-key
-    /// universe. `shuttle::check_random` explores 100 interleavings.
-    ///
-    /// No drainer thread: `FlowTable::drain_stale` has no production
-    /// callers — it's only used in these fuzz tests — so exercising it
-    /// under shuttle isn't worth the scheduling-space blowup (it
-    /// write-locks every DashMap shard and touches every flow's atomics).
-    #[test]
-    fn test_flow_table_concurrent_fuzz_shuttle() {
-        const N: usize = 4;
-        let keys = make_keys();
-
-        shuttle::check_random(
-            move || {
-                let table = Arc::new(FlowTable::default());
-                let mut handles = vec![];
-
-                handles.push(
-                    thread::Builder::new()
-                        .name("inserter".to_string())
-                        .spawn({
-                            let table = table.clone();
-                            let keys = keys.clone();
-                            move || {
-                                for _ in 0..N {
-                                    for k in &keys {
-                                        let fi = FlowInfo::new(
-                                            *k,
-                                            Instant::now() + Duration::from_secs(60),
-                                        );
-                                        let _ = table.insert(fi);
-                                        thread::yield_now();
-                                    }
-                                }
-                            }
-                        })
-                        .unwrap(),
-                );
-
-                handles.push(
-                    thread::Builder::new()
-                        .name("flipper".to_string())
-                        .spawn({
-                            let table = table.clone();
-                            let keys = keys.clone();
-                            move || {
-                                for _ in 0..N {
-                                    for k in &keys {
-                                        if let Some(fi) = table.lookup(k) {
-                                            fi.invalidate();
-                                        }
-                                        thread::yield_now();
-                                    }
-                                }
-                            }
-                        })
-                        .unwrap(),
-                );
-
-                handles.push(
-                    thread::Builder::new()
-                        .name("lookup".to_string())
-                        .spawn({
-                            let table = table.clone();
-                            let keys = keys.clone();
-                            move || {
-                                for _ in 0..N {
-                                    for k in &keys {
-                                        if let Some(fi) = table.lookup(k) {
-                                            // Status must always be one of
-                                            // the four legal variants; the
-                                            // load impl panics on a corrupt u8.
-                                            let s = fi.status();
-                                            assert!(matches!(
-                                                s,
-                                                FlowStatus::Active
-                                                    | FlowStatus::Cancelled
-                                                    | FlowStatus::Expired
-                                                    | FlowStatus::Detached
-                                            ));
-                                        }
-                                        thread::yield_now();
-                                    }
-                                }
-                            }
-                        })
-                        .unwrap(),
-                );
-
-                for h in handles {
-                    h.join().unwrap();
-                }
-
-                // Touch every surviving entry's status to flush any torn
-                // atomic reads (AtomicFlowStatus::load panics on corrupt u8).
-                table.for_each_flow(|_k, v| {
-                    let _ = v.status();
-                });
-            },
-            100,
-        );
-    }
+/// Drive one bolero shape per iteration through [`concurrency::stress`]:
+/// a single direct run on the std backend (real OS threads — build with
+/// `just test sanitize=thread`), or the full portfolio under shuttle.
+#[test]
+fn stress_test_concurrency_model() {
+    // Single-threaded runtime is enough: we never need the timer task to
+    // run, only a context for `insert`'s `tokio::task::spawn` to succeed.
+    let rt = cfg_select! {
+        feature = "shuttle" => None::<tokio::runtime::Runtime>,
+        _ => Some(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build tokio runtime")
+             )
+    };
+    let handle = rt.as_ref().map(|rt| rt.handle().clone());
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|scenario: Scenario| {
+            let handle = handle.clone();
+            concurrency::stress(move || {
+                scenario.run(handle.as_ref());
+            });
+        });
 }

--- a/flow-entry/src/flow_table/concurrent_fuzz.rs
+++ b/flow-entry/src/flow_table/concurrent_fuzz.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Concurrent fuzz tests for [`FlowTable`].
+//!
+//! Two complementary modules, both driven by the same operation universe
+//! (insert / lookup / invalidate / extend-expiry / drain-stale) over a small
+//! key set:
+//!
+//! * `sanitizer_fuzz` — compiled in the default (std) concurrency mode. Each
+//!   bolero iteration generates a [`FlowKey`], derives a tiny key set from
+//!   it, then spawns one real OS thread per operation. Built with
+//!   `just test sanitize=thread`, this surfaces data races inside the table.
+//!
+//! * `shuttle_fuzz` — compiled with `--features shuttle`. Bolero is *not*
+//!   used here: shuttle wants a deterministic initial state so it can
+//!   explore interleavings. The key set is hand-built (matching the
+//!   convention in `table.rs`'s existing shuttle suite) and we lean on
+//!   [`shuttle::check_random`] to produce schedule variety.
+
+#![cfg(test)]
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
+
+use concurrency::concurrency_mode;
+
+#[concurrency_mode(std)]
+mod sanitizer_fuzz {
+    use crate::flow_table::FlowTable;
+    use net::FlowKey;
+    use net::flows::{ExtractRef, FlowInfo};
+    use std::fmt;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::time::{Duration, Instant};
+
+    /// Stub [`FlowInfoItem`] payload: a single `Arc<AtomicU8>` that all flows
+    /// share within one bolero iteration. The blanket
+    /// `impl<T> FlowInfoItem for T where T: Debug + Send + Sync + 'static + Display`
+    /// picks this up automatically — no explicit trait impl needed.
+    ///
+    /// Purpose: exercise the RwLock-guarded `FlowInfoLocked` + `Box<dyn FlowInfoItem>`
+    /// + `extract_ref` path. The shared inner atomic concentrates the race
+    /// signal so the sanitizer flags contention regardless of which flow a
+    /// worker hits.
+    #[derive(Debug)]
+    struct StubItem {
+        status: Arc<AtomicU8>,
+    }
+    impl fmt::Display for StubItem {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "stub({})", self.status.load(Ordering::Relaxed))
+        }
+    }
+
+    /// Operation issued by one worker thread. Each worker is bound to one op
+    /// so the *interleaving* of ops across threads is the only source of
+    /// nondeterminism — handy when triaging a sanitizer report.
+    #[derive(Clone, Copy)]
+    enum Op {
+        Insert,
+        Lookup,
+        Invalidate,
+        ExtendExpiry,
+        DrainStale,
+        ReadStubStatus,
+        FlipStubStatus,
+    }
+
+    fn drive(table: &FlowTable, keys: &[FlowKey], stub_status: &Arc<AtomicU8>, op: Op) {
+        const OPS_PER_KEY: usize = 8;
+        for k in keys {
+            for i in 0..OPS_PER_KEY {
+                match op {
+                    Op::Insert => {
+                        // Far-future expiry so the per-flow timer never fires
+                        // inside the test window — we race the insert path,
+                        // not the expiry path.
+                        let fi = Arc::new(FlowInfo::new(
+                            *k,
+                            Instant::now() + Duration::from_secs(3600),
+                        ));
+                        // Stuff a stub item into the locked state so readers
+                        // and flippers have something to race on.
+                        {
+                            let mut guard = fi.locked.write();
+                            guard.nat_state = Some(Box::new(StubItem {
+                                status: stub_status.clone(),
+                            }));
+                        }
+                        let _ = table.insert_from_arc(&fi);
+                    }
+                    Op::Lookup => {
+                        let _ = table.lookup(k);
+                    }
+                    Op::Invalidate => {
+                        if let Some(fi) = table.lookup(k) {
+                            fi.invalidate();
+                        }
+                    }
+                    Op::ExtendExpiry => {
+                        if let Some(fi) = table.lookup(k) {
+                            let _ = fi.extend_expiry(Duration::from_secs(60));
+                        }
+                    }
+                    Op::DrainStale => {
+                        // Don't hammer drain_stale — once per key is plenty
+                        // and we want the race window to stay small enough
+                        // that the inserter usually wins.
+                        if i == 0 {
+                            table.drain_stale();
+                        }
+                    }
+                    Op::ReadStubStatus => {
+                        if let Some(fi) = table.lookup(k) {
+                            let guard = fi.locked.read();
+                            if let Some(stub) =
+                                guard.nat_state.as_ref().extract_ref::<StubItem>()
+                            {
+                                let _ = stub.status.load(Ordering::Relaxed);
+                            }
+                        }
+                    }
+                    Op::FlipStubStatus => {
+                        if let Some(fi) = table.lookup(k) {
+                            let guard = fi.locked.read();
+                            if let Some(stub) =
+                                guard.nat_state.as_ref().extract_ref::<StubItem>()
+                            {
+                                // Value is arbitrary; we only care that the store
+                                // races with concurrent loads on the same atomic.
+                                stub.status.store(0xA5, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Build a small key set out of one bolero-generated [`FlowKey`]: the
+    /// base key and its reverse. Two distinct keys is enough to expose both
+    /// same-key contention (workers racing on the same FlowKey, i.e. one
+    /// DashMap shard) and cross-key races (different shards).
+    fn key_set(base: FlowKey) -> Vec<FlowKey> {
+        let rev = base.reverse(None);
+        if rev == base { vec![base] } else { vec![base, rev] }
+    }
+
+    #[test]
+    fn test_flow_table_concurrent_fuzz_sanitizer() {
+        // FlowTable::insert calls tokio::task::spawn to schedule the
+        // per-flow expiry timer; that call panics if invoked outside a
+        // runtime context. We never need the timer task to actually run —
+        // far-future expiries see to that — so a single-threaded runtime is
+        // enough. Each worker enters the runtime via Handle::enter() so the
+        // spawn succeeds; queued timer tasks accumulate and are dropped
+        // with the runtime at the end of the test.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+        let handle = rt.handle().clone();
+
+        bolero::check!()
+            .with_type::<FlowKey>()
+            .with_test_time(std::time::Duration::from_secs(5))
+            .for_each(|base| {
+                let keys: Arc<Vec<FlowKey>> = Arc::new(key_set(*base));
+                let table = Arc::new(FlowTable::default());
+                // One atomic per iteration, cloned into every inserted stub.
+                // Every read/flip across all flows hits this same atomic, so
+                // the sanitizer sees the racing load/store regardless of which flow a
+                // worker happens to look up.
+                let stub_status = Arc::new(AtomicU8::new(0));
+                let ops = [
+                    Op::Insert,
+                    Op::Lookup,
+                    Op::Invalidate,
+                    Op::ExtendExpiry,
+                    Op::DrainStale,
+                    Op::ReadStubStatus,
+                    Op::FlipStubStatus,
+                ];
+
+                let handles: Vec<_> = ops
+                    .into_iter()
+                    .map(|op| {
+                        let keys = keys.clone();
+                        let table = table.clone();
+                        let stub_status = stub_status.clone();
+                        let handle = handle.clone();
+                        std::thread::spawn(move || {
+                            let _guard = handle.enter();
+                            drive(&table, &keys, &stub_status, op);
+                        })
+                    })
+                    .collect();
+
+                for h in handles {
+                    h.join().expect("worker panicked");
+                }
+
+                // Whatever survives must still be a valid FlowStatus value;
+                // AtomicFlowStatus::load panics on a corrupt u8, so touching
+                // .status() here catches use-after-free / torn writes that
+                // the sanitizer itself might not flag. Also touch the stub atomic via
+                // extract_ref to make sure the locked state isn't corrupted.
+                table.for_each_flow(|_k, v| {
+                    let _ = v.status();
+                    let guard = v.locked.read();
+                    if let Some(stub) = guard.nat_state.as_ref().extract_ref::<StubItem>() {
+                        let _ = stub.status.load(Ordering::Relaxed);
+                    }
+                });
+            });
+    }
+}
+
+#[concurrency_mode(shuttle)]
+mod shuttle_fuzz {
+    use crate::flow_table::FlowTable;
+    use concurrency::sync::Arc;
+    use concurrency::thread;
+    use net::flows::{FlowInfo, FlowStatus};
+    use net::packet::VpcDiscriminant;
+    use net::tcp::TcpPort;
+    use net::vxlan::Vni;
+    use net::{FlowKey, FlowKeyData, IpProtoKey, TcpProtoKey};
+    use std::net::IpAddr;
+    use std::time::{Duration, Instant};
+
+    fn make_keys() -> Vec<FlowKey> {
+        (1u16..=4u16)
+            .map(|i| {
+                FlowKey::Unidirectional(FlowKeyData::new(
+                    Some(VpcDiscriminant::VNI(
+                        Vni::new_checked(u32::from(i) + 10).unwrap(),
+                    )),
+                    format!("10.{i}.0.1").parse::<IpAddr>().unwrap(),
+                    format!("10.{i}.0.2").parse::<IpAddr>().unwrap(),
+                    IpProtoKey::Tcp(TcpProtoKey {
+                        src_port: TcpPort::new_checked(1000 + i).unwrap(),
+                        dst_port: TcpPort::new_checked(2000 + i).unwrap(),
+                    }),
+                ))
+            })
+            .collect()
+    }
+
+    /// Three workers (insert / flip-status / lookup) race over a 4-key
+    /// universe. `shuttle::check_random` explores 100 interleavings.
+    ///
+    /// No drainer thread: `FlowTable::drain_stale` has no production
+    /// callers — it's only used in these fuzz tests — so exercising it
+    /// under shuttle isn't worth the scheduling-space blowup (it
+    /// write-locks every DashMap shard and touches every flow's atomics).
+    #[test]
+    fn test_flow_table_concurrent_fuzz_shuttle() {
+        const N: usize = 4;
+        let keys = make_keys();
+
+        shuttle::check_random(
+            move || {
+                let table = Arc::new(FlowTable::default());
+                let mut handles = vec![];
+
+                handles.push(
+                    thread::Builder::new()
+                        .name("inserter".to_string())
+                        .spawn({
+                            let table = table.clone();
+                            let keys = keys.clone();
+                            move || {
+                                for _ in 0..N {
+                                    for k in &keys {
+                                        let fi = FlowInfo::new(
+                                            *k,
+                                            Instant::now() + Duration::from_secs(60),
+                                        );
+                                        let _ = table.insert(fi);
+                                        thread::yield_now();
+                                    }
+                                }
+                            }
+                        })
+                        .unwrap(),
+                );
+
+                handles.push(
+                    thread::Builder::new()
+                        .name("flipper".to_string())
+                        .spawn({
+                            let table = table.clone();
+                            let keys = keys.clone();
+                            move || {
+                                for _ in 0..N {
+                                    for k in &keys {
+                                        if let Some(fi) = table.lookup(k) {
+                                            fi.invalidate();
+                                        }
+                                        thread::yield_now();
+                                    }
+                                }
+                            }
+                        })
+                        .unwrap(),
+                );
+
+                handles.push(
+                    thread::Builder::new()
+                        .name("lookup".to_string())
+                        .spawn({
+                            let table = table.clone();
+                            let keys = keys.clone();
+                            move || {
+                                for _ in 0..N {
+                                    for k in &keys {
+                                        if let Some(fi) = table.lookup(k) {
+                                            // Status must always be one of
+                                            // the four legal variants; the
+                                            // load impl panics on a corrupt u8.
+                                            let s = fi.status();
+                                            assert!(matches!(
+                                                s,
+                                                FlowStatus::Active
+                                                    | FlowStatus::Cancelled
+                                                    | FlowStatus::Expired
+                                                    | FlowStatus::Detached
+                                            ));
+                                        }
+                                        thread::yield_now();
+                                    }
+                                }
+                            }
+                        })
+                        .unwrap(),
+                );
+
+                for h in handles {
+                    h.join().unwrap();
+                }
+
+                // Touch every surviving entry's status to flush any torn
+                // atomic reads (AtomicFlowStatus::load panics on corrupt u8).
+                table.for_each_flow(|_k, v| {
+                    let _ = v.status();
+                });
+            },
+            100,
+        );
+    }
+}

--- a/flow-entry/src/flow_table/concurrent_fuzz.rs
+++ b/flow-entry/src/flow_table/concurrent_fuzz.rs
@@ -24,6 +24,12 @@
 //! that never has two threads simultaneously runnable — always sees real
 //! concurrency, without skipping any shape.
 //!
+//! The per-scenario stub status doubles as a model of `nat`'s shared NAT
+//! pair status (`AtomicNatFlowStatus`, shared between a forward/reverse flow
+//! pair in `MasqueradeState::new_pair`): `Op::AdvanceStatus` advances a
+//! bounded `0..STATE_COUNT` state machine that multiple workers race on, and
+//! every read asserts the byte never escapes that range.
+//!
 //! # No loom
 //!
 //! The whole module is `#[cfg(not(feature = "loom"))]`. [`FlowTable`] is
@@ -60,6 +66,11 @@ use std::time::{Duration, Instant};
 /// `concurrency::sync` atomic, so it is the one piece of state a model
 /// checker definitely sees regardless of which flow a worker hits — it
 /// concentrates the race signal.
+///
+/// It also models `nat`'s [`AtomicNatFlowStatus`]: one status byte shared
+/// between a forward/reverse flow pair (`MasqueradeState::new_pair`),
+/// advanced as a bounded `0..STATE_COUNT` state machine by `Op::AdvanceStatus`.
+/// Concurrent advances race exactly as the two directions of a NAT pair do.
 #[derive(Debug)]
 struct StubItem {
     status: Arc<AtomicU8>,
@@ -69,6 +80,8 @@ impl fmt::Display for StubItem {
         write!(f, "stub({})", self.status.load(Ordering::Relaxed))
     }
 }
+
+const STATE_COUNT: u8 = 10;
 
 /// A single table operation. bolero generates op *streams*, so the
 /// interleaving of ops across worker threads is the source of
@@ -80,7 +93,7 @@ enum Op {
     Invalidate,
     ExtendExpiry,
     ReadStubStatus,
-    FlipStubStatus,
+    AdvanceStatus,
 }
 
 /// One bolero-generated test shape: a key seed plus an op stream for
@@ -189,10 +202,14 @@ fn apply_op(table: &FlowTable, keys: &[FlowKey], stub_status: &Arc<AtomicU8>, op
                         .as_ref()
                         .extract_ref::<StubItem>()
                 {
-                    let _ = stub.status.load(Ordering::Relaxed);
+                    // The shared status is only ever advanced within
+                    // 0..STATE_COUNT; an out-of-range byte means a torn write
+                    // or corrupted nat_state.
+                    let v = stub.status.load(Ordering::Relaxed);
+                    assert!(v < STATE_COUNT, "stub status out of range: {v}");
                 }
             }
-            Op::FlipStubStatus => {
+            Op::AdvanceStatus => {
                 if let Some(fi) = table.lookup(k)
                     && let Some(stub) = fi
                         .locked
@@ -201,9 +218,11 @@ fn apply_op(table: &FlowTable, keys: &[FlowKey], stub_status: &Arc<AtomicU8>, op
                         .as_ref()
                         .extract_ref::<StubItem>()
                 {
-                    // Value is arbitrary; we only care that the store
-                    // races with concurrent loads on the same atomic.
-                    stub.status.store(0xA5, Ordering::Relaxed);
+                    // Advance the shared status one step, modelling a packet
+                    // driving the NAT state machine via this flow.
+                    let cur = stub.status.load(Ordering::Relaxed);
+                    stub.status
+                        .store((cur + 1) % STATE_COUNT, Ordering::Relaxed);
                 }
             }
         }
@@ -267,7 +286,8 @@ impl Scenario {
             let _ = v.status();
             let guard = v.locked.read();
             if let Some(stub) = guard.nat_state.as_ref().extract_ref::<StubItem>() {
-                let _ = stub.status.load(Ordering::Relaxed);
+                let s = stub.status.load(Ordering::Relaxed);
+                assert!(s < STATE_COUNT, "stub status out of range: {s}");
             }
         });
     }

--- a/flow-entry/src/flow_table/mod.rs
+++ b/flow-entry/src/flow_table/mod.rs
@@ -5,6 +5,9 @@ mod display;
 pub mod nf_lookup;
 pub mod table;
 
+#[cfg(test)]
+mod concurrent_fuzz;
+
 pub use nf_lookup::FlowLookup;
 pub use table::{FlowTable, FlowTableReadGuard};
 

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -254,26 +254,6 @@ impl FlowTable {
         Ok(Some(ret))
     }
 
-    /// Drain all stale (Expired / Cancelled / deadline-passed Active) entries from the table.
-    ///
-    /// Returns the number of entries removed.
-    pub fn drain_stale(&self) -> usize {
-        let table = self.table.read();
-        let now = std::time::Instant::now();
-        let mut count = 0usize;
-        table.retain(|_, v| {
-            let status = v.status();
-            let stale = status != FlowStatus::Active || v.expires_at() <= now;
-            if stale {
-                v.update_status(FlowStatus::Expired);
-                v.token.cancel();
-                count += 1;
-            }
-            !stale
-        });
-        count
-    }
-
     /// Lookup a flow in the table.
     ///
     /// # Panics
@@ -855,14 +835,14 @@ mod tests {
                 let flow_info = FlowInfo::new(flow_key1, five_seconds_from_now);
                 flow_table_clone1.insert(flow_info).unwrap();
                 let result = flow_table_clone1.remove(&flow_key1).unwrap();
-                assert!(result.0 == flow_key1);
+                assert_eq!(result.0, flow_key1);
             }));
 
             handles.push(thread::spawn(move || {
                 let flow_info = FlowInfo::new(flow_key2, five_seconds_from_now);
                 flow_table_clone2.insert(flow_info).unwrap();
                 let result = flow_table.remove(&flow_key2).unwrap();
-                assert!(result.0 == flow_key2);
+                assert_eq!(result.0, flow_key2);
             }));
 
             handles.push(thread::spawn(move || flow_table_clone3.reshard(128)));

--- a/net/src/flows/flow_info.rs
+++ b/net/src/flows/flow_info.rs
@@ -406,3 +406,44 @@ impl FlowInfo {
         self.status.store(status, Ordering::Relaxed)
     }
 }
+
+#[cfg(any(test, feature = "bolero"))]
+impl FlowInfo {
+    /// Construct a [`FlowInfo`] with an explicit initial [`FlowStatus`].
+    ///
+    /// Test/fuzz-only convenience: production code goes through [`FlowInfo::new`]
+    /// (which seeds `Detached`) and lets the flow table promote to `Active` on
+    /// insert. Used by the bolero-driven concurrent-fuzz tests to seed flows in
+    /// any of the four legal states.
+    #[must_use]
+    pub fn new_with_status(flowkey: FlowKey, expires_at: Instant, status: FlowStatus) -> Self {
+        Self {
+            expires_at: AtomicInstant::new(expires_at),
+            flowkey,
+            genid: AtomicI64::new(0),
+            status: AtomicFlowStatus::from(status),
+            locked: RwLock::new(FlowInfoLocked::default()),
+            related: None,
+            token: CancellationToken::new(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use super::FlowStatus;
+    use bolero::{Driver, TypeGenerator};
+
+    impl TypeGenerator for FlowStatus {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            // Weight Active higher so generated workloads mostly look like real
+            // in-table flows, while still exercising the terminal states.
+            match driver.produce::<u8>()? % 8 {
+                0..=4 => Some(FlowStatus::Active),
+                5 => Some(FlowStatus::Cancelled),
+                6 => Some(FlowStatus::Expired),
+                _ => Some(FlowStatus::Detached),
+            }
+        }
+    }
+}

--- a/net/src/flows/flow_info.rs
+++ b/net/src/flows/flow_info.rs
@@ -418,13 +418,8 @@ impl FlowInfo {
     #[must_use]
     pub fn new_with_status(flowkey: FlowKey, expires_at: Instant, status: FlowStatus) -> Self {
         Self {
-            expires_at: AtomicInstant::new(expires_at),
-            flowkey,
-            genid: AtomicI64::new(0),
             status: AtomicFlowStatus::from(status),
-            locked: RwLock::new(FlowInfoLocked::default()),
-            related: None,
-            token: CancellationToken::new(),
+            ..Self::new(flowkey, expires_at)
         }
     }
 }
@@ -442,7 +437,8 @@ mod contract {
                 0..=4 => Some(FlowStatus::Active),
                 5 => Some(FlowStatus::Cancelled),
                 6 => Some(FlowStatus::Expired),
-                _ => Some(FlowStatus::Detached),
+                7 => Some(FlowStatus::Detached),
+                _ => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
This is a temp placeholder while I discuss with @sergeymatov.  Ignore for now if you aren't @sergeymatov 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR is a temporary placeholder while the author discusses changes with `@sergeymatov`; reviewers other than `@sergeymatov` are asked to ignore it for now. It adds a FlowTable concurrency fuzz test and supporting concurrency-harness adjustments, and removes a FlowTable API incompatible with shuttle-based testing.

Summary

- New bolero-driven concurrent fuzz test for FlowTable (cfg(test) and cfg(not(feature = "loom"))):
  - Adds flow-entry/src/flow_table/concurrent_fuzz.rs: generates Scenario { seed_key, ops: [Vec<Op>; 3] } via bolero, normalizes generation so at least two worker streams include Insert, and implements bolero::TypeGenerator for Scenario.
  - Runs three concurrent worker threads via concurrency::thread::scope (one per op stream). Uses a shared Arc<AtomicU8> stored in a StubItem inside flow nat_state to exercise racing updates and asserts per-entry status after workers finish.
  - Selects either a current-thread Tokio runtime for the std backend or no runtime when running under shuttle.
  - Adds a test function stress_test_concurrency_model() that drives generation through concurrency::stress.

- Concurrency harness changes and exports:
  - concurrency/src/stress.rs: adds a public helper pub fn shuttle_config() -> shuttle::Config (cfg(all(not(feature = "loom"), feature = "shuttle"))) returning a Config with 4 MiB stack size; refactors the shuttle branch of stress to use shuttle_config().
  - concurrency/src/lib.rs: documents and publicly re-exports stress::stress (removed #[doc(hidden)]), and conditionally re-exports stress::shuttle_config when shuttle is enabled and loom is not.
  - concurrency/tests/quiescent_shuttle.rs: replaces shuttle::check_random / check_pct helper calls with explicit shuttle::Runner construction (RandomScheduler / PctScheduler) and runner.run, using the shared shuttle_config where applicable.

- FlowTable API and tests:
  - flow-entry/src/flow_table/table.rs: removes the public pub fn drain_stale(&self) -> usize method; related concurrent test assertions were tightened to assert_eq! where appropriate.

- Bolero test utilities for FlowInfo:
  - net/src/flows/flow_info.rs: under cfg(any(test, feature = "bolero")), adds pub fn new_with_status(...) to construct FlowInfo with an explicit FlowStatus, and a bolero::TypeGenerator for FlowStatus that maps sampled u8 % 8 into Active/Cancelled/Expired/Detached with Active weighted higher.

Notes, testing, and metadata

- The PR is explicitly a discussion placeholder; author notes enabling the [bolero] feature in a non-dev context was accidental (IDE assistance) and should be treated as a test/dev-only concern.
- The new fuzz test is excluded from loom builds (FlowTable uses DashMap-like concurrency not suitable for loom).
- Backends supported by the stress harness: std (current-thread Tokio runtime) and shuttle (portfolio runners with Random / PCT schedulers).
- Lines changed: large additions in flow-entry/src/flow_table/concurrent_fuzz.rs (+~322), medium changes in concurrency and flow_info files; estimated review effort: Medium–High.

Conventional commits

- Commits follow conventional-style messages; no merge commits present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->