### PR TITLE
chore: document required nix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ of the Fabric.
 [nix]: https://nixos.org/download/#nix-install-linux
 [just]: https://github.com/casey/just
 
+
+> [!NOTE]
+> Ensure flakes are enabled (e.g. `experimental-features = nix-command flakes` in `~/.config/nix/nix.conf` for single-user installs, or `/etc/nix/nix.conf` for multi-user installs), or some commands will fail.
+
 ### Step 0. Clone the repository
 
 ```bash


### PR DESCRIPTION
following just the installation notes in the README I was not able to run 'just build' until someone pointed out to me the required option in nix.conf, so let's make sure future developers will not hit the same issue