### PR TITLE
Introduce and use IcmpErrorPacket view

### DIFF
--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -7,32 +7,21 @@
 use crate::NatPort;
 use crate::NatTranslationData;
 use net::buffer::PacketBufferMut;
-use net::checksum::{Checksum, ChecksumError};
+use net::checksum::Checksum;
 use net::headers::{
-    EmbeddedTransport, TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryEmbeddedTransportMut,
-    TryIcmpAny, TryInnerIpMut, TryInnerIpv4, TryIp,
+    EmbeddedTransport, TryEmbeddedHeadersMut, TryEmbeddedTransportMut, TryInnerIpMut,
 };
 use net::icmp_any::TruncatedIcmpAny;
-use net::icmp_any::{IcmpAnyChecksumErrorPlaceholder, IcmpAnyChecksumPayload};
-use net::ipv4::Ipv4;
 use net::packet::{DoneReason, Packet};
 use std::net::IpAddr;
 use std::num::NonZero;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IcmpErrorMsgError {
-    #[error("failure to get IP header")]
-    NoIpHeader,
-    #[error("not an ICMP packet")]
-    NotIcmp,
     #[error("failure to get embedded headers")]
     NoEmbeddedHeaders,
     #[error("failure to get inner IP header")]
     NoInnerIpHeader,
-    #[error("failed to validate ICMP checksum")]
-    BadChecksumIcmp(ChecksumError<IcmpAnyChecksumErrorPlaceholder>),
-    #[error("failed to validate ICMP inner IP checksum")]
-    BadChecksumInnerIpv4(ChecksumError<Ipv4>),
     #[error("invalid transport-layer port {0}")]
     InvalidPort(u16),
     #[error("invalid IP version")]
@@ -44,15 +33,9 @@ pub enum IcmpErrorMsgError {
 impl From<&IcmpErrorMsgError> for DoneReason {
     fn from(error: &IcmpErrorMsgError) -> Self {
         match error {
-            IcmpErrorMsgError::NoIpHeader => DoneReason::NotIp,
-            IcmpErrorMsgError::InvalidIpVersion | IcmpErrorMsgError::NotIcmp => {
-                DoneReason::InternalFailure
-            }
+            IcmpErrorMsgError::InvalidIpVersion => DoneReason::InternalFailure,
             IcmpErrorMsgError::InvalidPort(_) => DoneReason::Malformed,
             IcmpErrorMsgError::NotUnicast(_) => DoneReason::NatFailure,
-            IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_) => {
-                DoneReason::InvalidChecksum
-            }
             IcmpErrorMsgError::NoEmbeddedHeaders | IcmpErrorMsgError::NoInnerIpHeader => {
                 DoneReason::IcmpErrorIncomplete
             }
@@ -64,51 +47,6 @@ impl From<IcmpErrorMsgError> for DoneReason {
     fn from(error: IcmpErrorMsgError) -> Self {
         (&error).into()
     }
-}
-
-/// Validate the checksums for an ICMP packet.
-///
-/// From REQ-3 from RFC 5508, "NAT Behavioral Requirements for ICMP".
-/// NAT should silently discard packet if:
-///
-///    - ICMP checksum fails to validate
-///    - ICMP checksum for embedded packet fails to validate
-///
-/// This function is valid for any ICMP packet, whether it embeds a packet fragment or not. However,
-/// we expect ICMP Error messages to always include a fragment of the offending packet.
-pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
-    packet: &Packet<Buf>,
-) -> Result<(), IcmpErrorMsgError> {
-    let Some(net) = packet.try_ip() else {
-        return Err(IcmpErrorMsgError::NoIpHeader);
-    };
-    let Some(icmp) = packet.try_icmp_any() else {
-        return Err(IcmpErrorMsgError::NotIcmp);
-    };
-
-    let embedded = packet.embedded_headers();
-    let payload = packet.payload().as_ref();
-    let icmp_payload = icmp.get_payload_for_checksum(embedded, payload);
-    let checksum_payload = IcmpAnyChecksumPayload::from_net(net, icmp_payload.as_ref());
-
-    if let Err(e) = icmp.validate_checksum(&checksum_payload) {
-        return Err(IcmpErrorMsgError::BadChecksumIcmp(e.into()));
-    }
-
-    if !icmp.is_error_message() {
-        return Ok(());
-    }
-
-    // Validate inner packet for ICMP Error messages
-    let Some(embedded_ip) = packet.embedded_headers() else {
-        return Err(IcmpErrorMsgError::NoEmbeddedHeaders);
-    };
-    if let Some(inner_ipv4) = embedded_ip.try_inner_ipv4() {
-        inner_ipv4
-            .validate_checksum(&())
-            .map_err(IcmpErrorMsgError::BadChecksumInnerIpv4)?;
-    }
-    Ok(())
 }
 
 pub(crate) fn nat_translate_icmp_inner<Buf: PacketBufferMut>(
@@ -290,162 +228,23 @@ fn translate_inner_tcp_udp_dst(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use net::buffer::TestBuffer;
-    use net::eth::ethtype::EthType;
-    use net::headers::{HeadersBuilder, Net, Transport};
-    use net::icmp4::Icmp4;
-    use net::icmp4::{Icmp4DestUnreachable, Icmp4EchoRequest, Icmp4Type};
-    use net::ip::NextHeader;
-    use net::ipv4::Ipv4;
-    use net::packet::Packet;
-    use net::packet::test_utils::make_default_for_eth;
-    use net::parse::DeParse;
-    use std::net::Ipv4Addr;
-
-    #[test]
-    fn test_validate_checksums_icmp_no_network_layer() {
-        // Build a packet without IP header
-        let mut headers = HeadersBuilder::default();
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NoIpHeader));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_no_transport_layer() {
-        // Build a packet with IP but no transport
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NotIcmp));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_not_icmp() {
-        // Build a TCP packet
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::TCP);
-
-        let tcp = net::tcp::Tcp::new(
-            net::tcp::TcpPort::new_checked(1).unwrap(),
-            net::tcp::TcpPort::new_checked(2).unwrap(),
-        );
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Tcp(tcp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NotIcmp));
-    }
-
-    fn get_buffer_for_checksum_test(headers: &net::headers::Headers) -> TestBuffer {
-        // Fill the buffer with zeroes.
-        //
-        // This is for tests that build an ICMP Error message with no embedded packet fragment, and
-        // validate its checksum. To do so, we prepare a packet by building the headers, setting the
-        // checksum, then deparsing to a buffer. The checksum for ICMP is computed on the header and
-        // the data, and when we set it (icmp.update_checksum(&[])), we pass a pointer to the data.
-        // In such tests, there is no embedded packet fragment, so the data is null (&[]). When we
-        // deparse the packet, we write the headers to a buffer: If we create the buffer with
-        // TestBuffer::new(), it's not filled with zeroes, but with some data simulating some random
-        // payload. Instead, create a buffer filled with zeroes, so that any trailing data does not
-        // mess up with checksum computation.
-        let data = vec![0u8; headers.size().get() as usize];
-        TestBuffer::from_raw_data(&data)
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_query_message() {
-        // Build an ICMP Echo Request (query message)
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::ICMP);
-
-        let mut icmp = Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 1, seq: 1 }));
-        icmp.update_checksum(&[]).unwrap();
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Icmp4(icmp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = get_buffer_for_checksum_test(&headers);
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(()));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_error_no_embedded_headers() {
-        // Build an ICMP error message without embedded headers
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::ICMP);
-
-        let mut icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
-        icmp.update_checksum(&[]).unwrap();
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Icmp4(icmp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = get_buffer_for_checksum_test(&headers);
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NoEmbeddedHeaders));
-    }
-}
-
-#[cfg(test)]
 mod bolero_tests {
     use super::*;
     use crate::NatPort;
     use net::buffer::TestBuffer;
+    use net::checksum::ChecksumError;
     use net::headers::TryHeaders;
     use net::headers::{
-        Net, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut, TryIpv4,
+        Net, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut, TryIp, TryIpv4,
     };
     use net::icmp_any::IcmpAnyChecksum;
     use net::ipv4::{Ipv4Checksum, UnicastIpv4Addr};
     use net::ipv6::UnicastIpv6Addr;
     use net::packet::IcmpErrorMsg;
+    use net::packet::icmp_err::{IcmpErrorPacket, IcmpErrorPacketError};
     use std::net::{Ipv4Addr, Ipv6Addr};
 
+    #[derive(Debug, Clone, Copy)]
     enum TransportFields {
         Ports(u16, u16),
         Identifier(u16),
@@ -468,6 +267,11 @@ mod bolero_tests {
         bolero::check!()
             .with_generator(generator)
             .for_each(|icmp_error_msg| {
+                if IcmpErrorPacket::new(icmp_error_msg).is_none() {
+                    // No embedded transport, that's fine, we just skip this input
+                    return;
+                }
+
                 let mut icmp_error_msg_clone = icmp_error_msg.clone();
                 // First check that checksum is incorrect. There's a super-high chance that it fails
                 // with non-initialised checksums in all relevant haders, but 1) there may be only
@@ -475,11 +279,14 @@ mod bolero_tests {
                 // and 2) sometimes Bolero reuses headers in which we set the correct checksums.
                 // So we first "erase" all checksums by setting them to 0xffff.
                 erase_checksums(&mut icmp_error_msg_clone);
+
                 // Validate checksum is incorrect
-                let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
+                let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                    .unwrap()
+                    .validate_checksums();
                 assert!(matches!(
                     res,
-                    Err(IcmpErrorMsgError::BadChecksumIcmp(
+                    Err(IcmpErrorPacketError::BadChecksumIcmp(
                         ChecksumError::Mismatch { .. }
                     ))
                 ));
@@ -488,7 +295,9 @@ mod bolero_tests {
                 icmp_error_msg_clone.update_checksums();
 
                 // Now, ICMP and inner IP headers checksums should be valid
-                let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
+                let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                    .unwrap()
+                    .validate_checksums();
                 assert!(res.is_ok(), "Checksum validation failed: {res:?}");
 
                 // Also check outer IP header checksum, since we're at it
@@ -630,10 +439,15 @@ mod bolero_tests {
                         _ => unreachable!(),
                     }
 
-                    // Update and validate checksums for inner IP header, ICMP header, and outer IP header
-                    icmp_error_msg_clone.update_checksums();
-                    let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
-                    assert!(res.is_ok(), "Checksum validation failed: {res:?}");
+                    if new_ports.is_some() {
+                        // Update and validate checksums for inner IP header, ICMP header, and outer
+                        // IP header. We only check this when we have an inner transport header.
+                        icmp_error_msg_clone.update_checksums();
+                        let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                            .unwrap()
+                            .validate_checksums();
+                        assert!(res.is_ok(), "Checksum validation failed: {res:?}");
+                    }
                 },
             );
     }

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -7,32 +7,21 @@
 use crate::NatPort;
 use crate::NatTranslationData;
 use net::buffer::PacketBufferMut;
-use net::checksum::{Checksum, ChecksumError};
+use net::checksum::Checksum;
 use net::headers::{
-    EmbeddedTransport, TryEmbeddedHeaders, TryEmbeddedHeadersMut, TryEmbeddedTransportMut,
-    TryIcmpAny, TryInnerIpMut, TryInnerIpv4, TryIp,
+    EmbeddedTransport, TryEmbeddedHeadersMut, TryEmbeddedTransportMut, TryInnerIpMut,
 };
 use net::icmp_any::TruncatedIcmpAny;
-use net::icmp_any::{IcmpAnyChecksumErrorPlaceholder, IcmpAnyChecksumPayload};
-use net::ipv4::Ipv4;
 use net::packet::{DoneReason, Packet};
 use std::net::IpAddr;
 use std::num::NonZero;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IcmpErrorMsgError {
-    #[error("failure to get IP header")]
-    NoIpHeader,
-    #[error("not an ICMP packet")]
-    NotIcmp,
     #[error("failure to get embedded headers")]
     NoEmbeddedHeaders,
     #[error("failure to get inner IP header")]
     NoInnerIpHeader,
-    #[error("failed to validate ICMP checksum")]
-    BadChecksumIcmp(ChecksumError<IcmpAnyChecksumErrorPlaceholder>),
-    #[error("failed to validate ICMP inner IP checksum")]
-    BadChecksumInnerIpv4(ChecksumError<Ipv4>),
     #[error("invalid transport-layer port {0}")]
     InvalidPort(u16),
     #[error("invalid IP version")]
@@ -44,65 +33,14 @@ pub enum IcmpErrorMsgError {
 impl From<&IcmpErrorMsgError> for DoneReason {
     fn from(error: &IcmpErrorMsgError) -> Self {
         match error {
-            IcmpErrorMsgError::NoIpHeader => DoneReason::NotIp,
-            IcmpErrorMsgError::InvalidIpVersion | IcmpErrorMsgError::NotIcmp => {
-                DoneReason::InternalFailure
-            }
+            IcmpErrorMsgError::InvalidIpVersion => DoneReason::InternalFailure,
             IcmpErrorMsgError::InvalidPort(_) => DoneReason::Malformed,
             IcmpErrorMsgError::NotUnicast(_) => DoneReason::NatFailure,
-            IcmpErrorMsgError::BadChecksumIcmp(_) | IcmpErrorMsgError::BadChecksumInnerIpv4(_) => {
-                DoneReason::InvalidChecksum
-            }
             IcmpErrorMsgError::NoEmbeddedHeaders | IcmpErrorMsgError::NoInnerIpHeader => {
                 DoneReason::IcmpErrorIncomplete
             }
         }
     }
-}
-
-/// Validate the checksums for an ICMP packet.
-///
-/// From REQ-3 from RFC 5508, "NAT Behavioral Requirements for ICMP".
-/// NAT should silently discard packet if:
-///
-///    - ICMP checksum fails to validate
-///    - ICMP checksum for embedded packet fails to validate
-///
-/// This function is valid for any ICMP packet, whether it embeds a packet fragment or not. However,
-/// we expect ICMP Error messages to always include a fragment of the offending packet.
-pub(crate) fn validate_checksums_icmp<Buf: PacketBufferMut>(
-    packet: &Packet<Buf>,
-) -> Result<(), IcmpErrorMsgError> {
-    let Some(net) = packet.try_ip() else {
-        return Err(IcmpErrorMsgError::NoIpHeader);
-    };
-    let Some(icmp) = packet.try_icmp_any() else {
-        return Err(IcmpErrorMsgError::NotIcmp);
-    };
-
-    let embedded = packet.embedded_headers();
-    let payload = packet.payload().as_ref();
-    let icmp_payload = icmp.get_payload_for_checksum(embedded, payload);
-    let checksum_payload = IcmpAnyChecksumPayload::from_net(net, icmp_payload.as_ref());
-
-    if let Err(e) = icmp.validate_checksum(&checksum_payload) {
-        return Err(IcmpErrorMsgError::BadChecksumIcmp(e.into()));
-    }
-
-    if !icmp.is_error_message() {
-        return Ok(());
-    }
-
-    // Validate inner packet for ICMP Error messages
-    let Some(embedded_ip) = packet.embedded_headers() else {
-        return Err(IcmpErrorMsgError::NoEmbeddedHeaders);
-    };
-    if let Some(inner_ipv4) = embedded_ip.try_inner_ipv4() {
-        inner_ipv4
-            .validate_checksum(&())
-            .map_err(IcmpErrorMsgError::BadChecksumInnerIpv4)?;
-    }
-    Ok(())
 }
 
 pub(crate) fn nat_translate_icmp_inner<Buf: PacketBufferMut>(
@@ -284,162 +222,23 @@ fn translate_inner_tcp_udp_dst(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use net::buffer::TestBuffer;
-    use net::eth::ethtype::EthType;
-    use net::headers::{HeadersBuilder, Net, Transport};
-    use net::icmp4::Icmp4;
-    use net::icmp4::{Icmp4DestUnreachable, Icmp4EchoRequest, Icmp4Type};
-    use net::ip::NextHeader;
-    use net::ipv4::Ipv4;
-    use net::packet::Packet;
-    use net::packet::test_utils::make_default_for_eth;
-    use net::parse::DeParse;
-    use std::net::Ipv4Addr;
-
-    #[test]
-    fn test_validate_checksums_icmp_no_network_layer() {
-        // Build a packet without IP header
-        let mut headers = HeadersBuilder::default();
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NoIpHeader));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_no_transport_layer() {
-        // Build a packet with IP but no transport
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NotIcmp));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_not_icmp() {
-        // Build a TCP packet
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::TCP);
-
-        let tcp = net::tcp::Tcp::new(
-            net::tcp::TcpPort::new_checked(1).unwrap(),
-            net::tcp::TcpPort::new_checked(2).unwrap(),
-        );
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Tcp(tcp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = TestBuffer::new();
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NotIcmp));
-    }
-
-    fn get_buffer_for_checksum_test(headers: &net::headers::Headers) -> TestBuffer {
-        // Fill the buffer with zeroes.
-        //
-        // This is for tests that build an ICMP Error message with no embedded packet fragment, and
-        // validate its checksum. To do so, we prepare a packet by building the headers, setting the
-        // checksum, then deparsing to a buffer. The checksum for ICMP is computed on the header and
-        // the data, and when we set it (icmp.update_checksum(&[])), we pass a pointer to the data.
-        // In such tests, there is no embedded packet fragment, so the data is null (&[]). When we
-        // deparse the packet, we write the headers to a buffer: If we create the buffer with
-        // TestBuffer::new(), it's not filled with zeroes, but with some data simulating some random
-        // payload. Instead, create a buffer filled with zeroes, so that any trailing data does not
-        // mess up with checksum computation.
-        let data = vec![0u8; headers.size().get() as usize];
-        TestBuffer::from_raw_data(&data)
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_query_message() {
-        // Build an ICMP Echo Request (query message)
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::ICMP);
-
-        let mut icmp = Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 1, seq: 1 }));
-        icmp.update_checksum(&[]).unwrap();
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Icmp4(icmp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = get_buffer_for_checksum_test(&headers);
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Ok(()));
-    }
-
-    #[test]
-    fn test_validate_checksums_icmp_error_no_embedded_headers() {
-        // Build an ICMP error message without embedded headers
-        let mut headers = HeadersBuilder::default();
-        let mut ipv4 = Ipv4::default();
-        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
-        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
-        ipv4.set_next_header(NextHeader::ICMP);
-
-        let mut icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
-        icmp.update_checksum(&[]).unwrap();
-
-        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
-        headers.net(Some(Net::Ipv4(ipv4)));
-        headers.transport(Some(Transport::Icmp4(icmp)));
-
-        let headers = headers.build().unwrap();
-        let mut buffer = get_buffer_for_checksum_test(&headers);
-        headers.deparse(buffer.as_mut()).unwrap();
-        let packet = Packet::new(buffer).unwrap();
-
-        let result = validate_checksums_icmp(&packet);
-        assert_eq!(result, Err(IcmpErrorMsgError::NoEmbeddedHeaders));
-    }
-}
-
-#[cfg(test)]
 mod bolero_tests {
     use super::*;
     use crate::NatPort;
     use net::buffer::TestBuffer;
+    use net::checksum::ChecksumError;
     use net::headers::TryHeaders;
     use net::headers::{
-        Net, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut, TryIpv4,
+        Net, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut, TryIp, TryIpv4,
     };
     use net::icmp_any::IcmpAnyChecksum;
     use net::ipv4::{Ipv4Checksum, UnicastIpv4Addr};
     use net::ipv6::UnicastIpv6Addr;
     use net::packet::IcmpErrorMsg;
+    use net::packet::icmp_err::{IcmpErrorPacket, IcmpErrorPacketError};
     use std::net::{Ipv4Addr, Ipv6Addr};
 
+    #[derive(Debug, Clone, Copy)]
     enum TransportFields {
         Ports(u16, u16),
         Identifier(u16),
@@ -462,6 +261,11 @@ mod bolero_tests {
         bolero::check!()
             .with_generator(generator)
             .for_each(|icmp_error_msg| {
+                if IcmpErrorPacket::new(icmp_error_msg).is_none() {
+                    // No embedded transport, that's fine, we just skip this input
+                    return;
+                }
+
                 let mut icmp_error_msg_clone = icmp_error_msg.clone();
                 // First check that checksum is incorrect. There's a super-high chance that it fails
                 // with non-initialised checksums in all relevant haders, but 1) there may be only
@@ -469,11 +273,14 @@ mod bolero_tests {
                 // and 2) sometimes Bolero reuses headers in which we set the correct checksums.
                 // So we first "erase" all checksums by setting them to 0xffff.
                 erase_checksums(&mut icmp_error_msg_clone);
+
                 // Validate checksum is incorrect
-                let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
+                let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                    .unwrap()
+                    .validate_checksums();
                 assert!(matches!(
                     res,
-                    Err(IcmpErrorMsgError::BadChecksumIcmp(
+                    Err(IcmpErrorPacketError::BadChecksumIcmp(
                         ChecksumError::Mismatch { .. }
                     ))
                 ));
@@ -482,7 +289,9 @@ mod bolero_tests {
                 icmp_error_msg_clone.update_checksums();
 
                 // Now, ICMP and inner IP headers checksums should be valid
-                let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
+                let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                    .unwrap()
+                    .validate_checksums();
                 assert!(res.is_ok(), "Checksum validation failed: {res:?}");
 
                 // Also check outer IP header checksum, since we're at it
@@ -624,10 +433,15 @@ mod bolero_tests {
                         _ => unreachable!(),
                     }
 
-                    // Update and validate checksums for inner IP header, ICMP header, and outer IP header
-                    icmp_error_msg_clone.update_checksums();
-                    let res = validate_checksums_icmp::<TestBuffer>(&icmp_error_msg_clone);
-                    assert!(res.is_ok(), "Checksum validation failed: {res:?}");
+                    if new_ports.is_some() {
+                        // Update and validate checksums for inner IP header, ICMP header, and outer
+                        // IP header. We only check this when we have an inner transport header.
+                        icmp_error_msg_clone.update_checksums();
+                        let res = IcmpErrorPacket::new(&icmp_error_msg_clone)
+                            .unwrap()
+                            .validate_checksums();
+                        assert!(res.is_ok(), "Checksum validation failed: {res:?}");
+                    }
                 },
             );
     }

--- a/nat/src/icmp_handler/nf.rs
+++ b/nat/src/icmp_handler/nf.rs
@@ -6,11 +6,11 @@
 
 use flow_entry::flow_table::FlowTable;
 use net::buffer::PacketBufferMut;
-use net::flow_key::flowkey_embedded_in_icmp_error;
 use net::headers::TryIcmpAny;
 use net::icmp_any::IcmpAny;
 use net::icmp4::{Icmp4DestUnreachable, Icmp4Type};
 use net::icmp6::Icmp6Type;
+use net::packet::icmp_err::IcmpErrorPacket;
 use net::packet::{DoneReason, Packet};
 
 use concurrency::sync::Arc;
@@ -19,7 +19,6 @@ use strum::EnumMessage;
 use tracectl::trace_target;
 use tracing::{debug, warn};
 
-use super::icmp_error_msg::validate_checksums_icmp;
 use crate::common::NatFlowStatus;
 use crate::masquerade::icmp_handling::handle_icmp_error_masquerading;
 use crate::portfw::icmp_handling::handle_icmp_error_port_forwarding;
@@ -62,6 +61,12 @@ fn is_icmp_unrecoverable<Buf: PacketBufferMut>(packet: &mut Packet<Buf>) -> (boo
 
 impl IcmpErrorHandler {
     fn handle_icmp_error_msg<Buf: PacketBufferMut>(&self, packet: &mut Packet<Buf>) {
+        let Some(icmp_error_packet) = IcmpErrorPacket::new(packet) else {
+            debug!("Dropping ICMP error packet: could not parse it as ICMP error");
+            packet.done(DoneReason::IcmpErrorIncomplete);
+            return;
+        };
+
         // check origin of icmp error packet
         let Some(src_vpcd) = packet.meta().src_vpcd else {
             debug!("Dropping ICMP error packet: no src vpc discriminant");
@@ -70,10 +75,16 @@ impl IcmpErrorHandler {
         };
         debug!("Processing ICMP error packet from {src_vpcd}");
 
-        // drop packet if icmp checksums are not correct
-        if let Err(e) = validate_checksums_icmp(packet) {
+        // From REQ-3 from RFC 5508, "NAT Behavioral Requirements for ICMP".
+        // NAT should silently discard packet if:
+        //
+        //    - ICMP checksum fails to validate
+        //    - ICMP checksum for embedded packet fails to validate
+        //
+        // Drop packet if ICMP checksums are not correct
+        if let Err(e) = icmp_error_packet.validate_checksums() {
             debug!("Checksum validation failed for ICMP packet: {e}");
-            packet.done((&e).into());
+            packet.done(DoneReason::InvalidChecksum);
             return;
         }
 
@@ -88,7 +99,7 @@ impl IcmpErrorHandler {
         //    1) build a flow key for the offending packet and REVERSE it
         //    2) look up the flow table for a flow in the reverse path of the offending packet.
 
-        let flow_key = match flowkey_embedded_in_icmp_error(packet) {
+        let flow_key = match icmp_error_packet.embedded_flowkey() {
             Ok(flow_key) => flow_key,
             Err(e) => {
                 debug!("Could not build flow key for ICMP-error inner packet: {e}");

--- a/nat/src/icmp_handler/nf.rs
+++ b/nat/src/icmp_handler/nf.rs
@@ -6,11 +6,11 @@
 
 use flow_entry::flow_table::FlowTable;
 use net::buffer::PacketBufferMut;
-use net::flow_key::flowkey_embedded_in_icmp_error;
 use net::headers::TryIcmpAny;
 use net::icmp_any::IcmpAny;
 use net::icmp4::{Icmp4DestUnreachable, Icmp4Type};
 use net::icmp6::Icmp6Type;
+use net::packet::icmp_err::IcmpErrorPacket;
 use net::packet::{DoneReason, Packet};
 
 use concurrency::sync::Arc;
@@ -19,7 +19,6 @@ use strum::EnumMessage;
 use tracectl::trace_target;
 use tracing::{debug, warn};
 
-use super::icmp_error_msg::validate_checksums_icmp;
 use crate::common::NatFlowStatus;
 use crate::portfw::icmp_handling::handle_icmp_error_port_forwarding;
 use crate::stateful::icmp_handling::handle_icmp_error_masquerading;
@@ -62,6 +61,12 @@ fn is_icmp_unrecoverable<Buf: PacketBufferMut>(packet: &mut Packet<Buf>) -> (boo
 
 impl IcmpErrorHandler {
     fn handle_icmp_error_msg<Buf: PacketBufferMut>(&self, packet: &mut Packet<Buf>) {
+        let Some(icmp_error_packet) = IcmpErrorPacket::new(packet) else {
+            debug!("Dropping ICMP error packet: could not parse it as ICMP error");
+            packet.done(DoneReason::IcmpErrorIncomplete);
+            return;
+        };
+
         // check origin of icmp error packet
         let Some(src_vpcd) = packet.meta().src_vpcd else {
             debug!("Dropping ICMP error packet: no src vpc discriminant");
@@ -70,10 +75,16 @@ impl IcmpErrorHandler {
         };
         debug!("Processing ICMP error packet from {src_vpcd}");
 
-        // drop packet if icmp checksums are not correct
-        if let Err(e) = validate_checksums_icmp(packet) {
+        // From REQ-3 from RFC 5508, "NAT Behavioral Requirements for ICMP".
+        // NAT should silently discard packet if:
+        //
+        //    - ICMP checksum fails to validate
+        //    - ICMP checksum for embedded packet fails to validate
+        //
+        // Drop packet if ICMP checksums are not correct
+        if let Err(e) = icmp_error_packet.validate_checksums() {
             debug!("Checksum validation failed for ICMP packet: {e}");
-            packet.done(e.into());
+            packet.done(DoneReason::InvalidChecksum);
             return;
         }
 
@@ -88,7 +99,7 @@ impl IcmpErrorHandler {
         //    1) build a flow key for the offending packet and REVERSE it
         //    2) look up the flow table for a flow in the reverse path of the offending packet.
 
-        let flow_key = match flowkey_embedded_in_icmp_error(packet) {
+        let flow_key = match icmp_error_packet.embedded_flowkey() {
             Ok(flow_key) => flow_key,
             Err(e) => {
                 debug!("Could not build flow key for ICMP-error inner packet: {e}");

--- a/net/src/flows/flow_key.rs
+++ b/net/src/flows/flow_key.rs
@@ -22,6 +22,7 @@ use crate::icmp6::{Icmp6, TruncatedIcmp6};
 use crate::ip::NextHeader;
 use crate::packet::Packet;
 use crate::packet::VpcDiscriminant;
+use crate::packet::icmp_err::IcmpErrorPacket;
 use crate::tcp::{TcpPort, TcpPortError};
 use crate::udp::{UdpPort, UdpPortError};
 
@@ -619,62 +620,44 @@ impl<Buf: PacketBufferMut> TryFrom<&Packet<Buf>> for FlowKey {
     }
 }
 
-/// Build a `FlowKey` for the inner packet embedded in `packet` if it is an ICMP error packet.
-/// This function does not set any `VpcDiscriminant` and will fail if:
-///    * the packet is not an ICMP error packet
-///    * the headers for the embedded packet are not accessible as a whole
-///    * the ip or transport header is not readable
-///    * if the embedded packet is ICMP but has no identifier (is not an Echo Request / Echo Reply)
-///
-/// # Errors
-///
-/// This function returns a `FlowKey` on success and `FlowKeyError` otherwise.
-///
-pub fn flowkey_embedded_in_icmp_error<Buf: PacketBufferMut>(
-    packet: &mut Packet<Buf>,
-) -> Result<FlowKey, FlowKeyError> {
-    // we currently restrict this to ICMP error packets
-    if !packet.is_icmp_error() {
-        return Err(FlowKeyError::NotIcmpError);
+impl IcmpErrorPacket<'_> {
+    /// Build a `FlowKey` for the inner packet embedded in `packet` if it is an ICMP error packet.
+    /// This function does not set any `VpcDiscriminant` and will fail if:
+    ///
+    /// - the packet is not an ICMP error packet
+    /// - the headers for the embedded packet are not accessible as a whole
+    /// - the ip or transport header is not readable
+    /// - if the embedded packet is ICMP but has no identifier (is not an Echo Request / Echo Reply)
+    ///
+    /// # Errors
+    ///
+    /// This function returns a `FlowKey` on success and `FlowKeyError` otherwise.
+    pub fn embedded_flowkey(&self) -> Result<FlowKey, FlowKeyError> {
+        let src_ip = self.inner_net().src_addr();
+        let dst_ip = self.inner_net().dst_addr();
+
+        // build the protocol key
+        let proto_key = match self.inner_transport() {
+            EmbeddedTransport::Tcp(tcp) => {
+                IpProtoKey::Tcp(TcpProtoKey::from((tcp.source(), tcp.destination())))
+            }
+            EmbeddedTransport::Udp(udp) => {
+                IpProtoKey::Udp(UdpProtoKey::from((udp.source(), udp.destination())))
+            }
+            EmbeddedTransport::Icmp4(icmp) if let Some(icmp_id) = icmp.identifier() => {
+                IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(icmp_id))
+            }
+            EmbeddedTransport::Icmp6(icmp6) if let Some(icmp_id) = icmp6.identifier() => {
+                IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(icmp_id))
+            }
+            EmbeddedTransport::Icmp4(_) | EmbeddedTransport::Icmp6(_) => {
+                // we can only get an id if the packet is echo request / echo reply.
+                // that's fine because ICMP errors should not be sent for ICMP errors.
+                return Err(FlowKeyError::EmbeddedMissingIcmpId);
+            }
+        };
+        Ok(FlowKey::new(None, src_ip, dst_ip, proto_key))
     }
-
-    // access embedded packet fragment
-    let inner = packet
-        .embedded_headers()
-        .ok_or(FlowKeyError::NoEmbeddedHeaders)?;
-
-    // get data from embedded
-    let net = inner
-        .try_inner_ip()
-        .ok_or(FlowKeyError::EmbeddedMissingHeader("ip"))?;
-
-    let src_ip = net.src_addr();
-    let dst_ip = net.dst_addr();
-    let embedded_transport = inner
-        .try_embedded_transport()
-        .ok_or(FlowKeyError::EmbeddedMissingHeader("transport"))?;
-
-    // build the protocol key
-    let proto_key = match embedded_transport {
-        EmbeddedTransport::Tcp(tcp) => {
-            IpProtoKey::Tcp(TcpProtoKey::from((tcp.source(), tcp.destination())))
-        }
-        EmbeddedTransport::Udp(udp) => {
-            IpProtoKey::Udp(UdpProtoKey::from((udp.source(), udp.destination())))
-        }
-        EmbeddedTransport::Icmp4(icmp) if let Some(icmp_id) = icmp.identifier() => {
-            IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(icmp_id))
-        }
-        EmbeddedTransport::Icmp6(icmp6) if let Some(icmp_id) = icmp6.identifier() => {
-            IpProtoKey::Icmp(IcmpProtoKey::QueryMsgData(icmp_id))
-        }
-        EmbeddedTransport::Icmp4(_) | EmbeddedTransport::Icmp6(_) => {
-            // we can only get an id if the packet is echo request / echo reply.
-            // that's fine because ICMP errors should not be sent for ICMP errors.
-            return Err(FlowKeyError::EmbeddedMissingIcmpId);
-        }
-    };
-    Ok(FlowKey::new(None, src_ip, dst_ip, proto_key))
 }
 
 #[cfg(any(test, feature = "bolero"))]

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -669,6 +669,34 @@ impl DeParse for EmbeddedTransport {
     }
 }
 
+#[cfg(test)]
+use crate::icmp4::{Icmp4, TruncatedIcmp4Header};
+#[cfg(test)]
+use crate::icmp6::{Icmp6, TruncatedIcmp6Header};
+#[cfg(test)]
+use crate::tcp::{Tcp, TruncatedTcpHeader};
+#[cfg(test)]
+use crate::udp::TruncatedUdpHeader;
+
+macro_rules! impl_from_for_variant {
+    ($src:ty, $variant:ident, $inner:ty) => {
+        #[cfg(test)]
+        impl From<$src> for EmbeddedTransport {
+            fn from(val: $src) -> Self {
+                EmbeddedTransport::$variant(<$inner>::from(val))
+            }
+        }
+    };
+}
+impl_from_for_variant!(Tcp, Tcp, TruncatedTcp);
+impl_from_for_variant!(TruncatedTcpHeader, Tcp, TruncatedTcp);
+impl_from_for_variant!(Udp, Udp, TruncatedUdp);
+impl_from_for_variant!(TruncatedUdpHeader, Udp, TruncatedUdp);
+impl_from_for_variant!(Icmp4, Icmp4, TruncatedIcmp4);
+impl_from_for_variant!(TruncatedIcmp4Header, Icmp4, TruncatedIcmp4);
+impl_from_for_variant!(Icmp6, Icmp6, TruncatedIcmp6);
+impl_from_for_variant!(TruncatedIcmp6Header, Icmp6, TruncatedIcmp6);
+
 // ---------------------------------------------------------------------------
 // Try* accessor traits -- definitions + concrete impls on EmbeddedHeaders
 // ---------------------------------------------------------------------------

--- a/net/src/icmp4/truncated.rs
+++ b/net/src/icmp4/truncated.rs
@@ -238,6 +238,18 @@ impl DeParse for TruncatedIcmp4 {
     }
 }
 
+impl From<Icmp4> for TruncatedIcmp4 {
+    fn from(icmp: Icmp4) -> Self {
+        TruncatedIcmp4::FullHeader(icmp)
+    }
+}
+
+impl From<TruncatedIcmp4Header> for TruncatedIcmp4 {
+    fn from(header: TruncatedIcmp4Header) -> Self {
+        TruncatedIcmp4::PartialHeader(header)
+    }
+}
+
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use super::TruncatedIcmp4;

--- a/net/src/icmp6/truncated.rs
+++ b/net/src/icmp6/truncated.rs
@@ -238,6 +238,18 @@ impl DeParse for TruncatedIcmp6 {
     }
 }
 
+impl From<Icmp6> for TruncatedIcmp6 {
+    fn from(icmp: Icmp6) -> Self {
+        TruncatedIcmp6::FullHeader(icmp)
+    }
+}
+
+impl From<TruncatedIcmp6Header> for TruncatedIcmp6 {
+    fn from(header: TruncatedIcmp6Header) -> Self {
+        TruncatedIcmp6::PartialHeader(header)
+    }
+}
+
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use super::TruncatedIcmp6;

--- a/net/src/packet/icmp_err.rs
+++ b/net/src/packet/icmp_err.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! View a packet as an ICMP Error message with an embedded IP packet fragment.
+
+use crate::checksum::{Checksum, ChecksumError};
+use crate::headers::{
+    EmbeddedTransport, Net, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAny, TryInnerIp, TryIp,
+};
+use crate::icmp_any::{IcmpAny, IcmpAnyChecksumErrorPlaceholder, IcmpAnyChecksumPayload};
+use crate::ipv4::Ipv4;
+use crate::packet::{Packet, PacketBufferMut};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+/// Errors that can occur when validating an ICMP error message.
+pub enum IcmpErrorPacketError {
+    /// The ICMP checksum is not valid.
+    #[error("failed to validate ICMP checksum")]
+    BadChecksumIcmp(ChecksumError<IcmpAnyChecksumErrorPlaceholder>),
+    /// The inner IPv4 checksum is not valid.
+    #[error("failed to validate ICMP inner IP checksum")]
+    BadChecksumInnerIpv4(ChecksumError<Ipv4>),
+}
+
+/// A view of a packet as an ICMP error message with an embedded IP packet fragment.
+pub struct IcmpErrorPacket<'a> {
+    net: &'a Net,
+    icmp: IcmpAny<'a>,
+    icmp_payload: Vec<u8>,
+    inner_net: &'a Net,
+    inner_transport: &'a EmbeddedTransport,
+}
+
+impl<'a> IcmpErrorPacket<'a> {
+    /// Tries to view the given packet as an ICMP error message with an embedded IP packet fragment.
+    pub fn new<Buf: PacketBufferMut>(packet: &'a Packet<Buf>) -> Option<Self> {
+        let net = packet.try_ip()?;
+        let icmp = packet.try_icmp_any()?;
+        let inner_net = packet.try_inner_ip()?;
+        let inner_transport = packet.try_embedded_transport()?;
+        let icmp_payload = icmp
+            .get_payload_for_checksum(Some(packet.embedded_headers()?), packet.payload().as_ref());
+        Some(Self {
+            net,
+            icmp,
+            icmp_payload,
+            inner_net,
+            inner_transport,
+        })
+    }
+
+    /// The IP header for the embedded packet fragment that caused the ICMP error message to be
+    /// generated.
+    #[must_use]
+    pub fn inner_net(&self) -> &'a Net {
+        self.inner_net
+    }
+
+    /// The transport header of the embedded packet fragment that caused the ICMP error message to
+    /// be generated.
+    #[must_use]
+    pub fn inner_transport(&self) -> &'a EmbeddedTransport {
+        self.inner_transport
+    }
+
+    fn checksum_payload(&'a self) -> IcmpAnyChecksumPayload<'a> {
+        IcmpAnyChecksumPayload::from_net(self.net, &self.icmp_payload)
+    }
+
+    /// Validates the checksums of the ICMP error message and the embedded IP packet fragment.
+    ///
+    /// # Errors
+    ///
+    /// - If the ICMP checksum is not valid, returns `IcmpErrorPacketError::BadChecksumIcmp`.
+    /// - If the inner IPv4 checksum is not valid, returns
+    ///   `IcmpErrorPacketError::BadChecksumInnerIpv4`.
+    pub fn validate_checksums(&self) -> Result<(), IcmpErrorPacketError> {
+        self.icmp
+            .validate_checksum(&self.checksum_payload())
+            .map_err(|e| IcmpErrorPacketError::BadChecksumIcmp(e.into()))?;
+
+        if let Net::Ipv4(inner_ipv4) = self.inner_net {
+            inner_ipv4
+                .validate_checksum(&())
+                .map_err(IcmpErrorPacketError::BadChecksumInnerIpv4)?;
+        }
+        Ok(())
+    }
+}

--- a/net/src/packet/icmp_err.rs
+++ b/net/src/packet/icmp_err.rs
@@ -87,3 +87,217 @@ impl<'a> IcmpErrorPacket<'a> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer::TestBuffer;
+    use crate::eth::ethtype::EthType;
+    use crate::headers::{EmbeddedHeadersBuilder, Headers, HeadersBuilder, Net, Transport};
+    use crate::icmp4::{Icmp4, Icmp4DestUnreachable, Icmp4EchoRequest, Icmp4Type};
+    use crate::ip::NextHeader;
+    use crate::ipv4::Ipv4;
+    use crate::packet::Packet;
+    use crate::packet::test_utils::make_default_for_eth;
+    use crate::parse::DeParse;
+    use crate::tcp::{Tcp, TcpPort};
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn test_icmp_error_packet_no_network_layer() {
+        // Build a packet without IP header
+        let mut headers = HeadersBuilder::default();
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    #[test]
+    fn test_icmp_error_packet_no_transport_layer() {
+        // Build a packet with IP but no transport
+        let mut headers = HeadersBuilder::default();
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    #[test]
+    fn test_icmp_error_packet_not_icmp() {
+        // Build a TCP packet
+        let mut headers = HeadersBuilder::default();
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::TCP);
+
+        let tcp = Tcp::new(
+            TcpPort::new_checked(1).unwrap(),
+            TcpPort::new_checked(2).unwrap(),
+        );
+
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Tcp(tcp)));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    #[test]
+    fn test_icmp_error_packet_query_message() {
+        // Build an ICMP Echo Request (query message)
+        let mut headers = HeadersBuilder::default();
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::ICMP);
+
+        let icmp = Icmp4::with_type(Icmp4Type::EchoRequest(Icmp4EchoRequest { id: 1, seq: 1 }));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Icmp4(icmp)));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    #[test]
+    fn test_icmp_error_packet_no_embedded_headers() {
+        // Build an ICMP error message without embedded headers
+        let mut headers = HeadersBuilder::default();
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::ICMP);
+
+        let icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Icmp4(icmp)));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    #[test]
+    fn test_icmp_error_packet_no_embedded_transport() {
+        // Build an ICMP error message with embedded IP header, but no embedded transport
+        let mut headers = HeadersBuilder::default();
+        let mut embedded_headers = EmbeddedHeadersBuilder::default();
+
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::ICMP);
+
+        let mut inner_ipv4 = Ipv4::default();
+        inner_ipv4.set_source(Ipv4Addr::new(10, 20, 30, 40).try_into().unwrap());
+        inner_ipv4.set_destination(Ipv4Addr::new(50, 60, 70, 80));
+
+        embedded_headers.net(Some(Net::Ipv4(inner_ipv4)));
+        let embedded_headers = embedded_headers.build().unwrap();
+
+        let icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Icmp4(icmp)));
+        headers.embedded_ip(Some(embedded_headers));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = TestBuffer::new();
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet);
+        assert!(icmp_error_packet.is_none());
+    }
+
+    fn get_buffer_for_checksum_test(headers: &Headers) -> TestBuffer {
+        // Fill the buffer with zeroes.
+        //
+        // This is for tests that build an ICMP Error message with no embedded packet fragment, and
+        // validate its checksum. To do so, we prepare a packet by building the headers, setting the
+        // checksum, then deparsing to a buffer. The checksum for ICMP is computed on the header and
+        // the data, and when we set it (icmp.update_checksum(&[])), we pass a pointer to the data.
+        // In such tests, there is no embedded packet fragment, so the data is null (&[]). When we
+        // deparse the packet, we write the headers to a buffer: If we create the buffer with
+        // TestBuffer::new(), it's not filled with zeroes, but with some data simulating some random
+        // payload. Instead, create a buffer filled with zeroes, so that any trailing data does not
+        // mess up with checksum computation.
+        let data = vec![0u8; headers.size().get() as usize];
+        TestBuffer::from_raw_data(&data)
+    }
+
+    #[test]
+    fn test_icmp_error_packet_validate_checksums() {
+        // Build an ICMP error message with embedded headers
+        let mut headers = HeadersBuilder::default();
+        let mut embedded_headers = EmbeddedHeadersBuilder::default();
+
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::ICMP);
+
+        let mut inner_ipv4 = Ipv4::default();
+        inner_ipv4.set_source(Ipv4Addr::new(10, 20, 30, 40).try_into().unwrap());
+        inner_ipv4.set_destination(Ipv4Addr::new(50, 60, 70, 80));
+        inner_ipv4.set_next_header(NextHeader::TCP);
+        inner_ipv4.update_checksum(&()).unwrap();
+
+        let inner_tcp = Tcp::new(
+            TcpPort::new_checked(1234).unwrap(),
+            TcpPort::new_checked(5678).unwrap(),
+        );
+        embedded_headers.net(Some(Net::Ipv4(inner_ipv4)));
+        embedded_headers.transport(Some(inner_tcp.into()));
+        let embedded_headers = embedded_headers.build().unwrap();
+
+        let mut icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        icmp.update_checksum(&icmp.get_payload_for_checksum(Some(&embedded_headers), &[]))
+            .unwrap();
+
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Icmp4(icmp)));
+        headers.embedded_ip(Some(embedded_headers));
+
+        let headers = headers.build().unwrap();
+        let mut buffer = get_buffer_for_checksum_test(&headers);
+        headers.deparse(buffer.as_mut()).unwrap();
+        let packet = Packet::new(buffer).unwrap();
+
+        let icmp_error_packet = IcmpErrorPacket::new(&packet).unwrap();
+        icmp_error_packet.validate_checksums().unwrap();
+    }
+}

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -11,6 +11,8 @@ mod meta;
 mod stats;
 mod stats_display;
 
+pub mod icmp_err;
+
 pub use stats::PacketStats;
 
 #[cfg(any(test, feature = "bolero"))]

--- a/net/src/tcp/truncated.rs
+++ b/net/src/tcp/truncated.rs
@@ -231,6 +231,18 @@ impl DeParse for TruncatedTcp {
     }
 }
 
+impl From<Tcp> for TruncatedTcp {
+    fn from(tcp: Tcp) -> Self {
+        TruncatedTcp::FullHeader(tcp)
+    }
+}
+
+impl From<TruncatedTcpHeader> for TruncatedTcp {
+    fn from(header: TruncatedTcpHeader) -> Self {
+        TruncatedTcp::PartialHeader(header)
+    }
+}
+
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use super::{Tcp, TruncatedTcp, TruncatedTcpHeader};

--- a/net/src/udp/truncated.rs
+++ b/net/src/udp/truncated.rs
@@ -231,6 +231,18 @@ impl DeParse for TruncatedUdp {
     }
 }
 
+impl From<Udp> for TruncatedUdp {
+    fn from(udp: Udp) -> Self {
+        TruncatedUdp::FullHeader(udp)
+    }
+}
+
+impl From<TruncatedUdpHeader> for TruncatedUdp {
+    fn from(header: TruncatedUdpHeader) -> Self {
+        TruncatedUdp::PartialHeader(header)
+    }
+}
+
 #[cfg(any(test, feature = "bolero"))]
 mod contract {
     use super::{TruncatedUdp, TruncatedUdpHeader, Udp};


### PR DESCRIPTION
Introduce a new “validated” type to represent an ICMP Error packet with embedded IP and transport headers, and use it to simplify the checksum validation code and flow key extraction code in the ICMP Error handler.

Please refer to individual commit descriptions for details.

On top of #1587.