### PR TITLE
Bump fossa-action to v2

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,6 +30,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}


### PR DESCRIPTION
The only breaking change for this new major version is the switch from Node 20 to Node 24, we shouldn't be affected.

Link: https://github.com/fossas/fossa-action/releases/tag/v2.0.0

On top of #1619, which should unblock CI.