### PR TITLE
Fix Cargo.lock and add check to ensure the working tree remains clean after build

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -184,6 +184,21 @@ jobs:
         with:
           recipe: "doctest"
 
+      - &verify-clean-tree
+        name: "verify-clean-tree"
+        run: |
+          set -euo pipefail
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error:: Building the project left the tree dirty."
+            echo "----- git status --porcelain -----"
+            git status --porcelain
+            echo "----- git diff -----"
+            git diff
+            echo "----- hint -----"
+            echo "If the diff is on Cargo.lock, run a build locally and commit the updated lock file."
+            exit 1
+          fi
+
       - &tmate
         name: "Setup tmate session for debug"
         if: "${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}"
@@ -257,6 +272,7 @@ jobs:
           )
           just "${base_args[@]}" push-container "${NIX_TARGET}"
           just "${base_args[@]}" "version=${VERSION}-${PROFILE}" push-container "${NIX_TARGET}"
+      - *verify-clean-tree
       - *tmate
 
   sanitize:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "dataplane-acl"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "arrayvec",
  "dataplane-concurrency",


### PR DESCRIPTION
Update Cargo.lock to account for the project version change for the latest crate, `dataplane-acl`.

To avoid missing things in the future such as Cargo.lock updates for new crates when a PR has been created before a version bump (which we should catch at least in the merge queue with the proposed step), or any other file generated in-tree during the build, add a dedicated step to the dev.yml workflow.