### PR TITLE
User ACLs: Add k8s converter from Fabric CRD, and ACLs validation

### DIFF
--- a/config/src/converters/k8s/config/acl.rs
+++ b/config/src/converters/k8s/config/acl.rs
@@ -425,7 +425,7 @@ mod test {
             ),
         )
         .unwrap();
-        assert_eq!(r.action(), AclAction::Allow);
+        assert_eq!(r.action, AclAction::Allow);
 
         // 'to' blank, inferred from 'from'
         assert!(
@@ -501,7 +501,7 @@ mod test {
             ),
         )
         .unwrap();
-        assert!(!r.pattern().src().is_empty());
+        assert!(!r.pattern.src.is_empty());
 
         // Same subnet name doesn't exist under VPC-2: fails when VPC-2 is the "from" side
         assert!(
@@ -581,7 +581,7 @@ mod test {
             ),
         )
         .unwrap();
-        assert!(r.pattern().src().is_empty());
+        assert!(r.pattern.src.is_empty());
     }
 
     // An entry with ports but neither cidr nor vpcSubnet is legal ("any address, these ports") but
@@ -614,7 +614,7 @@ mod test {
             ),
         )
         .unwrap();
-        assert!(r.pattern().src().is_empty());
+        assert!(r.pattern.src.is_empty());
 
         let empty_ports = GatewayAgentPeeringsAclRulesMatch {
             dst: None,
@@ -690,8 +690,9 @@ mod test {
         .validate()
         .unwrap();
 
-        let mut acl = Acl::new(AclAction::Deny, vec![converted_rule]);
-        acl.validate(&left, &right).unwrap();
+        let acl = Acl::new(AclAction::Deny, vec![converted_rule])
+            .validate(&left, &right)
+            .unwrap();
         assert_eq!(
             acl.rules()[0].pattern().src(),
             &PrefixPortsSet::from([PrefixWithOptionalPorts::new(
@@ -751,15 +752,15 @@ mod test {
         // The two rules built via `rule()` default to no explicit scope (CRD `None`), which maps to
         // `AclScope::Flow`; the third rule explicitly requested `Packet` scope, which must survive
         // the conversion.
-        assert_eq!(converted.rules()[0].scope(), AclScope::Flow);
-        assert_eq!(converted.rules()[1].scope(), AclScope::Flow);
-        assert_eq!(converted.rules()[2].scope(), AclScope::Packet);
+        assert_eq!(converted.rules()[0].scope, AclScope::Flow);
+        assert_eq!(converted.rules()[1].scope, AclScope::Flow);
+        assert_eq!(converted.rules()[2].scope, AclScope::Packet);
 
         // Same for `log`: the two rules built via `rule()` default to no explicit `log` (CRD
         // `None`), which maps to `false`; the third rule explicitly requested `log: true`, which
         // must survive the conversion too.
-        assert!(!converted.rules()[0].log());
-        assert!(!converted.rules()[1].log());
-        assert!(converted.rules()[2].log());
+        assert!(!converted.rules()[0].log);
+        assert!(!converted.rules()[1].log);
+        assert!(converted.rules()[2].log);
     }
 }

--- a/config/src/converters/k8s/config/acl.rs
+++ b/config/src/converters/k8s/config/acl.rs
@@ -1,0 +1,765 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+use k8s_intf::gateway_agent_crd::{
+    GatewayAgentPeeringsAcl, GatewayAgentPeeringsAclDefault, GatewayAgentPeeringsAclRules,
+    GatewayAgentPeeringsAclRulesAction, GatewayAgentPeeringsAclRulesMatch,
+    GatewayAgentPeeringsAclRulesMatchDst, GatewayAgentPeeringsAclRulesMatchSrc,
+    GatewayAgentPeeringsAclRulesScope,
+};
+use lpm::prefix::{PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
+
+use crate::converters::k8s::FromK8sConversionError;
+use crate::converters::k8s::config::expose::parse_port_ranges;
+use crate::converters::k8s::config::{SubnetMap, VpcSubnetMap};
+use crate::external::overlay::acl::{Acl, AclAction, AclPattern, AclProtoMatch, AclRule, AclScope};
+
+fn resolve_prefix(
+    cidr: Option<&str>,
+    vpc_subnet: Option<&str>,
+    subnets: &SubnetMap,
+) -> Result<Prefix, FromK8sConversionError> {
+    match (cidr, vpc_subnet) {
+        // unreachable as we only call this function if at least one of these fields is not None
+        (None, None) => Err(FromK8sConversionError::MissingData(
+            "ACL match entry must specify either cidr or vpcSubnet".to_string(),
+        )),
+        (Some(_), Some(_)) => Err(FromK8sConversionError::NotAllowed(
+            "ACL match entry must specify either cidr or vpcSubnet, not both".to_string(),
+        )),
+        (Some(cidr), None) => cidr
+            .parse::<Prefix>()
+            .map_err(|e| FromK8sConversionError::InvalidData(format!("CIDR format: {cidr}: {e}"))),
+        (None, Some(subnet_name)) => subnets.get(subnet_name).copied().ok_or_else(|| {
+            FromK8sConversionError::NotAllowed(format!(
+                "ACL match references unknown VPC subnet {subnet_name}"
+            ))
+        }),
+    }
+}
+
+fn parse_proto(proto: Option<&str>) -> Result<AclProtoMatch, FromK8sConversionError> {
+    let Some(proto) = proto else {
+        return Ok(AclProtoMatch::Any);
+    };
+    match proto {
+        "tcp" => Ok(AclProtoMatch::Tcp),
+        "udp" => Ok(AclProtoMatch::Udp),
+        other => other.parse::<u8>().map(AclProtoMatch::Other).map_err(|_| {
+            FromK8sConversionError::InvalidData(format!(
+                "ACL protocol '{other}': expected \"tcp\", \"udp\", or a numeric protocol"
+            ))
+        }),
+    }
+}
+
+/// Common shape of an ACL match entry (`match.src[]` / `match.dst[]`).
+///
+/// The CRD generates distinct `...MatchSrc`/`...MatchDst` types with identical fields; this lets
+/// [`convert_match_side`] handle both sides without duplicating the resolution logic.
+trait AclMatchEntry {
+    fn cidr(&self) -> Option<&str>;
+    fn vpc_subnet(&self) -> Option<&str>;
+    fn ports(&self) -> Option<&[String]>;
+}
+
+impl AclMatchEntry for GatewayAgentPeeringsAclRulesMatchSrc {
+    fn cidr(&self) -> Option<&str> {
+        self.cidr.as_deref()
+    }
+    fn vpc_subnet(&self) -> Option<&str> {
+        self.vpc_subnet.as_deref()
+    }
+    fn ports(&self) -> Option<&[String]> {
+        self.ports.as_deref()
+    }
+}
+
+impl AclMatchEntry for GatewayAgentPeeringsAclRulesMatchDst {
+    fn cidr(&self) -> Option<&str> {
+        self.cidr.as_deref()
+    }
+    fn vpc_subnet(&self) -> Option<&str> {
+        self.vpc_subnet.as_deref()
+    }
+    fn ports(&self) -> Option<&[String]> {
+        self.ports.as_deref()
+    }
+}
+
+/// Parse a `ports` list shared by both concrete and "any address" match entries.
+///
+/// A present-but-empty list is rejected rather than silently treated as "all ports" or "no
+/// ports" — the CRD does not require callers to omit the field instead of sending an empty list,
+/// so guessing which meaning was intended would be unsafe for an access-control rule.
+fn parse_entry_ports(ports: &[String]) -> Result<Vec<PortRange>, FromK8sConversionError> {
+    if ports.is_empty() {
+        return Err(FromK8sConversionError::MissingData(
+            "ACL match entry ports list must not be empty; omit the field to match all ports"
+                .to_string(),
+        ));
+    }
+    ports.iter().try_fold(Vec::new(), |mut ranges, port_str| {
+        ranges.extend(parse_port_ranges(port_str)?);
+        Ok(ranges)
+    })
+}
+
+/// Build a [`PrefixPortsSet`] plus any "any address within the peering" port ranges from one side
+/// (`src` or `dst`) of an ACL rule's `match` block.
+fn convert_match_side<T: AclMatchEntry>(
+    entries: Option<&[T]>,
+    subnets: &SubnetMap,
+) -> Result<(PrefixPortsSet, Vec<PortRange>), FromK8sConversionError> {
+    let Some(entries) = entries else {
+        return Ok((PrefixPortsSet::new(), Vec::new()));
+    };
+    let mut items = Vec::new();
+    let mut any_ports = Vec::new();
+    for entry in entries {
+        match (entry.cidr(), entry.vpc_subnet(), entry.ports()) {
+            // All fields omitted, the rule matches all traffic
+            (None, None, None) => return Ok((PrefixPortsSet::new(), Vec::new())),
+            // Match all addresses, ports returned separately since we need the peering manifest
+            // to resolve them to prefixes
+            (None, None, Some(ports)) => any_ports.extend(parse_entry_ports(ports)?),
+            (cidr, vpc_subnet, ports) => {
+                let prefix = resolve_prefix(cidr, vpc_subnet, subnets)?;
+                match ports {
+                    None => items.push(PrefixWithOptionalPorts::from(prefix)),
+                    Some(ports) => {
+                        for range in parse_entry_ports(ports)? {
+                            items.push(PrefixWithOptionalPorts::new(prefix, Some(range)));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok((items.into_iter().collect(), any_ports))
+}
+
+impl From<GatewayAgentPeeringsAclRulesAction> for AclAction {
+    fn from(action: GatewayAgentPeeringsAclRulesAction) -> Self {
+        match action {
+            GatewayAgentPeeringsAclRulesAction::Deny => AclAction::Deny,
+            GatewayAgentPeeringsAclRulesAction::Allow => AclAction::Allow,
+        }
+    }
+}
+
+impl From<&GatewayAgentPeeringsAclRulesScope> for AclScope {
+    fn from(scope: &GatewayAgentPeeringsAclRulesScope) -> Self {
+        match scope {
+            GatewayAgentPeeringsAclRulesScope::Flow
+            | GatewayAgentPeeringsAclRulesScope::KopiumEmpty => AclScope::Flow,
+            GatewayAgentPeeringsAclRulesScope::Packet => AclScope::Packet,
+        }
+    }
+}
+
+/// Convert a rule's `match` block.
+///
+/// `src_subnets`/`dst_subnets` are the subnet maps of the rule's (already-resolved) `from`/`to`
+/// VPCs, respectively, since `vpcSubnet` references in `src` resolve against the from-side VPC
+/// and in `dst` against the to-side VPC.
+impl TryFrom<(&SubnetMap, &SubnetMap, &GatewayAgentPeeringsAclRulesMatch)> for AclPattern {
+    type Error = FromK8sConversionError;
+
+    fn try_from(
+        (src_subnets, dst_subnets, m): (&SubnetMap, &SubnetMap, &GatewayAgentPeeringsAclRulesMatch),
+    ) -> Result<Self, Self::Error> {
+        let (src, src_any_ports) = convert_match_side(m.src.as_deref(), src_subnets)?;
+        let (dst, dst_any_ports) = convert_match_side(m.dst.as_deref(), dst_subnets)?;
+        let proto = parse_proto(m.proto.as_deref())?;
+        Ok(AclPattern::new(
+            src,
+            dst,
+            src_any_ports,
+            dst_any_ports,
+            proto,
+        ))
+    }
+}
+
+/// Complete a rule's `from`/`to` pair against the two VPC names of a peering.
+///
+/// At most one of `from`/`to` may be blank; if so, it is inferred from the other side and the two
+/// known VPC names.
+///
+/// # Errors
+///
+/// Returns an error if both values are blank, or if a non-blank value matches neither VPC name.
+fn complete_from_to(
+    rule_name: &str,
+    from: &str,
+    to: &str,
+    left_name: &str,
+    right_name: &str,
+) -> Result<(String, String), FromK8sConversionError> {
+    match (from, to) {
+        // Accept if values match the names of the two VPCs
+        (from, to) if from == left_name && to == right_name => {
+            Ok((from.to_string(), to.to_string()))
+        }
+        (from, to) if from == right_name && to == left_name => {
+            Ok((from.to_string(), to.to_string()))
+        }
+
+        // Accept, and complete, if one value matches a VPC, and the other is empty
+        (from, to) if from == left_name && to.is_empty() => {
+            Ok((from.to_string(), right_name.to_string()))
+        }
+        (from, to) if from == right_name && to.is_empty() => {
+            Ok((from.to_string(), left_name.to_string()))
+        }
+        (from, to) if from.is_empty() && to == left_name => {
+            Ok((right_name.to_string(), to.to_string()))
+        }
+        (from, to) if from.is_empty() && to == right_name => {
+            Ok((left_name.to_string(), to.to_string()))
+        }
+
+        // Reject both values empty
+        (from, to) if from.is_empty() && to.is_empty() => Err(FromK8sConversionError::MissingData(
+            format!("Rule '{rule_name}' must specify at least one of 'from' or 'to' fields"),
+        )),
+        // Reject if one value is non-empty but does not match either VPC
+        (from, to) => Err(FromK8sConversionError::NotAllowed(format!(
+            "Rule '{rule_name}' has invalid 'from' or 'to' fields: '{from}' -> '{to}'",
+        ))),
+    }
+}
+
+fn convert_rule(
+    vpc_subnets: &VpcSubnetMap,
+    left_name: &str,
+    right_name: &str,
+    rule: &GatewayAgentPeeringsAclRules,
+) -> Result<AclRule, FromK8sConversionError> {
+    let rule_name = rule.name.clone().unwrap_or_default();
+    let (from, to) = complete_from_to(
+        &rule_name,
+        rule.from.as_deref().unwrap_or_default(),
+        rule.to.as_deref().unwrap_or_default(),
+        left_name,
+        right_name,
+    )?;
+
+    let empty_map = SubnetMap::new();
+    let from_subnets = vpc_subnets.get(&from).unwrap_or(&empty_map);
+    let to_subnets = vpc_subnets.get(&to).unwrap_or(&empty_map);
+
+    let pattern = match rule.r#match.as_ref() {
+        Some(m) => AclPattern::try_from((from_subnets, to_subnets, m))?,
+        None => AclPattern::default(),
+    };
+
+    let scope = rule.scope.as_ref().map(AclScope::from).unwrap_or_default();
+
+    Ok(AclRule::new(
+        rule_name,
+        from,
+        to,
+        rule.action.clone().into(),
+        pattern,
+        scope,
+        rule.log.unwrap_or(false),
+    ))
+}
+
+impl TryFrom<(&VpcSubnetMap, &str, &str, &GatewayAgentPeeringsAcl)> for Acl {
+    type Error = FromK8sConversionError;
+
+    fn try_from(
+        (vpc_subnets, left_name, right_name, acl): (
+            &VpcSubnetMap,
+            &str,
+            &str,
+            &GatewayAgentPeeringsAcl,
+        ),
+    ) -> Result<Self, Self::Error> {
+        // "deny-unless-exposed" maps to "allow" in dataplane
+        let default = match acl.default {
+            GatewayAgentPeeringsAclDefault::Deny => AclAction::Deny,
+            GatewayAgentPeeringsAclDefault::DenyUnlessExposed
+            | GatewayAgentPeeringsAclDefault::KopiumEmpty => AclAction::Allow,
+        };
+
+        let rules = acl
+            .rules
+            .as_ref()
+            .map(|rules| {
+                rules
+                    .iter()
+                    .map(|rule| convert_rule(vpc_subnets, left_name, right_name, rule))
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(Acl::new(default, rules))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use k8s_intf::gateway_agent_crd::GatewayAgentPeeringsAclRulesScope;
+    use lpm::prefix::Prefix as LpmPrefix;
+
+    fn subnets(entries: &[(&str, &str)]) -> VpcSubnetMap {
+        let mut vpc_subnets = VpcSubnetMap::new();
+        for (vpc, subnet_map) in [("VPC-1", entries), ("VPC-2", &[])] {
+            let mut map = SubnetMap::new();
+            for (name, cidr) in subnet_map {
+                map.insert((*name).to_string(), cidr.parse::<LpmPrefix>().unwrap());
+            }
+            vpc_subnets.insert(vpc.to_string(), map);
+        }
+        vpc_subnets
+    }
+
+    fn rule(
+        name: &str,
+        from: &str,
+        to: &str,
+        action: GatewayAgentPeeringsAclRulesAction,
+        r#match: Option<GatewayAgentPeeringsAclRulesMatch>,
+    ) -> GatewayAgentPeeringsAclRules {
+        GatewayAgentPeeringsAclRules {
+            action,
+            from: (!from.is_empty()).then(|| from.to_string()),
+            log: None,
+            r#match,
+            name: (!name.is_empty()).then(|| name.to_string()),
+            scope: None,
+            to: (!to.is_empty()).then(|| to.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_default_action_mapping() {
+        for (default, expected) in [
+            (GatewayAgentPeeringsAclDefault::Deny, AclAction::Deny),
+            (
+                GatewayAgentPeeringsAclDefault::DenyUnlessExposed,
+                AclAction::Allow,
+            ),
+            // CRD doc: "deny-unless-exposed" is the default when the field is empty/unset.
+            (
+                GatewayAgentPeeringsAclDefault::KopiumEmpty,
+                AclAction::Allow,
+            ),
+        ] {
+            let acl = GatewayAgentPeeringsAcl {
+                default,
+                rules: None,
+            };
+            let converted = Acl::try_from((&subnets(&[]), "VPC-1", "VPC-2", &acl)).unwrap();
+            assert_eq!(converted.default_action(), expected);
+        }
+    }
+
+    #[test]
+    fn test_proto_parsing() {
+        assert_eq!(parse_proto(None).unwrap(), AclProtoMatch::Any);
+        assert_eq!(parse_proto(Some("tcp")).unwrap(), AclProtoMatch::Tcp);
+        assert_eq!(parse_proto(Some("udp")).unwrap(), AclProtoMatch::Udp);
+        assert_eq!(parse_proto(Some("47")).unwrap(), AclProtoMatch::Other(47));
+        assert!(parse_proto(Some("bogus")).is_err());
+        // "icmp" is not supported yet
+        assert!(parse_proto(Some("icmp")).is_err());
+    }
+
+    #[test]
+    fn test_scope_mapping() {
+        assert_eq!(
+            AclScope::from(&GatewayAgentPeeringsAclRulesScope::Flow),
+            AclScope::Flow
+        );
+        assert_eq!(
+            AclScope::from(&GatewayAgentPeeringsAclRulesScope::Packet),
+            AclScope::Packet
+        );
+        assert_eq!(
+            AclScope::from(&GatewayAgentPeeringsAclRulesScope::KopiumEmpty),
+            AclScope::Flow
+        );
+    }
+
+    #[test]
+    fn test_resolve_prefix_cidr_xor_subnet() {
+        let subnets = SubnetMap::from([(
+            "subnet-1".to_string(),
+            "10.0.1.0/24".parse::<LpmPrefix>().unwrap(),
+        )]);
+        assert!(resolve_prefix(None, None, &subnets).is_err());
+        assert!(resolve_prefix(Some("10.0.0.0/24"), Some("subnet-1"), &subnets).is_err());
+        assert_eq!(
+            resolve_prefix(Some("10.0.0.0/24"), None, &subnets).unwrap(),
+            "10.0.0.0/24".parse::<LpmPrefix>().unwrap()
+        );
+        assert_eq!(
+            resolve_prefix(None, Some("subnet-1"), &subnets).unwrap(),
+            "10.0.1.0/24".parse::<LpmPrefix>().unwrap()
+        );
+        assert!(resolve_prefix(None, Some("unknown"), &subnets).is_err());
+    }
+
+    #[test]
+    fn test_convert_rule_from_to_completion() {
+        let vpc_subnets = subnets(&[]);
+
+        // Both explicit
+        let r = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                None,
+            ),
+        )
+        .unwrap();
+        assert_eq!(r.action(), AclAction::Allow);
+
+        // 'to' blank, inferred from 'from'
+        assert!(
+            convert_rule(
+                &vpc_subnets,
+                "VPC-1",
+                "VPC-2",
+                &rule(
+                    "r",
+                    "VPC-1",
+                    "",
+                    GatewayAgentPeeringsAclRulesAction::Allow,
+                    None,
+                ),
+            )
+            .is_ok()
+        );
+
+        // Both blank: rejected
+        assert!(
+            convert_rule(
+                &vpc_subnets,
+                "VPC-1",
+                "VPC-2",
+                &rule("r", "", "", GatewayAgentPeeringsAclRulesAction::Allow, None),
+            )
+            .is_err()
+        );
+
+        // Unknown VPC name: rejected
+        assert!(
+            convert_rule(
+                &vpc_subnets,
+                "VPC-1",
+                "VPC-2",
+                &rule(
+                    "r",
+                    "VPC-X",
+                    "VPC-2",
+                    GatewayAgentPeeringsAclRulesAction::Allow,
+                    None,
+                ),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_convert_rule_vpc_subnet_resolution_uses_from_to_sides() {
+        let vpc_subnets = subnets(&[("web", "10.0.1.0/24")]);
+
+        let m = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: None,
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: None,
+                ports: None,
+                vpc_subnet: Some("web".to_string()),
+            }]),
+        };
+
+        // "web" exists under VPC-1's subnets: resolves when VPC-1 is the "from" side
+        let r = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(m.clone()),
+            ),
+        )
+        .unwrap();
+        assert!(!r.pattern().src().is_empty());
+
+        // Same subnet name doesn't exist under VPC-2: fails when VPC-2 is the "from" side
+        assert!(
+            convert_rule(
+                &vpc_subnets,
+                "VPC-1",
+                "VPC-2",
+                &rule(
+                    "r",
+                    "VPC-2",
+                    "VPC-1",
+                    GatewayAgentPeeringsAclRulesAction::Allow,
+                    Some(m),
+                ),
+            )
+            .is_err()
+        );
+    }
+
+    // An explicitly-empty (but present) `ports` list must not be silently treated as "all ports":
+    // that would silently expand an empty PrefixPortsSet into "match the entire manifest" via
+    // `AclRule::validate_pattern_coverage`, turning a scoped rule into an unscoped one.
+    #[test]
+    fn test_convert_rule_rejects_empty_ports_list() {
+        let vpc_subnets = subnets(&[]);
+        let m = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: None,
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: Some("10.0.0.0/24".to_string()),
+                ports: Some(vec![]),
+                vpc_subnet: None,
+            }]),
+        };
+        let result = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(m),
+            ),
+        );
+        assert!(
+            matches!(result, Err(FromK8sConversionError::MissingData(_))),
+            "{result:?}"
+        );
+    }
+
+    // Per the spec, a match entry with neither `cidr` nor `vpcSubnet` matches any address within
+    // the peering. A fully empty entry (no ports either) makes the whole side unrestricted.
+    #[test]
+    fn test_convert_rule_fully_empty_match_entry_is_unrestricted() {
+        let vpc_subnets = subnets(&[]);
+        let m = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: None,
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: None,
+                ports: None,
+                vpc_subnet: None,
+            }]),
+        };
+        let r = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(m),
+            ),
+        )
+        .unwrap();
+        assert!(r.pattern().src().is_empty());
+    }
+
+    // An entry with ports but neither cidr nor vpcSubnet is legal ("any address, these ports") but
+    // can't be resolved to concrete prefixes without the peering's manifest, so at conversion time
+    // it leaves `pattern.src()` empty; a present-but-empty ports list on such an entry is still
+    // rejected, same as for a concrete-prefix entry.
+    #[test]
+    fn test_convert_rule_any_address_with_ports() {
+        let vpc_subnets = subnets(&[]);
+
+        let ports_only = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: None,
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: None,
+                ports: Some(vec!["443".to_string()]),
+                vpc_subnet: None,
+            }]),
+        };
+        let r = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(ports_only),
+            ),
+        )
+        .unwrap();
+        assert!(r.pattern().src().is_empty());
+
+        let empty_ports = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: None,
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: None,
+                ports: Some(vec![]),
+                vpc_subnet: None,
+            }]),
+        };
+        let result = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(empty_ports),
+            ),
+        );
+        assert!(
+            matches!(result, Err(FromK8sConversionError::MissingData(_))),
+            "{result:?}"
+        );
+    }
+
+    // End-to-end: an "any address, these ports" match entry, once converted and validated against
+    // a real peering, resolves to the manifest's advertised prefixes restricted to those ports.
+    #[test]
+    fn test_convert_rule_any_address_with_ports_resolves_against_manifest() {
+        use crate::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
+
+        let vpc_subnets = subnets(&[]);
+        let m = GatewayAgentPeeringsAclRulesMatch {
+            dst: None,
+            proto: Some("tcp".to_string()),
+            src: Some(vec![GatewayAgentPeeringsAclRulesMatchSrc {
+                cidr: None,
+                ports: Some(vec!["443".to_string()]),
+                vpc_subnet: None,
+            }]),
+        };
+        let converted_rule = convert_rule(
+            &vpc_subnets,
+            "VPC-1",
+            "VPC-2",
+            &rule(
+                "r",
+                "VPC-1",
+                "VPC-2",
+                GatewayAgentPeeringsAclRulesAction::Allow,
+                Some(m),
+            ),
+        )
+        .unwrap();
+
+        let left = VpcManifest::with_exposes(
+            "VPC-1",
+            vec![VpcExpose::empty().ip(PrefixWithOptionalPorts::from(
+                "10.0.0.0/24".parse::<LpmPrefix>().unwrap(),
+            ))],
+        )
+        .validate()
+        .unwrap();
+        let right = VpcManifest::with_exposes(
+            "VPC-2",
+            vec![VpcExpose::empty().ip(PrefixWithOptionalPorts::from(
+                "10.1.0.0/24".parse::<LpmPrefix>().unwrap(),
+            ))],
+        )
+        .validate()
+        .unwrap();
+
+        let mut acl = Acl::new(AclAction::Deny, vec![converted_rule]);
+        acl.validate(&left, &right).unwrap();
+        assert_eq!(
+            acl.rules()[0].pattern().src(),
+            &PrefixPortsSet::from([PrefixWithOptionalPorts::new(
+                "10.0.0.0/24".parse::<LpmPrefix>().unwrap(),
+                Some(PortRange::new(443, 443).unwrap()),
+            )])
+        );
+    }
+
+    #[test]
+    fn test_full_acl_conversion() {
+        let vpc_subnets = subnets(&[]);
+        let acl = GatewayAgentPeeringsAcl {
+            default: GatewayAgentPeeringsAclDefault::Deny,
+            rules: Some(vec![
+                rule(
+                    "web",
+                    "VPC-1",
+                    "VPC-2",
+                    GatewayAgentPeeringsAclRulesAction::Allow,
+                    Some(GatewayAgentPeeringsAclRulesMatch {
+                        dst: Some(vec![GatewayAgentPeeringsAclRulesMatchDst {
+                            cidr: Some("10.1.0.0/24".to_string()),
+                            ports: Some(vec!["443".to_string()]),
+                            vpc_subnet: None,
+                        }]),
+                        proto: Some("tcp".to_string()),
+                        src: None,
+                    }),
+                ),
+                rule(
+                    "return",
+                    "VPC-2",
+                    "VPC-1",
+                    GatewayAgentPeeringsAclRulesAction::Allow,
+                    None,
+                ),
+            ]),
+        };
+
+        let mut rule_with_scope = rule(
+            "scoped",
+            "VPC-1",
+            "VPC-2",
+            GatewayAgentPeeringsAclRulesAction::Deny,
+            None,
+        );
+        rule_with_scope.scope = Some(GatewayAgentPeeringsAclRulesScope::Packet);
+        rule_with_scope.log = Some(true);
+        let mut acl_with_scope = acl.clone();
+        acl_with_scope.rules.as_mut().unwrap().push(rule_with_scope);
+
+        let converted = Acl::try_from((&vpc_subnets, "VPC-1", "VPC-2", &acl_with_scope)).unwrap();
+        assert_eq!(converted.default_action(), AclAction::Deny);
+        assert_eq!(converted.rules().len(), 3);
+
+        // The two rules built via `rule()` default to no explicit scope (CRD `None`), which maps to
+        // `AclScope::Flow`; the third rule explicitly requested `Packet` scope, which must survive
+        // the conversion.
+        assert_eq!(converted.rules()[0].scope(), AclScope::Flow);
+        assert_eq!(converted.rules()[1].scope(), AclScope::Flow);
+        assert_eq!(converted.rules()[2].scope(), AclScope::Packet);
+
+        // Same for `log`: the two rules built via `rule()` default to no explicit `log` (CRD
+        // `None`), which maps to `false`; the third rule explicitly requested `log: true`, which
+        // must survive the conversion too.
+        assert!(!converted.rules()[0].log());
+        assert!(!converted.rules()[1].log());
+        assert!(converted.rules()[2].log());
+    }
+}

