### PR TITLE
Upgrade npins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.3"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "heck",
  "indexmap",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "dplane-rpc"
 version = "1.1.2"
-source = "git+https://github.com/githedgehog/dplane-rpc.git?branch=pr%2Fdaniel-noland%2Fbumps#7bb6b46fd78051a8e532a70b16732ad99188721e"
+source = "git+https://github.com/githedgehog/dplane-rpc.git?branch=pr%2Fdaniel-noland%2Fbumps#6c84b7aff35abb4e94fbb0d09870a0b4a2322913"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -4599,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4622,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -5954,9 +5954,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6476,18 +6476,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5414,7 +5414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ tracing-test = { version = "0.2.6", default-features = false, features = [] }
 tracing-throttle = { version = "0.4.2", default-features = false, features = [] }
 ureq = { version = "3.3.0", default-features = false, features = [] }
 url = { version = "2.5.8", default-features = false, features = [] }
-uuid = { version = "1.23.2", default-features = false, features = [] }
+uuid = { version = "1.23.3", default-features = false, features = [] }
 
 # NOTE: panic strategy is intentionally left unset here.
 #

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -65,7 +65,9 @@ let
         if pkgs == null then
           {
             inherit (builtins) fetchTarball fetchurl;
-            # For some fucking reason, fetchGit has a different signature than the other builtin fetchers …
+            # Frustratingly, due to flakes and `fetchTree`, `fetchGit`
+            # has a different signature than the other builtin
+            # fetchers
             fetchGit = args: (builtins.fetchGit args).outPath;
           }
         else
@@ -95,7 +97,6 @@ let
               };
           };
 
-      # Dispatch to the correct code path based on the type
       path =
         if spec.type == "Git" then
           mkGitSource fetchers spec
@@ -105,8 +106,8 @@ let
           mkPyPiSource fetchers spec
         else if spec.type == "Channel" then
           mkChannelSource fetchers spec
-        else if spec.type == "Tarball" then
-          mkTarballSource fetchers spec
+        else if spec.type == "Url" || spec.type == "MutableUrl" then
+          mkUrlSource fetchers spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -192,16 +193,20 @@ let
       sha256 = hash;
     };
 
-  mkTarballSource =
-    { fetchTarball, ... }:
+  mkUrlSource =
     {
-      url,
-      locked_url ? url,
-      hash,
+      fetchTarball,
+      fetchurl,
       ...
     }:
-    fetchTarball {
-      url = locked_url;
+    {
+      url,
+      hash,
+      unpack,
+      ...
+    }:
+    (if unpack then fetchTarball else fetchurl) {
+      inherit url;
       sha256 = hash;
     };
 
@@ -211,16 +216,22 @@ let
       image_name,
       image_tag,
       image_digest,
+      hash,
       ...
-    }:
+    }@args:
     if pkgs == null then
       builtins.throw "container sources require passing in a Nixpkgs value: https://github.com/andir/npins/blob/master/README.md#using-the-nixpkgs-fetchers"
     else
-      pkgs.dockerTools.pullImage {
-        imageName = image_name;
-        imageDigest = image_digest;
-        finalImageTag = image_tag;
-      };
+      pkgs.dockerTools.pullImage (
+        {
+          imageName = image_name;
+          imageDigest = image_digest;
+          finalImageTag = image_tag;
+          hash = hash;
+        }
+        // (if args.arch or null != null then { arch = args.arch; } else { })
+      );
+
 in
 mkFunctor (
   {
@@ -231,7 +242,7 @@ mkFunctor (
       if builtins.isPath input then
         # while `readFile` will throw an error anyways if the path doesn't exist,
         # we still need to check beforehand because *our* error can be caught but not the one from the builtin
-        # *piegames sighs*
+        # See: <https://git.lix.systems/lix-project/lix/issues/1098>
         if builtins.pathExists input then
           builtins.fromJSON (builtins.readFile input)
         else
@@ -242,7 +253,7 @@ mkFunctor (
         throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
     version = data.version;
   in
-  if version == 7 then
+  if version == 8 then
     builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
   else
     throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -97,9 +97,9 @@
       },
       "branch": "stable/10.5",
       "submodules": false,
-      "revision": "45523c44fe498fe5f2e74550b2e2be0ff108c1e8",
-      "url": "https://github.com/FRRouting/frr/archive/45523c44fe498fe5f2e74550b2e2be0ff108c1e8.tar.gz",
-      "hash": "sha256-LuqMHgfV6+lguVALph6NChNCno5iHPlQG9cK9gEcYT4="
+      "revision": "886d4eaa723dfe17b3f10fadfc282e00cfdca68d",
+      "url": "https://github.com/FRRouting/frr/archive/886d4eaa723dfe17b3f10fadfc282e00cfdca68d.tar.gz",
+      "hash": "sha256-nb4ByGsNDxWKJtp7WT45Ld6FYbpYSl4JYLHGZ0pBmM0="
     },
     "frr-agent": {
       "type": "Git",
@@ -163,8 +163,8 @@
       "type": "Channel",
       "name": "nixpkgs-unstable",
       "artifact": "nixexprs.tar.xz",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1011620.cbb5cf358f50/nixexprs.tar.xz",
-      "hash": "sha256-d86UGSjwACWRttincQzeiAEZYVPtP3kODhr9hYZD4e8="
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1012902.8c3cede7ddc2/nixexprs.tar.xz",
+      "hash": "sha256-omq0piVC7vKHVxfJi9uIW1EHQLsFSnDhbkLeO2rkSyw="
     },
     "opengrep": {
       "type": "GitRelease",
@@ -233,9 +233,9 @@
       },
       "branch": "master",
       "submodules": false,
-      "revision": "7d5f8d75fc195a236b46633d7679139698aeb35f",
-      "url": "https://github.com/oxalica/rust-overlay/archive/7d5f8d75fc195a236b46633d7679139698aeb35f.tar.gz",
-      "hash": "sha256-MUQPFiskEENaJ2N82TRIqpKlHXGXJJkPfKH6W788oQo="
+      "revision": "d286e9691bb03045febbf8304a658eab1487d1b5",
+      "url": "https://github.com/oxalica/rust-overlay/archive/d286e9691bb03045febbf8304a658eab1487d1b5.tar.gz",
+      "hash": "sha256-tVuGHgt/TsWu1rUAqEL+eWRIJJHtiPE2+yQ63b+/WTU="
     }
   },
   "version": 8

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -162,6 +162,7 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
+      "artifact": "nixexprs.tar.xz",
       "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.11pre1011620.cbb5cf358f50/nixexprs.tar.xz",
       "hash": "sha256-d86UGSjwACWRttincQzeiAEZYVPtP3kODhr9hYZD4e8="
     },
@@ -237,5 +238,5 @@
       "hash": "sha256-MUQPFiskEENaJ2N82TRIqpKlHXGXJJkPfKH6W788oQo="
     }
   },
-  "version": 7
+  "version": 8
 }


### PR DESCRIPTION
We had the following error for dependency updates:

```console
$ bash scripts/bump.sh
++ dirname scripts/bump.sh
+ pushd scripts/..
/var/home/qmo/dev/dataplane /var/home/qmo/dev/dataplane
+ npins update
Error: Failed to deserialize sources.json

Caused by:
    Version 7 is too old, you need to run upgrade
```

To address it, we simply ran the following command and committed the changes:

```console
$ npins upgrade
```

@daniel-noland Can you please double-check this is OK?