### PR TITLE
Paella of sea bugs with jamon iberico, cinnamon, maple syrup and peanut butter.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,20 +1507,27 @@ name = "dataplane-interface-manager"
 version = "0.22.0"
 dependencies = [
  "bolero",
+ "caps",
  "dataplane-concurrency",
  "dataplane-net",
  "dataplane-rekon",
+ "dataplane-test-utils",
  "derive_builder",
+ "fixin",
  "futures",
  "libc",
  "multi_index_map",
+ "n-vm",
  "nix 0.31.3",
  "rtnetlink",
  "serde",
  "static_assertions",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
+ "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,6 +1771,7 @@ dependencies = [
  "dataplane-common",
  "dataplane-concurrency",
  "dataplane-config",
+ "dataplane-interface-manager",
  "dataplane-left-right-tlcache",
  "dataplane-lifecycle",
  "dataplane-lpm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "derive_builder",
  "dplane-rpc",
  "futures-util",
+ "inotify",
  "ipnet",
  "left-right 0.11.7 (git+https://github.com/githedgehog/left-right.git?branch=fredi%2Ffix-writehandle-drop)",
  "linkme",

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@
 FROM debug-tools:dev
 
 ARG PROFILE=debug
+ARG PLATFORM=x86_64-unknown-linux-gnu
 LABEL sterile=false
-COPY --link --chown=0:0 ./target/${PROFILE}/dataplane /bin/dataplane
-COPY --link --chown=0:0 ./target/${PROFILE}/dataplane-init /bin/dataplane-init
-COPY --link --chown=0:0 ./target/${PROFILE}/cli /bin/cli
+COPY --link --chown=0:0 ./target/${PLATFORM}/${PROFILE}/dataplane /bin/dataplane
+COPY --link --chown=0:0 ./target/${PLATFORM}/${PROFILE}/dataplane-init /bin/dataplane-init
+COPY --link --chown=0:0 ./target/${PLATFORM}/${PROFILE}/cli /bin/cli
 
 WORKDIR /
 # this is a privileged container, we really do want to run as root

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -512,8 +512,7 @@ async fn tx_packet(
             }
         }
         Err(e) => {
-            // this should be a warn/error. Making it debug until we rate-limit logs
-            debug!(
+            warn!(
                 worker = id,
                 rx_intf_name = rx_if_name,
                 "Serialize failed: {e:?}"

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -331,7 +331,7 @@ fn packet_recv(
     max_to_read: usize,
     pkts: &mut Vec<Box<Packet<TestBuffer>>>,
 ) -> Result<(), nix::Error> {
-    let mut raw = [0u8; 9100];
+    let mut raw = [0u8; 9600];
     let mut ret = Ok(());
     pkts.clear();
     while pkts.len() < max_to_read {

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -134,7 +134,7 @@ fn spawn_signal_handler(
     rt_handle: &tokio::runtime::Handle,
     mut sigrx: tokio::sync::mpsc::Receiver<DpSignal>,
     root: CancellationToken,
-    mut _router_ctl: RouterCtlSender,
+    mut router_ctl: RouterCtlSender,
 ) {
     rt_handle.spawn(async move {
         loop {
@@ -143,7 +143,10 @@ fn spawn_signal_handler(
                     info!("Processing signal {sig:?} from signal catcher");
                     match sig {
                         DpSignal::SIGTERM | DpSignal::SIGINT | DpSignal::SIGQUIT => root.cancel(),
-                        DpSignal::SIGUSR1 | DpSignal::SIGUSR2 | DpSignal::SIGHUP | DpSignal::SIGALRM | DpSignal::SIGPIPE => {}
+                        DpSignal::SIGUSR2 | DpSignal::SIGHUP | DpSignal::SIGALRM | DpSignal::SIGPIPE => {},
+                        DpSignal::SIGUSR1 => {
+                            let _ = router_ctl.rebind_cli().await;
+                        }
                     }
                 }
                 () = root.cancelled() => {

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -273,6 +273,7 @@ pub fn main() {
             MgmtParams {
                 config_dir: args.config_dir().cloned(),
                 hostname: gwname.clone(),
+                interfaces: args.interfaces().map(|i| i.interface).collect(),
                 processor_params: ConfigProcessorParams {
                     router_ctl: setup.router.get_ctl_tx(),
                     pipeline_data: pipeline_factory().get_data(),

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -15,7 +15,7 @@ use nix::unistd::gethostname;
 use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeConfig};
 
-use routing::{BmpServerParams, RouterCtlSender, RouterParamsBuilder};
+use routing::{BmpServerParams, RouterParamsBuilder};
 use tracectl::{
     TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
 };
@@ -134,7 +134,6 @@ fn spawn_signal_handler(
     rt_handle: &tokio::runtime::Handle,
     mut sigrx: tokio::sync::mpsc::Receiver<DpSignal>,
     root: CancellationToken,
-    mut router_ctl: RouterCtlSender,
 ) {
     rt_handle.spawn(async move {
         loop {
@@ -143,10 +142,7 @@ fn spawn_signal_handler(
                     info!("Processing signal {sig:?} from signal catcher");
                     match sig {
                         DpSignal::SIGTERM | DpSignal::SIGINT | DpSignal::SIGQUIT => root.cancel(),
-                        DpSignal::SIGUSR2 | DpSignal::SIGHUP | DpSignal::SIGALRM | DpSignal::SIGPIPE => {},
-                        DpSignal::SIGUSR1 => {
-                            let _ = router_ctl.rebind_cli().await;
-                        }
+                        DpSignal::SIGUSR1 | DpSignal::SIGUSR2 | DpSignal::SIGHUP | DpSignal::SIGALRM | DpSignal::SIGPIPE => {},
                     }
                 }
                 () = root.cancelled() => {
@@ -250,12 +246,7 @@ pub fn main() {
     )
     .expect("failed to start router");
 
-    spawn_signal_handler(
-        &mgmt_handle,
-        sigrx,
-        shutdown.root.clone(),
-        setup.router.get_ctl_tx(),
-    );
+    spawn_signal_handler(&mgmt_handle, sigrx, shutdown.root.clone());
 
     spawn_metrics(
         &shutdown.metrics,

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -6,14 +6,16 @@ use crate::statistics::spawn_metrics;
 use args::{CmdArgs, Parser};
 
 use crate::drivers::kernel::DriverKernel;
-use lifecycle::{Shutdown, default_deadlines, spawn_shutdown_watchdog};
+use lifecycle::{
+    CancellationToken, DpSignal, Shutdown, default_deadlines, spawn_shutdown_watchdog,
+};
 use mgmt::{ConfigProcessorParams, LaunchError, MgmtParams, run_mgmt};
 
 use nix::unistd::gethostname;
 use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeConfig};
 
-use routing::{BmpServerParams, RouterParamsBuilder};
+use routing::{BmpServerParams, RouterCtlSender, RouterParamsBuilder};
 use tracectl::{
     TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
 };
@@ -127,6 +129,32 @@ fn parse_bmp_params(args: &CmdArgs) -> (Option<BmpServerParams>, Option<BmpOptio
     }
 }
 
+// Main signal handling of dataplane occurs here
+fn spawn_signal_handler(
+    rt_handle: &tokio::runtime::Handle,
+    mut sigrx: tokio::sync::mpsc::Receiver<DpSignal>,
+    root: CancellationToken,
+    mut _router_ctl: RouterCtlSender,
+) {
+    rt_handle.spawn(async move {
+        loop {
+            tokio::select! {
+                Some(sig) = sigrx.recv() => {
+                    info!("Processing signal {sig:?} from signal catcher");
+                    match sig {
+                        DpSignal::SIGTERM | DpSignal::SIGINT | DpSignal::SIGQUIT => root.cancel(),
+                        DpSignal::SIGUSR1 | DpSignal::SIGUSR2 | DpSignal::SIGHUP | DpSignal::SIGALRM | DpSignal::SIGPIPE => {}
+                    }
+                }
+                () = root.cancelled() => {
+                    break;
+                }
+            }
+        }
+        info!("Signal handler ended");
+    });
+}
+
 #[allow(clippy::too_many_lines)]
 pub fn main() {
     let args = CmdArgs::parse();
@@ -188,7 +216,7 @@ pub fn main() {
         .expect("Failed to build mgmt runtime");
     let mgmt_handle = mgmt_runtime.handle().clone();
 
-    lifecycle::spawn_signal_handler(&mgmt_handle, shutdown.root.clone())
+    let sigrx = lifecycle::spawn_signal_catcher(&mgmt_handle, shutdown.root.clone())
         .expect("failed to install signal handler");
 
     spawn_shutdown_watchdog(shutdown.root.clone(), default_deadlines::TOTAL, 124)
@@ -218,6 +246,13 @@ pub fn main() {
         router_params,
     )
     .expect("failed to start router");
+
+    spawn_signal_handler(
+        &mgmt_handle,
+        sigrx,
+        shutdown.root.clone(),
+        setup.router.get_ctl_tx(),
+    );
 
     spawn_metrics(
         &shutdown.metrics,

--- a/interface-manager/Cargo.toml
+++ b/interface-manager/Cargo.toml
@@ -28,11 +28,18 @@ serde = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true, features = [] }
 thiserror = { workspace = true, features = ["std"] }
 tokio = { workspace = true, default-features = false, features = ["fs", "io-util"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 # internal
+fixin = { workspace = true }
 net = { workspace = true, features = ["bolero", "test_buffer", "serde", "netdevsim"] }
+n-vm = { workspace = true }
+test-utils = { workspace = true }
 
 # external
+caps = { workspace = true, default-features = false, features = [] }
 bolero = { workspace = true, default-features = false, features = ["alloc"] }
+tracing-subscriber = { workspace = true }
+tracing-test = { workspace = true }

--- a/interface-manager/src/lib.rs
+++ b/interface-manager/src/lib.rs
@@ -19,6 +19,7 @@ use concurrency::sync::Arc;
 use std::marker::PhantomData;
 
 pub mod interface;
+pub mod monitor;
 pub mod tc;
 
 use rtnetlink::Handle;

--- a/interface-manager/src/monitor/mod.rs
+++ b/interface-manager/src/monitor/mod.rs
@@ -120,9 +120,9 @@ impl InterfaceMonitor {
     /// # Errors
     ///
     /// This method fails if a netlink connection cannot be created.
-    pub async fn run(self: Arc<Self>) -> Result<(), ()> {
+    pub async fn run(monitor: Arc<Self>) -> Result<(), ()> {
         info!("Starting interface monitor");
-        for i in &self.tracked {
+        for i in &monitor.tracked {
             info!("Will track status of interface {i}");
         }
         let (conn, _, mut messages) = rtnetlink::new_multicast_connection(&[MulticastGroup::Link])
@@ -131,14 +131,14 @@ impl InterfaceMonitor {
 
         tokio::spawn(conn);
 
-        let tx = self.tx.clone();
-        let ct = self.ct.clone();
+        let tx = monitor.tx.clone();
+        let ct = monitor.ct.clone();
         loop {
             tokio::select! {
                 nlmsg = messages.recv() => {
                     match nlmsg {
                         Ok((msg, _)) => {
-                            if let Some(event) = self.netlink_to_event(msg) && tx.send(event).is_err() {
+                            if let Some(event) = monitor.netlink_to_event(msg) && tx.send(event).is_err() {
                                 warn!("Warning, there are no link event readers!");
                             }
                         }
@@ -180,7 +180,6 @@ mod test {
         handle.link().add(msg).execute().await.unwrap();
     }
 
-    #[traced_test]
     #[tokio::test]
     #[wrap(with_caps([Capability::CAP_NET_ADMIN]))]
     #[n_vm::in_vm]
@@ -193,7 +192,7 @@ mod test {
         let ifmonitor = Arc::new(InterfaceMonitor::new(ct, &[test_ifname]));
         let mut subsc1 = ifmonitor.subscribe();
         let mut subsc2 = ifmonitor.subscribe();
-        tokio::spawn(ifmonitor.clone().run());
+        tokio::spawn(InterfaceMonitor::run(ifmonitor.clone()));
 
         create_dummy(INTERFACE).await;
 

--- a/interface-manager/src/monitor/mod.rs
+++ b/interface-manager/src/monitor/mod.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! A small interface monitor. The interface monitor listens to netlink events asynchronously
+//! and disseminates them over a broadcast channel. It does not make any attempt to interpret
+//! the events received via netlink. The interface monitor reports events on ethernet interfaces.
+//! For testing, it can be allowed to report events for other types of network devices.
+
+use concurrency::sync::Arc;
+use net::interface::{InterfaceIndex, InterfaceName};
+use rtnetlink::MulticastGroup;
+use rtnetlink::packet_core::{NetlinkMessage, NetlinkPayload};
+use rtnetlink::packet_route::RouteNetlinkMessage;
+use rtnetlink::packet_route::link::{LinkAttribute, LinkFlags};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+#[allow(unused)]
+use tracing::{debug, error, info, warn};
+
+/// A type representing an event on an Ethernet interface.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct EthEvent {
+    pub name: InterfaceName,
+    pub ifindex: InterfaceIndex,
+    pub ifup: bool,
+    pub iflowerup: bool,
+    pub ifrunning: bool,
+    pub carrier: bool,
+    pub carrierup: u32,
+    pub carrierdown: u32,
+}
+impl std::fmt::Display for EthEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ifup = if self.ifup { "yes" } else { "no" };
+        let ifloup = if self.iflowerup { "yes" } else { "no" };
+        let ifrun = if self.ifrunning { "yes" } else { "no" };
+        let carrier = if self.carrier { "yes" } else { "no" };
+        write!(
+            f,
+            "ifname:{} ({}) ifup:{ifup} iflowerup:{ifloup} ifrun:{ifrun} carrier:{carrier} carrierup:{} carrierdown:{}",
+            self.name, self.ifindex, self.carrierup, self.carrierdown
+        )
+    }
+}
+
+/// Interface monitor
+pub struct InterfaceMonitor {
+    tx: broadcast::Sender<EthEvent>,
+    ct: CancellationToken,
+    tracked: Vec<InterfaceName>,
+}
+impl InterfaceMonitor {
+    #[must_use]
+    pub fn new(ct: CancellationToken, track: &[InterfaceName]) -> Self {
+        let (tx, _) = broadcast::channel::<EthEvent>(100);
+        Self {
+            tx,
+            ct,
+            tracked: track.into(),
+        }
+    }
+    #[must_use]
+    pub fn subscribe(&self) -> broadcast::Receiver<EthEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Convert a netlink message to an `EthEvent` if it is a `NewLink` message for a tracked interface
+    fn netlink_to_event(&self, msg: NetlinkMessage<RouteNetlinkMessage>) -> Option<EthEvent> {
+        let (_hdr, payload) = msg.into_parts();
+
+        let NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewLink(link_msg)) = payload else {
+            return None;
+        };
+        let ifindex = link_msg.header.index;
+        let ifup = link_msg.header.flags.contains(LinkFlags::Up);
+        let iflowerup = link_msg.header.flags.contains(LinkFlags::LowerUp);
+        let ifrunning = link_msg.header.flags.contains(LinkFlags::Running);
+        let ifname = link_msg.attributes.iter().find_map(|a| match a {
+            LinkAttribute::IfName(name) => Some(name.clone()),
+            _ => None,
+        })?;
+        let ifname = InterfaceName::try_from(ifname).ok()?;
+        if !self.tracked.contains(&ifname) {
+            return None;
+        }
+        let carrier = link_msg.attributes.iter().find_map(|a| match a {
+            LinkAttribute::Carrier(value) => Some(value),
+            _ => None,
+        })?;
+        let carrierup = link_msg.attributes.iter().find_map(|a| match a {
+            LinkAttribute::CarrierUpCount(value) => Some(*value),
+            _ => None,
+        })?;
+        let carrierdown = link_msg.attributes.iter().find_map(|a| match a {
+            LinkAttribute::CarrierDownCount(value) => Some(*value),
+            _ => None,
+        })?;
+        // `LinkAttribute::OperState` is not reliable for events, so we ignore it.
+        // N.B. the above attributes are required (watch the ?)
+
+        // construct the event object
+        let event = EthEvent {
+            name: ifname,
+            ifindex: InterfaceIndex::new(ifindex.try_into().ok()?),
+            ifup,
+            iflowerup,
+            ifrunning,
+            carrier: *carrier != 0,
+            carrierup,
+            carrierdown,
+        };
+        info!("Got event for {event}");
+        Some(event)
+    }
+
+    /// Start an interface monitor to track the set of network devices
+    ///
+    /// # Errors
+    ///
+    /// This method fails if a netlink connection cannot be created.
+    pub async fn run(self: Arc<Self>) -> Result<(), ()> {
+        info!("Starting interface monitor");
+        for i in &self.tracked {
+            info!("Will track status of interface {i}");
+        }
+        let (conn, _, mut messages) = rtnetlink::new_multicast_connection(&[MulticastGroup::Link])
+            .inspect_err(|e| error!("Failed to open netlink connection: {e}"))
+            .map_err(|_| ())?;
+
+        tokio::spawn(conn);
+
+        let tx = self.tx.clone();
+        let ct = self.ct.clone();
+        loop {
+            tokio::select! {
+                nlmsg = messages.recv() => {
+                    match nlmsg {
+                        Ok((msg, _)) => {
+                            if let Some(event) = self.netlink_to_event(msg) && tx.send(event).is_err() {
+                                warn!("Warning, there are no link event readers!");
+                            }
+                        }
+                        Err(e) => {
+                            error!("Recv error in netlink socket: {e}");
+                            break;
+                        }
+                    }
+                }
+                () = ct.cancelled() => {
+                    info!("Interface monitor got cancelled");
+                    break;
+                }
+            }
+        }
+        info!("Interface monitor is shutting down now");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::InterfaceMonitor;
+    use caps::Capability;
+    use concurrency::sync::Arc;
+    use fixin::wrap;
+    use net::interface::InterfaceName;
+    use rtnetlink::{LinkDummy, LinkMessageBuilder, new_connection};
+    use test_utils::with_caps;
+    use tokio::time::Duration;
+    use tokio_util::sync::CancellationToken;
+    use tracing::debug;
+    use tracing_test::traced_test;
+
+    async fn create_dummy(name: &str) {
+        let (connection, handle, _) = new_connection().unwrap();
+        tokio::spawn(connection);
+        let msg = LinkMessageBuilder::<LinkDummy>::new(name).build();
+        handle.link().add(msg).execute().await.unwrap();
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    #[wrap(with_caps([Capability::CAP_NET_ADMIN]))]
+    #[n_vm::in_vm]
+    #[cfg_attr(not(emulated), traced_test)]
+    #[ignore = "disabled until nv_m support is re-enabled"]
+    async fn test_interface_monitor() {
+        const INTERFACE: &str = "test-dummy";
+        let test_ifname = InterfaceName::try_from(INTERFACE).unwrap();
+        let ct = CancellationToken::new();
+        let ifmonitor = Arc::new(InterfaceMonitor::new(ct, &[test_ifname]));
+        let mut subsc1 = ifmonitor.subscribe();
+        let mut subsc2 = ifmonitor.subscribe();
+        tokio::spawn(ifmonitor.clone().run());
+
+        create_dummy(INTERFACE).await;
+
+        let j1 = tokio::spawn(async move {
+            let event = subsc1.recv().await.unwrap();
+            println!("listener1: {event}");
+        });
+        let j2 = tokio::spawn(async move {
+            let event = subsc2.recv().await.unwrap();
+            println!("listener2: {event}");
+        });
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        debug!("Will now cancel the interface monitor");
+        ifmonitor.ct.cancel();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(ifmonitor.ct.is_cancelled());
+        let _ = j1.await;
+        let _ = j2.await;
+    }
+}

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -23,6 +23,7 @@ use concurrency::sync::atomic::{AtomicBool, Ordering};
 use std::future::Future;
 use std::time::Duration;
 
+use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 use tokio::time::error::Elapsed;
 use tracing::{error, info, warn};
@@ -250,38 +251,96 @@ impl Default for Shutdown {
     }
 }
 
-/// Spawn a task on `handle` that trips `root` on `SIGINT`/`SIGTERM`, and
-/// also exits if `root` was tripped through another path.
+/// Type to indicate the type of signal that was caught
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum DpSignal {
+    SIGINT,
+    SIGTERM,
+    SIGQUIT,
+    SIGUSR1,
+    SIGUSR2,
+    SIGHUP,
+    SIGALRM,
+    SIGPIPE,
+}
+
+/// Spawn a task on `handle` that installs signal listeners for `SIGINT`/`SIGTERM` (and
+/// other signals which would otherwise terminate the process by default) and relays `DpSignal`s
+/// over a channel to the `Receiver` returned by this function.
+///
+/// The receiver should trip `root` on `SIGINT`/`SIGTERM`, which will also terminate this task.
 ///
 /// # Errors
 /// Returns [`std::io::Error`] if either signal handler install fails.
 #[cfg(unix)]
-pub fn spawn_signal_handler(
+pub fn spawn_signal_catcher(
     handle: &tokio::runtime::Handle,
     root: CancellationToken,
-) -> std::io::Result<()> {
+) -> std::io::Result<Receiver<DpSignal>> {
     use tokio::signal::unix::{SignalKind, signal};
+    let (tx, rx) = tokio::sync::mpsc::channel::<DpSignal>(10);
 
     // Install inside the runtime context so the handlers register with
     // its signal driver, not just the EnterGuard.
-    let (mut sigint, mut sigterm) = {
+    let (
+        mut sigint,
+        mut sigterm,
+        mut sigquit,
+        mut sigusr1,
+        mut sigusr2,
+        mut sighup,
+        mut sigalrm,
+        mut sigpipe,
+    ) = {
         let _guard = handle.enter();
         (
             signal(SignalKind::interrupt())?,
             signal(SignalKind::terminate())?,
+            signal(SignalKind::quit())?,
+            signal(SignalKind::user_defined1())?,
+            signal(SignalKind::user_defined2())?,
+            signal(SignalKind::hangup())?,
+            signal(SignalKind::alarm())?,
+            signal(SignalKind::pipe())?,
         )
     };
 
     handle.spawn(async move {
-        tokio::select! {
-            _ = sigint.recv()    => info!("SIGINT received; tripping shutdown"),
-            _ = sigterm.recv()   => info!("SIGTERM received; tripping shutdown"),
-            () = root.cancelled() => {}
+        loop {
+            tokio::select! {
+                _ = sigint.recv()  => {
+                    let _ = tx.send(DpSignal::SIGINT).await;
+                },
+                _ = sigterm.recv() => {
+                    let _ = tx.send(DpSignal::SIGTERM).await;
+                },
+                _ = sigquit.recv() => {
+                    let _ = tx.send(DpSignal::SIGQUIT).await;
+                },
+                _ = sigusr1.recv() => {
+                    let _ = tx.send(DpSignal::SIGUSR1).await;
+                },
+                _ = sigusr2.recv() => {
+                    let _ = tx.send(DpSignal::SIGUSR2).await;
+                },
+                _ = sighup.recv() => {
+                    let _ = tx.send(DpSignal::SIGHUP).await;
+                },
+                _ = sigalrm.recv() => {
+                    let _ = tx.send(DpSignal::SIGALRM).await;
+                },
+                _ = sigpipe.recv() => {
+                    let _ = tx.send(DpSignal::SIGPIPE).await;
+                },
+
+                () = root.cancelled() => break,
+            }
         }
-        root.cancel();
+        info!("Signal catcher ended");
     });
 
-    Ok(())
+    Ok(rx)
 }
 
 /// Spawn a detached OS thread that calls [`std::process::exit`] `deadline`

--- a/mgmt/src/processor/gwconfigdb.rs
+++ b/mgmt/src/processor/gwconfigdb.rs
@@ -48,18 +48,13 @@ impl GwConfigDatabase {
         self.applied = config;
     }
 
-    /// Get a refcounted reference to the applied `GwConfig`
-    pub fn get_applied(&self) -> Arc<ValidatedGwConfig> {
-        self.applied.clone()
-    }
-
     /// Get the generation Id of the currently applied config, if any.
     #[must_use]
     pub fn get_current_gen(&self) -> GenId {
         self.applied.genid()
     }
 
-    /// Get a reference to the config currently applied, if any.
+    /// Get a refcounted reference to the applied `GwConfig`
     #[must_use]
     pub fn get_current_config(&self) -> Arc<ValidatedGwConfig> {
         self.applied.clone()

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -133,7 +133,11 @@ pub fn run_mgmt(
         params.interfaces.as_slice(),
     ));
     let if_subsc = ifmonitor.subscribe();
-    mgmt.spawn_fatal_on_exit("interface monitor", ifmonitor.run(), handle);
+    mgmt.spawn_fatal_on_exit(
+        "interface monitor",
+        InterfaceMonitor::run(ifmonitor),
+        handle,
+    );
     mgmt.spawn_fatal_on_exit(
         "interface event relay",
         interface_event_notify(if_subsc, params.processor_params.router_ctl.clone()),

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -7,10 +7,13 @@ use crate::processor::k8s_client::{K8sClient, K8sClientError};
 use crate::processor::k8s_less_client::{K8sLess, K8sLessError};
 use crate::processor::mgmt_client::ConfigClient;
 use crate::processor::proc::ConfigProcessor;
-
 use crate::processor::proc::ConfigProcessorParams;
+use interface_manager::monitor::{EthEvent, InterfaceMonitor};
+
 use concurrency::sync::Arc;
 use lifecycle::{CancellationToken, Subsystem};
+use net::interface::InterfaceName;
+use routing::RouterCtlSender;
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug, thiserror::Error)]
@@ -28,6 +31,7 @@ pub enum LaunchError {
 pub struct MgmtParams {
     pub config_dir: Option<String>,
     pub hostname: String,
+    pub interfaces: Vec<InterfaceName>,
     pub processor_params: ConfigProcessorParams,
 }
 
@@ -84,19 +88,58 @@ async fn k8s_mgmt_init(
     Ok(())
 }
 
+async fn interface_event_notify(
+    mut rx: tokio::sync::broadcast::Receiver<EthEvent>,
+    mut rtr_ctl: RouterCtlSender,
+) {
+    use tokio::sync::broadcast::error::RecvError;
+    loop {
+        tokio::select! {
+            sig = rx.recv() => match sig {
+                Ok(ev) => {
+                    info!("Notifying router about interface event...");
+                    if rtr_ctl.send_ifevent(ev).await.is_err() {
+                        warn!("Failed to relay interface event to router")
+                    }
+                }
+                Err(RecvError::Lagged(n)) => {
+                    warn!("Dropped {n} interface events (rx lag)");
+                }
+                Err(RecvError::Closed) => {
+                    warn!("Interface monitor channel was closed. Will no longer relay interface events");
+                    break;
+                }
+            },
+        }
+    }
+}
+
 /// Init mgmt synchronously on `handle`, then spawn the long-lived tasks
 /// (config processor, status updater, config watcher) tracked under
 /// `mgmt`. Init observes `mgmt.root_token()` so SIGINT during init returns
 /// [`LaunchError::Cancelled`] within cancel latency.
 ///
 /// # Errors
-/// Returns [`LaunchError`] on init failure. [`LaunchError::Canc    elled`] is
+/// Returns [`LaunchError`] on init failure. [`LaunchError::Cancelled`] is
 /// a clean-shutdown signal — callers must not flip the fatal flag for it.
 pub fn run_mgmt(
     handle: &tokio::runtime::Handle,
     mgmt: &Subsystem,
     params: MgmtParams,
 ) -> Result<(), LaunchError> {
+    // start interface monitor
+    let ifmonitor = Arc::new(InterfaceMonitor::new(
+        mgmt.cancel_token(),
+        params.interfaces.as_slice(),
+    ));
+    let if_subsc = ifmonitor.subscribe();
+    mgmt.spawn_fatal_on_exit("interface monitor", ifmonitor.run(), handle);
+    mgmt.spawn_fatal_on_exit(
+        "interface event relay",
+        interface_event_notify(if_subsc, params.processor_params.router_ctl.clone()),
+        handle,
+    );
+
     // create config processor and run it
     let (processor, client) = ConfigProcessor::new(params.processor_params, handle);
     mgmt.spawn_fatal_on_exit("k8s-less config processor", processor.run(), handle);

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -5,6 +5,7 @@
 
 use crate::processor::k8s_client::{K8sClient, K8sClientError};
 use crate::processor::k8s_less_client::{K8sLess, K8sLessError};
+use crate::processor::mgmt_client::ConfigClient;
 use crate::processor::proc::ConfigProcessor;
 
 use crate::processor::proc::ConfigProcessorParams;
@@ -89,13 +90,17 @@ async fn k8s_mgmt_init(
 /// [`LaunchError::Cancelled`] within cancel latency.
 ///
 /// # Errors
-/// Returns [`LaunchError`] on init failure. [`LaunchError::Cancelled`] is
+/// Returns [`LaunchError`] on init failure. [`LaunchError::Canc    elled`] is
 /// a clean-shutdown signal — callers must not flip the fatal flag for it.
 pub fn run_mgmt(
     handle: &tokio::runtime::Handle,
     mgmt: &Subsystem,
     params: MgmtParams,
 ) -> Result<(), LaunchError> {
+    // create config processor and run it
+    let (processor, client) = ConfigProcessor::new(params.processor_params, handle);
+    mgmt.spawn_fatal_on_exit("k8s-less config processor", processor.run(), handle);
+
     if let Some(config_dir) = &params.config_dir {
         warn!("Running in k8s-less mode....");
         handle.block_on(run_k8s_less(
@@ -103,16 +108,11 @@ pub fn run_mgmt(
             mgmt,
             params.hostname.as_str(),
             config_dir,
-            params.processor_params,
+            client,
         ))
     } else {
         debug!("Will start watching k8s for configuration changes");
-        handle.block_on(run_k8s(
-            handle,
-            mgmt,
-            params.hostname.as_str(),
-            params.processor_params,
-        ))
+        handle.block_on(run_k8s(handle, mgmt, params.hostname.as_str(), client))
     }
 }
 
@@ -121,15 +121,13 @@ async fn run_k8s_less(
     mgmt: &Subsystem,
     hostname: &str,
     config_dir: &str,
-    processor_params: ConfigProcessorParams,
+    client: ConfigClient,
 ) -> Result<(), LaunchError> {
-    let (processor, client) = ConfigProcessor::new(processor_params);
     let k8sless = Arc::new(K8sLess::new(hostname, config_dir, client));
     let k8sless_for_watch = k8sless.clone();
 
     init_cancellable(k8sless.init(), &mgmt.root_token()).await?;
 
-    mgmt.spawn_fatal_on_exit("k8s-less config processor", processor.run(), handle);
     let k8sless_for_status = k8sless.clone();
     mgmt.spawn_fatal_on_exit(
         "k8s-less status updater",
@@ -158,15 +156,12 @@ async fn run_k8s(
     handle: &tokio::runtime::Handle,
     mgmt: &Subsystem,
     hostname: &str,
-    processor_params: ConfigProcessorParams,
+    client: ConfigClient,
 ) -> Result<(), LaunchError> {
-    let (processor, client) = ConfigProcessor::new(processor_params);
     let k8s_client = Arc::new(K8sClient::new(hostname, client));
     let k8s_client_for_status = k8s_client.clone();
-
     k8s_mgmt_init(&k8s_client, &mgmt.root_token()).await?;
 
-    mgmt.spawn_fatal_on_exit("k8s config processor", processor.run(), handle);
     mgmt.spawn_fatal_on_exit(
         "k8s status updater",
         async move {

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -8,8 +8,6 @@ use config::external::overlay::ValidatedOverlay;
 use flow_entry::flow_table::FlowTable;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::RwLock;
-
-use tokio::spawn;
 use tokio::sync::mpsc;
 
 use config::external::overlay::vpc::ValidatedVpcTable;
@@ -117,18 +115,25 @@ impl ConfigProcessor {
     /// Create a [`ConfigProcessor`] and return a [`ConfigClient`] to interact with it
     /////////////////////////////////////////////////////////////////////////////////
     #[must_use]
-    pub(crate) fn new(proc_params: ConfigProcessorParams) -> (Self, ConfigClient) {
+    pub(crate) fn new(
+        proc_params: ConfigProcessorParams,
+        handle: &tokio::runtime::Handle,
+    ) -> (Self, ConfigClient) {
         debug!("Creating config processor...");
-        let (tx, rx) = mpsc::channel(Self::CHANNEL_SIZE);
+        let _g = handle.enter();
 
+        // create netlink socket and spawn background task
         let Ok((connection, netlink, _)) = rtnetlink::new_connection() else {
             panic!("failed to create connection");
         };
-        spawn(connection);
+        handle.spawn(connection);
 
+        // build vpc manager
         let netlink = Arc::new(netlink);
         let vpc_mgr = VpcManager::<RequiredInformationBase>::new(netlink);
 
+        // create processor
+        let (tx, rx) = mpsc::channel(Self::CHANNEL_SIZE);
         let processor = ConfigProcessor {
             config_db: GwConfigDatabase::new(),
             rx,

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -188,7 +188,7 @@ impl ConfigProcessor {
 
     /// Attempt to apply the previously applied config.
     async fn rollback(&mut self) {
-        let active = self.config_db.get_applied();
+        let active = self.config_db.get_current_config();
         let active_genid = active.genid();
         info!("Rolling back to config with genid {}...", active.genid());
         let result = self.apply_gw_config(active.clone()).await.map(drop);

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -487,9 +487,11 @@ pub mod test {
             bmp_options: None,
         };
 
+        let rth = tokio::runtime::Handle::current();
+
         /* start config processor to test the processing of a config. The processor embeds the
         config database . In this test, we don't use any channel to communicate the config. */
-        let (mut processor, _) = ConfigProcessor::new(processor_config);
+        let (mut processor, _) = ConfigProcessor::new(processor_config, &rth);
 
         /* let the processor process the config */
         match processor.process_incoming_config(config).await {

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -123,7 +123,7 @@ impl Masquerade {
     }
 
     /// Update the `FlowStatus` of a masqueraded flow with a packet, depending on the direction of the
-    /// communication and the protocol, and return how much the timeout of a flow should be extended.
+    /// communication and the protocol and extend the lifetime of the flow (or invalidate it) accordingly.
     fn refresh_masquerade_state<Buf: PacketBufferMut>(
         packet: &Packet<Buf>,
         flow_info: &FlowInfo,
@@ -149,7 +149,9 @@ impl Masquerade {
             | NatFlowStatus::SHalfClose
             | NatFlowStatus::LastAck => Some(Self::MASQUERADE_CLOSING_TIMEOUT),
             NatFlowStatus::OneWay => {
-                warn!("Unexpected oneway state");
+                // this could happen if a burst of packets are sent before any state is there (snat),
+                // or if we got a TCP segment back without expected flags. This should never happen for
+                // a UDP packet in the reverse direction, though.
                 None
             }
         };
@@ -176,8 +178,8 @@ impl Masquerade {
             return None;
         }
         debug!("Hit ACTIVE flow: {}", flow_info.logfmt());
-        let value = flow_info.locked.read();
-        let Some(state) = value.nat_state.as_ref()?.extract_ref::<MasqueradeState>() else {
+        let locked = flow_info.locked.read();
+        let Some(state) = locked.nat_state.as_ref()?.extract_ref::<MasqueradeState>() else {
             debug!("Unable to access masquerade state");
             return None;
         };
@@ -205,7 +207,7 @@ impl Masquerade {
         Some((state.as_translate(), state.idle_timeout()))
     }
 
-    fn setup_flow_nat_state(
+    fn setup_flow_masquerade_state(
         flow_info: &FlowInfo,
         state: MasqueradeState,
         dst_vpcd: VpcDiscriminant,
@@ -274,8 +276,8 @@ impl Masquerade {
         );
 
         // set up their NAT state
-        Self::setup_flow_nat_state(&forward, forward_state, dst_vpc_id);
-        Self::setup_flow_nat_state(&reverse, reverse_state, src_vpc_id);
+        Self::setup_flow_masquerade_state(&forward, forward_state, dst_vpc_id);
+        Self::setup_flow_masquerade_state(&reverse, reverse_state, src_vpc_id);
 
         // set the genid of the flows
         forward.set_genid_pair(genid);

--- a/net/src/packet/meta.rs
+++ b/net/src/packet/meta.rs
@@ -113,6 +113,8 @@ pub enum DoneReason {
     InternalDrop,         /* the packet was dropped internally due to a queue being full */
     Local,                /* the packet has to be locally consumed by kernel */
     Delivered,            /* the packet buffer was delivered by the NF - e.g. for xmit */
+    DeparseError, /* the packet was processed and delivered to driver, but not be sent due to serialization issue */
+    NoHeadRoom, /* the packet was processed and delivered to driver, but not serialized due lack of headroom */
 }
 
 bitflags! {

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -30,7 +30,7 @@ use crate::headers::{
     TryHeaders, TryHeadersMut, TryIpMut, TryVxlan,
 };
 use crate::ip::{dscp::Dscp, ecn::Ecn};
-use crate::parse::{DeParse, Parse, ParseError};
+use crate::parse::{DeParse, DeParseError, Parse, ParseError};
 use crate::udp::{Udp, UdpChecksum};
 
 use crate::checksum::Checksum;
@@ -60,6 +60,16 @@ pub struct InvalidPacket<Buf: PacketBufferMut> {
     mbuf: Buf,
     #[source]
     error: ParseError<EthError>,
+}
+
+/// Errors which may occur when failing update a buffer from a [`Packet`]
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum SerializeError<E> {
+    #[error("Not enough headroom")]
+    NoHeadRoom,
+    #[error("De-parsing error: {0}")]
+    DeparseError(DeParseError<E>),
 }
 
 impl<Buf: PacketBufferMut> Packet<Buf> {
@@ -322,20 +332,45 @@ impl<Buf: PacketBufferMut> Packet<Buf> {
         self
     }
 
-    /// Update the packet's buffer based on any changes to the packets [`Headers`].
+    /// Consume a [`Packet`] and update its buffer based on any changes to its [`Headers`].
     ///
     /// # Errors
     ///
-    /// Returns a [`Prepend::Error`] error if the packet does not have enough headroom to
-    /// serialize.
-    pub fn serialize(mut self) -> Result<Buf, <Buf as Prepend>::Error> {
+    /// This method returns `SerializeError::NoHeadRoom`if the packet does not have enough headroom to
+    /// serialize or `SerializeError::DeparseError` if it does, but the de-parsing the `Packet` failed.
+    #[inline]
+    pub(crate) fn do_serialize(&mut self) -> Result<(), SerializeError<()>> {
         self.update_checksums();
         let needed = self.headers.size().get();
-        let buf = self.payload.prepend(needed)?;
+        let buf = self
+            .payload
+            .prepend(needed)
+            .map_err(|_| SerializeError::NoHeadRoom)?;
         self.headers
             .deparse(buf)
-            .unwrap_or_else(|e| unreachable!("{e:?}", e = e));
-        Ok(self.payload)
+            .map_err(SerializeError::DeparseError)?;
+
+        Ok(())
+    }
+
+    /// Consume a [`Packet`] and update its buffer based on any changes to its [`Headers`].
+    /// On error, mark the packet accordingly.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `SerializeError::NoHeadRoom`if the packet does not have enough headroom to
+    /// serialize or `SerializeError::DeparseError` if it does, but the de-parsing the `Packet` failed.
+    pub fn serialize(mut self) -> Result<Buf, SerializeError<()>> {
+        match self.do_serialize() {
+            Ok(()) => Ok(self.payload),
+            Err(e) => {
+                match e {
+                    SerializeError::NoHeadRoom => self.done_force(DoneReason::NoHeadRoom),
+                    SerializeError::DeparseError(_) => self.done_force(DoneReason::DeparseError),
+                }
+                Err(e)
+            }
+        }
     }
 }
 

--- a/net/src/packet/stats_display.rs
+++ b/net/src/packet/stats_display.rs
@@ -50,6 +50,10 @@ impl Display for DoneReason {
             Self::InternalDrop => f.pad("Internal drop"),
             Self::Local => f.pad("Locally delivered"),
             Self::Delivered => f.pad("Delivered"),
+
+            // these occur post delivery, prior to xmit
+            Self::NoHeadRoom => f.pad("No headroom"),
+            Self::DeparseError => f.pad("Deparse error"),
         }
     }
 }

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -36,6 +36,7 @@ chrono = { workspace = true, features = ["clock"] }
 derive_builder = { workspace = true, features = ["default", "std"] }
 futures-util = { workspace = true }
 ipnet = { workspace = true }
+inotify = { workspace = true, features = ["stream"] }
 left-right = { workspace = true }
 linkme = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -19,6 +19,7 @@ common = { workspace = true }
 config = { workspace = true }
 concurrency = { workspace = true }
 dplane-rpc = { workspace = true }
+interface-manager = { workspace = true }
 left-right-tlcache = { workspace = true }
 lifecycle = { workspace = true }
 lpm = { workspace = true }

--- a/routing/src/cli/display.rs
+++ b/routing/src/cli/display.rs
@@ -477,12 +477,12 @@ fn fmt_interface_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 
 impl Display for IfState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            IfState::Unknown => write!(f, "{:9}", "unknown")?,
-            IfState::Up => write!(f, "{:9}", "up")?,
-            IfState::Down => write!(f, "{:9}", "down")?,
-        }
-        Ok(())
+        let s = match *self {
+            IfState::Unknown => "unknown",
+            IfState::Up => "up",
+            IfState::Down => "down",
+        };
+        f.pad(s)
     }
 }
 impl Display for IfDataEthernet {

--- a/routing/src/frr/frrmi.rs
+++ b/routing/src/frr/frrmi.rs
@@ -15,7 +15,7 @@ use crate::router::revent::{ROUTER_EVENTS, RouterEvent, revent};
 use config::GenId;
 
 #[allow(unused)]
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use tracectl::trace_target;
 trace_target!("frrmi", LevelFilter::DEBUG, &["routing-full"]);
@@ -240,7 +240,7 @@ impl Frrmi {
 
         // Attempt to clean-up the config before re-applying the actual config.
         // This is disabled as the blank config is unsuitable for us and providing a suitable
-        //  one requires the ability to build frr configs, which we don't have here.
+        // one requires the ability to build frr configs, which we don't have here.
         if false {
             self.requests.push_front(FrrmiRequest::blank());
         }
@@ -328,22 +328,22 @@ impl Frrmi {
         };
         loop {
             let pending = self.readb.next_read_len();
-            trace!("Recv data (read:{} pending:{pending})", self.readb.used);
+            debug!("Recv data (read:{} pending:{pending})", self.readb.used);
             match Self::recv(sock, &mut self.readb, pending) {
                 Ok(0) => {
                     revent!(RouterEvent::FrrmiPeerLeft);
                     return Err(FrrErr::PeerLeft);
                 }
                 Ok(_) => {
-                    if self.readb.next_read_len() == 0 {
-                        {
-                            let response = self.readb.deserialize()?;
-                            return Ok(Some(response));
-                        }
+                    let pending = self.readb.next_read_len();
+                    if pending == 0 {
+                        let response = self.readb.deserialize()?;
+                        return Ok(Some(response));
                     }
                     // did not receive the complete message and need to read more
+                    debug!("Expecting {pending} octets of data from frr agent");
                 }
-                // we must wait. Can't provide a message yet
+                // we must wait and cannot provide a message yet
                 Err(ref e) if e.kind() == ErrorKind::WouldBlock => return Ok(None),
                 // recv failed due to unrecoverable reason. Will restart
                 Err(e) => return Err(FrrErr::IOFailure(e.to_string())),

--- a/routing/src/frr/frrmi.rs
+++ b/routing/src/frr/frrmi.rs
@@ -209,8 +209,8 @@ impl Frrmi {
         }
         self.sock.as_mut().ok_or(FrrErr::NotConnected)?;
         if let Some(req) = self.requests.pop_front() {
-            debug!("Initiating new FRR reconfiguration (gen: {})", req.genid);
             let genid = req.genid;
+            debug!("Initiating new FRR reconfiguration (gen: {genid})");
             self.send_msg(req)?;
             revent!(RouterEvent::FrrConfigApplyRequested(genid));
         }

--- a/routing/src/interfaces/iftable.rs
+++ b/routing/src/interfaces/iftable.rs
@@ -209,7 +209,7 @@ impl IfTable {
     //////////////////////////////////////////////////////////////////////
     /// Set the operational state of an [`Interface`]
     //////////////////////////////////////////////////////////////////////
-    pub(crate) fn set_iface_oper_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
+    pub(super) fn set_iface_oper_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         if let Some(ifr) = self.get_interface_mut(ifindex) {
             ifr.set_oper_state(state);
         }
@@ -218,7 +218,7 @@ impl IfTable {
     //////////////////////////////////////////////////////////////////////
     /// Set the admin state of an [`Interface`]
     //////////////////////////////////////////////////////////////////////
-    pub(crate) fn set_iface_admin_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
+    pub(super) fn set_iface_admin_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         if let Some(ifr) = self.get_interface_mut(ifindex) {
             ifr.set_admin_state(state);
         }

--- a/routing/src/interfaces/iftablerw.rs
+++ b/routing/src/interfaces/iftablerw.rs
@@ -121,13 +121,11 @@ impl IfTableWriter {
             .append(IfTableChange::DelIpAddress((ifindex, ifaddr)));
         self.0.publish();
     }
-    #[allow(unused)]
     pub fn set_iface_oper_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         self.0
             .append(IfTableChange::UpdateOpState((ifindex, state)));
         self.0.publish();
     }
-    #[allow(unused)]
     pub fn set_iface_admin_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         self.0
             .append(IfTableChange::UpdateAdmState((ifindex, state)));

--- a/routing/src/interfaces/interface.rs
+++ b/routing/src/interfaces/interface.rs
@@ -5,6 +5,8 @@
 
 use crate::fib::fibtype::FibKey;
 use crate::rib::vrf::VrfId;
+use crate::router::revent::{ROUTER_EVENTS, RouterEvent, revent};
+
 use net::eth::mac::SourceMac;
 use net::interface::address::IfAddr;
 use net::interface::{InterfaceIndex, Mtu};
@@ -171,6 +173,7 @@ impl Interface {
                 "Operational state of interface {} changed: {} -> {}",
                 self.name, self.oper_state, state
             );
+            revent!(RouterEvent::IfOperChange(self.name.clone(), state));
             self.oper_state = state;
         }
     }
@@ -184,6 +187,7 @@ impl Interface {
                 "Admin state of interface {} changed: {} -> {}",
                 self.name, self.admin_state, state
             );
+            revent!(RouterEvent::IfAdmChange(self.name.clone(), state));
             self.admin_state = state;
         }
     }

--- a/routing/src/interfaces/interface.rs
+++ b/routing/src/interfaces/interface.rs
@@ -5,7 +5,6 @@
 
 use crate::fib::fibtype::FibKey;
 use crate::rib::vrf::VrfId;
-use crate::router::revent::{ROUTER_EVENTS, RouterEvent, revent};
 
 use net::eth::mac::SourceMac;
 use net::interface::address::IfAddr;
@@ -168,28 +167,14 @@ impl Interface {
     /// Set the operational state of an [`Interface`]
     //////////////////////////////////////////////////////////////////
     pub(crate) fn set_oper_state(&mut self, state: IfState) {
-        if self.oper_state != state {
-            info!(
-                "Operational state of interface {} changed: {} -> {}",
-                self.name, self.oper_state, state
-            );
-            revent!(RouterEvent::IfOperChange(self.name.clone(), state));
-            self.oper_state = state;
-        }
+        self.oper_state = state;
     }
 
     //////////////////////////////////////////////////////////////////
     /// Set the administrative state of an [`Interface`]
     //////////////////////////////////////////////////////////////////
     pub(crate) fn set_admin_state(&mut self, state: IfState) {
-        if self.admin_state != state {
-            info!(
-                "Admin state of interface {} changed: {} -> {}",
-                self.name, self.admin_state, state
-            );
-            revent!(RouterEvent::IfAdmChange(self.name.clone(), state));
-            self.admin_state = state;
-        }
+        self.admin_state = state;
     }
     //////////////////////////////////////////////////////////////////
     /// Detach an [`Interface`], unconditionally

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -215,16 +215,13 @@ fn handle_configure(
         return;
     }
 
-    /* request application of frr config */
+    /* request application of frr config. This is infallible */
     if let Some(frr_config) = config.get_frr_config() {
         rio.request_frr_config(config.genid(), frr_config.clone());
     }
 
-    /* generate event depending on result */
-    match result {
-        Ok(()) => revent!(RouterEvent::ConfigSuceeded(config.genid())),
-        Err(_) => revent!(RouterEvent::ConfigFailed(config.genid())),
-    }
+    /* generate event: we successfully applied the router config and FRR's is on its way  */
+    revent!(RouterEvent::ConfigSuceeded(config.genid()));
 
     /* reply */
     let _ = reply_to.send(RouterCtlReply::Result(result)).map_err(|e| {

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -5,6 +5,7 @@
 
 use concurrency::sync::Arc;
 use config::{GwConfigMeta, ValidatedGwConfig};
+use interface_manager::monitor::EthEvent;
 use mio::Interest;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -17,6 +18,7 @@ use tracing::{debug, error, info, warn};
 use crate::RouterError;
 use crate::config::RouterConfig;
 use crate::frr::frrmi::FrrAppliedConfig;
+use crate::interfaces::interface::IfState;
 use crate::router::revent::{ROUTER_EVENTS, RouterEvent, revent};
 use crate::router::rio::{CPSOCK, Rio};
 use crate::routingdb::RoutingDb;
@@ -53,9 +55,11 @@ pub(crate) enum RouterCtlMsg {
     Config(Arc<ValidatedGwConfig>),
     ConfigHistory(Arc<Vec<GwConfigMeta>>),
     RebindCli,
+    IfEvent(EthEvent),
 }
 
 /// Object to send control messages to the router
+#[derive(Clone)]
 pub struct RouterCtlSender(tokio::sync::mpsc::Sender<RouterCtlMsg>);
 impl RouterCtlSender {
     #[must_use]
@@ -163,6 +167,14 @@ impl RouterCtlSender {
             .map_err(|_| RouterError::Internal("Failed to send cli rebind request"))?;
         Ok(())
     }
+    pub async fn send_ifevent(&mut self, ev: EthEvent) -> Result<(), RouterError> {
+        let msg = RouterCtlMsg::IfEvent(ev);
+        self.0
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send interface event"))?;
+        Ok(())
+    }
 }
 
 /// Handle a lock request for the indicated CPI
@@ -245,6 +257,17 @@ fn handle_config(rio: &mut Rio, config: Arc<ValidatedGwConfig>) {
 fn handle_config_history(rio: &mut Rio, history: Arc<Vec<GwConfigMeta>>) {
     rio.cfg_history = history;
 }
+fn handle_ifevent(ev: &EthEvent, db: &mut RoutingDb) {
+    let iftw = &mut db.iftw;
+    let adm_state = if ev.ifup { IfState::Up } else { IfState::Down };
+    let oper_state = if ev.iflowerup && ev.ifrunning && ev.carrier {
+        IfState::Up
+    } else {
+        IfState::Down
+    };
+    iftw.set_iface_admin_state(ev.ifindex, adm_state);
+    iftw.set_iface_oper_state(ev.ifindex, oper_state);
+}
 
 /// Handle a request from the control channel
 pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
@@ -261,6 +284,7 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
         Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
         Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
         Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
+        Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(&ev, db),
         Err(TryRecvError::Empty) => {}
         Err(e) => {
             error!("Error receiving from ctl channel {e:?}");

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -6,7 +6,7 @@
 use concurrency::sync::Arc;
 use config::{GwConfigMeta, ValidatedGwConfig};
 use interface_manager::monitor::EthEvent;
-use mio::Interest;
+use mio::{Interest, Waker};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::oneshot;
@@ -31,15 +31,19 @@ pub(crate) enum RouterCtlReply {
     FrrConfig(Option<FrrAppliedConfig>),
 }
 
-#[repr(transparent)]
-pub struct LockGuard(Option<Sender<RouterCtlMsg>>);
+pub struct LockGuard {
+    tx: Option<Sender<RouterCtlMsg>>,
+    waker: Arc<Waker>,
+}
 impl Drop for LockGuard {
     fn drop(&mut self) {
-        let tx = self.0.take();
-        if let Some(tx) = tx {
+        if let Some(tx) = self.tx.take() {
+            let waker = Arc::clone(&self.waker);
             task::spawn(async move {
                 if let Err(e) = tx.send(RouterCtlMsg::GuardedUnlock).await {
                     error!("Fatal: could not send unlock request!!: {e}");
+                } else {
+                    let _ = waker.wake();
                 }
             });
         }
@@ -60,24 +64,41 @@ pub(crate) enum RouterCtlMsg {
 
 /// Object to send control messages to the router
 #[derive(Clone)]
-pub struct RouterCtlSender(tokio::sync::mpsc::Sender<RouterCtlMsg>);
+pub struct RouterCtlSender {
+    tx: tokio::sync::mpsc::Sender<RouterCtlMsg>,
+    waker: Arc<Waker>,
+}
 impl RouterCtlSender {
     #[must_use]
-    pub(crate) fn new(tx: Sender<RouterCtlMsg>) -> Self {
-        Self(tx)
+    pub(crate) fn new(tx: Sender<RouterCtlMsg>, waker: Arc<Waker>) -> Self {
+        Self { tx, waker }
     }
+
     #[must_use]
     pub(crate) fn as_lock_guard(&self) -> LockGuard {
-        LockGuard(Some(self.0.clone()))
+        LockGuard {
+            tx: Some(self.tx.clone()),
+            waker: Arc::clone(&self.waker),
+        }
     }
+    async fn send_and_wake(&mut self, msg: RouterCtlMsg) -> Result<(), RouterError> {
+        self.tx
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send router ctl request"))?;
+
+        // wake up poller
+        self.waker
+            .wake()
+            .map_err(|_| RouterError::Internal("Failed to wake RIO"))?;
+        Ok(())
+    }
+
     pub async fn lock(&mut self) -> Result<LockGuard, RouterError> {
         debug!("Requesting CPI lock...");
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::Lock(reply_tx);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send lock request"))?;
+        self.send_and_wake(msg).await?;
         let reply = reply_rx
             .await
             .map_err(|_| RouterError::Internal("Failed to receive lock reply"))?;
@@ -93,10 +114,8 @@ impl RouterCtlSender {
         debug!("Requesting CPI unlock...");
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::Unlock(reply_tx);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send unlock request"))?;
+        self.send_and_wake(msg).await?;
+
         let reply = reply_rx
             .await
             .map_err(|_| RouterError::Internal("Failed to receive unlock reply"))?;
@@ -110,10 +129,8 @@ impl RouterCtlSender {
         debug!("Requesting router to apply config for gen {genid}...");
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::Configure(config, reply_tx);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send configure request"))?;
+        self.send_and_wake(msg).await?;
+
         let reply = reply_rx
             .await
             .map_err(|_| RouterError::Internal("Failed to receive configure reply"))?;
@@ -128,10 +145,8 @@ impl RouterCtlSender {
     ) -> Result<Option<FrrAppliedConfig>, RouterError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::GetFrrAppliedConfig(reply_tx);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send get FRR applied config"))?;
+        self.send_and_wake(msg).await?;
+
         let reply = reply_rx
             .await
             .map_err(|_| RouterError::Internal("Failed to receive reply for get FRR config"))?;
@@ -142,38 +157,22 @@ impl RouterCtlSender {
     }
     pub async fn send_config(&mut self, config: Arc<ValidatedGwConfig>) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::Config(config);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send ValidatedGwConfig"))?;
-        Ok(())
+        self.send_and_wake(msg).await
     }
     pub async fn send_config_history(
         &mut self,
         history: Arc<Vec<GwConfigMeta>>,
     ) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::ConfigHistory(history);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send config history"))?;
-        Ok(())
+        self.send_and_wake(msg).await
     }
     pub async fn rebind_cli(&mut self) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::RebindCli;
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send cli rebind request"))?;
-        Ok(())
+        self.send_and_wake(msg).await
     }
     pub async fn send_ifevent(&mut self, ev: EthEvent) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::IfEvent(ev);
-        self.0
-            .send(msg)
-            .await
-            .map_err(|_| RouterError::Internal("Failed to send interface event"))?;
-        Ok(())
+        self.send_and_wake(msg).await
     }
 }
 
@@ -285,25 +284,29 @@ fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
     iftw.set_iface_oper_state(ifindex, oper_state);
 }
 
-/// Handle a request from the control channel
+/// Handle requests from the control channel. Since the channel is integrated with the poll loop via a `Waker`
+/// and the `Waker` coalesce multiple readiness events, we drain completely on each call with a loop.
 pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
-    match rio.ctl_rx.try_recv() {
-        Ok(RouterCtlMsg::Lock(reply_to)) => handle_lock(rio, true, Some(reply_to)),
-        Ok(RouterCtlMsg::Unlock(reply_to)) => handle_lock(rio, false, Some(reply_to)),
-        Ok(RouterCtlMsg::GuardedUnlock) => handle_lock(rio, false, None),
-        Ok(RouterCtlMsg::Configure(config, reply_to)) => {
-            handle_configure(rio, config, db, reply_to);
-        }
-        Ok(RouterCtlMsg::GetFrrAppliedConfig(reply_to)) => {
-            handle_get_frr_applied_config(rio, reply_to);
-        }
-        Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
-        Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
-        Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
-        Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
-        Err(TryRecvError::Empty) => {}
-        Err(e) => {
-            error!("Error receiving from ctl channel {e:?}");
+    loop {
+        match rio.ctl_rx.try_recv() {
+            Ok(RouterCtlMsg::Lock(reply_to)) => handle_lock(rio, true, Some(reply_to)),
+            Ok(RouterCtlMsg::Unlock(reply_to)) => handle_lock(rio, false, Some(reply_to)),
+            Ok(RouterCtlMsg::GuardedUnlock) => handle_lock(rio, false, None),
+            Ok(RouterCtlMsg::Configure(config, reply_to)) => {
+                handle_configure(rio, config, db, reply_to);
+            }
+            Ok(RouterCtlMsg::GetFrrAppliedConfig(reply_to)) => {
+                handle_get_frr_applied_config(rio, reply_to);
+            }
+            Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
+            Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
+            Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
+            Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
+            Err(TryRecvError::Empty) => break,
+            Err(e) => {
+                error!("Error receiving from ctl channel {e:?}");
+                break;
+            }
         }
     }
 }

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -257,7 +257,7 @@ fn handle_config(rio: &mut Rio, config: Arc<ValidatedGwConfig>) {
 fn handle_config_history(rio: &mut Rio, history: Arc<Vec<GwConfigMeta>>) {
     rio.cfg_history = history;
 }
-fn handle_ifevent(ev: &EthEvent, db: &mut RoutingDb) {
+fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
     let iftw = &mut db.iftw;
     let adm_state = if ev.ifup { IfState::Up } else { IfState::Down };
     let oper_state = if ev.iflowerup && ev.ifrunning && ev.carrier {
@@ -265,8 +265,24 @@ fn handle_ifevent(ev: &EthEvent, db: &mut RoutingDb) {
     } else {
         IfState::Down
     };
-    iftw.set_iface_admin_state(ev.ifindex, adm_state);
-    iftw.set_iface_oper_state(ev.ifindex, oper_state);
+    let ifindex = ev.ifindex;
+    if let Some(iftable) = iftw.enter() {
+        let Some(iface) = iftable.get_interface(ifindex) else {
+            return;
+        };
+        if iface.admin_state != adm_state {
+            revent!(RouterEvent::IfAdmChange(
+                ev.clone(),
+                iface.admin_state,
+                adm_state
+            ));
+        }
+        if iface.oper_state != oper_state {
+            revent!(RouterEvent::IfOperChange(ev, iface.oper_state, oper_state));
+        }
+    }
+    iftw.set_iface_admin_state(ifindex, adm_state);
+    iftw.set_iface_oper_state(ifindex, oper_state);
 }
 
 /// Handle a request from the control channel
@@ -284,7 +300,7 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
         Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
         Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
         Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
-        Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(&ev, db),
+        Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
         Err(TryRecvError::Empty) => {}
         Err(e) => {
             error!("Error receiving from ctl channel {e:?}");

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -52,6 +52,7 @@ pub(crate) enum RouterCtlMsg {
     GetFrrAppliedConfig(RouterCtlReplyTx),
     Config(Arc<ValidatedGwConfig>),
     ConfigHistory(Arc<Vec<GwConfigMeta>>),
+    RebindCli,
 }
 
 /// Object to send control messages to the router
@@ -154,6 +155,14 @@ impl RouterCtlSender {
             .map_err(|_| RouterError::Internal("Failed to send config history"))?;
         Ok(())
     }
+    pub async fn rebind_cli(&mut self) -> Result<(), RouterError> {
+        let msg = RouterCtlMsg::RebindCli;
+        self.0
+            .send(msg)
+            .await
+            .map_err(|_| RouterError::Internal("Failed to send cli rebind request"))?;
+        Ok(())
+    }
 }
 
 /// Handle a lock request for the indicated CPI
@@ -251,6 +260,7 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
         }
         Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
         Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
+        Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
         Err(TryRecvError::Empty) => {}
         Err(e) => {
             error!("Error receiving from ctl channel {e:?}");

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -58,7 +58,6 @@ pub(crate) enum RouterCtlMsg {
     GetFrrAppliedConfig(RouterCtlReplyTx),
     Config(Arc<ValidatedGwConfig>),
     ConfigHistory(Arc<Vec<GwConfigMeta>>),
-    RebindCli,
     IfEvent(EthEvent),
 }
 
@@ -164,10 +163,6 @@ impl RouterCtlSender {
         history: Arc<Vec<GwConfigMeta>>,
     ) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::ConfigHistory(history);
-        self.send_and_wake(msg).await
-    }
-    pub async fn rebind_cli(&mut self) -> Result<(), RouterError> {
-        let msg = RouterCtlMsg::RebindCli;
         self.send_and_wake(msg).await
     }
     pub async fn send_ifevent(&mut self, ev: EthEvent) -> Result<(), RouterError> {
@@ -300,7 +295,6 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
             }
             Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
             Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
-            Ok(RouterCtlMsg::RebindCli) => rio.cli_sock_restore(),
             Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
             Err(TryRecvError::Empty) => break,
             Err(e) => {

--- a/routing/src/router/revent.rs
+++ b/routing/src/router/revent.rs
@@ -3,9 +3,11 @@
 
 //! Router events and eventlog
 
+use crate::IfState;
 use crate::event::EventLog;
 use crate::router::cpi::CpiStatus;
 use config::GenId;
+use interface_manager::monitor::EthEvent;
 use std::cell::RefCell;
 use std::fmt::Display;
 
@@ -25,6 +27,9 @@ pub enum RouterEvent {
     FrrConfigApplyRequested(GenId),
     FrrConfigApplySuccess(GenId),
     FrrConfigApplyFailure(GenId),
+
+    IfAdmChange(EthEvent, IfState, IfState),
+    IfOperChange(EthEvent, IfState, IfState),
 }
 
 impl Display for RouterEvent {
@@ -56,6 +61,22 @@ impl Display for RouterEvent {
             }
             RouterEvent::FrrConfigApplyFailure(genid) => {
                 write!(f, "FRR configuration for generation {genid} FAILED")?;
+            }
+            RouterEvent::IfOperChange(ev, old, new) => {
+                let ifc = &ev.name;
+                write!(
+                    f,
+                    "{ifc}: oper state changed {old} -> {new} (carrier:{:#?}, carrier-up:{} carrier-down:{})",
+                    ev.carrier, ev.carrierup, ev.carrierdown
+                )?;
+            }
+            RouterEvent::IfAdmChange(ev, old, new) => {
+                let ifc = &ev.name;
+                write!(
+                    f,
+                    "{ifc}: admin state changed {old} -> {new} (carrier:{:#?}, carrier-up:{} carrier-down:{})",
+                    ev.carrier, ev.carrierup, ev.carrierdown
+                )?;
             }
         }
         Ok(())

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -336,9 +336,28 @@ impl Rio {
     }
 }
 
+// Drop-guard so panic-unwind or unexpected loop exit trips
+// report_fatal.
+struct ExitGuard {
+    subsystem: Subsystem,
+}
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        if self.subsystem.is_cancelled() {
+            return;
+        }
+        let reason = if std::thread::panicking() {
+            "RIO thread panicked"
+        } else {
+            "RIO thread exited unexpectedly"
+        };
+        self.subsystem.report_fatal(reason);
+    }
+}
+
 #[allow(clippy::missing_errors_doc, clippy::too_many_lines)]
 pub(crate) fn start_rio(
-    router: &Subsystem,
+    subsystem: &Subsystem,
     conf: &RioConf,
     fibtw: FibTableWriter,
     iftw: IfTableWriter,
@@ -348,30 +367,13 @@ pub(crate) fn start_rio(
     let mut rio = Rio::new(conf)?;
     let ctl_tx = rio.ctl_tx.clone();
     let cli_sources = cli_sources.unwrap_or_default();
-    let cancel = router.cancel_token();
+    let cancel = subsystem.cancel_token();
     let loop_cancel = cancel.clone();
-    let guard_subsystem = router.clone();
+    let guard_subsystem = subsystem.clone();
 
     /* router IO loop */
     let rio_loop = move || {
-        // Drop-guard so panic-unwind or unexpected loop exit trips
-        // report_fatal.
-        struct ExitGuard {
-            subsystem: Subsystem,
-        }
-        impl Drop for ExitGuard {
-            fn drop(&mut self) {
-                if self.subsystem.is_cancelled() {
-                    return;
-                }
-                let reason = if std::thread::panicking() {
-                    "RIO thread panicked"
-                } else {
-                    "RIO thread exited unexpectedly"
-                };
-                self.subsystem.report_fatal(reason);
-            }
-        }
+        // drop-guard to detect loop termination
         let _guard = ExitGuard {
             subsystem: guard_subsystem,
         };

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -82,6 +82,7 @@ pub(crate) struct RioConf {
 }
 
 fn open_unix_sock(path: &String) -> Result<UnixDatagram, RouterError> {
+    debug!("Opening UX sock; target bind point is {path}");
     let _ = std::fs::remove_file(path);
     let sock = UnixDatagram::bind(path).map_err(|_| RouterError::InvalidPath(path.to_owned()))?;
     let mut perms = fs::metadata(path)
@@ -91,6 +92,7 @@ fn open_unix_sock(path: &String) -> Result<UnixDatagram, RouterError> {
     fs::set_permissions(path, perms).map_err(|_| RouterError::PermError)?;
     sock.set_nonblocking(true)
         .map_err(|_| RouterError::Internal("Failure setting non-blocking socket"))?;
+    debug!("Successfully opened UX sock @ {path}");
     Ok(sock)
 }
 
@@ -198,6 +200,23 @@ impl Rio {
             cli_cache: IoCache::new(),
         })
     }
+
+    pub(crate) fn cli_sock_restore(&mut self) {
+        let raw_fd = self.clisock.as_raw_fd();
+        debug!("Restoring CLI socket. Current fd is {raw_fd}...");
+        self.deregister(raw_fd);
+        let _ = self.clisock.shutdown(std::net::Shutdown::Both);
+
+        // open new sock, bind it and register it
+        let Ok(new_sock) = open_cli_sock(&self.cli_sock_path) else {
+            error!("Failed to open CLI sock");
+            return;
+        };
+        self.clisock = new_sock;
+        self.register(CLISOCK, self.clisock.as_raw_fd(), Interest::READABLE);
+        debug!("CLI socket restored at {}", self.cli_sock_path);
+    }
+
     pub(crate) fn register(&self, token: Token, fd: i32, interests: Interest) {
         debug!("Registering fd {fd}...");
         let mut ev_sock = SourceFd(&fd);

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -22,7 +22,10 @@ use cli::IoCache;
 use cli::cliproto::{CLI_RX_BUFF_SIZE, CliRequest};
 use config::{GwConfigMeta, ValidatedGwConfig};
 use dplane_rpc::socks::RpcCachedSock;
+use inotify::{EventMask, Inotify, WatchMask};
 use lifecycle::{CancellationToken, Subsystem};
+use std::os::fd::AsRawFd;
+use std::path::Path;
 
 use mio::unix::SourceFd;
 use mio::{Events, Interest, Poll, Token, Waker};
@@ -31,7 +34,6 @@ use concurrency::sync::Arc;
 use concurrency::thread::{self, JoinHandle};
 use nix::sys::socket::{getsockopt, setsockopt, sockopt::SndBuf};
 use std::fs;
-use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixDatagram;
 use std::time::{Duration, Instant};
@@ -107,10 +109,32 @@ fn open_cli_sock(path: &String) -> Result<UnixDatagram, RouterError> {
     Ok(sock)
 }
 
+// set up an inotify watcher for the directory where the CLI socket path lives.
+// This is way more reliable than tracking the file itself, since unlinking the path
+// only removes the directory entry, but the inode remains if the sock is open; so
+// no DELETE_SELF would be emitted.
+fn setup_clipath_watcher(path: &str) -> Result<Inotify, RouterError> {
+    let inotify = Inotify::init().map_err(|_| RouterError::Internal("Failed to init inotify"))?;
+    let dir = Path::new(path)
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or(RouterError::Internal("CLI socket path has no parent dir"))?;
+
+    let mask = WatchMask::DELETE | WatchMask::MOVED_FROM;
+    inotify
+        .watches()
+        .add(dir, mask)
+        .map_err(|_| RouterError::Internal("Failed to add watcher for inotify"))?;
+
+    debug!("Will track {path} via ({})", dir.display());
+    Ok(inotify)
+}
+
 pub(crate) const CPSOCK: Token = Token(0);
 pub(crate) const CLISOCK: Token = Token(1);
 pub(crate) const FRRMISOCK: Token = Token(2);
 pub(crate) const CTL_CHANNEL: Token = Token(3);
+pub(crate) const CLIPATH_WATCHER: Token = Token(4);
 
 /// `Rio` is the router IO loop state
 pub(crate) struct Rio {
@@ -131,6 +155,7 @@ pub(crate) struct Rio {
     pub(crate) gwconfig: Option<Arc<ValidatedGwConfig>>,
     pub(crate) cfg_history: Arc<Vec<GwConfigMeta>>,
     pub(crate) cli_cache: IoCache,
+    pub(crate) inotify: Inotify,
 }
 impl Rio {
     fn new(conf: &RioConf) -> Result<Rio, RouterError> {
@@ -158,6 +183,11 @@ impl Rio {
         /* create unix sock for cli and bind it */
         let clisock = open_cli_sock(&cli_sock_path)?;
 
+        /* add a watcher to the cli sock directory to detect if the file is removed */
+        let inotify = setup_clipath_watcher(&cli_sock_path)?;
+        let inotify_fd = inotify.as_raw_fd();
+        let mut inotify_src_fd = SourceFd(&inotify_fd);
+
         /* frrmi - communication to frr-agent */
         let frrmi = Frrmi::new(&frrmi_sock_path);
 
@@ -175,7 +205,7 @@ impl Rio {
         let clisock_fd = clisock.as_raw_fd();
         let mut ev_clisock = SourceFd(&clisock_fd);
 
-        /* create poller and register cp_sock and cli_sock */
+        /* create poller and register cp_sock, cli_sock, ctl waker and cli path inotify watcher */
         let poller = Poll::new().map_err(|_| RouterError::Internal("Poll creation failed"))?;
         poller
             .registry()
@@ -185,6 +215,11 @@ impl Rio {
             .registry()
             .register(&mut ev_clisock, CLISOCK, Interest::READABLE)
             .map_err(|_| RouterError::Internal("Failed to register CLI sock"))?;
+
+        poller
+            .registry()
+            .register(&mut inotify_src_fd, CLIPATH_WATCHER, Interest::READABLE)
+            .map_err(|_| RouterError::Internal("Failed to register CLIPATH watcher"))?;
 
         // Waker to integrate the async ctl channel with the poller
         let waker = Arc::new(
@@ -209,6 +244,7 @@ impl Rio {
             gwconfig: None,
             cfg_history: Arc::from(vec![]),
             cli_cache: IoCache::new(),
+            inotify,
         })
     }
 
@@ -438,7 +474,7 @@ pub(crate) fn start_rio(
             /* did any request time out? */
             rio.frrmi.timeout();
 
-            /* events on unix sockets */
+            /* handle events */
             for event in &events {
                 match event.token() {
                     CPSOCK => {
@@ -505,6 +541,23 @@ pub(crate) fn start_rio(
                                     let _ = rio.reregister(FRRMISOCK, fd, Interest::READABLE);
                                 }
                             }
+                        }
+                    }
+                    CLIPATH_WATCHER => {
+                        let mut buffer = [0u8; 4096];
+                        let sock_name = Path::new(&rio.cli_sock_path).file_name();
+                        match rio.inotify.read_events(&mut buffer) {
+                            Ok(evs) => {
+                                let removed = evs.into_iter().any(|e| {
+                                    e.mask.intersects(EventMask::DELETE | EventMask::MOVED_FROM)
+                                        && e.name == sock_name
+                                });
+                                if removed && !Path::new(&rio.cli_sock_path).exists() {
+                                    debug!("CLI socket file was removed...");
+                                    rio.cli_sock_restore();
+                                }
+                            }
+                            Err(e) => warn!("Error reading inotify events: {e}"),
                         }
                     }
                     CTL_CHANNEL => handle_ctl_msg(&mut rio, &mut db),

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -25,7 +25,7 @@ use dplane_rpc::socks::RpcCachedSock;
 use lifecycle::{CancellationToken, Subsystem};
 
 use mio::unix::SourceFd;
-use mio::{Events, Interest, Poll, Token};
+use mio::{Events, Interest, Poll, Token, Waker};
 
 use concurrency::sync::Arc;
 use concurrency::thread::{self, JoinHandle};
@@ -47,6 +47,7 @@ const CTL_CHANNEL_CAPACITY: usize = 100;
 pub(crate) struct RioHandle {
     cancel: CancellationToken,
     ctl: Sender<RouterCtlMsg>,
+    waker: Arc<Waker>,
     handle: Option<JoinHandle<()>>,
 }
 impl RioHandle {
@@ -70,7 +71,7 @@ impl RioHandle {
     }
     #[must_use]
     pub(crate) fn get_ctl_tx(&self) -> RouterCtlSender {
-        RouterCtlSender::new(self.ctl.clone())
+        RouterCtlSender::new(self.ctl.clone(), self.waker.clone())
     }
 }
 
@@ -82,7 +83,7 @@ pub(crate) struct RioConf {
 }
 
 fn open_unix_sock(path: &String) -> Result<UnixDatagram, RouterError> {
-    debug!("Opening UX sock; target bind point is {path}");
+    debug!("Opening UNIX sock; target bind point is {path}");
     let _ = std::fs::remove_file(path);
     let sock = UnixDatagram::bind(path).map_err(|_| RouterError::InvalidPath(path.to_owned()))?;
     let mut perms = fs::metadata(path)
@@ -109,6 +110,8 @@ fn open_cli_sock(path: &String) -> Result<UnixDatagram, RouterError> {
 pub(crate) const CPSOCK: Token = Token(0);
 pub(crate) const CLISOCK: Token = Token(1);
 pub(crate) const FRRMISOCK: Token = Token(2);
+pub(crate) const CTL_CHANNEL: Token = Token(3);
+
 /// `Rio` is the router IO loop state
 pub(crate) struct Rio {
     #[allow(unused)]
@@ -122,6 +125,7 @@ pub(crate) struct Rio {
     pub(crate) frrmi: Frrmi,
     pub(crate) ctl_tx: Sender<RouterCtlMsg>,
     pub(crate) ctl_rx: Receiver<RouterCtlMsg>,
+    pub(crate) waker: Arc<Waker>,
     pub(crate) cpistats: CpiStats,
     stale_timeout: Option<Instant>,
     pub(crate) gwconfig: Option<Arc<ValidatedGwConfig>>,
@@ -182,6 +186,12 @@ impl Rio {
             .register(&mut ev_clisock, CLISOCK, Interest::READABLE)
             .map_err(|_| RouterError::Internal("Failed to register CLI sock"))?;
 
+        // Waker to integrate the async ctl channel with the poller
+        let waker = Arc::new(
+            Waker::new(poller.registry(), CTL_CHANNEL)
+                .map_err(|_| RouterError::Internal("Failed to create ctl channel waker"))?,
+        );
+
         Ok(Rio {
             name: conf.name.clone(),
             frozen: false,
@@ -193,6 +203,7 @@ impl Rio {
             frrmi,
             ctl_tx,
             ctl_rx,
+            waker,
             cpistats: CpiStats::new(),
             stale_timeout: None,
             gwconfig: None,
@@ -385,6 +396,7 @@ pub(crate) fn start_rio(
 ) -> Result<RioHandle, RouterError> {
     let mut rio = Rio::new(conf)?;
     let ctl_tx = rio.ctl_tx.clone();
+    let waker = rio.waker.clone();
     let cli_sources = cli_sources.unwrap_or_default();
     let cancel = subsystem.cancel_token();
     let loop_cancel = cancel.clone();
@@ -495,15 +507,13 @@ pub(crate) fn start_rio(
                             }
                         }
                     }
+                    CTL_CHANNEL => handle_ctl_msg(&mut rio, &mut db),
                     _ => {}
                 }
             }
 
             /* check stale timeout. If expired, remove stale routes */
             rio.check_stale_timeout(&mut db);
-
-            /* handle control-channel messages */
-            handle_ctl_msg(&mut rio, &mut db);
         }
     };
     let handle = thread::Builder::new()
@@ -514,6 +524,7 @@ pub(crate) fn start_rio(
     Ok(RioHandle {
         cancel,
         ctl: ctl_tx,
+        waker,
         handle: Some(handle),
     })
 }


### PR DESCRIPTION
Fixes several small things experienced on deployments:
* allows rebinding CLI socket ~~(by sending SIGUSR1 to dataplane)~~ in case the corresponding file system entry is accidentally removed.
* Splits signal handler in two to avoid circular dependencies and adds listeners to disable default behavior that would stop dataplane (e.g. with the prior code, dataplane would stop upon receiving things like SIGUSR2, or SIGALRM or SIGPIPE).
* add support to account packets that were correctly processed but dropped if the last step (serialization) prior xmit failed.
``` 
━━━━━━━━━━━━━━━━━━━━━━ Packet stats ━━━━━━━━━━━━━━━━
    Packet result                  count
   [ .. ]
    Eth: not for us                2633
    Locally delivered              2633
    Delivered                      0
    Deparse error                  0 <-- here
    No headroom                    0 <--- here

```
* Fix dockerfile for quick builds
* Add netlink listener to interface manager to be able to log / register interface operational status changes and register events so that they can be looked up from cli. This allows detecting physical issues that may cause route flapping on faulty interface/transceiver/cabling (or excluding them).
```  
━━━━━━━━━━━━━━━━━━━━━ ROUTER_EVENTS ━━━━━━━━━━━━━━━━
 generated: 27 stored: 27 capacity: 1000

 0    2026-06-26T 15:24:13: Started!
 1    2026-06-26T 15:24:13: Connected to frr-agent
[ .. ]  
 11   2026-06-26T 15:24:43: eth2: oper state changed unknown -> down (carrier:false, carrier-up:1 carrier-down:2)
 12   2026-06-26T 15:24:49: eth2: oper state changed down -> up (carrier:true, carrier-up:2 carrier-down:2)
 13   2026-06-26T 15:25:58: eth2: oper state changed up -> down (carrier:false, carrier-up:2 carrier-down:3)
 14   2026-06-26T 15:26:02: eth2: oper state changed down -> up (carrier:true, carrier-up:3 carrier-down:3)
 15   2026-06-26T 15:26:14: eth2: admin state changed up -> down (carrier:false, carrier-up:3 carrier-down:4)
 16   2026-06-26T 15:26:14: eth2: oper state changed up -> down (carrier:false, carrier-up:3 carrier-down:4)
 17   2026-06-26T 15:26:31: eth2: admin state changed down -> up (carrier:true, carrier-up:4 carrier-down:4)
 18   2026-06-26T 15:26:31: eth2: oper state changed down -> up (carrier:true, carrier-up:4 carrier-down:4)
 19   2026-06-26T 15:26:40: eth2: admin state changed up -> down (carrier:false, carrier-up:4 carrier-down:5)
 20   2026-06-26T 15:26:40: eth2: oper state changed up -> down (carrier:false, carrier-up:4 carrier-down:5)
 21   2026-06-26T 15:26:48: eth2: admin state changed down -> up (carrier:true, carrier-up:5 carrier-down:5)
 22   2026-06-26T 15:26:48: eth2: oper state changed down -> up (carrier:true, carrier-up:5 carrier-down:5)
```
* better integrate the router control channel into the router IO loop by adding a waker.