--- a/config/src/converters/k8s/config/expose.rs
+++ b/config/src/converters/k8s/config/expose.rs
@@ -14,7 +14,7 @@ use crate::converters::k8s::FromK8sConversionError;
 use crate::converters::k8s::config::SubnetMap;
 use crate::external::overlay::vpcpeering::VpcExpose;
 
-fn parse_port_ranges(ports_str: &str) -> Result<Vec<PortRange>, FromK8sConversionError> {
+pub(crate) fn parse_port_ranges(ports_str: &str) -> Result<Vec<PortRange>, FromK8sConversionError> {
     ports_str
         // Split port ranges for prefix on ','
         .split(',')

--- a/config/src/converters/k8s/config/mod.rs
+++ b/config/src/converters/k8s/config/mod.rs
@@ -5,6 +5,7 @@
 
 #![deny(clippy::all, clippy::pedantic)]
 
+pub mod acl;
 pub mod bgp;
 pub mod communities;
 pub mod device;

--- a/config/src/converters/k8s/config/peering.rs
+++ b/config/src/converters/k8s/config/peering.rs
@@ -6,6 +6,7 @@ use k8s_intf::gateway_agent_crd::{GatewayAgentPeerings, GatewayAgentPeeringsPeer
 
 use crate::converters::k8s::FromK8sConversionError;
 use crate::converters::k8s::config::{SubnetMap, VpcSubnetMap};
+use crate::external::overlay::acl::Acl;
 use crate::external::overlay::vpcpeering::{VpcManifest, VpcPeering};
 
 impl TryFrom<(&SubnetMap, &str, &GatewayAgentPeeringsPeering)> for VpcManifest {
@@ -42,6 +43,7 @@ impl TryFrom<(&VpcSubnetMap, &str, &GatewayAgentPeerings)> for VpcPeering {
             )))?
             .clone();
 
+        let acl_spec = peering.acl.as_ref();
         if let Some(peering) = peering.peering.as_ref() {
             let num_peerings = peering.len();
             if peering.len() != 2 {
@@ -62,7 +64,18 @@ impl TryFrom<(&VpcSubnetMap, &str, &GatewayAgentPeerings)> for VpcPeering {
             let right = manifests.pop().unwrap_or_else(|| unreachable!());
             let left = manifests.pop().unwrap_or_else(|| unreachable!());
 
-            Ok(VpcPeering::new(peering_name, left, right, gwgroup))
+            let mut vpc_peering = VpcPeering::new(peering_name, left, right, gwgroup);
+            if let Some(acl) = acl_spec {
+                let acl = Acl::try_from((
+                    vpc_subnets,
+                    vpc_peering.left.name.as_str(),
+                    vpc_peering.right.name.as_str(),
+                    acl,
+                ))?;
+                vpc_peering.acl = Some(acl);
+            }
+
+            Ok(vpc_peering)
         } else {
             Err(FromK8sConversionError::MissingData(
                 "Vpc reference in peering".to_string(),
@@ -165,5 +178,56 @@ mod test {
                 assert_eq!(peering.name, peering_name);
                 // Rest of the assertions come from the types and the unwrap in the conversion above
             });
+    }
+
+    #[test]
+    fn test_vpc_peering_conversion_acl() {
+        use k8s_intf::gateway_agent_crd::{
+            GatewayAgentPeeringsAcl, GatewayAgentPeeringsAclDefault, GatewayAgentPeeringsAclRules,
+            GatewayAgentPeeringsAclRulesAction,
+        };
+        use std::collections::BTreeMap;
+
+        let subnets = VpcSubnetMap::from([
+            ("vpc0".to_string(), SubnetMap::new()),
+            ("vpc1".to_string(), SubnetMap::new()),
+        ]);
+
+        let peering_side = GatewayAgentPeeringsPeering {
+            expose: Some(vec![]),
+        };
+        let peerings_map = BTreeMap::from([
+            ("vpc0".to_string(), peering_side.clone()),
+            ("vpc1".to_string(), peering_side),
+        ]);
+
+        let acl = GatewayAgentPeeringsAcl {
+            default: GatewayAgentPeeringsAclDefault::Deny,
+            rules: Some(vec![GatewayAgentPeeringsAclRules {
+                action: GatewayAgentPeeringsAclRulesAction::Allow,
+                from: Some("vpc0".to_string()),
+                to: Some("vpc1".to_string()),
+                log: None,
+                r#match: None,
+                name: Some("allow-all".to_string()),
+                scope: None,
+            }]),
+        };
+
+        let k8s_peering = GatewayAgentPeerings {
+            gateway_group: Some("default".to_string()),
+            peering: Some(peerings_map),
+            acl: Some(acl),
+        };
+
+        let vpc_peering = VpcPeering::try_from((&subnets, "test-peering", &k8s_peering)).unwrap();
+        let converted_acl = vpc_peering.acl.expect("acl should be present");
+        assert_eq!(converted_acl.rules().len(), 1);
+
+        let mut k8s_peering_no_acl = k8s_peering;
+        k8s_peering_no_acl.acl = None;
+        let vpc_peering_no_acl =
+            VpcPeering::try_from((&subnets, "test-peering", &k8s_peering_no_acl)).unwrap();
+        assert!(vpc_peering_no_acl.acl.is_none());
     }
 }

--- a/config/src/errors.rs
+++ b/config/src/errors.rs
@@ -76,6 +76,8 @@ pub enum ConfigError {
     OverlappingPrefixes(PrefixWithOptionalPorts, PrefixWithOptionalPorts),
     #[error("Inconsistent IP version in VpcExpose: {0}")]
     InconsistentIpVersion(Box<VpcExpose>),
+    #[error("Invalid ACL configuration: {0}")]
+    InvalidAcl(String),
     // NAT-specific
     #[error("Mismatched prefixes sizes for static NAT: {0:?} and {1:?}")]
     MismatchedPrefixSizes(PrefixWithPortsSize, PrefixWithPortsSize),

--- a/config/src/external/overlay/acl.rs
+++ b/config/src/external/overlay/acl.rs
@@ -322,3 +322,490 @@ impl ValidatedAcl {
         self.default_action
     }
 }
+
+// =================================================================================================
+// ACL validation tests
+//
+// These tests cover the expected semantics and restrictions for ACL rules attached to a VPC peering
+// (the from/to directions, protocol/port consistency, IP version consistency, and coverage of the
+// rule patterns against the peering manifests).
+// =================================================================================================
+#[cfg(test)]
+mod validation_tests {
+    use super::{Acl, AclAction, AclPattern, AclProtoMatch, AclRule, AclScope};
+    use crate::ConfigError;
+    use crate::external::overlay::vpcpeering::{ValidatedManifest, VpcExpose, VpcManifest};
+
+    use lpm::prefix::{PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
+
+    // Helper: build a validated manifest, exposing the given (no-NAT) prefixes
+    fn manifest(name: &str, ips: &[&str]) -> ValidatedManifest {
+        let mut expose = VpcExpose::empty();
+        for ip in ips {
+            expose = expose.ip((*ip).into());
+        }
+        VpcManifest::with_exposes(name, vec![expose])
+            .validate()
+            .unwrap()
+    }
+
+    // Helper: the standard two-side peering used by most tests
+    // VPC-1 owns 10.0.0.0/16, VPC-2 owns 10.1.0.0/16
+    fn manifests() -> (ValidatedManifest, ValidatedManifest) {
+        (
+            manifest("VPC-1", &["10.0.0.0/16"]),
+            manifest("VPC-2", &["10.1.0.0/16"]),
+        )
+    }
+
+    // Helper: build a PrefixPortsSet from a list of CIDR strings (no port restriction)
+    fn prefixes(entries: &[&str]) -> PrefixPortsSet {
+        entries
+            .iter()
+            .map(|p| PrefixWithOptionalPorts::new(Prefix::from(*p), None))
+            .collect()
+    }
+
+    // Helper: a single prefix with a port range
+    fn prefix_with_ports(prefix_str: &str, start: u16, end: u16) -> PrefixWithOptionalPorts {
+        PrefixWithOptionalPorts::new(
+            Prefix::from(prefix_str),
+            Some(PortRange::new(start, end).unwrap()),
+        )
+    }
+
+    // Helper: assemble an AclPattern
+    fn pattern(src: PrefixPortsSet, dst: PrefixPortsSet, proto: AclProtoMatch) -> AclPattern {
+        AclPattern { src, dst, proto }
+    }
+
+    // Helper: assemble an AclRule
+    fn rule(name: &str, from: &str, to: &str, action: AclAction, pattern: AclPattern) -> AclRule {
+        AclRule {
+            name: name.to_owned(),
+            from: from.to_owned(),
+            to: to.to_owned(),
+            action,
+            pattern,
+            scope: AclScope::Flow,
+            log: false,
+        }
+    }
+
+    // Helper: validate a single rule against the standard peering, returning the (possibly
+    // completed/restricted) rule on success
+    fn validate_rule(mut rule: AclRule) -> Result<AclRule, ConfigError> {
+        let (left, right) = manifests();
+        rule.validate(&left, &right).map(|()| rule)
+    }
+
+    // Helper: a pattern matching all traffic in the rule's direction (empty src/dst, any proto)
+    fn match_all() -> AclPattern {
+        pattern(
+            PrefixPortsSet::new(),
+            PrefixPortsSet::new(),
+            AclProtoMatch::Any,
+        )
+    }
+
+    // =============================================================================================
+    // from/to direction validation
+    // =============================================================================================
+
+    // Explicit from/to naming the two peering sides passes
+    #[test]
+    fn test_acl_from_to_explicit_passes() {
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, match_all());
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // Explicit from/to with the sides swapped passes
+    #[test]
+    fn test_acl_from_to_swapped_passes() {
+        let rule = rule("r", "VPC-2", "VPC-1", AclAction::Allow, match_all());
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // "from" set to the left VPC, "to" omitted: the right VPC is implied
+    #[test]
+    fn test_acl_from_left_only_completes_to() {
+        let rule = rule("r", "VPC-1", "", AclAction::Allow, match_all());
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.to, "VPC-2");
+    }
+
+    // "from" set to the right VPC, "to" omitted: the left VPC is implied
+    #[test]
+    fn test_acl_from_right_only_completes_to() {
+        let rule = rule("r", "VPC-2", "", AclAction::Allow, match_all());
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.to, "VPC-1");
+    }
+
+    // "to" set to the right VPC, "from" omitted: the left VPC is implied
+    #[test]
+    fn test_acl_to_right_only_completes_from() {
+        let rule = rule("r", "", "VPC-2", AclAction::Allow, match_all());
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.from, "VPC-1");
+    }
+
+    // "to" set to the left VPC, "from" omitted: the right VPC is implied
+    #[test]
+    fn test_acl_to_left_only_completes_from() {
+        let rule = rule("r", "", "VPC-1", AclAction::Allow, match_all());
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.from, "VPC-2");
+    }
+
+    // Omitting both "from" and "to" is rejected
+    #[test]
+    fn test_acl_both_from_and_to_empty_rejected() {
+        let rule = rule("r", "", "", AclAction::Allow, match_all());
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A "from" value that is not one of the peering's two VPCs is rejected
+    #[test]
+    fn test_acl_unknown_from_rejected() {
+        let rule = rule("r", "VPC-X", "VPC-2", AclAction::Allow, match_all());
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A "to" value that is not one of the peering's two VPCs is rejected
+    #[test]
+    fn test_acl_unknown_to_rejected() {
+        let rule = rule("r", "VPC-1", "VPC-X", AclAction::Allow, match_all());
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // Using identical "to" and "from" values is rejected
+    #[test]
+    fn test_acl_to_from_equal_rejected() {
+        let rule = rule("r", "VPC-1", "VPC-1", AclAction::Allow, match_all());
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // =============================================================================================
+    // Rule name validation (at the ACL level)
+    // =============================================================================================
+
+    // Duplicate rule names within an ACL are rejected
+    #[test]
+    fn test_acl_duplicate_rule_names_rejected() {
+        let (left, right) = manifests();
+        let mut acl = Acl {
+            default: AclAction::Deny,
+            rules: vec![
+                rule("dup", "VPC-1", "VPC-2", AclAction::Allow, match_all()),
+                rule("dup", "VPC-2", "VPC-1", AclAction::Allow, match_all()),
+            ],
+        };
+        let result = acl.validate(&left, &right);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // Distinct rule names within an ACL pass
+    #[test]
+    fn test_acl_distinct_rule_names_passes() {
+        let (left, right) = manifests();
+        let mut acl = Acl {
+            default: AclAction::Deny,
+            rules: vec![
+                rule("forward1", "VPC-1", "VPC-2", AclAction::Allow, match_all()),
+                rule("forward2", "VPC-1", "VPC-2", AclAction::Allow, match_all()),
+                rule("reverse", "VPC-2", "VPC-1", AclAction::Allow, match_all()),
+            ],
+        };
+        assert!(acl.validate(&left, &right).is_ok());
+    }
+
+    // =============================================================================================
+    // Protocol / port consistency validation
+    // =============================================================================================
+
+    // TCP with port matching passes
+    #[test]
+    fn test_acl_tcp_with_ports_passes() {
+        let p = pattern(
+            [prefix_with_ports("10.0.0.0/24", 1024, 2048)].into(),
+            [prefix_with_ports("10.1.0.0/24", 443, 443)].into(),
+            AclProtoMatch::Tcp,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // UDP with port matching passes
+    #[test]
+    fn test_acl_udp_with_ports_passes() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            [prefix_with_ports("10.1.0.0/24", 53, 53)].into(),
+            AclProtoMatch::Udp,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // ICMP with port matching is rejected (ICMP has no ports)
+    #[test]
+    fn test_acl_icmp_with_ports_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            [prefix_with_ports("10.1.0.0/24", 443, 443)].into(),
+            AclProtoMatch::Icmp,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A numeric protocol with port matching is rejected
+    #[test]
+    fn test_acl_other_proto_with_ports_rejected() {
+        let p = pattern(
+            [prefix_with_ports("10.0.0.0/24", 80, 80)].into(),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Other(47),
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // "Any" protocol with port matching is rejected (ports are only meaningful per-protocol)
+    #[test]
+    fn test_acl_any_proto_with_ports_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            [prefix_with_ports("10.1.0.0/24", 443, 443)].into(),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // ICMP without ports passes
+    #[test]
+    fn test_acl_icmp_without_ports_passes() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Icmp,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // Unknown protocol without ports passes
+    #[test]
+    fn test_acl_other_proto_without_ports_passes() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Other(47),
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        assert!(validate_rule(rule).is_ok());
+    }
+
+    // =============================================================================================
+    // IP version consistency validation
+    // =============================================================================================
+
+    // Mixed IPv4/IPv6 within the "src" set is rejected
+    #[test]
+    fn test_acl_mixed_src_ip_versions_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24", "2001:db8::/64"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // Mixed IPv4/IPv6 within the "dst" set is rejected
+    #[test]
+    fn test_acl_mixed_dst_ip_versions_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["10.1.0.0/24", "2001:db8::/64"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // Mixed IPv4/IPv6 between "src" and "dst" sets is rejected
+    #[test]
+    fn test_acl_mixed_src_dst_ip_versions_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["2001:db8::/64"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // =============================================================================================
+    // Pattern coverage validation (src vs from-side, dst vs to-side)
+    // =============================================================================================
+
+    // An empty src/dst (the blanket "match all in this direction" rule) is accepted, and the
+    // empty sets are filled in with the manifests' prefixes
+    #[test]
+    fn test_acl_empty_match_covers_manifest() {
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, match_all());
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.pattern.src, prefixes(&["10.0.0.0/16"]));
+        assert_eq!(validated.pattern.dst, prefixes(&["10.1.0.0/16"]));
+    }
+
+    // A src that does not intersect the from-side's addresses is rejected (can never match)
+    #[test]
+    fn test_acl_src_outside_from_manifest_rejected() {
+        let p = pattern(
+            prefixes(&["192.168.0.0/24"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A dst that does not intersect the to-side's advertised addresses is rejected
+    #[test]
+    fn test_acl_dst_outside_to_manifest_rejected() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["192.168.0.0/24"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A src broader than the from-side's addresses is accepted, but restricted (clamped) to the
+    // intersection with the manifest
+    #[test]
+    fn test_acl_src_broader_than_manifest_is_restricted() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/8"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Any,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let validated = validate_rule(rule).expect("should validate");
+        // 10.0.0.0/8 is clamped to VPC-1's 10.0.0.0/16
+        assert_eq!(validated.pattern.src, prefixes(&["10.0.0.0/16"]));
+    }
+
+    // A fully-specified, in-range rule passes unchanged
+    #[test]
+    fn test_acl_full_valid_match_passes() {
+        let p = pattern(
+            prefixes(&["10.0.0.0/24"]),
+            prefixes(&["10.1.0.0/24"]),
+            AclProtoMatch::Tcp,
+        );
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.pattern.src, prefixes(&["10.0.0.0/24"]));
+        assert_eq!(validated.pattern.dst, prefixes(&["10.1.0.0/24"]));
+    }
+
+    // =============================================================================================
+    // Default ACL values
+    // =============================================================================================
+
+    #[test]
+    fn test_default_rule_values() {
+        let rule = AclRule::default();
+        assert_eq!(rule.action(), AclAction::Deny);
+        assert_eq!(rule.scope(), AclScope::Flow);
+        assert!(!rule.log());
+    }
+
+    // =============================================================================================
+    // ACL-level smoke test
+    // =============================================================================================
+
+    // A complete ACL with a default action and several valid rules validates, and the accessors
+    // report what was configured
+    #[test]
+    fn test_acl_multiple_rules_passes() {
+        let (left, right) = manifests();
+        let mut acl = Acl {
+            default: AclAction::Deny,
+            rules: vec![
+                rule(
+                    "web",
+                    "VPC-1",
+                    "VPC-2",
+                    AclAction::Allow,
+                    pattern(
+                        prefixes(&["10.0.0.0/24"]),
+                        [prefix_with_ports("10.1.0.0/24", 443, 443)].into(),
+                        AclProtoMatch::Tcp,
+                    ),
+                ),
+                rule("return", "VPC-2", "VPC-1", AclAction::Allow, match_all()),
+            ],
+        };
+        assert!(acl.validate(&left, &right).is_ok());
+        assert_eq!(acl.default_action(), AclAction::Deny);
+        assert_eq!(acl.rules().len(), 2);
+    }
+}

--- a/config/src/external/overlay/acl.rs
+++ b/config/src/external/overlay/acl.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Access Control Lists (ACLs)
+
+use super::vpcpeering::ValidatedManifest;
+use crate::ConfigError;
+use crate::utils::normalize;
+use lpm::prefix::PrefixPortsSet;
+use tracing::debug;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AclAction {
+    Allow,
+    #[default]
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum AclProtoMatch {
+    Tcp,
+    Udp,
+    Icmp,
+    Other(u8),
+    #[default]
+    Any,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AclPattern {
+    src: PrefixPortsSet,
+    dst: PrefixPortsSet,
+    proto: AclProtoMatch,
+}
+
+impl AclPattern {
+    #[must_use]
+    pub fn src(&self) -> &PrefixPortsSet {
+        &self.src
+    }
+
+    #[must_use]
+    pub fn dst(&self) -> &PrefixPortsSet {
+        &self.dst
+    }
+
+    #[must_use]
+    pub fn proto(&self) -> &AclProtoMatch {
+        &self.proto
+    }
+
+    fn validate_ports(&self) -> bool {
+        match self.proto {
+            AclProtoMatch::Tcp | AclProtoMatch::Udp => true,
+            AclProtoMatch::Other(_) | AclProtoMatch::Icmp | AclProtoMatch::Any => {
+                !self.src.uses_ports() && !self.dst.uses_ports()
+            }
+        }
+    }
+
+    fn validate(&mut self) -> Result<(), ConfigError> {
+        if !self.validate_ports() {
+            return Err(ConfigError::InvalidAcl(format!(
+                "Protocol {:?} does not support port matching",
+                self.proto
+            )));
+        }
+        if !PrefixPortsSet::have_consistent_ip_version(&[&self.src, &self.dst]) {
+            return Err(ConfigError::InvalidAcl(format!(
+                "Source and/or destination prefixes have inconsistent IP versions: {:?}, {:?}",
+                self.src, self.dst
+            )));
+        }
+        normalize(&mut self.src);
+        normalize(&mut self.dst);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AclScope {
+    #[default]
+    Flow,
+    Packet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AclRule {
+    name: String,
+    from: String,
+    to: String,
+    action: AclAction,
+    pattern: AclPattern,
+    scope: AclScope,
+    log: bool,
+}
+
+impl AclRule {
+    #[must_use]
+    pub fn action(&self) -> AclAction {
+        self.action
+    }
+
+    #[must_use]
+    pub fn pattern(&self) -> &AclPattern {
+        &self.pattern
+    }
+
+    #[must_use]
+    pub fn log(&self) -> bool {
+        self.log
+    }
+
+    #[must_use]
+    pub fn scope(&self) -> AclScope {
+        self.scope
+    }
+
+    // This function assumes that validate_from_to has already been called, so exactly one of
+    // from/to matches manifest_left/manifest_right
+    fn manifest_to<'a>(
+        &self,
+        manifest_left: &'a ValidatedManifest,
+        manifest_right: &'a ValidatedManifest,
+    ) -> &'a ValidatedManifest {
+        if self.to == manifest_left.name() {
+            manifest_left
+        } else {
+            manifest_right
+        }
+    }
+
+    // This function assumes that validate_from_to has already been called, so exactly one of
+    // from/to matches manifest_left/manifest_right
+    fn manifest_from<'a>(
+        &self,
+        manifest_left: &'a ValidatedManifest,
+        manifest_right: &'a ValidatedManifest,
+    ) -> &'a ValidatedManifest {
+        if self.from == manifest_left.name() {
+            manifest_left
+        } else {
+            manifest_right
+        }
+    }
+
+    fn validate_from_to(
+        &mut self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<(), ConfigError> {
+        match (&self.from, &self.to) {
+            // Accept if values match the names of the two manifests
+            (from, to) if from == manifest_left.name() && to == manifest_right.name() => Ok(()),
+            (from, to) if from == manifest_right.name() && to == manifest_left.name() => Ok(()),
+
+            // Accept, and complete, if one value matches a manifest, and the other is empty
+            (from, to) if from == manifest_left.name() && to.is_empty() => {
+                self.to = manifest_right.name().to_string();
+                Ok(())
+            }
+            (from, to) if from == manifest_right.name() && to.is_empty() => {
+                self.to = manifest_left.name().to_string();
+                Ok(())
+            }
+            (from, to) if from.is_empty() && to == manifest_left.name() => {
+                self.from = manifest_right.name().to_string();
+                Ok(())
+            }
+            (from, to) if from.is_empty() && to == manifest_right.name() => {
+                self.from = manifest_left.name().to_string();
+                Ok(())
+            }
+
+            // Reject both values empty
+            (from, to) if from.is_empty() && to.is_empty() => {
+                Err(ConfigError::InvalidAcl(format!(
+                    "Rule '{}' must specify at least one of 'from' or 'to' fields",
+                    self.name,
+                )))
+            }
+            // Reject if one value is non-empty but does not match either manifest
+            _ => Err(ConfigError::InvalidAcl(format!(
+                "Rule '{}' has invalid 'from' or 'to' fields: '{}' -> '{}'",
+                self.name, self.from, self.to,
+            ))),
+        }
+    }
+
+    fn validate_pattern_coverage(
+        name: &str,
+        prefixes_acl: &mut PrefixPortsSet,
+        prefixes_manifest: &PrefixPortsSet,
+    ) -> Result<(), ConfigError> {
+        // If the list of prefixes is empty, it means we match all prefixes from the manifest.
+        if prefixes_acl.is_empty() {
+            *prefixes_acl = prefixes_manifest.clone();
+            return Ok(());
+        }
+
+        // If the ACL prefixes don't match any of the manifest prefixes, reject it.
+        let intersection = prefixes_acl.intersection_prefixes_and_ports(prefixes_manifest);
+        if intersection.is_empty() {
+            return Err(ConfigError::InvalidAcl(format!(
+                "ACL rule '{name}' has a 'match' that does not match any traffic in the manifest: {prefixes_acl:?} vs {prefixes_manifest:?}",
+            )));
+        }
+
+        // If some addresses/ports covered by the ACL fall outside of the scope of the manifest, log
+        // a message, and restrict the ACL to the manifest scope.
+        if intersection.total_prefixes_size() != prefixes_acl.total_prefixes_size() {
+            debug!(
+                "ACL rule '{name}' has a 'match' that doesn't fully covers the manifest traffic: {prefixes_acl:?} vs {prefixes_manifest:?}",
+            );
+            *prefixes_acl = intersection;
+        }
+        Ok(())
+    }
+
+    fn validate_patterns_coverage(
+        &mut self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<(), ConfigError> {
+        let manifest_from = self.manifest_from(manifest_left, manifest_right);
+        if manifest_from.has_default_expose() {
+            // ACL pattern necessarily covers all traffic. Do not restrict the ACL pattern to the
+            // manifest's prefixes, we'll use a wildcard match anyway.
+        } else {
+            let src_set = manifest_from.all_ips();
+            Self::validate_pattern_coverage(&self.name, &mut self.pattern.src, &src_set)?;
+        }
+
+        let manifest_to = self.manifest_to(manifest_left, manifest_right);
+        if manifest_to.has_default_expose() {
+            // ACL pattern necessarily covers all traffic. Do not restrict the ACL pattern to the
+            // manifest's prefixes, we'll use a wildcard match anyway.
+        } else {
+            let dst_set = manifest_to.all_public_ips();
+            Self::validate_pattern_coverage(&self.name, &mut self.pattern.dst, &dst_set)?;
+        }
+        Ok(())
+    }
+
+    fn validate(
+        &mut self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<(), ConfigError> {
+        self.validate_from_to(manifest_left, manifest_right)?;
+        self.pattern.validate()?;
+        self.validate_patterns_coverage(manifest_left, manifest_right)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Acl {
+    default: AclAction,
+    rules: Vec<AclRule>,
+}
+
+impl Acl {
+    #[must_use]
+    pub fn default_action(&self) -> AclAction {
+        self.default
+    }
+
+    #[must_use]
+    pub fn rules(&self) -> &[AclRule] {
+        &self.rules
+    }
+
+    fn validate_rules_names(&self) -> Result<(), ConfigError> {
+        let mut seen_names = std::collections::HashSet::new();
+        for rule in &self.rules {
+            if rule.name.is_empty() {
+                continue;
+            }
+            if !seen_names.insert(&rule.name) {
+                return Err(ConfigError::InvalidAcl(format!(
+                    "Duplicate non-empty ACL rule name: '{}'",
+                    rule.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate the ACL rules.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the rules are invalid, or if there are duplicate rule names.
+    pub fn validate(
+        &mut self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<(), ConfigError> {
+        self.validate_rules_names()?;
+        for rule in &mut self.rules {
+            rule.validate(manifest_left, manifest_right)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedAcl {
+    rules: Vec<AclRule>,
+    default_action: AclAction,
+}
+
+impl ValidatedAcl {
+    #[must_use]
+    pub fn rules(&self) -> &[AclRule] {
+        &self.rules
+    }
+
+    #[must_use]
+    pub fn default_action(&self) -> AclAction {
+        self.default_action
+    }
+}

--- a/config/src/external/overlay/acl.rs
+++ b/config/src/external/overlay/acl.rs
@@ -6,7 +6,7 @@
 use super::vpcpeering::ValidatedManifest;
 use crate::ConfigError;
 use crate::utils::normalize;
-use lpm::prefix::PrefixPortsSet;
+use lpm::prefix::{PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
 use tracing::debug;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -30,10 +30,33 @@ pub enum AclProtoMatch {
 pub struct AclPattern {
     src: PrefixPortsSet,
     dst: PrefixPortsSet,
+    /// Port ranges for match entries that specified neither `cidr` nor `vpcSubnet`, meaning "any
+    /// address within the peering, restricted to these ports". These can't be resolved into
+    /// concrete prefixes until the peering's manifests are known, so they're materialized into
+    /// `src`/`dst` during [`AclRule::validate_patterns_coverage`] rather than at conversion time.
+    src_any_ports: Vec<PortRange>,
+    dst_any_ports: Vec<PortRange>,
     proto: AclProtoMatch,
 }
 
 impl AclPattern {
+    #[must_use]
+    pub(crate) fn new(
+        src: PrefixPortsSet,
+        dst: PrefixPortsSet,
+        src_any_ports: Vec<PortRange>,
+        dst_any_ports: Vec<PortRange>,
+        proto: AclProtoMatch,
+    ) -> Self {
+        Self {
+            src,
+            dst,
+            src_any_ports,
+            dst_any_ports,
+            proto,
+        }
+    }
+
     #[must_use]
     pub fn src(&self) -> &PrefixPortsSet {
         &self.src
@@ -53,7 +76,10 @@ impl AclPattern {
         match self.proto {
             AclProtoMatch::Tcp | AclProtoMatch::Udp => true,
             AclProtoMatch::Other(_) | AclProtoMatch::Icmp | AclProtoMatch::Any => {
-                !self.src.uses_ports() && !self.dst.uses_ports()
+                !self.src.uses_ports()
+                    && !self.dst.uses_ports()
+                    && self.src_any_ports.is_empty()
+                    && self.dst_any_ports.is_empty()
             }
         }
     }
@@ -96,6 +122,27 @@ pub struct AclRule {
 }
 
 impl AclRule {
+    #[must_use]
+    pub(crate) fn new(
+        name: String,
+        from: String,
+        to: String,
+        action: AclAction,
+        pattern: AclPattern,
+        scope: AclScope,
+        log: bool,
+    ) -> Self {
+        Self {
+            name,
+            from,
+            to,
+            action,
+            pattern,
+            scope,
+            log,
+        }
+    }
+
     #[must_use]
     pub fn action(&self) -> AclAction {
         self.action
@@ -144,45 +191,23 @@ impl AclRule {
         }
     }
 
+    // The k8s CRD converter completes a rule's `from`/`to` against the peering's two VPC names
+    // before an `AclRule` is ever built (see `converters::k8s::config::acl::complete_from_to`).
     fn validate_from_to(
-        &mut self,
+        &self,
         manifest_left: &ValidatedManifest,
         manifest_right: &ValidatedManifest,
     ) -> Result<(), ConfigError> {
-        match (&self.from, &self.to) {
-            // Accept if values match the names of the two manifests
+        match (self.from.as_str(), self.to.as_str()) {
             (from, to) if from == manifest_left.name() && to == manifest_right.name() => Ok(()),
             (from, to) if from == manifest_right.name() && to == manifest_left.name() => Ok(()),
-
-            // Accept, and complete, if one value matches a manifest, and the other is empty
-            (from, to) if from == manifest_left.name() && to.is_empty() => {
-                self.to = manifest_right.name().to_string();
-                Ok(())
-            }
-            (from, to) if from == manifest_right.name() && to.is_empty() => {
-                self.to = manifest_left.name().to_string();
-                Ok(())
-            }
-            (from, to) if from.is_empty() && to == manifest_left.name() => {
-                self.from = manifest_right.name().to_string();
-                Ok(())
-            }
-            (from, to) if from.is_empty() && to == manifest_right.name() => {
-                self.from = manifest_left.name().to_string();
-                Ok(())
-            }
-
-            // Reject both values empty
-            (from, to) if from.is_empty() && to.is_empty() => {
-                Err(ConfigError::InvalidAcl(format!(
-                    "Rule '{}' must specify at least one of 'from' or 'to' fields",
-                    self.name,
-                )))
-            }
-            // Reject if one value is non-empty but does not match either manifest
             _ => Err(ConfigError::InvalidAcl(format!(
-                "Rule '{}' has invalid 'from' or 'to' fields: '{}' -> '{}'",
-                self.name, self.from, self.to,
+                "Rule '{}' has invalid 'from'/'to' fields: '{}' -> '{}', expected the peering's two VPCs '{}' and '{}'",
+                self.name,
+                self.from,
+                self.to,
+                manifest_left.name(),
+                manifest_right.name(),
             ))),
         }
     }
@@ -217,28 +242,64 @@ impl AclRule {
         Ok(())
     }
 
+    /// Materialize "any address within the peering, restricted to these ports" entries into
+    /// concrete prefixes, one per port range per prefix advertised by `manifest_prefixes`.
+    fn expand_any_ports(manifest_prefixes: &PrefixPortsSet, ports: &[PortRange]) -> PrefixPortsSet {
+        ports
+            .iter()
+            .flat_map(|port| {
+                manifest_prefixes
+                    .iter()
+                    .map(move |p| PrefixWithOptionalPorts::new(p.prefix(), Some(*port)))
+            })
+            .collect()
+    }
+
+    fn manifest_coverage_set(
+        manifest: &ValidatedManifest,
+        is_v4: bool,
+        is_public: bool,
+    ) -> PrefixPortsSet {
+        if manifest.has_default_expose() {
+            [PrefixWithOptionalPorts::from(if is_v4 {
+                Prefix::root_v4()
+            } else {
+                Prefix::root_v6()
+            })]
+            .into()
+        } else if is_public {
+            manifest.all_public_ips()
+        } else {
+            manifest.all_ips()
+        }
+    }
+
     fn validate_patterns_coverage(
         &mut self,
         manifest_left: &ValidatedManifest,
         manifest_right: &ValidatedManifest,
     ) -> Result<(), ConfigError> {
-        let manifest_from = self.manifest_from(manifest_left, manifest_right);
-        if manifest_from.has_default_expose() {
-            // ACL pattern necessarily covers all traffic. Do not restrict the ACL pattern to the
-            // manifest's prefixes, we'll use a wildcard match anyway.
+        // A default-only manifest's is_v4()/is_v6() are always false, so fall back to the other side
+        let is_v4 = if manifest_left.is_default_only() {
+            manifest_right.is_v4()
         } else {
-            let src_set = manifest_from.all_ips();
-            Self::validate_pattern_coverage(&self.name, &mut self.pattern.src, &src_set)?;
-        }
+            manifest_left.is_v4()
+        };
+
+        let manifest_from = self.manifest_from(manifest_left, manifest_right);
+        let src_set = Self::manifest_coverage_set(manifest_from, is_v4, false);
+        let any =
+            Self::expand_any_ports(&src_set, &std::mem::take(&mut self.pattern.src_any_ports));
+        self.pattern.src = self.pattern.src.union_prefixes_and_ports(&any);
+        Self::validate_pattern_coverage(&self.name, &mut self.pattern.src, &src_set)?;
 
         let manifest_to = self.manifest_to(manifest_left, manifest_right);
-        if manifest_to.has_default_expose() {
-            // ACL pattern necessarily covers all traffic. Do not restrict the ACL pattern to the
-            // manifest's prefixes, we'll use a wildcard match anyway.
-        } else {
-            let dst_set = manifest_to.all_public_ips();
-            Self::validate_pattern_coverage(&self.name, &mut self.pattern.dst, &dst_set)?;
-        }
+        let dst_set = Self::manifest_coverage_set(manifest_to, is_v4, true);
+        let any =
+            Self::expand_any_ports(&dst_set, &std::mem::take(&mut self.pattern.dst_any_ports));
+        self.pattern.dst = self.pattern.dst.union_prefixes_and_ports(&any);
+        Self::validate_pattern_coverage(&self.name, &mut self.pattern.dst, &dst_set)?;
+
         Ok(())
     }
 
@@ -261,6 +322,11 @@ pub struct Acl {
 }
 
 impl Acl {
+    #[must_use]
+    pub(crate) fn new(default: AclAction, rules: Vec<AclRule>) -> Self {
+        Self { default, rules }
+    }
+
     #[must_use]
     pub fn default_action(&self) -> AclAction {
         self.default
@@ -349,6 +415,13 @@ mod validation_tests {
             .unwrap()
     }
 
+    // Helper: build a validated manifest with only a default expose (no concrete prefixes)
+    fn default_manifest(name: &str) -> ValidatedManifest {
+        VpcManifest::with_exposes(name, vec![VpcExpose::empty().set_default()])
+            .validate()
+            .unwrap()
+    }
+
     // Helper: the standard two-side peering used by most tests
     // VPC-1 owns 10.0.0.0/16, VPC-2 owns 10.1.0.0/16
     fn manifests() -> (ValidatedManifest, ValidatedManifest) {
@@ -376,7 +449,13 @@ mod validation_tests {
 
     // Helper: assemble an AclPattern
     fn pattern(src: PrefixPortsSet, dst: PrefixPortsSet, proto: AclProtoMatch) -> AclPattern {
-        AclPattern { src, dst, proto }
+        AclPattern {
+            src,
+            dst,
+            src_any_ports: Vec::new(),
+            dst_any_ports: Vec::new(),
+            proto,
+        }
     }
 
     // Helper: assemble an AclRule
@@ -426,36 +505,24 @@ mod validation_tests {
         assert!(validate_rule(rule).is_ok());
     }
 
-    // "from" set to the left VPC, "to" omitted: the right VPC is implied
     #[test]
-    fn test_acl_from_left_only_completes_to() {
+    fn test_acl_to_blank_rejected() {
         let rule = rule("r", "VPC-1", "", AclAction::Allow, match_all());
-        let validated = validate_rule(rule).expect("should validate");
-        assert_eq!(validated.to, "VPC-2");
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
     }
 
-    // "from" set to the right VPC, "to" omitted: the left VPC is implied
     #[test]
-    fn test_acl_from_right_only_completes_to() {
-        let rule = rule("r", "VPC-2", "", AclAction::Allow, match_all());
-        let validated = validate_rule(rule).expect("should validate");
-        assert_eq!(validated.to, "VPC-1");
-    }
-
-    // "to" set to the right VPC, "from" omitted: the left VPC is implied
-    #[test]
-    fn test_acl_to_right_only_completes_from() {
+    fn test_acl_from_blank_rejected() {
         let rule = rule("r", "", "VPC-2", AclAction::Allow, match_all());
-        let validated = validate_rule(rule).expect("should validate");
-        assert_eq!(validated.from, "VPC-1");
-    }
-
-    // "to" set to the left VPC, "from" omitted: the right VPC is implied
-    #[test]
-    fn test_acl_to_left_only_completes_from() {
-        let rule = rule("r", "", "VPC-1", AclAction::Allow, match_all());
-        let validated = validate_rule(rule).expect("should validate");
-        assert_eq!(validated.from, "VPC-2");
+        let result = validate_rule(rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
     }
 
     // Omitting both "from" and "to" is rejected
@@ -764,6 +831,97 @@ mod validation_tests {
         let validated = validate_rule(rule).expect("should validate");
         assert_eq!(validated.pattern.src, prefixes(&["10.0.0.0/24"]));
         assert_eq!(validated.pattern.dst, prefixes(&["10.1.0.0/24"]));
+    }
+
+    // =============================================================================================
+    // "Any address within the peering" (neither cidr nor vpcSubnet set) match entries
+    // =============================================================================================
+
+    // A match entry with neither cidr/vpcSubnet nor ports (an empty entry) matches any address on
+    // any port, same as omitting the field entirely.
+    #[test]
+    fn test_acl_any_address_any_port_covers_manifest() {
+        let mut p = match_all();
+        p.src_any_ports = vec![]; // no explicit ports: empty src == "match everything"
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(validated.pattern.src, prefixes(&["10.0.0.0/16"]));
+    }
+
+    // A match entry with neither cidr nor vpcSubnet, but with ports set, matches any address
+    // advertised by the manifest restricted to those ports -- not literally "any port".
+    #[test]
+    fn test_acl_any_address_with_ports_restricts_to_manifest_prefixes_and_ports() {
+        let mut p = pattern(
+            PrefixPortsSet::new(),
+            PrefixPortsSet::new(),
+            AclProtoMatch::Tcp,
+        );
+        p.src_any_ports = vec![PortRange::new(443, 443).unwrap()];
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let validated = validate_rule(rule).expect("should validate");
+        assert_eq!(
+            validated.pattern.src,
+            [prefix_with_ports("10.0.0.0/16", 443, 443)].into()
+        );
+        // dst was left fully unrestricted (empty, no any_ports): still "match everything".
+        assert_eq!(validated.pattern.dst, prefixes(&["10.1.0.0/16"]));
+    }
+
+    // A protocol that doesn't support ports (e.g. ICMP) rejects an "any address" port-restricted
+    // entry just like it rejects a concrete-prefix one.
+    #[test]
+    fn test_acl_any_address_with_ports_rejected_for_portless_proto() {
+        let mut p = pattern(
+            PrefixPortsSet::new(),
+            PrefixPortsSet::new(),
+            AclProtoMatch::Icmp,
+        );
+        p.src_any_ports = vec![PortRange::new(443, 443).unwrap()];
+        let icmp_rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p.clone());
+        let result = validate_rule(icmp_rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+
+        // same thing for numeric protocols
+        p.proto = AclProtoMatch::Other(46);
+        let num_rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let result = validate_rule(num_rule);
+        assert!(
+            matches!(result, Err(ConfigError::InvalidAcl(_))),
+            "{result:?}"
+        );
+    }
+
+    // A default-exposed manifest has no concrete prefixes to resolve "any address" against, so an
+    // "any address, these ports" entry on that side must fall back to the address family's root
+    // prefix instead of being silently dropped.
+    #[test]
+    fn test_acl_any_address_with_ports_against_default_expose_resolves_to_root_prefix() {
+        // VPC-1 is concrete IPv4, which also tells us the peering's IP family; VPC-2 only has a
+        // default expose, so it has no prefixes of its own to fall back on.
+        let left = manifest("VPC-1", &["10.0.0.0/16"]);
+        let right = default_manifest("VPC-2");
+
+        let mut p = pattern(
+            PrefixPortsSet::new(),
+            PrefixPortsSet::new(),
+            AclProtoMatch::Tcp,
+        );
+        p.dst_any_ports = vec![PortRange::new(443, 443).unwrap()];
+        let mut rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+
+        rule.validate(&left, &right).expect("should validate");
+        assert_eq!(
+            rule.pattern.dst,
+            [PrefixWithOptionalPorts::new(
+                Prefix::root_v4(),
+                Some(PortRange::new(443, 443).unwrap())
+            )]
+            .into()
+        );
     }
 
     // =============================================================================================

--- a/config/src/external/overlay/acl.rs
+++ b/config/src/external/overlay/acl.rs
@@ -28,15 +28,15 @@ pub enum AclProtoMatch {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct AclPattern {
-    src: PrefixPortsSet,
-    dst: PrefixPortsSet,
+    pub src: PrefixPortsSet,
+    pub dst: PrefixPortsSet,
     /// Port ranges for match entries that specified neither `cidr` nor `vpcSubnet`, meaning "any
     /// address within the peering, restricted to these ports". These can't be resolved into
     /// concrete prefixes until the peering's manifests are known, so they're materialized into
     /// `src`/`dst` during [`AclRule::validate_patterns_coverage`] rather than at conversion time.
-    src_any_ports: Vec<PortRange>,
-    dst_any_ports: Vec<PortRange>,
-    proto: AclProtoMatch,
+    pub src_any_ports: Vec<PortRange>,
+    pub dst_any_ports: Vec<PortRange>,
+    pub proto: AclProtoMatch,
 }
 
 impl AclPattern {
@@ -57,21 +57,6 @@ impl AclPattern {
         }
     }
 
-    #[must_use]
-    pub fn src(&self) -> &PrefixPortsSet {
-        &self.src
-    }
-
-    #[must_use]
-    pub fn dst(&self) -> &PrefixPortsSet {
-        &self.dst
-    }
-
-    #[must_use]
-    pub fn proto(&self) -> &AclProtoMatch {
-        &self.proto
-    }
-
     fn validate_ports(&self) -> bool {
         match self.proto {
             AclProtoMatch::Tcp | AclProtoMatch::Udp => true,
@@ -84,7 +69,7 @@ impl AclPattern {
         }
     }
 
-    fn validate(&mut self) -> Result<(), ConfigError> {
+    fn validate(mut self) -> Result<ValidatedAclPattern, ConfigError> {
         if !self.validate_ports() {
             return Err(ConfigError::InvalidAcl(format!(
                 "Protocol {:?} does not support port matching",
@@ -99,7 +84,35 @@ impl AclPattern {
         }
         normalize(&mut self.src);
         normalize(&mut self.dst);
-        Ok(())
+        Ok(ValidatedAclPattern {
+            src: self.src,
+            dst: self.dst,
+            proto: self.proto,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ValidatedAclPattern {
+    src: PrefixPortsSet,
+    dst: PrefixPortsSet,
+    proto: AclProtoMatch,
+}
+
+impl ValidatedAclPattern {
+    #[must_use]
+    pub fn src(&self) -> &PrefixPortsSet {
+        &self.src
+    }
+
+    #[must_use]
+    pub fn dst(&self) -> &PrefixPortsSet {
+        &self.dst
+    }
+
+    #[must_use]
+    pub fn proto(&self) -> &AclProtoMatch {
+        &self.proto
     }
 }
 
@@ -112,13 +125,13 @@ pub enum AclScope {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct AclRule {
-    name: String,
-    from: String,
-    to: String,
-    action: AclAction,
-    pattern: AclPattern,
-    scope: AclScope,
-    log: bool,
+    pub name: String,
+    pub from: String,
+    pub to: String,
+    pub action: AclAction,
+    pub pattern: AclPattern,
+    pub scope: AclScope,
+    pub log: bool,
 }
 
 impl AclRule {
@@ -143,13 +156,74 @@ impl AclRule {
         }
     }
 
+    // The k8s CRD converter completes a rule's `from`/`to` against the peering's two VPC names
+    // before an `AclRule` is ever built (see `converters::k8s::config::acl::complete_from_to`).
+    fn validate_from_to(
+        &self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<(), ConfigError> {
+        match (self.from.as_str(), self.to.as_str()) {
+            (from, to) if from == manifest_left.name() && to == manifest_right.name() => Ok(()),
+            (from, to) if from == manifest_right.name() && to == manifest_left.name() => Ok(()),
+            _ => Err(ConfigError::InvalidAcl(format!(
+                "Rule '{}' has invalid 'from'/'to' fields: '{}' -> '{}', expected the peering's two VPCs '{}' and '{}'",
+                self.name,
+                self.from,
+                self.to,
+                manifest_left.name(),
+                manifest_right.name(),
+            ))),
+        }
+    }
+
+    fn validate(
+        self,
+        manifest_left: &ValidatedManifest,
+        manifest_right: &ValidatedManifest,
+    ) -> Result<ValidatedAclRule, ConfigError> {
+        self.validate_from_to(manifest_left, manifest_right)?;
+        let src_any_ports = self.pattern.src_any_ports.clone();
+        let dst_any_ports = self.pattern.dst_any_ports.clone();
+        let pattern = self.pattern.validate()?;
+        let mut validated_rule = ValidatedAclRule {
+            name: self.name,
+            from: self.from,
+            to: self.to,
+            action: self.action,
+            pattern,
+            scope: self.scope,
+            log: self.log,
+        };
+        validated_rule.validate_patterns_coverage(
+            manifest_left,
+            manifest_right,
+            &src_any_ports,
+            &dst_any_ports,
+        )?;
+        Ok(validated_rule)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ValidatedAclRule {
+    name: String,
+    from: String,
+    to: String,
+    action: AclAction,
+    pattern: ValidatedAclPattern,
+    scope: AclScope,
+    log: bool,
+}
+
+impl ValidatedAclRule {
     #[must_use]
     pub fn action(&self) -> AclAction {
         self.action
     }
 
     #[must_use]
-    pub fn pattern(&self) -> &AclPattern {
+    pub fn pattern(&self) -> &ValidatedAclPattern {
         &self.pattern
     }
 
@@ -191,24 +265,35 @@ impl AclRule {
         }
     }
 
-    // The k8s CRD converter completes a rule's `from`/`to` against the peering's two VPC names
-    // before an `AclRule` is ever built (see `converters::k8s::config::acl::complete_from_to`).
-    fn validate_from_to(
-        &self,
-        manifest_left: &ValidatedManifest,
-        manifest_right: &ValidatedManifest,
-    ) -> Result<(), ConfigError> {
-        match (self.from.as_str(), self.to.as_str()) {
-            (from, to) if from == manifest_left.name() && to == manifest_right.name() => Ok(()),
-            (from, to) if from == manifest_right.name() && to == manifest_left.name() => Ok(()),
-            _ => Err(ConfigError::InvalidAcl(format!(
-                "Rule '{}' has invalid 'from'/'to' fields: '{}' -> '{}', expected the peering's two VPCs '{}' and '{}'",
-                self.name,
-                self.from,
-                self.to,
-                manifest_left.name(),
-                manifest_right.name(),
-            ))),
+    /// Materialize "any address within the peering, restricted to these ports" entries into
+    /// concrete prefixes, one per port range per prefix advertised by `manifest_prefixes`.
+    fn expand_any_ports(manifest_prefixes: &PrefixPortsSet, ports: &[PortRange]) -> PrefixPortsSet {
+        ports
+            .iter()
+            .flat_map(|port| {
+                manifest_prefixes
+                    .iter()
+                    .map(move |p| PrefixWithOptionalPorts::new(p.prefix(), Some(*port)))
+            })
+            .collect()
+    }
+
+    fn manifest_coverage_set(
+        manifest: &ValidatedManifest,
+        is_v4: bool,
+        is_public: bool,
+    ) -> PrefixPortsSet {
+        if manifest.has_default_expose() {
+            [PrefixWithOptionalPorts::from(if is_v4 {
+                Prefix::root_v4()
+            } else {
+                Prefix::root_v6()
+            })]
+            .into()
+        } else if is_public {
+            manifest.all_public_ips()
+        } else {
+            manifest.all_ips()
         }
     }
 
@@ -242,42 +327,12 @@ impl AclRule {
         Ok(())
     }
 
-    /// Materialize "any address within the peering, restricted to these ports" entries into
-    /// concrete prefixes, one per port range per prefix advertised by `manifest_prefixes`.
-    fn expand_any_ports(manifest_prefixes: &PrefixPortsSet, ports: &[PortRange]) -> PrefixPortsSet {
-        ports
-            .iter()
-            .flat_map(|port| {
-                manifest_prefixes
-                    .iter()
-                    .map(move |p| PrefixWithOptionalPorts::new(p.prefix(), Some(*port)))
-            })
-            .collect()
-    }
-
-    fn manifest_coverage_set(
-        manifest: &ValidatedManifest,
-        is_v4: bool,
-        is_public: bool,
-    ) -> PrefixPortsSet {
-        if manifest.has_default_expose() {
-            [PrefixWithOptionalPorts::from(if is_v4 {
-                Prefix::root_v4()
-            } else {
-                Prefix::root_v6()
-            })]
-            .into()
-        } else if is_public {
-            manifest.all_public_ips()
-        } else {
-            manifest.all_ips()
-        }
-    }
-
     fn validate_patterns_coverage(
         &mut self,
         manifest_left: &ValidatedManifest,
         manifest_right: &ValidatedManifest,
+        src_any_ports: &[PortRange],
+        dst_any_ports: &[PortRange],
     ) -> Result<(), ConfigError> {
         // A default-only manifest's is_v4()/is_v6() are always false, so fall back to the other side
         let is_v4 = if manifest_left.is_default_only() {
@@ -288,29 +343,16 @@ impl AclRule {
 
         let manifest_from = self.manifest_from(manifest_left, manifest_right);
         let src_set = Self::manifest_coverage_set(manifest_from, is_v4, false);
-        let any =
-            Self::expand_any_ports(&src_set, &std::mem::take(&mut self.pattern.src_any_ports));
+        let any = Self::expand_any_ports(&src_set, src_any_ports);
         self.pattern.src = self.pattern.src.union_prefixes_and_ports(&any);
         Self::validate_pattern_coverage(&self.name, &mut self.pattern.src, &src_set)?;
 
         let manifest_to = self.manifest_to(manifest_left, manifest_right);
         let dst_set = Self::manifest_coverage_set(manifest_to, is_v4, true);
-        let any =
-            Self::expand_any_ports(&dst_set, &std::mem::take(&mut self.pattern.dst_any_ports));
+        let any = Self::expand_any_ports(&dst_set, dst_any_ports);
         self.pattern.dst = self.pattern.dst.union_prefixes_and_ports(&any);
         Self::validate_pattern_coverage(&self.name, &mut self.pattern.dst, &dst_set)?;
 
-        Ok(())
-    }
-
-    fn validate(
-        &mut self,
-        manifest_left: &ValidatedManifest,
-        manifest_right: &ValidatedManifest,
-    ) -> Result<(), ConfigError> {
-        self.validate_from_to(manifest_left, manifest_right)?;
-        self.pattern.validate()?;
-        self.validate_patterns_coverage(manifest_left, manifest_right)?;
         Ok(())
     }
 }
@@ -359,27 +401,32 @@ impl Acl {
     ///
     /// Returns an error if any of the rules are invalid, or if there are duplicate rule names.
     pub fn validate(
-        &mut self,
+        &self,
         manifest_left: &ValidatedManifest,
         manifest_right: &ValidatedManifest,
-    ) -> Result<(), ConfigError> {
+    ) -> Result<ValidatedAcl, ConfigError> {
         self.validate_rules_names()?;
-        for rule in &mut self.rules {
-            rule.validate(manifest_left, manifest_right)?;
-        }
-        Ok(())
+        let rules = self
+            .rules
+            .iter()
+            .map(|rule| rule.clone().validate(manifest_left, manifest_right))
+            .collect::<Result<_, _>>()?;
+        Ok(ValidatedAcl {
+            rules,
+            default_action: self.default,
+        })
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValidatedAcl {
-    rules: Vec<AclRule>,
+    rules: Vec<ValidatedAclRule>,
     default_action: AclAction,
 }
 
 impl ValidatedAcl {
     #[must_use]
-    pub fn rules(&self) -> &[AclRule] {
+    pub fn rules(&self) -> &[ValidatedAclRule] {
         &self.rules
     }
 
@@ -400,6 +447,7 @@ impl ValidatedAcl {
 mod validation_tests {
     use super::{Acl, AclAction, AclPattern, AclProtoMatch, AclRule, AclScope};
     use crate::ConfigError;
+    use crate::external::overlay::acl::ValidatedAclRule;
     use crate::external::overlay::vpcpeering::{ValidatedManifest, VpcExpose, VpcManifest};
 
     use lpm::prefix::{PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
@@ -473,9 +521,9 @@ mod validation_tests {
 
     // Helper: validate a single rule against the standard peering, returning the (possibly
     // completed/restricted) rule on success
-    fn validate_rule(mut rule: AclRule) -> Result<AclRule, ConfigError> {
+    fn validate_rule(rule: AclRule) -> Result<ValidatedAclRule, ConfigError> {
         let (left, right) = manifests();
-        rule.validate(&left, &right).map(|()| rule)
+        rule.validate(&left, &right)
     }
 
     // Helper: a pattern matching all traffic in the rule's direction (empty src/dst, any proto)
@@ -577,7 +625,7 @@ mod validation_tests {
     #[test]
     fn test_acl_duplicate_rule_names_rejected() {
         let (left, right) = manifests();
-        let mut acl = Acl {
+        let acl = Acl {
             default: AclAction::Deny,
             rules: vec![
                 rule("dup", "VPC-1", "VPC-2", AclAction::Allow, match_all()),
@@ -595,7 +643,7 @@ mod validation_tests {
     #[test]
     fn test_acl_distinct_rule_names_passes() {
         let (left, right) = manifests();
-        let mut acl = Acl {
+        let acl = Acl {
             default: AclAction::Deny,
             rules: vec![
                 rule("forward1", "VPC-1", "VPC-2", AclAction::Allow, match_all()),
@@ -911,16 +959,15 @@ mod validation_tests {
             AclProtoMatch::Tcp,
         );
         p.dst_any_ports = vec![PortRange::new(443, 443).unwrap()];
-        let mut rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
+        let rule = rule("r", "VPC-1", "VPC-2", AclAction::Allow, p);
 
-        rule.validate(&left, &right).expect("should validate");
+        let validated_rule = rule.validate(&left, &right).expect("should validate");
         assert_eq!(
-            rule.pattern.dst,
-            [PrefixWithOptionalPorts::new(
+            validated_rule.pattern().dst(),
+            &PrefixPortsSet::from([PrefixWithOptionalPorts::new(
                 Prefix::root_v4(),
                 Some(PortRange::new(443, 443).unwrap())
-            )]
-            .into()
+            )])
         );
     }
 
@@ -931,9 +978,9 @@ mod validation_tests {
     #[test]
     fn test_default_rule_values() {
         let rule = AclRule::default();
-        assert_eq!(rule.action(), AclAction::Deny);
-        assert_eq!(rule.scope(), AclScope::Flow);
-        assert!(!rule.log());
+        assert_eq!(rule.action, AclAction::Deny);
+        assert_eq!(rule.scope, AclScope::Flow);
+        assert!(!rule.log);
     }
 
     // =============================================================================================
@@ -945,7 +992,7 @@ mod validation_tests {
     #[test]
     fn test_acl_multiple_rules_passes() {
         let (left, right) = manifests();
-        let mut acl = Acl {
+        let acl = Acl {
             default: AclAction::Deny,
             rules: vec![
                 rule(
@@ -962,7 +1009,7 @@ mod validation_tests {
                 rule("return", "VPC-2", "VPC-1", AclAction::Allow, match_all()),
             ],
         };
-        assert!(acl.validate(&left, &right).is_ok());
+        let acl = acl.validate(&left, &right).expect("should validate");
         assert_eq!(acl.default_action(), AclAction::Deny);
         assert_eq!(acl.rules().len(), 2);
     }

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -3,6 +3,7 @@
 
 //! Dataplane configuration model: overlay configuration
 
+pub mod acl;
 pub mod tests;
 pub mod validation_tests;
 pub mod vpc;

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, warn};
 
 use crate::external::overlay::VpcManifest;
 use crate::external::overlay::VpcPeeringTable;
+use crate::external::overlay::acl::{Acl, ValidatedAcl};
 use crate::external::overlay::vpcpeering::ValidatedManifest;
 use crate::external::overlay::vpcpeering::VpcExposeNatConfig;
 use crate::internal::interfaces::interface::InterfaceConfigTable;
@@ -32,6 +33,7 @@ pub struct Peering {
     pub remote: VpcManifest, /* remote manifest */
     pub remote_id: VpcId,    /* Id of peer */
     pub gwgroup: String,     /* gateway group serving this peering */
+    pub acl: Option<Acl>,    /* optional ACL for this peering */
 }
 
 impl Peering {
@@ -47,12 +49,21 @@ impl Peering {
             ));
         }
 
+        let local = self.local.validate()?;
+        let remote = self.remote.validate()?;
+        let acl = if let Some(acl) = &self.acl {
+            Some(acl.validate(&local, &remote)?)
+        } else {
+            None
+        };
+
         let valid_peering_candidate = ValidatedPeering {
             name: self.name.clone(),
-            local: self.local.validate()?,
-            remote: self.remote.validate()?,
+            local,
+            remote,
             remote_id: self.remote_id.clone(),
             gwgroup: self.gwgroup.clone(),
+            acl,
         };
         valid_peering_candidate.validate_nat_combinations()?;
 
@@ -80,6 +91,7 @@ impl Peering {
             remote: fake_remote,
             remote_id: self.remote_id.clone(),
             gwgroup: self.gwgroup.clone(),
+            acl: None,
         }
     }
 }
@@ -91,6 +103,7 @@ pub struct ValidatedPeering {
     remote: ValidatedManifest, /* remote manifest */
     remote_id: VpcId,          /* Id of peer */
     gwgroup: String,           /* gateway group serving this peering */
+    acl: Option<ValidatedAcl>, /* optional ACL for this peering */
 }
 
 impl ValidatedPeering {
@@ -238,6 +251,7 @@ impl Vpc {
                     remote: remote.clone(),
                     remote_id: remote_id.clone(),
                     gwgroup: p.gwgroup.clone(),
+                    acl: p.acl.clone(),
                 }
             })
             .collect();
@@ -317,6 +331,7 @@ impl Vpc {
                     remote: fake_remote,
                     remote_id: peering.remote_id.clone(),
                     gwgroup: peering.gwgroup.clone(),
+                    acl: None,
                 }
             })
             .collect::<Vec<_>>();

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -119,6 +119,20 @@ impl ValidatedPeering {
         &self.gwgroup
     }
 
+    #[must_use]
+    pub fn is_v4(&self) -> bool {
+        // This is a validated object, we checked at validation time that both manifests use the
+        // same IP version, so we only need to look at one of them.
+        //
+        // We also know that at least one of the manifests has a non-default expose, so we can
+        // always tell the IP version in use from one of them.
+        if self.local.is_default_only() {
+            self.remote.is_v4()
+        } else {
+            self.local.is_v4()
+        }
+    }
+
     fn validate_nat_combinations(&self) -> ConfigResult {
         // If stateful NAT is set up on one side of the peering, we don't support NAT (static or
         // stateful) on the other side.

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -3,6 +3,7 @@
 
 //! Dataplane configuration model: vpc peering
 
+use crate::external::overlay::acl::Acl;
 use crate::utils::{
     check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, collapse_prefixes,
     normalize,
@@ -838,6 +839,7 @@ pub struct VpcPeering {
     pub left: VpcManifest,  /* manifest for one side of the peering */
     pub right: VpcManifest, /* manifest for the other side */
     pub gwgroup: String,    /* name of gateway group */
+    pub acl: Option<Acl>,   /* optional peering-scoped ACL */
 }
 impl VpcPeering {
     #[must_use]
@@ -847,6 +849,7 @@ impl VpcPeering {
             left,
             right,
             gwgroup,
+            acl: None,
         }
     }
 
@@ -859,6 +862,7 @@ impl VpcPeering {
             left,
             right,
             gwgroup: "default".to_string(),
+            acl: None,
         }
     }
 

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -295,23 +295,13 @@ impl VpcExpose {
         // TODO: We can loosen this restriction in the future. When we do, some additional
         //       considerations might be required to validate independently the IPv4 and the IPv6
         //       prefixes and exclusion prefixes in the rest of this function.
-        let mut is_ipv4_opt = None;
-        for prefixes in [
+        if !PrefixPortsSet::have_consistent_ip_version(&[
             &self.ips,
             &self.nots,
             self.as_range_or_empty(),
             self.not_as_or_empty(),
-        ] {
-            if prefixes.iter().any(|p| {
-                if let Some(is_ipv4) = is_ipv4_opt {
-                    p.prefix().is_ipv4() != is_ipv4
-                } else {
-                    is_ipv4_opt = Some(p.prefix().is_ipv4());
-                    false
-                }
-            }) {
-                return Err(ConfigError::InconsistentIpVersion(Box::new(self.clone())));
-            }
+        ]) {
+            return Err(ConfigError::InconsistentIpVersion(Box::new(self.clone())));
         }
 
         // Port 0 is not allowed in the exposed ranges. We do not check the excluded ranges here,

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -721,6 +721,31 @@ impl ValidatedManifest {
         self.filter_exposes(|expose| expose.has_port_forwarding() && expose.is_66())
     }
 
+    #[must_use]
+    pub fn is_v4(&self) -> bool {
+        self.valexp.iter().any(ValidatedExpose::is_v4)
+    }
+
+    #[must_use]
+    pub fn is_v6(&self) -> bool {
+        self.valexp.iter().any(ValidatedExpose::is_v6)
+    }
+
+    #[must_use]
+    pub fn is_default_only(&self) -> bool {
+        self.valexp.len() == 1 && self.valexp.first().is_some_and(ValidatedExpose::is_default)
+    }
+
+    #[must_use]
+    pub fn is_v4_or_default(&self) -> bool {
+        self.is_default_only() || self.is_v4()
+    }
+
+    #[must_use]
+    pub fn is_v6_or_default(&self) -> bool {
+        self.is_default_only() || self.is_v6()
+    }
+
     fn validate_expose_collisions(&self) -> ConfigResult {
         // Check that prefixes in each expose don't overlap with prefixes in other exposes
         for (index, expose_left) in self.valexp.iter().enumerate() {

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -5,7 +5,7 @@
 
 use crate::utils::{
     check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, collapse_prefixes,
-    merge_contiguous_prefixes, merge_overlapping_prefixes,
+    normalize,
 };
 use concurrency::sync::LazyLock;
 use lpm::prefix::{IpRangeWithPorts, L4Protocol, Prefix, PrefixPortsSet, PrefixWithOptionalPorts};
@@ -335,11 +335,9 @@ impl VpcExpose {
         // Apply exclusion prefixes
         let mut clone = self.clone();
         collapse_prefixes(&mut clone);
-        merge_overlapping_prefixes(&mut clone.ips);
-        merge_contiguous_prefixes(&mut clone.ips);
+        normalize(&mut clone.ips);
         if let Some(nat) = &mut clone.nat {
-            merge_overlapping_prefixes(&mut nat.as_range);
-            merge_contiguous_prefixes(&mut nat.as_range);
+            normalize(&mut nat.as_range);
         }
         let collapsed_expose = ValidatedExpose {
             default: clone.default,

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -681,6 +681,11 @@ impl ValidatedManifest {
     }
 
     #[must_use]
+    pub fn has_default_expose(&self) -> bool {
+        self.valexp().iter().any(ValidatedExpose::is_default)
+    }
+
+    #[must_use]
     pub fn default_expose(&self) -> Option<&ValidatedExpose> {
         self.valexp().iter().find(|expose| expose.is_default())
     }
@@ -781,6 +786,24 @@ impl ValidatedManifest {
             }
         }
         Ok(())
+    }
+
+    #[must_use]
+    pub fn all_ips(&self) -> PrefixPortsSet {
+        self.valexp
+            .iter()
+            .fold(PrefixPortsSet::new(), |acc, valexp| {
+                acc.union_prefixes_and_ports(valexp.ips())
+            })
+    }
+
+    #[must_use]
+    pub fn all_public_ips(&self) -> PrefixPortsSet {
+        self.valexp
+            .iter()
+            .fold(PrefixPortsSet::new(), |acc, valexp| {
+                acc.union_prefixes_and_ports(valexp.public_ips())
+            })
     }
 }
 

--- a/config/src/utils/collapse.rs
+++ b/config/src/utils/collapse.rs
@@ -237,6 +237,7 @@ mod tests {
             remote: manifest_empty.clone(),
             remote_id: "12345".try_into().expect("Failed to create VPC ID"),
             gwgroup: "default".into(),
+            acl: None,
         };
 
         let expected_expose = VpcExpose::empty()

--- a/config/src/utils/mod.rs
+++ b/config/src/utils/mod.rs
@@ -8,8 +8,7 @@ mod overlap;
 
 pub(crate) use collapse::collapse_prefixes;
 pub(crate) use overlap::{
-    check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap,
-    merge_contiguous_prefixes, merge_overlapping_prefixes,
+    check_private_prefixes_dont_overlap, check_public_prefixes_dont_overlap, normalize,
 };
 
 #[derive(thiserror::Error, Debug, Clone)]

--- a/config/src/utils/overlap.rs
+++ b/config/src/utils/overlap.rs
@@ -64,7 +64,7 @@ fn check_prefixes_dont_overlap(
     Ok(())
 }
 
-pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
+fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
     let mut prefixes_to_merge = prefixes.iter().copied().collect::<Vec<_>>();
     let mut merged_prefixes = PrefixPortsSet::default();
 
@@ -82,7 +82,7 @@ pub fn merge_overlapping_prefixes(prefixes: &mut PrefixPortsSet) {
     *prefixes = merged_prefixes;
 }
 
-pub fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
+fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
     let mut uses_ports = false;
     let mut did_merge = false;
     let mut merged_prefixes = PrefixPortsSet::default();
@@ -127,6 +127,11 @@ pub fn merge_contiguous_prefixes(prefixes: &mut PrefixPortsSet) {
     if uses_ports && did_merge {
         merge_contiguous_prefixes(prefixes);
     }
+}
+
+pub fn normalize(prefix_set: &mut PrefixPortsSet) {
+    merge_overlapping_prefixes(prefix_set);
+    merge_contiguous_prefixes(prefix_set);
 }
 
 #[cfg(test)]

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -1233,6 +1233,7 @@ mod tests {
             ),
             remote_id: "VPC02".try_into().unwrap(),
             gwgroup: "default".into(),
+            acl: None,
         });
 
         vpc_table.add(vpc1.clone()).unwrap();
@@ -1291,6 +1292,7 @@ mod tests {
             ),
             remote_id: "VPC02".try_into().unwrap(),
             gwgroup: "default".into(),
+            acl: None,
         });
 
         vpc1.peerings.push(Peering {
@@ -1305,6 +1307,7 @@ mod tests {
             ),
             remote_id: "VPC03".try_into().unwrap(),
             gwgroup: "default".into(),
+            acl: None,
         });
 
         vpc_table.add(vpc1.clone()).unwrap();

--- a/k8s-intf/src/bolero/peering.rs
+++ b/k8s-intf/src/bolero/peering.rs
@@ -94,6 +94,7 @@ impl ValueGenerator for LegalValuePeeringsGenerator<'_> {
         Some(GatewayAgentPeerings {
             gateway_group: Some(d.produce::<String>()?),
             peering: Some(peering),
+            acl: None, // FIXME: Add a proper implementation when used
         })
     }
 }

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -182,6 +182,16 @@ impl PrefixPortsSet {
         result
     }
 
+    /// Given two [`PrefixPortsSet`] objects, returns the set containing the union of prefixes with
+    /// their associated ports.
+    #[must_use]
+    pub fn union_prefixes_and_ports(&self, other: &PrefixPortsSet) -> PrefixPortsSet {
+        self.iter()
+            .copied()
+            .chain(other.iter().copied())
+            .collect::<PrefixPortsSet>()
+    }
+
     /// Return the total "size" of all prefixes in the set.
     ///
     /// The "size" is the number of IP addresses in the IP prefix, multiplied by the number of ports
@@ -192,6 +202,15 @@ impl PrefixPortsSet {
             .iter()
             .map(PrefixWithOptionalPorts::size)
             .sum::<PrefixWithPortsSize>()
+    }
+
+    /// Returns true if at least one of the prefixes in the set has an associated port range that is
+    /// not the full range (not covering all ports).
+    #[must_use]
+    pub fn uses_ports(&self) -> bool {
+        self.0
+            .iter()
+            .any(|p| p.ports().is_some_and(|ports| !ports.is_max_range()))
     }
 
     /// Returns true if all prefixes in the set have the same IP version (all IPv4 or all IPv6).

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -193,6 +193,24 @@ impl PrefixPortsSet {
             .map(PrefixWithOptionalPorts::size)
             .sum::<PrefixWithPortsSize>()
     }
+
+    /// Returns true if all prefixes in the set have the same IP version (all IPv4 or all IPv6).
+    #[must_use]
+    pub fn have_consistent_ip_version(prefix_sets: &[&PrefixPortsSet]) -> bool {
+        let mut is_ipv4 = None;
+        for prefix_set in prefix_sets {
+            for prefix in *prefix_set {
+                if let Some(is_ipv4) = is_ipv4 {
+                    if prefix.prefix().is_ipv4() != is_ipv4 {
+                        return false;
+                    }
+                } else {
+                    is_ipv4 = Some(prefix.prefix().is_ipv4());
+                }
+            }
+        }
+        true
+    }
 }
 
 impl IntoIterator for PrefixPortsSet {

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -100,6 +100,7 @@ mod context {
             remote: manifest2.clone(),
             remote_id: "12345".try_into().unwrap(),
             gwgroup: "default".into(),
+            acl: None,
         };
         let peering2 = Peering {
             name: "test_peering2".into(),
@@ -107,6 +108,7 @@ mod context {
             remote: manifest1,
             remote_id: "67890".try_into().unwrap(),
             gwgroup: "default".into(),
+            acl: None,
         };
 
         // VPC-1

--- a/nat/src/static_nat/setup/mod.rs
+++ b/nat/src/static_nat/setup/mod.rs
@@ -188,6 +188,7 @@ mod tests {
             remote: manifest2,
             remote_id: "12345".try_into().expect("Failed to create VPC ID"),
             gwgroup: "default".into(),
+            acl: None,
         };
 
         let src_vni = Vni::new_checked(100).unwrap();

--- a/nat/src/static_nat/test.rs
+++ b/nat/src/static_nat/test.rs
@@ -224,6 +224,7 @@ fn build_context() -> NatTables {
         remote: manifest2.clone(),
         remote_id: "12345".try_into().expect("Failed to create VPC ID"),
         gwgroup: "default".into(),
+        acl: None,
     };
     let peering2 = Peering {
         name: "test_peering2".into(),
@@ -231,6 +232,7 @@ fn build_context() -> NatTables {
         remote: manifest1,
         remote_id: "67890".try_into().expect("Failed to create VPC ID"),
         gwgroup: "default".into(),
+        acl: None,
     };
 
     // This code is extremely convoluted

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -82,10 +82,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v0.125.1",
-      "revision": "18bef9bfdeb846081255a561a4bee30db234272e",
-      "url": "https://api.github.com/repos/githedgehog/fabric/tarball/refs/tags/v0.125.1",
-      "hash": "sha256-eEl+BdxTkx76ytBRrxcUM7oqNFoyYrgyAHlyZ5yzRgM=",
+      "version": "v0.126.0",
+      "revision": "b66a16fcf0f21523d6f416b7b6bcf92dd0e5fea7",
+      "url": "https://api.github.com/repos/githedgehog/fabric/tarball/refs/tags/v0.126.0",
+      "hash": "sha256-/pF/MXy33jc33CRUcOjfZ4uL33TDfPzDpQ3ZoZsdc9A=",
       "frozen": true
     },
     "frr": {


### PR DESCRIPTION
Translate the newly-added spec.peerings[].acl CRD field into the internal Acl/AclRule/AclPattern model and attach it to VpcPeering. Also fixes two kopium-generated struct literals (GatewayAgentPeerings, GatewayAgentGatewayLogs) in the k8s-intf bolero generators that no longer compiled once the CRD gained the acl and rateLimit fields.

this PR will fail until https://github.com/githedgehog/fabric/pull/1498 is merged; it was built and tested locally by building the CRDs from the feature branch.
it also does not concern itself with validation (past what is strictly required for the conversion) or the broader integration of ACLs within dataplane.

[EDIT: The Fabric changes have been merged in the dedicated repo, and are pulled in this PR via the npin update. Validation for ACL is also present in the branch.]