### PR TITLE
clean-ups + vpc route abstraction + extend validation for failover

### DIFF
--- a/cli/bin/cmdtree_dp.rs
+++ b/cli/bin/cmdtree_dp.rs
@@ -81,6 +81,11 @@ fn cmd_show_vpc() -> Node {
     root += Node::new("peerings")
         .desc("Show the peerings of each vpc")
         .action(CliAction::ShowVpcPeerings);
+
+    root += Node::new("routing")
+        .desc("Show the routing table of each vpc")
+        .action(CliAction::ShowVpcRouting);
+
     root
 }
 fn cmd_show_ip() -> Node {

--- a/cli/src/cliproto.rs
+++ b/cli/src/cliproto.rs
@@ -286,6 +286,7 @@ pub enum CliAction {
     // config: vpcs & peerings
     ShowVpc,
     ShowVpcPeerings,
+    ShowVpcRouting,
 
     // router: Eventlog
     RouterEventLog,

--- a/config/src/display.rs
+++ b/config/src/display.rs
@@ -425,6 +425,10 @@ impl ValidatedVpcTable {
     pub fn as_peerings(&self) -> ValidatedVpcTablePeerings<'_> {
         ValidatedVpcTablePeerings(self)
     }
+    #[must_use]
+    pub fn as_route_tables(&self) -> VpcTableRoutingTables<'_> {
+        VpcTableRoutingTables(self)
+    }
 }
 
 impl Vpc {
@@ -498,7 +502,7 @@ impl Display for ValidatedOverlay {
 
 macro_rules! VPC_RT_TBL_FMT {
     () => {
-        "{:<30} {:<10} {:<12} {:<13} {:<16}"
+        " {:<30} {:<10} {:<12} {:<13} {:<16}"
     };
 }
 fn fmt_vpc_rt_table_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/config/src/display.rs
+++ b/config/src/display.rs
@@ -16,7 +16,9 @@ use crate::external::overlay::vpcpeering::{
     VpcExposePortForwarding, VpcExposeStaticNat,
 };
 use crate::external::overlay::vpcpeering::{VpcManifest, VpcPeering, VpcPeeringTable};
+use crate::external::overlay::vpcrouting::{ExposeAction, VpcRoute, VpcRouteTable};
 use crate::external::overlay::{Overlay, ValidatedOverlay};
+
 use chrono::{DateTime, Utc};
 use net::vxlan::Vni;
 
@@ -347,6 +349,18 @@ impl Display for ValidatedVpcSummary<'_> {
     }
 }
 
+pub struct VpcTableRoutingTables<'a>(&'a ValidatedVpcTable);
+impl Display for VpcTableRoutingTables<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for vpc in self.0.values() {
+            Heading(vpc.name().to_string()).fmt(f)?;
+            vpc.route_table().fmt(f)?;
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}
+
 pub struct VpcTableSummary<'a>(&'a VpcTable);
 impl Display for VpcTableSummary<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -477,6 +491,58 @@ impl Display for Overlay {
 impl Display for ValidatedOverlay {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.vpc_table().as_summary().fmt(f)
+    }
+}
+
+/* ===== VPC routing tables =====*/
+
+macro_rules! VPC_RT_TBL_FMT {
+    () => {
+        "{:<30} {:<10} {:<12} {:<13} {:<16}"
+    };
+}
+fn fmt_vpc_rt_table_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        VPC_RT_TBL_FMT!(),
+        "destinations", "remote-VPC", "remote-vni", "remote-action", "gw-group"
+    )
+}
+
+impl Display for ExposeAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(match self {
+            ExposeAction::Default => "default",
+            ExposeAction::Forward => "forward",
+            ExposeAction::StaticNat => "static-nat",
+            ExposeAction::PortForwarding => "port-forward",
+            ExposeAction::Masquerade => "masqueraded",
+        })
+    }
+}
+
+impl Display for VpcRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let dst = self.destination().to_string();
+        writeln!(
+            f,
+            VPC_RT_TBL_FMT!(),
+            dst,
+            self.dst_vpc(),
+            self.dst_vni(),
+            self.remote_action(),
+            self.gw_group()
+        )
+    }
+}
+
+impl Display for VpcRouteTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_vpc_rt_table_heading(f)?;
+        for route_set in self.iter() {
+            route_set.fmt(f)?;
+        }
+        Ok(())
     }
 }
 

