### PR TITLE
ci: Ignore RUSTSEC-2026-0173 (unmaintained proc-macro-error2)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,8 @@ feature-depth = 1
 ignore = [
     # paste is unmaintained but is needed by netlink-packet-core.  We should submit a patch when possible.
     "RUSTSEC-2024-0436",
+    # proc-macro-error2 is unmaintained but is needed by multi_index_map_derive, and our own fixin; ignore until both dependencies have migrated away from it.
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
CI currently blocks on the `cargo deny check` step because of advisory [RUSTSEC-2026-0173](https://rustsec.org/advisories/RUSTSEC-2026-0173): dependency proc-macro-error2 is now unmaintained. This is not a direct dependency, it's pulled by multi_index_map_derive and our own fixin crate. Until both have transitioned to an alternative solution, we'll ignore this advisory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Updated deny.toml to add RUSTSEC-2026-0173 to the advisories ignore list and included a comment explaining that proc-macro-error2 is unmaintained but required transitively by multi_index_map_derive and the repository's fixin crate; the advisory is ignored until those dependencies migrate.

## Commit Format

The commit follows conventional commit format (`chore: ...`) with no merge commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->