### PR TITLE
decouple bmp server from router

### DIFF
--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -49,8 +49,6 @@ where
 
 /// Start a router and provide the associated pipeline
 pub(crate) fn start_router<Buf: PacketBufferMut>(
-    mgmt: &lifecycle::Subsystem,
-    mgmt_handle: &tokio::runtime::Handle,
     router: &lifecycle::Subsystem,
     params: RouterParams,
 ) -> Result<InternalSetup<Buf>, RouterError> {
@@ -86,7 +84,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
     };
 
     // create router
-    let router = Router::new(mgmt, mgmt_handle, router, params, Some(cli_sources))?;
+    let router = Router::new(router, params, Some(cli_sources))?;
     let iftr_factory = router.get_iftabler_factory();
     let fibtr_factory = router.get_fibtr_factory();
     let atabler_factory = router.get_atabler_factory();

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -106,22 +106,17 @@ fn process_tracing_cmds(args: &CmdArgs) {
 
 fn parse_bmp_params(args: &CmdArgs) -> (Option<BmpServerParams>, Option<BmpOptions>) {
     if args.bmp_enabled() {
-        let bind = args.bmp_address();
+        let bind_addr = args.bmp_address();
         let interval: Duration = args.bmp_interval();
 
-        info!("BMP: enabled, listening on {bind}, interval={:?}", interval);
+        info!("BMP: required. Bind-address: {bind_addr}, interval={interval:?}");
 
         // BMP server (for routing crate)
-        let server = BmpServerParams {
-            bind_addr: bind,
-            stats_interval: interval,
-            min_retry: None,
-            max_retry: None,
-        };
+        let server = BmpServerParams { bind_addr };
 
         // BMP options for FRR (for internal config)
-        let host = bind.ip().to_string();
-        let port = TcpPort::try_from(bind.port()).expect("Invalid BMP port");
+        let host = bind_addr.ip().to_string();
+        let port = TcpPort::try_from(bind_addr.port()).expect("Invalid BMP port");
         let client = BmpOptions::new("bmp1", host, port)
             .set_retry(interval, interval.saturating_mul(4u32))
             .set_stats_interval(interval)

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -15,7 +15,7 @@ use nix::unistd::gethostname;
 use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeConfig};
 
-use routing::{BmpServerParams, RouterParamsBuilder};
+use routing::{BmpServerParams, RouterParamsBuilder, spawn_bmp_server};
 use tracectl::{
     TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
 };
@@ -134,6 +134,15 @@ fn parse_bmp_params(args: &CmdArgs) -> (Option<BmpServerParams>, Option<BmpOptio
     }
 }
 
+fn start_bmp(
+    mgmt: &lifecycle::Subsystem,
+    mgmt_handle: &tokio::runtime::Handle,
+    bmp_params: &BmpServerParams,
+    dp_status: Arc<RwLock<DataplaneStatus>>,
+) -> tokio::task::JoinHandle<()> {
+    spawn_bmp_server(mgmt, mgmt_handle, bmp_params.bind_addr, dp_status)
+}
+
 // Main signal handling of dataplane occurs here
 fn spawn_signal_handler(
     rt_handle: &tokio::runtime::Handle,
@@ -223,35 +232,37 @@ pub fn main() {
     let sigrx = lifecycle::spawn_signal_catcher(&mgmt_handle, shutdown.root.clone())
         .expect("failed to install signal handler");
 
+    spawn_signal_handler(&mgmt_handle, sigrx, shutdown.root.clone());
+
     spawn_shutdown_watchdog(shutdown.root.clone(), default_deadlines::TOTAL, 124)
         .expect("failed to spawn shutdown watchdog");
 
-    /* router parameters */
+    // start bmp server if indicated via cmd line
+    let _bmp_handle = if let Some(bmp_params) = &bmp_server_params {
+        Some(start_bmp(
+            &shutdown.mgmt,
+            &mgmt_handle,
+            bmp_params,
+            dp_status.clone(),
+        ))
+    } else {
+        None
+    };
+
+    // assemble router parameters
     let mut binding = RouterParamsBuilder::default();
-    let mut rp_builder = binding
+    let rp_builder = binding
         .cli_sock_path(args.cli_sock_path())
         .cpi_sock_path(args.cpi_sock_path())
-        .frr_agent_path(args.frr_agent_path())
-        .dp_status(dp_status.clone());
-
-    if let Some(server) = bmp_server_params {
-        rp_builder = rp_builder.bmp(server);
-    }
+        .frr_agent_path(args.frr_agent_path());
 
     let Ok(router_params) = rp_builder.build() else {
         error!("Bad router configuration");
         panic!("Bad router configuration");
     };
 
-    let mut setup = start_router(
-        &shutdown.mgmt,
-        &mgmt_handle,
-        &shutdown.router,
-        router_params,
-    )
-    .expect("failed to start router");
-
-    spawn_signal_handler(&mgmt_handle, sigrx, shutdown.root.clone());
+    // start router
+    let mut setup = start_router(&shutdown.router, router_params).expect("failed to start router");
 
     spawn_metrics(
         &shutdown.metrics,
@@ -336,8 +347,6 @@ pub fn main() {
 
     let exit_code = i32::from(shutdown.is_fatal());
 
-    // Router::stop()'s BMP abort needs mgmt_runtime live, so stop router
-    // before shutting the runtime down.
     setup.router.stop();
     mgmt_runtime.shutdown_timeout(Duration::from_secs(2));
 
@@ -347,5 +356,6 @@ pub fn main() {
             Err(e) => error!("Pyroscope stop failed: {e}"),
         }
     }
+    info!("Dataplane shutdown completed");
     std::process::exit(exit_code);
 }

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -425,15 +425,12 @@ pub mod test {
             .cpi_sock_path("/tmp/cpi.sock")
             .cli_sock_path("/tmp/cli.sock")
             .frr_agent_path("/tmp/frr-agent.sock")
-            .dp_status(dp_status_r.clone())
             .build()
             .expect("Should succeed due to defaults");
 
         /* start router */
-        let test_mgmt = lifecycle::Subsystem::new("mgmt", lifecycle::CancellationToken::new());
         let test_router = lifecycle::Subsystem::new("router", lifecycle::CancellationToken::new());
-        let handle = tokio::runtime::Handle::current();
-        let router = Router::new(&test_mgmt, &handle, &test_router, router_params, None);
+        let router = Router::new(&test_router, router_params, None);
         if let Err(e) = &router {
             error!("New router failed: {e}");
             panic!();

--- a/routing/src/bmp/mod.rs
+++ b/routing/src/bmp/mod.rs
@@ -20,7 +20,7 @@ trace_target!("bmp", LevelFilter::INFO, &[]);
 /// Spawn the BMP server on `handle`, tracked under `mgmt` so it drains
 /// with the rest of mgmt's tasks.
 #[must_use]
-pub fn spawn_background(
+pub fn spawn_bmp_server(
     mgmt: &Subsystem,
     handle: &tokio::runtime::Handle,
     bind: std::net::SocketAddr,

--- a/routing/src/frr/test.rs
+++ b/routing/src/frr/test.rs
@@ -124,10 +124,7 @@ pub mod tests {
     use super::fake_frr_agent::*;
     use crate::config::RouterConfig;
     use crate::{Router, RouterParamsBuilder};
-    use concurrency::sync::Arc;
-    use config::internal::status::DataplaneStatus;
     use std::time::Duration;
-    use tokio::sync::RwLock;
     use tracing_test::traced_test;
 
     #[cfg_attr(not(emulated), traced_test)]
@@ -137,24 +134,18 @@ pub mod tests {
         ignore = "binds Unix domain sockets; miri has no UDS, qemu-user has flaky epoll readiness"
     )]
     async fn test_fake_frr_agent() {
-        let dp_status: Arc<RwLock<DataplaneStatus>> = Arc::new(RwLock::new(DataplaneStatus::new()));
-
         /* set router params */
         let router_params = RouterParamsBuilder::default()
             .cpi_sock_path("/tmp/cpi.sock")
             .cli_sock_path("/tmp/cli.sock")
             .frr_agent_path("/tmp/frr-agent.sock")
-            .dp_status(dp_status)
             .build()
             .expect("Should succeed due to defaults");
 
         /* start router */
-        let mgmt = lifecycle::Subsystem::new("mgmt", lifecycle::CancellationToken::new());
         let router_subsystem =
             lifecycle::Subsystem::new("router", lifecycle::CancellationToken::new());
-        let handle = tokio::runtime::Handle::current();
-        let mut router =
-            Router::new(&mgmt, &handle, &router_subsystem, router_params, None).unwrap();
+        let mut router = Router::new(&router_subsystem, router_params, None).unwrap();
         let mut ctl = router.get_ctl_tx();
 
         /* start fake frr agent */

--- a/routing/src/lib.rs
+++ b/routing/src/lib.rs
@@ -43,6 +43,7 @@ pub use interfaces::interface::{IfDataEthernet, IfState, IfType, Interface};
 pub use rib::encapsulation::{Encapsulation, VxlanEncapsulation};
 pub use rib::vrf::{RouterVrfConfig, VrfId};
 
+pub use bmp::spawn_bmp_server;
 pub use router::ctl::RouterCtlSender;
 pub use router::{BmpServerParams, CliSources, Router, RouterParams, RouterParamsBuilder};
 

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -14,17 +14,14 @@ use common::cliprovider::CliDataProvider;
 use derive_builder::Builder;
 use std::fmt::Display;
 use std::path::PathBuf;
+use std::time::Duration;
 use tracing::{debug, error};
 
 // sockets
 use std::net::SocketAddr;
 
-// keep async task handle for BMP
-use tokio::task::JoinHandle;
-
 use crate::atable::atablerw::{AtableReader, AtableReaderFactory};
 use crate::atable::resolver::AtResolver;
-use crate::bmp;
 use crate::errors::RouterError;
 use crate::fib::fibtable::{FibTableReader, FibTableReaderFactory, FibTableWriter};
 use crate::interfaces::iftablerw::{IfTableReader, IfTableReaderFactory, IfTableWriter};
@@ -34,13 +31,6 @@ use crate::router::rio::{RioConf, RioHandle, start_rio};
 use args::DEFAULT_DP_UX_PATH;
 use args::DEFAULT_DP_UX_PATH_CLI;
 use args::DEFAULT_FRR_AGENT_PATH;
-
-// mandatory dataplane status handle
-use concurrency::sync::Arc;
-use config::internal::status::DataplaneStatus;
-use tokio::sync::RwLock;
-
-use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct BmpServerParams {
@@ -69,13 +59,6 @@ pub struct RouterParams {
 
     #[builder(setter(into), default = DEFAULT_FRR_AGENT_PATH.to_string().into())]
     pub frr_agent_path: PathBuf,
-
-    // Optional BMP server parameters: whether to start server.
-    #[builder(setter(strip_option), default)]
-    pub bmp: Option<BmpServerParams>,
-
-    // Mandatory dataplane status handle
-    pub dp_status: Arc<RwLock<DataplaneStatus>>,
 }
 
 /// Optional struct containing accessors to state outside of routing,
@@ -108,8 +91,6 @@ pub struct Router {
     rio_handle: RioHandle,
     iftr: IfTableReader,
     fibtr: FibTableReader,
-    // keep BMP task alive while Router lives
-    bmp_handle: Option<JoinHandle<()>>,
 }
 
 impl Router {
@@ -144,8 +125,6 @@ impl Router {
     /// Start a `Router`
     #[allow(clippy::new_without_default)]
     pub fn new(
-        mgmt: &lifecycle::Subsystem,
-        mgmt_handle: &tokio::runtime::Handle,
         router: &lifecycle::Subsystem,
         params: RouterParams,
         cli_sources: Option<CliSources>,
@@ -167,22 +146,6 @@ impl Router {
 
         debug!("{name}: Starting router IO...");
         let rio_handle = start_rio(router, &rioconf, fibtw, iftw, atabler, cli_sources)?;
-
-        let bmp_handle = if let Some(bmp_params) = &params.bmp {
-            debug!(
-                "{name}: Starting BMP server on {} (interval={:?})",
-                bmp_params.bind_addr, bmp_params.stats_interval
-            );
-            Some(bmp::spawn_background(
-                mgmt,
-                mgmt_handle,
-                bmp_params.bind_addr,
-                params.dp_status.clone(),
-            ))
-        } else {
-            None
-        };
-
         debug!("{name}: Successfully started router with parameters:\n{params}");
         let router = Router {
             name: name.to_owned(),
@@ -191,7 +154,6 @@ impl Router {
             rio_handle,
             iftr,
             fibtr,
-            bmp_handle,
         };
         Ok(router)
     }
@@ -203,13 +165,6 @@ impl Router {
             error!("Failed to stop IO for router '{}': {e}", self.name);
         }
         self.resolver.stop();
-
-        // BMP is also tracked under the mgmt subsystem, which normally
-        // drains it cleanly via `Shutdown::drain_in_order`. This abort is
-        // a safety net for the case where the mgmt drain hit its deadline.
-        if let Some(handle) = self.bmp_handle.take() {
-            handle.abort();
-        }
 
         debug!("Router '{}' is now stopped", self.name);
     }

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -14,7 +14,6 @@ use common::cliprovider::CliDataProvider;
 use derive_builder::Builder;
 use std::fmt::Display;
 use std::path::PathBuf;
-use std::time::Duration;
 use tracing::{debug, error};
 
 // sockets
@@ -36,12 +35,6 @@ use args::DEFAULT_FRR_AGENT_PATH;
 pub struct BmpServerParams {
     /// TCP bind address for the BMP listener
     pub bind_addr: SocketAddr,
-    /// Periodic stats emit interval (milliseconds)
-    pub stats_interval: Duration,
-    /// Optional reconnect/backoff lower bound (milliseconds)
-    pub min_retry: Option<Duration>,
-    /// Optional reconnect/backoff upper bound (milliseconds)
-    pub max_retry: Option<Duration>,
 }
 
 /// Struct to configure router object. N.B we derive a builder type `RouterConfig`


### PR DESCRIPTION
The bmp server receives bmp feed directly from bgpd. If enabled, the router will configure bgpd to feed it. Otherwise, it won't. There's little advantage coupling it with the router IO, which requires propagating several items unnecessarily (runtime handle, subsystem, state).

Remove this coupling by starting the server independently.