--- a/config/src/display.rs
+++ b/config/src/display.rs
@@ -18,6 +18,7 @@ use crate::external::overlay::vpcpeering::{
 use crate::external::overlay::vpcpeering::{VpcManifest, VpcPeering, VpcPeeringTable};
 use crate::external::overlay::{Overlay, ValidatedOverlay};
 use chrono::{DateTime, Utc};
+use net::vxlan::Vni;
 
 use common::cliprovider::Heading;
 const SEP: &str = "       ";
@@ -134,10 +135,11 @@ fn fmt_remote_manifest(
     f: &mut std::fmt::Formatter<'_>,
     manifest: &VpcManifest,
     remote_id: &VpcId,
+    remote_vni: Vni,
 ) -> std::fmt::Result {
     writeln!(
         f,
-        "     remote VPC is {} (id:{}):",
+        "     remote VPC is {} (id:{}), vni: {remote_vni}:",
         manifest.name, remote_id
     )?;
     for e in &manifest.exposes {
@@ -152,7 +154,7 @@ impl Display for Peering {
         writeln!(f, "   gwgroup: {}", &self.gwgroup)?;
         fmt_local_manifest(f, &self.local)?;
         writeln!(f)?;
-        fmt_remote_manifest(f, &self.remote, &self.remote_id)?;
+        fmt_remote_manifest(f, &self.remote, &self.remote_id, self.remote_vni)?;
         writeln!(f)
     }
 }
@@ -172,12 +174,12 @@ fn fmt_remote_validated_manifest(
     f: &mut std::fmt::Formatter<'_>,
     manifest: &ValidatedManifest,
     remote_id: &VpcId,
+    remote_vni: Vni,
 ) -> std::fmt::Result {
     writeln!(
         f,
-        "     remote VPC is {} (id:{}):",
+        "     remote VPC is {} (id:{remote_id}) vni:{remote_vni} :",
         manifest.name(),
-        remote_id
     )?;
     for e in manifest.valexp() {
         e.fmt(f)?;
@@ -191,7 +193,7 @@ impl Display for ValidatedPeering {
         writeln!(f, "   gwgroup: {}", self.gwgroup())?;
         fmt_local_validated_manifest(f, self.local())?;
         writeln!(f)?;
-        fmt_remote_validated_manifest(f, self.remote(), self.remote_id())?;
+        fmt_remote_validated_manifest(f, self.remote(), self.remote_id(), self.remote_vni())?;
         writeln!(f)
     }
 }

--- a/config/src/errors.rs
+++ b/config/src/errors.rs
@@ -42,8 +42,6 @@ pub enum ConfigError {
     InvalidVpcVni(u32),
     #[error("Config with id {0} not found")]
     NoSuchConfig(GenId),
-    #[error("A config with id {0} already exists")]
-    ConfigAlreadyExists(GenId),
     #[error("Failure applying config: {0}")]
     FailureApply(String),
     #[error("Forbidden: {0}")]
@@ -58,20 +56,14 @@ pub enum ConfigError {
     MissingIdentifier(&'static str),
     #[error("Missing mandatory parameter: {0}")]
     MissingParameter(&'static str),
-    #[error("Incomplete: {0}")]
-    Incomplete(String),
     #[error("Multiple instances of {0} found, expected {1}")]
     TooManyInstances(&'static str, usize),
     #[error("Internal error: {0}")]
     InternalFailure(String),
-    #[error("MTU out of range [68, 65535]: {0}")]
-    BadMtu(u32),
 
     // Peering and VpcExpose validation
     #[error("All prefixes are excluded in VpcExpose: {0}")]
     ExcludedAllPrefixes(Box<VpcExpose>),
-    #[error("Exclusion prefix {0} not contained within existing allowed prefix")]
-    OutOfRangeExclusionPrefix(PrefixWithOptionalPorts),
     #[error("VPC prefixes overlap: {0} and {1}")]
     OverlappingPrefixes(PrefixWithOptionalPorts, PrefixWithOptionalPorts),
     #[error("Inconsistent IP version in VpcExpose: {0}")]

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -7,6 +7,7 @@ pub mod tests;
 pub mod validation_tests;
 pub mod vpc;
 pub mod vpcpeering;
+pub mod vpcrouting;
 
 use crate::{ConfigError, ConfigResult};
 use tracing::{debug, error};

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -10,7 +10,7 @@ pub mod vpcpeering;
 
 use crate::{ConfigError, ConfigResult};
 use tracing::{debug, error};
-use vpc::{ValidatedVpcTable, VpcIdMap, VpcTable};
+use vpc::{ValidatedVpcTable, VpcTable};
 use vpcpeering::{VpcManifest, VpcPeeringTable};
 
 #[derive(Clone, Debug, Default)]
@@ -27,6 +27,7 @@ impl Overlay {
             peering_table,
         }
     }
+
     /// Check if a `Vpc` referred in a peering exists
     fn check_peering_vpc(&self, peering: &str, manifest: &VpcManifest) -> ConfigResult {
         self.vpc_table.get_vpc(&manifest.name).ok_or_else(|| {
@@ -36,29 +37,14 @@ impl Overlay {
         Ok(())
     }
 
-    /// Validate all peerings, checking if the VPCs they refer to exist in vpc table
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a peering references a VPC that does not exist in the VPC table.
-    pub fn validate_peerings(&self) -> ConfigResult {
+    /// Validate all peerings: check if the VPCs they refer to exist in vpc table
+    fn validate_peering_vpcs(&self) -> ConfigResult {
         debug!("Validating VPC peerings...");
         for peering in self.peering_table.values() {
             self.check_peering_vpc(&peering.name, &peering.left)?;
             self.check_peering_vpc(&peering.name, &peering.right)?;
         }
         Ok(())
-    }
-
-    /// Build a `VpcIdMap`. We have already checked that all VPC Ids are distinct
-    #[must_use]
-    pub(crate) fn vpcid_map(&self) -> VpcIdMap {
-        let id_map: VpcIdMap = self
-            .vpc_table
-            .values()
-            .map(|vpc| (vpc.name.clone(), vpc.id.clone()))
-            .collect();
-        id_map
     }
 
     /// Validate the overlay configuration, returning a `ValidatedOverlay` if successful.
@@ -69,26 +55,20 @@ impl Overlay {
     pub fn validate(&self) -> Result<ValidatedOverlay, ConfigError> {
         debug!("Validating overlay configuration...");
 
-        self.validate_peerings()?;
+        // validate peerings:
+        self.validate_peering_vpcs()?;
 
         // Collect peerings for every VPC and validate the table
-        let validated_vpc_table = self.collect_peerings().validate()?;
-        let validated_overlay = ValidatedOverlay {
-            vpc_table: validated_vpc_table,
-        };
+        let vpc_table = self
+            .vpc_table
+            .collect_peerings(&self.peering_table)
+            .validate()?;
+
+        let validated_overlay = ValidatedOverlay { vpc_table };
 
         let peering_table = &self.peering_table;
         debug!("Overlay configuration is VALID:\n{validated_overlay}\n{peering_table}");
         Ok(validated_overlay)
-    }
-
-    /// Collect peerings from the peering table for every VPC.
-    ///
-    /// Should only be called in `validate`, or in tests.
-    pub(crate) fn collect_peerings(&self) -> VpcTable {
-        let id_map = self.vpcid_map();
-        self.vpc_table
-            .collect_peerings(&self.peering_table, &id_map)
     }
 
     /// FOR TESTS ONLY. Fake validation for the overlay.
@@ -100,7 +80,7 @@ impl Overlay {
     #[allow(unsafe_code)]
     #[must_use]
     pub unsafe fn fake_validated_overlay_for_tests(&self) -> ValidatedOverlay {
-        let vpc_table = self.collect_peerings();
+        let vpc_table = self.vpc_table.collect_peerings(&self.peering_table);
         let fake_valid_vpc_table = unsafe { vpc_table.fake_validated_vpc_table_for_tests() };
         ValidatedOverlay {
             vpc_table: fake_valid_vpc_table,

--- a/config/src/external/overlay/mod.rs
+++ b/config/src/external/overlay/mod.rs
@@ -89,7 +89,7 @@ impl Overlay {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ValidatedOverlay {
     vpc_table: ValidatedVpcTable,
 }

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -1171,7 +1171,7 @@ pub mod test {
 
         let overlay = Overlay::new(vpc_table, peering_table);
         assert!(overlay.validate().is_err_and(
-            |e| e == ConfigError::Forbidden("Multiple 'default' destinations exposed to VPC")
+            |e| e == ConfigError::Forbidden("Multiple default destinations exposed to VPC")
         ));
     }
 

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -10,7 +10,6 @@
 pub mod test {
     use crate::external::ConfigError;
     use crate::external::overlay::Overlay;
-    use crate::external::overlay::VpcIdMap;
     use crate::external::overlay::vpc::{Vpc, VpcTable};
     use crate::external::overlay::vpcpeering::VpcExpose;
     use crate::external::overlay::vpcpeering::VpcManifest;
@@ -688,14 +687,8 @@ pub mod test {
         /* display peering table */
         println!("{peering_table}");
 
-        /* collect ids */
-        let id_map: VpcIdMap = vpc_table
-            .values()
-            .map(|vpc| (vpc.name.clone(), vpc.id.clone()))
-            .collect();
-
         /* collect the peerings for each VPC */
-        vpc_table.collect_peerings(&peering_table, &id_map);
+        vpc_table = vpc_table.collect_peerings(&peering_table);
 
         /* display VPC table */
         println!("{}", vpc_table.as_summary());

--- a/config/src/external/overlay/tests.rs
+++ b/config/src/external/overlay/tests.rs
@@ -65,7 +65,7 @@ pub mod test {
 
         /* invalid vni should be rejected */
         let vpc1 = Vpc::new("VPC-1", "AAAAA", 0);
-        assert_eq!(vpc1, Err(ConfigError::InvalidVpcVni(0)));
+        assert!(vpc1.is_err_and(|e| matches!(e, ConfigError::InvalidVpcVni(0))));
 
         /* add vpc with valid vni 3000 */
         let vpc1 = Vpc::new("VPC-1", "AAAAA", 3000).expect("Should succeed");
@@ -90,12 +90,14 @@ pub mod test {
         );
 
         /* vpc with bad Id should not build */
-        let bad = Vpc::new("VPC-2", "AAA", 9000);
-        assert_eq!(bad, Err(ConfigError::BadVpcId("AAA".to_string())));
+        let bad_id = "AAA".to_string();
+        let bad = Vpc::new("VPC-2", &bad_id, 9000);
+        assert!(bad.is_err_and(|e| matches!(e, ConfigError::BadVpcId(_bad_id))));
 
         /* vpc with bad Id should not build */
-        let bad = Vpc::new("VPC-2", "!1234", 9000);
-        assert_eq!(bad, Err(ConfigError::BadVpcId("!1234".to_string())));
+        let bad_id = "!1234".to_string();
+        let bad = Vpc::new("VPC-2", &bad_id, 9000);
+        assert!(bad.is_err_and(|e| matches!(e, ConfigError::BadVpcId(_bad_id))));
     }
 
     #[test]

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -187,7 +187,7 @@ impl TryFrom<&str> for VpcId {
     }
 }
 
-pub(crate) type VpcIdMap = BTreeMap<String, VpcId>;
+type VpcIdMap = BTreeMap<String, VpcId>;
 
 /// Representation of a VPC from the RPC
 #[derive(Clone, Debug, PartialEq)]
@@ -266,16 +266,15 @@ impl Vpc {
             .map(Peering::validate)
             .collect::<Result<_, _>>()?;
 
-        let valid_vpc_candidate = ValidatedVpc {
+        let validated_vpc = ValidatedVpc {
             name: self.name.clone(),
             id: self.id.clone(),
             vni: self.vni,
             interfaces: self.interfaces.clone(),
             peerings: validated_peerings,
         };
-
-        valid_vpc_candidate.check_overlap_and_default()?;
-        Ok(valid_vpc_candidate)
+        validated_vpc.check_overlap_and_default()?;
+        Ok(validated_vpc)
     }
 
     /// FOR TESTS ONLY. Fake validation for the VPC peering manifests.
@@ -468,6 +467,17 @@ impl VpcTable {
         Ok(())
     }
 
+    /// Build a `VpcIdMap`
+    #[must_use]
+    fn vpcid_map(&self) -> VpcIdMap {
+        debug!("Building a VPC Id map...");
+        let id_map: VpcIdMap = self
+            .values()
+            .map(|vpc| (vpc.name.clone(), vpc.id.clone()))
+            .collect();
+        id_map
+    }
+
     /// Get a [`Vpc`] from the vpc table by name
     #[must_use]
     pub fn get_vpc(&self, vpc_name: &str) -> Option<&Vpc> {
@@ -490,16 +500,13 @@ impl VpcTable {
     }
 
     /// Collect peerings for all [`Vpc`]s in this [`VpcTable`]
-    pub(crate) fn collect_peerings(
-        &self,
-        peering_table: &VpcPeeringTable,
-        idmap: &VpcIdMap,
-    ) -> VpcTable {
+    pub(crate) fn collect_peerings(&self, peering_table: &VpcPeeringTable) -> VpcTable {
+        let idmap = self.vpcid_map();
         debug!("Collecting peerings for all VPCs..");
         let mut new_table = self.clone();
         new_table
             .values_mut()
-            .for_each(|vpc| vpc.set_peerings(peering_table, idmap));
+            .for_each(|vpc| vpc.set_peerings(peering_table, &idmap));
         new_table
     }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -31,6 +31,7 @@ pub struct Peering {
     pub local: VpcManifest,  /* local manifest */
     pub remote: VpcManifest, /* remote manifest */
     pub remote_id: VpcId,    /* Id of peer */
+    pub remote_vni: Vni,     /* Vni of peer -- should be vpc discriminant in future */
     pub gwgroup: String,     /* gateway group serving this peering */
 }
 
@@ -52,6 +53,7 @@ impl Peering {
             local: self.local.validate()?,
             remote: self.remote.validate()?,
             remote_id: self.remote_id.clone(),
+            remote_vni: self.remote_vni,
             gwgroup: self.gwgroup.clone(),
         };
         valid_peering_candidate.validate_nat_combinations()?;
@@ -79,6 +81,7 @@ impl Peering {
             local: fake_local,
             remote: fake_remote,
             remote_id: self.remote_id.clone(),
+            remote_vni: self.remote_vni,
             gwgroup: self.gwgroup.clone(),
         }
     }
@@ -90,6 +93,7 @@ pub struct ValidatedPeering {
     local: ValidatedManifest,  /* local manifest */
     remote: ValidatedManifest, /* remote manifest */
     remote_id: VpcId,          /* Id of peer */
+    remote_vni: Vni,           /* Vni of peer -- should be vpc discriminant in future */
     gwgroup: String,           /* gateway group serving this peering */
 }
 
@@ -112,6 +116,11 @@ impl ValidatedPeering {
     #[must_use]
     pub fn remote_id(&self) -> &VpcId {
         &self.remote_id
+    }
+
+    #[must_use]
+    pub fn remote_vni(&self) -> Vni {
+        self.remote_vni
     }
 
     #[must_use]
@@ -187,7 +196,19 @@ impl TryFrom<&str> for VpcId {
     }
 }
 
-type VpcIdMap = BTreeMap<String, VpcId>;
+struct VpcSummary {
+    vpcid: VpcId,
+    vni: Vni,
+}
+impl From<&Vpc> for VpcSummary {
+    fn from(vpc: &Vpc) -> Self {
+        Self {
+            vpcid: vpc.id.clone(),
+            vni: vpc.vni,
+        }
+    }
+}
+type VpcMap = BTreeMap<String, VpcSummary>;
 
 /// Representation of a VPC from the RPC
 #[derive(Clone, Debug, PartialEq)]
@@ -196,7 +217,7 @@ pub struct Vpc {
     pub id: VpcId,                        /* internal Id, unique*/
     pub vni: Vni,                         /* mandatory */
     pub interfaces: InterfaceConfigTable, /* user-defined interfaces in this VPC */
-    pub peerings: Vec<Peering>,           /* peerings of this VPC - NOT set via gRPC */
+    pub peerings: Vec<Peering>,           /* peerings of this VPC (collected) */
 }
 impl Vpc {
     pub fn new(name: &str, id: &str, vni: u32) -> Result<Self, ConfigError> {
@@ -211,18 +232,19 @@ impl Vpc {
     }
 
     /// Collect all peerings from the [`VpcPeeringTable`] table this vpc participates in
-    fn set_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcIdMap) {
+    fn set_peerings(&mut self, peering_table: &VpcPeeringTable, idmap: &VpcMap) {
         debug!("Collecting peerings for vpc '{}'...", self.name);
         self.peerings = peering_table
             .peerings_vpc(&self.name)
             .map(|p| {
                 let (local, remote) = p.get_peering_manifests(&self.name);
-                let remote_id = idmap.get(&remote.name).unwrap_or_else(|| unreachable!());
+                let remote_vpc = idmap.get(&remote.name).unwrap_or_else(|| unreachable!());
                 Peering {
                     name: p.name.clone(),
                     local: local.clone(),
                     remote: remote.clone(),
-                    remote_id: remote_id.clone(),
+                    remote_id: remote_vpc.vpcid.clone(),
+                    remote_vni: remote_vpc.vni,
                     gwgroup: p.gwgroup.clone(),
                 }
             })
@@ -301,6 +323,7 @@ impl Vpc {
                     local: fake_local,
                     remote: fake_remote,
                     remote_id: peering.remote_id.clone(),
+                    remote_vni: peering.remote_vni,
                     gwgroup: peering.gwgroup.clone(),
                 }
             })
@@ -467,13 +490,13 @@ impl VpcTable {
         Ok(())
     }
 
-    /// Build a `VpcIdMap`
+    /// Build a `VpcMap`
     #[must_use]
-    fn vpcid_map(&self) -> VpcIdMap {
-        debug!("Building a VPC Id map...");
-        let id_map: VpcIdMap = self
+    fn vpc_map(&self) -> VpcMap {
+        debug!("Building a VPC map...");
+        let id_map: VpcMap = self
             .values()
-            .map(|vpc| (vpc.name.clone(), vpc.id.clone()))
+            .map(|vpc| (vpc.name.clone(), VpcSummary::from(vpc)))
             .collect();
         id_map
     }
@@ -501,12 +524,12 @@ impl VpcTable {
 
     /// Collect peerings for all [`Vpc`]s in this [`VpcTable`]
     pub(crate) fn collect_peerings(&self, peering_table: &VpcPeeringTable) -> VpcTable {
-        let idmap = self.vpcid_map();
+        let vpc_map = self.vpc_map();
         debug!("Collecting peerings for all VPCs..");
         let mut new_table = self.clone();
         new_table
             .values_mut()
-            .for_each(|vpc| vpc.set_peerings(peering_table, &idmap));
+            .for_each(|vpc| vpc.set_peerings(peering_table, &vpc_map));
         new_table
     }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -5,7 +5,6 @@
 
 #![allow(clippy::missing_errors_doc)]
 
-use lpm::prefix::IpRangeWithPorts;
 use net::vxlan::Vni;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -16,6 +15,7 @@ use crate::external::overlay::VpcManifest;
 use crate::external::overlay::VpcPeeringTable;
 use crate::external::overlay::vpcpeering::ValidatedManifest;
 use crate::external::overlay::vpcpeering::VpcExposeNatConfig;
+use crate::external::overlay::vpcrouting::VpcRouteTable;
 use crate::internal::interfaces::interface::InterfaceConfigTable;
 use crate::{ConfigError, ConfigResult};
 
@@ -288,6 +288,8 @@ impl Vpc {
             .map(Peering::validate)
             .collect::<Result<_, _>>()?;
 
+        VpcRouteTable::build(&validated_peerings).validate()?;
+
         let validated_vpc = ValidatedVpc {
             name: self.name.clone(),
             id: self.id.clone(),
@@ -295,7 +297,6 @@ impl Vpc {
             interfaces: self.interfaces.clone(),
             peerings: validated_peerings,
         };
-        validated_vpc.check_overlap_and_default()?;
         Ok(validated_vpc)
     }
 
@@ -389,64 +390,6 @@ impl ValidatedVpc {
                 .iter()
                 .any(|e| e.has_port_forwarding() || e.has_masquerade())
         })
-    }
-
-    /// Check that prefixes exposed to a given VPC do not overlap. Exceptions:
-    ///
-    /// - overlap is allowed between a prefix and a default expose (it overlaps by design)
-    /// - overlap is allowed between prefixes from different exposes if both their exposes use
-    ///   masquerade (we can fall back to the flow table to disambiguate the destination VPC)
-    ///
-    /// Also check that at most one default expose is exposed to the VPC.
-    fn check_overlap_and_default(&self) -> ConfigResult {
-        // FIXME: Find a less expensive approach to find overlapping prefixes
-        for (i, current_peering) in self.peerings().iter().enumerate() {
-            // Check we don't have non-default, overlapping prefixes exposed to the VPC
-            for other_peering in &self.peerings()[i + 1..] {
-                for current_expose in current_peering.remote().valexp() {
-                    for other_expose in other_peering.remote().valexp() {
-                        if current_expose.has_masquerade() && other_expose.has_masquerade() {
-                            // Overlap is allowed if both expose blocks use masquerade
-                            continue;
-                        }
-                        match (current_expose.is_default(), other_expose.is_default()) {
-                            (true, true) => {
-                                // We support at most one default destination exposed to any VPC
-                                error!(
-                                    "Multiple 'default' destinations exposed to VPC {}",
-                                    self.name()
-                                );
-                                return Err(ConfigError::Forbidden(
-                                    "Multiple 'default' destinations exposed to VPC",
-                                ));
-                            }
-                            (true, false) | (false, true) => {
-                                // Overlap is allowed between a prefix and a default expose
-                                continue;
-                            }
-                            (false, false) => { /* keep processing */ }
-                        }
-                        for current_prefix in current_expose.public_ips() {
-                            for other_prefix in other_expose.public_ips() {
-                                if current_prefix.overlaps(other_prefix) {
-                                    error!(
-                                        "Prefixes exposed to VPC {} overlap: {} and {}",
-                                        self.name(),
-                                        current_prefix,
-                                        other_prefix
-                                    );
-                                    return Err(ConfigError::OverlappingPrefixes(
-                                        *current_prefix,
-                                        *other_prefix,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -288,7 +288,7 @@ impl Vpc {
             .map(Peering::validate)
             .collect::<Result<_, _>>()?;
 
-        VpcRouteTable::build(&validated_peerings).validate()?;
+        let route_table = VpcRouteTable::build(&validated_peerings).validate()?;
 
         let validated_vpc = ValidatedVpc {
             name: self.name.clone(),
@@ -296,6 +296,7 @@ impl Vpc {
             vni: self.vni,
             interfaces: self.interfaces.clone(),
             peerings: validated_peerings,
+            route_table,
         };
         Ok(validated_vpc)
     }
@@ -330,12 +331,15 @@ impl Vpc {
             })
             .collect::<Vec<_>>();
 
+        let not_validated_rt = VpcRouteTable::build(&fake_validated_peerings);
+
         ValidatedVpc {
             name: self.name.clone(),
             id: self.id.clone(),
             vni: self.vni,
             interfaces: self.interfaces.clone(),
             peerings: fake_validated_peerings,
+            route_table: not_validated_rt,
         }
     }
 }
@@ -347,6 +351,7 @@ pub struct ValidatedVpc {
     vni: Vni,                         /* mandatory */
     interfaces: InterfaceConfigTable, /* user-defined interfaces in this VPC */
     peerings: Vec<ValidatedPeering>,  /* peerings of this VPC - NOT set via gRPC */
+    route_table: VpcRouteTable,
 }
 
 impl ValidatedVpc {
@@ -373,6 +378,11 @@ impl ValidatedVpc {
     #[must_use]
     pub fn peerings(&self) -> &[ValidatedPeering] {
         &self.peerings
+    }
+
+    #[must_use]
+    pub fn route_table(&self) -> &VpcRouteTable {
+        &self.route_table
     }
 
     /// Tell how many peerings this VPC has

--- a/config/src/external/overlay/vpc.rs
+++ b/config/src/external/overlay/vpc.rs
@@ -211,7 +211,7 @@ impl From<&Vpc> for VpcSummary {
 type VpcMap = BTreeMap<String, VpcSummary>;
 
 /// Representation of a VPC from the RPC
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Vpc {
     pub name: String,                     /* name of vpc, used as key */
     pub id: VpcId,                        /* internal Id, unique*/
@@ -340,7 +340,7 @@ impl Vpc {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug)]
 pub struct ValidatedVpc {
     name: String,                     /* name of vpc, used as key */
     id: VpcId,                        /* internal Id, unique*/
@@ -515,7 +515,7 @@ impl VpcTable {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct ValidatedVpcTable {
     vpcs: BTreeMap<String, ValidatedVpc>,
     ids: BTreeMap<VpcId, String>, // name of vpc

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -839,7 +839,7 @@ impl VpcPeering {
     }
     /// Given a peering fetch the manifests, orderly depending on the provided vpc name
     #[must_use]
-    pub fn get_peering_manifests(&self, vpc: &str) -> (&VpcManifest, &VpcManifest) {
+    pub(crate) fn get_peering_manifests(&self, vpc: &str) -> (&VpcManifest, &VpcManifest) {
         if self.left.name == vpc {
             (&self.left, &self.right)
         } else {

--- a/config/src/external/overlay/vpcrouting.rs
+++ b/config/src/external/overlay/vpcrouting.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Dataplane configuration model: vpc routing
+
+use crate::ConfigError;
+use crate::external::ValidatedPeering;
+use crate::external::overlay::vpcpeering::ValidatedExpose;
+use lpm::prefix::{IpRangeWithPorts, PrefixPortsSet, PrefixWithOptionalPorts};
+use net::vxlan::Vni;
+use ordermap::OrderMap;
+
+/// A type indicating the action required by an exposed destination
+#[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
+pub enum ExposeAction {
+    Masquerade,
+    PortForwarding,
+    StaticNat,
+    Forward,
+    Default,
+}
+impl From<&ValidatedExpose> for ExposeAction {
+    fn from(expose: &ValidatedExpose) -> Self {
+        if expose.has_masquerade() {
+            return ExposeAction::Masquerade;
+        } else if expose.has_port_forwarding() {
+            return ExposeAction::PortForwarding;
+        } else if expose.has_static_nat() {
+            return ExposeAction::StaticNat;
+        } else if expose.is_default() {
+            return ExposeAction::Default;
+        }
+        ExposeAction::Forward
+    }
+}
+
+/// A type representing a route to a remote vpc
+#[derive(Debug)]
+pub struct VpcRoute {
+    dst: PrefixWithOptionalPorts, // destination(s) this route applies to
+    dstvpc: String,               // destination VPC
+    dstvni: Vni,                  // data path discriminant towards destination
+    rem_action: ExposeAction,     // action required by remote VPC
+    gwgroup: String,              // gateway group handling the peering this route corresponds to
+}
+
+/// A type representing a set of routes to the same destination.
+/// This type is currently not public
+#[derive(Debug)]
+struct VpcRouteSet(Vec<VpcRoute>);
+impl VpcRouteSet {
+    #[must_use]
+    fn new() -> Self {
+        Self(Vec::new())
+    }
+    fn iter(&self) -> impl Iterator<Item = &VpcRoute> {
+        self.0.iter()
+    }
+}
+
+impl VpcRoute {
+    #[must_use]
+    fn is_default(&self) -> bool {
+        self.rem_action == ExposeAction::Default
+    }
+    #[must_use]
+    fn is_masquerade(&self) -> bool {
+        self.rem_action == ExposeAction::Masquerade
+    }
+    /// Tell if a route is allowed to overlap with some other route.
+    fn can_overlap(&self, other: &VpcRoute) -> bool {
+        if self.dstvpc == other.dstvpc {
+            return true;
+        }
+        if self.is_masquerade() && other.is_masquerade() {
+            return true;
+        }
+        // both can't be default at the same time
+        self.is_default() ^ other.is_default()
+    }
+}
+
+/// A table of `VpcRoutes`.
+///
+/// For any destination `PrefixWithOptionalPorts`, this table can keep
+/// a collection of `VpcRoute`s in the form of a `VpcRouteSet`. Routes to
+/// the same destination are kept together in a `VpcRouteSet`.
+#[derive(Debug)]
+pub struct VpcRouteTable {
+    table: OrderMap<PrefixWithOptionalPorts, VpcRouteSet>,
+}
+
+impl VpcRouteTable {
+    #[must_use]
+    fn new() -> Self {
+        Self {
+            table: OrderMap::default(),
+        }
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &VpcRoute> {
+        self.table.values().flat_map(VpcRouteSet::iter)
+    }
+
+    #[must_use]
+    /// Build a `VpcRouteTable` from the set of `ValidatedPeering` of a VPC
+    pub fn build(peerings: &Vec<ValidatedPeering>) -> Self {
+        let mut rt = VpcRouteTable::new();
+        for peering in peerings {
+            for expose in peering.remote().valexp() {
+                let destinations = if expose.is_default() {
+                    &PrefixPortsSet::root_v4()
+                } else {
+                    expose.public_ips()
+                };
+                // build a route for each of the destinations of the remote expose
+                for prefix in destinations {
+                    let route = VpcRoute {
+                        dstvpc: peering.remote().name().to_string(),
+                        gwgroup: peering.gwgroup().clone(),
+                        dst: *prefix,
+                        rem_action: ExposeAction::from(expose),
+                        dstvni: peering.remote_vni(),
+                    };
+                    let set = rt.table.entry(*prefix).or_insert(VpcRouteSet::new());
+                    set.0.push(route);
+                }
+            }
+        }
+        rt
+    }
+
+    /// Consume and validate a `VpcRouteTable`
+    ///
+    /// # Errors
+    ///
+    /// This method returns `ConfigError` if the `VpcRouteTable` fails to meet the validation rules:
+    ///   1) a vpc can have one default route at the most
+    ///   2) destinations cannot overlap except if they are masqueraded or a default
+    ///   3) overlapping destinations, when allowed, must use the same gateway group
+    ///
+    pub fn validate(self) -> Result<Self, ConfigError> {
+        let all_routes: Vec<&VpcRoute> = self.table.values().flat_map(VpcRouteSet::iter).collect();
+        for (i, &route) in all_routes.iter().enumerate() {
+            for &other in &all_routes[i + 1..] {
+                if route.is_default() && other.is_default() {
+                    return Err(ConfigError::Forbidden(
+                        "Multiple default destinations exposed to VPC",
+                    ));
+                }
+                if route.dst.overlaps(&other.dst) {
+                    if !route.can_overlap(other) {
+                        return Err(ConfigError::OverlappingPrefixes(route.dst, other.dst));
+                    }
+                    if route.gwgroup != other.gwgroup {
+                        return Err(ConfigError::Forbidden(
+                            "Overlapping exposes cannot use distinct groups",
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(self)
+    }
+}

--- a/config/src/external/overlay/vpcrouting.rs
+++ b/config/src/external/overlay/vpcrouting.rs
@@ -80,6 +80,30 @@ impl VpcRoute {
     }
 }
 
+// pub getters
+impl VpcRoute {
+    #[must_use]
+    pub fn destination(&self) -> PrefixWithOptionalPorts {
+        self.dst
+    }
+    #[must_use]
+    pub fn dst_vpc(&self) -> &str {
+        &self.dstvpc
+    }
+    #[must_use]
+    pub fn remote_action(&self) -> ExposeAction {
+        self.rem_action
+    }
+    #[must_use]
+    pub fn dst_vni(&self) -> Vni {
+        self.dstvni
+    }
+    #[must_use]
+    pub fn gw_group(&self) -> &str {
+        &self.gwgroup
+    }
+}
+
 /// A table of `VpcRoutes`.
 ///
 /// For any destination `PrefixWithOptionalPorts`, this table can keep

--- a/config/src/internal/interfaces/interface.rs
+++ b/config/src/internal/interfaces/interface.rs
@@ -65,7 +65,7 @@ pub struct InterfaceConfig {
     pub pci: Option<net::pci::PciEbdf>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 /// An interface configuration table
 pub struct InterfaceConfigTable(BTreeMap<String, InterfaceConfig>);
 

--- a/config/src/utils/collapse.rs
+++ b/config/src/utils/collapse.rs
@@ -236,6 +236,7 @@ mod tests {
             local: manifest,
             remote: manifest_empty.clone(),
             remote_id: "12345".try_into().expect("Failed to create VPC ID"),
+            remote_vni: 100.try_into().unwrap(),
             gwgroup: "default".into(),
         };
 

--- a/flow-filter/src/setup.rs
+++ b/flow-filter/src/setup.rs
@@ -1232,6 +1232,7 @@ mod tests {
                 vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
             ),
             remote_id: "VPC02".try_into().unwrap(),
+            remote_vni: vpc2.vni,
             gwgroup: "default".into(),
         });
 
@@ -1290,6 +1291,7 @@ mod tests {
                 vec![VpcExpose::empty().ip("20.0.0.0/24".into())],
             ),
             remote_id: "VPC02".try_into().unwrap(),
+            remote_vni: vpc2.vni,
             gwgroup: "default".into(),
         });
 
@@ -1304,6 +1306,7 @@ mod tests {
                 vec![VpcExpose::empty().ip("20.0.0.0/25".into())],
             ),
             remote_id: "VPC03".try_into().unwrap(),
+            remote_vni: vpc3.vni,
             gwgroup: "default".into(),
         });
 

--- a/lpm/src/prefix/with_ports.rs
+++ b/lpm/src/prefix/with_ports.rs
@@ -61,7 +61,7 @@ pub trait IpRangeWithPorts {
 }
 
 /// A structure containing a prefix and a port range.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(any(test, feature = "bolero"), derive(bolero::TypeGenerator))]
 pub struct PrefixWithPorts {
     prefix: Prefix,
@@ -158,6 +158,22 @@ impl PrefixPortsSet {
         Self::default()
     }
 
+    #[must_use]
+    pub fn root_v4() -> Self {
+        let mut empty = Self::new();
+        let root_v4 = PrefixWithOptionalPorts::new(Prefix::root_v4(), None);
+        empty.insert(root_v4);
+        empty
+    }
+
+    #[must_use]
+    pub fn root_v6() -> Self {
+        let mut empty = Self::new();
+        let root_v6 = PrefixWithOptionalPorts::new(Prefix::root_v6(), None);
+        empty.insert(root_v6);
+        empty
+    }
+
     /// Given two [`PrefixPortsSet`] objects, returns the set containing the intersection of
     /// prefixes and ports. This new set may contain overlapping prefixes (within the set), if any
     /// of the two initial sets contains overlapping prefixes (within that set) that also overlap
@@ -239,7 +255,7 @@ impl std::ops::DerefMut for PrefixPortsSet {
 /// type would be semantically equivalent. To avoid this, the constructor
 /// of this type guarantees that `max_range` is mapped to None, without
 /// needing to call an additional simplify method.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrefixWithOptionalPorts {
     prefix: Prefix,
     ports: Option<PortRange>,
@@ -356,7 +372,7 @@ where
 }
 
 /// A port range, with a start and an end port (both included in the range).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PortRange {
     start: u16,
     end: u16,

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -93,12 +93,17 @@ mod context {
 
         let manifest2 = VpcManifest::with_exposes("VPC-2", vec![expose3, expose4]);
 
+        // VPC-1 and VPC-2
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
+        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2().as_u32()).unwrap();
+
         // Peerings
         let peering1 = Peering {
             name: "test_peering1".into(),
             local: manifest1.clone(),
             remote: manifest2.clone(),
             remote_id: "12345".try_into().unwrap(),
+            remote_vni: vpc2.vni,
             gwgroup: "default".into(),
         };
         let peering2 = Peering {
@@ -106,15 +111,11 @@ mod context {
             local: manifest2,
             remote: manifest1,
             remote_id: "67890".try_into().unwrap(),
+            remote_vni: vpc1.vni,
             gwgroup: "default".into(),
         };
 
-        // VPC-1
-        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
         vpc1.peerings.push(peering1.clone());
-
-        // VPC-2
-        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2().as_u32()).unwrap();
         vpc2.peerings.push(peering2.clone());
 
         // VPC table

--- a/nat/src/static_nat/setup/mod.rs
+++ b/nat/src/static_nat/setup/mod.rs
@@ -182,16 +182,18 @@ mod tests {
         manifest2.add_expose(expose3);
         manifest2.add_expose(expose4);
 
+        let src_vni = Vni::new_checked(100).unwrap();
+        let dst_vni = Vni::new_checked(200).unwrap();
+
         let peering: Peering = Peering {
             name: "test_peering".into(),
             local: manifest1,
             remote: manifest2,
             remote_id: "12345".try_into().expect("Failed to create VPC ID"),
+            remote_vni: dst_vni,
             gwgroup: "default".into(),
         };
 
-        let src_vni = Vni::new_checked(100).unwrap();
-        let dst_vni = Vni::new_checked(200).unwrap();
         let mut vpctable = VpcTable::new();
         let mut src_vpc = Vpc::new("VPC", "12345", src_vni.as_u32()).unwrap();
         src_vpc.peerings.push(peering.clone());

--- a/nat/src/static_nat/test.rs
+++ b/nat/src/static_nat/test.rs
@@ -218,11 +218,23 @@ fn build_context() -> NatTables {
 
     let manifest2 = VpcManifest::with_exposes("VPC-2", vec![expose3, expose4]);
 
+    // This code is extremely convoluted
+    let mut vpctable = VpcTable::new();
+
+    // vpc-1
+    let vni1 = Vni::new_checked(100).unwrap();
+    let mut vpc1 = Vpc::new("VPC-1", "67890", vni1.as_u32()).unwrap();
+
+    // vpc-2
+    let vni2 = Vni::new_checked(200).unwrap();
+    let mut vpc2 = Vpc::new("VPC-2", "12345", vni2.as_u32()).unwrap();
+
     let peering1 = Peering {
         name: "test_peering1".into(),
         local: manifest1.clone(),
         remote: manifest2.clone(),
         remote_id: "12345".try_into().expect("Failed to create VPC ID"),
+        remote_vni: vpc2.vni,
         gwgroup: "default".into(),
     };
     let peering2 = Peering {
@@ -230,22 +242,16 @@ fn build_context() -> NatTables {
         local: manifest2,
         remote: manifest1,
         remote_id: "67890".try_into().expect("Failed to create VPC ID"),
+        remote_vni: vpc1.vni,
         gwgroup: "default".into(),
     };
 
-    // This code is extremely convoluted
-    let mut vpctable = VpcTable::new();
-
-    // vpc-1
-    let vni1 = Vni::new_checked(100).unwrap();
-    let mut vpc1 = Vpc::new("VPC-1", "67890", vni1.as_u32()).unwrap();
+    // Add peerings to vpcs
     vpc1.peerings.push(peering1.clone());
-    vpctable.add(vpc1).unwrap();
-
-    // vpc-2
-    let vni2 = Vni::new_checked(200).unwrap();
-    let mut vpc2 = Vpc::new("VPC-2", "12345", vni2.as_u32()).unwrap();
     vpc2.peerings.push(peering2.clone());
+
+    // add vpcs to table
+    vpctable.add(vpc1).unwrap();
     vpctable.add(vpc2).unwrap();
 
     let mut nat_table = NatTables::new();

--- a/routing/src/cli/handler.rs
+++ b/routing/src/cli/handler.rs
@@ -392,6 +392,7 @@ fn show_config(request: CliRequest, config: Option<&Arc<ValidatedGwConfig>>) -> 
     let contents = match request.action {
         CliAction::ShowVpc => vpc_table.as_summary().to_string(),
         CliAction::ShowVpcPeerings => vpc_table.as_peerings().to_string(),
+        CliAction::ShowVpcRouting => vpc_table.as_route_tables().to_string(),
         CliAction::ShowGatewayGroups => config.external().gwgroups().to_string(),
         CliAction::ShowGatewayCommunities => config.external().communities().to_string(),
         CliAction::ShowConfigInternal => {
@@ -446,6 +447,7 @@ fn do_handle_cli_request(
         CliAction::ShowTech => show_tech(request, db, rio, sources),
         CliAction::ShowVpc
         | CliAction::ShowVpcPeerings
+        | CliAction::ShowVpcRouting
         | CliAction::ShowGatewayCommunities
         | CliAction::ShowGatewayGroups
         | CliAction::ShowConfigInternal => show_config(request, rio.gwconfig.as_ref()),


### PR DESCRIPTION
 * Adds a new representation for vpc peerings in the form of VPC level routes
 * Replaces validation of overlaps allowed based on the VPC routes
 * extends validation for failover gateway groups
 Fixes https://github.com/githedgehog/internal/issues/447