### PR TITLE
track bgp session state in dataplane

### DIFF
--- a/config/src/converters/k8s/status/bgp.rs
+++ b/config/src/converters/k8s/status/bgp.rs
@@ -243,6 +243,7 @@ mod tests {
             connections_dropped: 7,
             established_transitions: 8,
             last_reset_reason: None,
+            last_reset_time: None,
             messages: Some(messages),
             ipv4_unicast_prefixes: Some(prefixes.clone()),
             ipv6_unicast_prefixes: Some(prefixes.clone()),

--- a/config/src/converters/k8s/status/bgp.rs
+++ b/config/src/converters/k8s/status/bgp.rs
@@ -118,8 +118,7 @@ impl TryFrom<&BgpNeighborStatus> for GatewayAgentStatusStateBgpVrfsNeighbors {
             ipv4_unicast_prefixes,
             ipv6_unicast_prefixes,
             l2_vpnevpn_prefixes,
-            last_reset_reason: (!n.last_reset_reason.is_empty())
-                .then(|| n.last_reset_reason.clone()),
+            last_reset_reason: n.last_reset_reason.clone(),
             local_as: Some(n.local_as),
             messages,
             peer_as: Some(n.peer_as),
@@ -243,7 +242,7 @@ mod tests {
             session_state: BgpNeighborSessionState::Established,
             connections_dropped: 7,
             established_transitions: 8,
-            last_reset_reason: "none".to_string(),
+            last_reset_reason: None,
             messages: Some(messages),
             ipv4_unicast_prefixes: Some(prefixes.clone()),
             ipv6_unicast_prefixes: Some(prefixes.clone()),

--- a/config/src/converters/k8s/status/bgp.rs
+++ b/config/src/converters/k8s/status/bgp.rs
@@ -90,11 +90,7 @@ impl TryFrom<&BgpNeighborStatus> for GatewayAgentStatusStateBgpVrfsNeighbors {
     type Error = ToK8sConversionError;
 
     fn try_from(n: &BgpNeighborStatus) -> Result<Self, Self::Error> {
-        let messages = n
-            .messages
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessages::try_from)
-            .transpose()?;
+        let messages = GatewayAgentStatusStateBgpVrfsNeighborsMessages::try_from(&n.messages)?;
 
         let ipv4_unicast_prefixes = n
             .ipv4_unicast_prefixes
@@ -120,7 +116,7 @@ impl TryFrom<&BgpNeighborStatus> for GatewayAgentStatusStateBgpVrfsNeighbors {
             l2_vpnevpn_prefixes,
             last_reset_reason: n.last_reset_reason.clone(),
             local_as: Some(n.local_as),
-            messages,
+            messages: Some(messages),
             peer_as: Some(n.peer_as),
             remote_router_id: (!n.remote_router_id.is_empty()).then(|| n.remote_router_id.clone()),
             session_state: Some(n.session_state.into()),
@@ -132,16 +128,13 @@ impl TryFrom<&BgpMessages> for GatewayAgentStatusStateBgpVrfsNeighborsMessages {
     type Error = ToK8sConversionError;
 
     fn try_from(m: &BgpMessages) -> Result<Self, Self::Error> {
-        let received = m
-            .received
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessagesReceived::from);
-        let sent = m
-            .sent
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessagesSent::from);
+        let received = GatewayAgentStatusStateBgpVrfsNeighborsMessagesReceived::from(&m.received);
+        let sent = GatewayAgentStatusStateBgpVrfsNeighborsMessagesSent::from(&m.sent);
 
-        Ok(GatewayAgentStatusStateBgpVrfsNeighborsMessages { received, sent })
+        Ok(GatewayAgentStatusStateBgpVrfsNeighborsMessages {
+            received: Some(received),
+            sent: Some(sent),
+        })
     }
 }
 
@@ -222,8 +215,8 @@ mod tests {
         };
 
         let messages = BgpMessages {
-            received: Some(msg_counters.clone()),
-            sent: Some(msg_counters),
+            received: msg_counters.clone(),
+            sent: msg_counters,
         };
 
         let prefixes = BgpNeighborPrefixes {
@@ -244,7 +237,7 @@ mod tests {
             established_transitions: 8,
             last_reset_reason: None,
             last_reset_time: None,
-            messages: Some(messages),
+            messages,
             ipv4_unicast_prefixes: Some(prefixes.clone()),
             ipv6_unicast_prefixes: Some(prefixes.clone()),
             l2vpn_evpn_prefixes: Some(prefixes),

--- a/config/src/internal/routing/bmp.rs
+++ b/config/src/internal/routing/bmp.rs
@@ -47,6 +47,9 @@ pub struct BmpOptions {
     pub monitor_ipv6_pre: bool,
     pub monitor_ipv6_post: bool,
 
+    /// Route mirroring
+    pub mirror: bool,
+
     /// VRFs/views to import into the default BMP instance:
     /// renders as multiple `bmp import-vrf-view <vrf>`
     pub import_vrf_views: Vec<String>,
@@ -66,6 +69,7 @@ impl Default for BmpOptions {
             monitor_ipv4_post: true,
             monitor_ipv6_pre: false,
             monitor_ipv6_post: false,
+            mirror: false,
             import_vrf_views: Vec::new(),
         }
     }
@@ -122,6 +126,12 @@ impl BmpOptions {
     pub fn monitor_ipv6(mut self, pre: bool, post: bool) -> Self {
         self.monitor_ipv6_pre = pre;
         self.monitor_ipv6_post = post;
+        self
+    }
+
+    #[must_use]
+    pub fn mirror(mut self, value: bool) -> Self {
+        self.mirror = value;
         self
     }
 

--- a/config/src/internal/status/mod.rs
+++ b/config/src/internal/status/mod.rs
@@ -67,6 +67,19 @@ pub enum BgpNeighborSessionState {
     Established,
 }
 
+impl std::fmt::Display for BgpNeighborSessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unset => f.pad("Unset"),
+            Self::Idle => f.pad("Idle"),
+            Self::Connect => f.pad("Connect"),
+            Self::Active => f.pad("Active"),
+            Self::Open => f.pad("Open"),
+            Self::Established => f.pad("Established"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct InterfaceStatus {
     pub ifname: String,

--- a/config/src/internal/status/mod.rs
+++ b/config/src/internal/status/mod.rs
@@ -300,7 +300,7 @@ pub struct BgpNeighborStatus {
     pub session_state: BgpNeighborSessionState,
     pub connections_dropped: u64,
     pub established_transitions: u64,
-    pub last_reset_reason: String,
+    pub last_reset_reason: Option<String>,
     pub messages: Option<BgpMessages>,
     pub ipv4_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub ipv6_unicast_prefixes: Option<BgpNeighborPrefixes>,

--- a/config/src/internal/status/mod.rs
+++ b/config/src/internal/status/mod.rs
@@ -301,6 +301,7 @@ pub struct BgpNeighborStatus {
     pub connections_dropped: u64,
     pub established_transitions: u64,
     pub last_reset_reason: Option<String>,
+    pub last_reset_time: Option<std::time::Instant>, // not in model
     pub messages: Option<BgpMessages>,
     pub ipv4_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub ipv6_unicast_prefixes: Option<BgpNeighborPrefixes>,

--- a/config/src/internal/status/mod.rs
+++ b/config/src/internal/status/mod.rs
@@ -278,8 +278,8 @@ impl BgpMessageCounters {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BgpMessages {
-    pub received: Option<BgpMessageCounters>,
-    pub sent: Option<BgpMessageCounters>,
+    pub received: BgpMessageCounters,
+    pub sent: BgpMessageCounters,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -302,7 +302,7 @@ pub struct BgpNeighborStatus {
     pub established_transitions: u64,
     pub last_reset_reason: Option<String>,
     pub last_reset_time: Option<std::time::Instant>, // not in model
-    pub messages: Option<BgpMessages>,
+    pub messages: BgpMessages,
     pub ipv4_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub ipv6_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub l2vpn_evpn_prefixes: Option<BgpNeighborPrefixes>,

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -119,7 +119,8 @@ fn parse_bmp_params(args: &CmdArgs) -> (Option<BmpServerParams>, Option<BmpOptio
         let client = BmpOptions::new("bmp1", host, port)
             .set_retry(interval, interval.saturating_mul(4u32))
             .set_stats_interval(interval)
-            .monitor_ipv4(true, true);
+            .monitor_ipv4(true, true)
+            .mirror(true);
 
         (Some(server), Some(client))
     } else {

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -14,8 +14,7 @@ use mgmt::{ConfigProcessorParams, LaunchError, MgmtParams, run_mgmt};
 use nix::unistd::gethostname;
 use pyroscope::backend::{BackendConfig, PprofConfig, pprof_backend};
 use pyroscope::pyroscope::{PyroscopeAgentBuilder, PyroscopeConfig};
-
-use routing::{BmpServerParams, RouterParamsBuilder, spawn_bmp_server};
+use routing::{BmpServerParams, RouterCtlSender, RouterParamsBuilder, spawn_bmp_server};
 use tracectl::{
     TracingControl, TracingRateLimitConfig, custom_target, get_trace_ctl, trace_target,
 };
@@ -134,8 +133,9 @@ fn start_bmp(
     mgmt_handle: &tokio::runtime::Handle,
     bmp_params: &BmpServerParams,
     dp_status: Arc<RwLock<DataplaneStatus>>,
+    rtr_ctl: RouterCtlSender,
 ) -> tokio::task::JoinHandle<()> {
-    spawn_bmp_server(mgmt, mgmt_handle, bmp_params.bind_addr, dp_status)
+    spawn_bmp_server(mgmt, mgmt_handle, bmp_params.bind_addr, dp_status, rtr_ctl)
 }
 
 // Main signal handling of dataplane occurs here
@@ -248,18 +248,6 @@ pub fn main() {
     spawn_shutdown_watchdog(shutdown.root.clone(), default_deadlines::TOTAL, 124)
         .expect("failed to spawn shutdown watchdog");
 
-    // start bmp server if indicated via cmd line
-    let _bmp_handle = if let Some(bmp_params) = &bmp_server_params {
-        Some(start_bmp(
-            &shutdown.mgmt,
-            &mgmt_handle,
-            bmp_params,
-            dp_status.clone(),
-        ))
-    } else {
-        None
-    };
-
     // assemble router parameters
     let mut binding = RouterParamsBuilder::default();
     let rp_builder = binding
@@ -274,6 +262,20 @@ pub fn main() {
 
     // start router
     let mut setup = start_router(&shutdown.router, router_params).expect("failed to start router");
+
+    // start bmp server if indicated via cmd line. It is fine to start it after the router since no bgp session may be up
+    // until a configuration is applied, and the mgmt is not yet up.
+    let _bmp_handle = if let Some(bmp_params) = &bmp_server_params {
+        Some(start_bmp(
+            &shutdown.mgmt,
+            &mgmt_handle,
+            bmp_params,
+            dp_status.clone(),
+            setup.router.get_ctl_tx(),
+        ))
+    } else {
+        None
+    };
 
     spawn_metrics(
         &shutdown.metrics,

--- a/mgmt/src/processor/launch.rs
+++ b/mgmt/src/processor/launch.rs
@@ -90,7 +90,7 @@ async fn k8s_mgmt_init(
 
 async fn interface_event_notify(
     mut rx: tokio::sync::broadcast::Receiver<EthEvent>,
-    mut rtr_ctl: RouterCtlSender,
+    rtr_ctl: RouterCtlSender,
 ) {
     use tokio::sync::broadcast::error::RecvError;
     loop {

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -53,10 +53,7 @@ use vpcmap::map::{VpcMap, VpcMapWriter};
 use config::internal::routing::bmp::BmpOptions;
 
 /// Populate FRR status into the dataplane status structure
-pub async fn populate_status_with_frr(
-    status: &mut DataplaneStatus,
-    router_ctl: &mut RouterCtlSender,
-) {
+pub async fn populate_status_with_frr(status: &mut DataplaneStatus, router_ctl: &RouterCtlSender) {
     let mut frr = FrrStatus::new();
 
     if let Ok(Some(FrrAppliedConfig { genid, .. })) = router_ctl.get_frr_applied_config().await {
@@ -173,7 +170,7 @@ impl ConfigProcessor {
             config.meta().store(Arc::from(meta));
         }
         let history = Arc::from(self.config_db.history().clone());
-        let router_ctl = &mut self.proc_params.router_ctl;
+        let router_ctl = &self.proc_params.router_ctl;
         let _ = router_ctl.send_config_history(history).await;
         self.config_db.log();
     }
@@ -356,7 +353,7 @@ impl ConfigProcessor {
         }
 
         // FRR minimal info
-        populate_status_with_frr(&mut status, &mut self.proc_params.router_ctl).await;
+        populate_status_with_frr(&mut status, &self.proc_params.router_ctl).await;
 
         ConfigResponse::GetDataplaneStatus(Box::new(status))
     }
@@ -460,7 +457,7 @@ impl VpcManager<RequiredInformationBase> {
 async fn apply_router_config(
     kernel_vrfs: &HashMap<InterfaceName, Interface>,
     config: Arc<ValidatedGwConfig>,
-    router_ctl: &mut RouterCtlSender,
+    router_ctl: &RouterCtlSender,
 ) -> ConfigResult {
     let genid = config.genid();
 
@@ -593,7 +590,7 @@ impl ConfigProcessor {
         debug!("Applying config with genid '{genid}'...");
 
         let vpc_mgr = &self.vpc_mgr;
-        let router_ctl = &mut self.proc_params.router_ctl;
+        let router_ctl = &self.proc_params.router_ctl;
         let vpcmapw = &mut self.proc_params.vpcmapw;
         let nattablesw = &mut self.proc_params.nattablesw;
         let natallocatorw = &mut self.proc_params.natallocatorw;

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -16,6 +16,7 @@ use config::internal::status::{
 };
 
 use concurrency::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::RouterCtlSender;
@@ -31,6 +32,7 @@ pub struct BgpNeighEvent {
     pub(crate) prev: BgpNeighborSessionState, // previous state
     pub(crate) new: BgpNeighborSessionState,  // new state
     pub(crate) last_reset_reason: Option<String>,
+    pub(crate) last_downtime: Option<Duration>,
 }
 impl BgpNeighEvent {
     #[must_use]
@@ -41,6 +43,7 @@ impl BgpNeighEvent {
         prev: BgpNeighborSessionState,
         new: BgpNeighborSessionState,
         last_reset_reason: Option<String>,
+        last_downtime: Option<Duration>,
     ) -> Self {
         Self {
             peer_key,
@@ -49,6 +52,7 @@ impl BgpNeighEvent {
             prev,
             new,
             last_reset_reason,
+            last_downtime,
         }
     }
 }
@@ -181,11 +185,12 @@ fn post_policy_from_peer_type(pt: BmpPeerType) -> bool {
 fn bgp_event(
     prev_state: BgpNeighborSessionState,
     neigh_key: String,
-    neigh: &BgpNeighborStatus,
+    neigh: &mut BgpNeighborStatus,
 ) -> Option<BgpNeighEvent> {
     if prev_state == neigh.session_state {
         return None;
     }
+
     let ev = BgpNeighEvent::new(
         neigh_key,
         neigh.remote_router_id.clone(),
@@ -193,6 +198,7 @@ fn bgp_event(
         prev_state,
         neigh.session_state,
         neigh.last_reset_reason.clone(),
+        neigh.last_reset_time.map(|instant| instant.elapsed()),
     );
     Some(ev)
 }
@@ -300,6 +306,7 @@ fn on_peer_down(
                 set_neighbor_session_state(neigh, BgpNeighborSessionState::Idle);
                 neigh.connections_dropped = neigh.connections_dropped.saturating_add(1);
                 neigh.last_reset_reason = Some(pretty(pd.reason().get_type()));
+                neigh.last_reset_time = Some(std::time::Instant::now());
 
                 debug!(
                     "BMP: peer-down vrf={} key={} prev_state={:?} new_state={:?} prev_connections_dropped={} new_connections_dropped={}",

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -5,14 +5,14 @@
 
 use netgauze_bgp_pkt::BgpMessage;
 use netgauze_bmp_pkt::v3::{
-    BmpMessageValue, PeerDownNotificationMessage, PeerUpNotificationMessage,
-    RouteMonitoringMessage, StatisticsReportMessage,
+    BmpMessageValue, MirroredBgpMessage, PeerDownNotificationMessage, PeerUpNotificationMessage,
+    RouteMirroringMessage, RouteMirroringValue, RouteMonitoringMessage, StatisticsReportMessage,
 };
 use netgauze_bmp_pkt::{BmpMessage, BmpPeerType};
 
 use config::internal::status::{
-    BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus, BgpVrfStatus,
-    DataplaneStatus,
+    BgpMessages, BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus,
+    BgpVrfStatus, DataplaneStatus,
 };
 
 use concurrency::sync::Arc;
@@ -94,6 +94,7 @@ pub async fn handle_bmp_message(
             }
             BmpMessageValue::RouteMonitoring(rm) => on_route_monitoring(&mut status_guard, rm),
             BmpMessageValue::StatisticsReport(sr) => on_statistics(&mut status_guard, sr),
+            BmpMessageValue::RouteMirroring(rm) => on_route_mirroring(&mut status_guard, rm),
             _ => {}
         },
         // V4 not handled yet
@@ -339,12 +340,43 @@ fn on_peer_down(
     None
 }
 
+fn update_msg_counts_from_neigh(msgs: &mut BgpMessages, rm: &RouteMirroringMessage) {
+    let rcv = &mut msgs.received;
+    let mirrored = rm.mirrored();
+    for value in mirrored {
+        if let RouteMirroringValue::BgpMessage(msg) = value
+            && let MirroredBgpMessage::Parsed(m) = msg
+        {
+            match m {
+                // FIXME: FRR docs say "route mirroring is fully implemented,
+                // however BGP OPEN messages are not currently included in route mirroring messages.
+                // Their contents can be extracted from the “peer up” notification for sessions that established successfully."
+                BgpMessage::Open(_) => rcv.open = rcv.open.saturating_add(1),
+
+                // FIXME: we're just counting updates here, but an update may contain many
+                // NLRIs and withdrawn routes.
+                BgpMessage::Update(_) => rcv.update = rcv.update.saturating_add(1),
+
+                BgpMessage::KeepAlive => rcv.keepalive = rcv.keepalive.saturating_add(1),
+                BgpMessage::RouteRefresh(_) => {
+                    rcv.route_refresh = rcv.route_refresh.saturating_add(1);
+                }
+
+                // FIXME: we only count notification messages, ignoring the reason for the
+                // notification, which could provide important info.
+                BgpMessage::Notification(_) => {
+                    rcv.notification = rcv.notification.saturating_add(1);
+                }
+            }
+        }
+    }
+}
+
 fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage) {
     let peer = rm.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
         return;
     }
-
     let post = post_policy_from_peer_type(peer.peer_type());
     if post {
         return;
@@ -375,6 +407,28 @@ fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage
         "BMP: route-monitoring vrf={} key={} post_policy={} ipv4_received={} ipv4_received_pre={}",
         vrf, key, post, pref.received, pref.received_pre_policy,
     );
+}
+
+fn on_route_mirroring(status: &mut DataplaneStatus, rm: &RouteMirroringMessage) {
+    let peer = rm.peer_header();
+    if !is_real_bgp_neighbor(peer.peer_type()) {
+        return;
+    }
+    let post = post_policy_from_peer_type(peer.peer_type());
+    if post {
+        return;
+    }
+
+    let vrf = vrf_from_peer_header(peer);
+    let key = key_from_peer_header(peer);
+
+    let bgp = ensure_bgp(status);
+    let vrf_s = ensure_vrf(bgp, &vrf);
+    let neigh = ensure_neighbor(vrf_s, &key);
+
+    // count messages received. Mirroring mirrors bgp messages received by the BGP speaker.
+    // RFC 8671 defines adj-rib-out mirroring, but FRR does not implement it.
+    update_msg_counts_from_neigh(&mut neigh.messages, rm);
 }
 
 fn on_statistics(status: &mut DataplaneStatus, sr: &StatisticsReportMessage) {

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -25,7 +25,8 @@ use tracing::{debug, error};
 /// A struct representing a status change of a BGP peering. Most of the information here
 /// comes from `BgpNeighborStatus`.
 pub struct BgpNeighEvent {
-    pub(crate) peer: String,
+    pub(crate) peer_key: String,
+    pub(crate) peer_router_id: String,
     pub(crate) peer_asn: u32,
     pub(crate) prev: BgpNeighborSessionState, // previous state
     pub(crate) new: BgpNeighborSessionState,  // new state
@@ -34,14 +35,16 @@ pub struct BgpNeighEvent {
 impl BgpNeighEvent {
     #[must_use]
     pub fn new(
-        peer: String,
+        peer_key: String,
+        peer_router_id: String,
         peer_asn: u32,
         prev: BgpNeighborSessionState,
         new: BgpNeighborSessionState,
         last_reset_reason: Option<String>,
     ) -> Self {
         Self {
-            peer,
+            peer_key,
+            peer_router_id,
             peer_asn,
             prev,
             new,
@@ -177,12 +180,14 @@ fn post_policy_from_peer_type(pt: BmpPeerType) -> bool {
 /// Otherwise, return `None`
 fn bgp_event(
     prev_state: BgpNeighborSessionState,
+    neigh_key: String,
     neigh: &BgpNeighborStatus,
 ) -> Option<BgpNeighEvent> {
     if prev_state == neigh.session_state {
         return None;
     }
     let ev = BgpNeighEvent::new(
+        neigh_key,
         neigh.remote_router_id.clone(),
         neigh.peer_as,
         prev_state,
@@ -253,7 +258,7 @@ fn on_peer_up(
     );
 
     // generate event (if status changed)
-    bgp_event(prev_state, neigh)
+    bgp_event(prev_state, key, neigh)
 }
 
 fn pretty(reason: PeerDownReasonCode) -> String {
@@ -307,7 +312,7 @@ fn on_peer_down(
                 );
 
                 // generate event (if status changed)
-                return bgp_event(prev_state, neigh);
+                return bgp_event(prev_state, key, neigh);
             }
             debug!(
                 "BMP: peer-down for unknown neighbor: vrf={} key={}",

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -17,6 +17,16 @@ use config::internal::status::{
 
 use tracing::debug;
 
+/// A struct representing a status change of a BGP peering. Most of the information here
+/// comes from `BgpNeighborStatus`.
+pub struct BgpNeighEvent {
+    pub(crate) peer: String,
+    pub(crate) peer_asn: u32,
+    pub(crate) prev: BgpNeighborSessionState, // previous state
+    pub(crate) new: BgpNeighborSessionState,  // new state
+    pub(crate) last_reset_reason: String,
+}
+
 /// Update `DataplaneStatus` from a single BMP message.
 pub fn handle_bmp_message(status: &mut DataplaneStatus, msg: &BmpMessage) {
     match msg {

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -11,8 +11,8 @@ use netgauze_bmp_pkt::v3::{
 use netgauze_bmp_pkt::{BmpMessage, BmpPeerType};
 
 use config::internal::status::{
-    BgpMessageCounters, BgpMessages, BgpNeighborPrefixes, BgpNeighborSessionState,
-    BgpNeighborStatus, BgpStatus, BgpVrfStatus, DataplaneStatus,
+    BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus, BgpVrfStatus,
+    DataplaneStatus,
 };
 
 use concurrency::sync::Arc;
@@ -243,13 +243,6 @@ fn on_peer_up(
         neigh.local_as = u32::from(open.my_as());
     }
 
-    if neigh.messages.is_none() {
-        neigh.messages = Some(BgpMessages {
-            received: Some(BgpMessageCounters::new()),
-            sent: Some(BgpMessageCounters::new()),
-        });
-    }
-
     debug!(
         "BMP: peer-up vrf={} key={} peer_addr={} prev_state={:?} new_state={:?} peer_as={} local_as={} peer_port={} remote_id={}",
         vrf,
@@ -364,16 +357,10 @@ fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage
     let vrf_s = ensure_vrf(bgp, &vrf);
     let neigh = ensure_neighbor(vrf_s, &key);
 
-    let msgs = neigh.messages.get_or_insert_with(|| BgpMessages {
-        received: Some(BgpMessageCounters::new()),
-        sent: Some(BgpMessageCounters::new()),
-    });
-
     // Count UPDATE messages received (best-effort)
     if let BgpMessage::Update(_) = rm.update_message() {
-        if let Some(rcv) = msgs.received.as_mut() {
-            rcv.update = rcv.update.saturating_add(1);
-        }
+        let rcv = &mut neigh.messages.received;
+        rcv.update = rcv.update.saturating_add(1);
     }
 
     // Minimal prefix counters placeholder (per RM message) — can be upgraded later to real NLRI counting.
@@ -401,12 +388,7 @@ fn on_statistics(status: &mut DataplaneStatus, sr: &StatisticsReportMessage) {
 
     let bgp = ensure_bgp(status);
     let vrf_s = ensure_vrf(bgp, &vrf);
-    let neigh = ensure_neighbor(vrf_s, &key);
-
-    let _ = neigh.messages.get_or_insert_with(|| BgpMessages {
-        received: Some(BgpMessageCounters::new()),
-        sent: Some(BgpMessageCounters::new()),
-    });
+    let _neigh = ensure_neighbor(vrf_s, &key);
 
     debug!(
         "BMP: statistics-report vrf={} key={} (TODO: decode stats later)",

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -15,7 +15,8 @@ use config::internal::status::{
     BgpNeighborStatus, BgpStatus, BgpVrfStatus, DataplaneStatus,
 };
 
-use tracing::debug;
+use crate::RouterCtlSender;
+use tracing::{debug, error};
 
 /// A struct representing a status change of a BGP peering. Most of the information here
 /// comes from `BgpNeighborStatus`.
@@ -26,9 +27,31 @@ pub struct BgpNeighEvent {
     pub(crate) new: BgpNeighborSessionState,  // new state
     pub(crate) last_reset_reason: String,
 }
+impl BgpNeighEvent {
+    #[must_use]
+    pub fn new(
+        peer: String,
+        peer_asn: u32,
+        prev: BgpNeighborSessionState,
+        new: BgpNeighborSessionState,
+        last_reset_reason: String,
+    ) -> Self {
+        Self {
+            peer,
+            peer_asn,
+            prev,
+            new,
+            last_reset_reason,
+        }
+    }
+}
 
 /// Update `DataplaneStatus` from a single BMP message.
-pub fn handle_bmp_message(status: &mut DataplaneStatus, msg: &BmpMessage) {
+pub async fn handle_bmp_message(
+    status: &mut DataplaneStatus,
+    msg: &BmpMessage,
+    rtr_ctl: &RouterCtlSender,
+) {
     match msg {
         BmpMessage::V3(v) => match v {
             // NOTE: NetGauze uses `Initiation`, not `InitiationMessage`
@@ -38,8 +61,8 @@ pub fn handle_bmp_message(status: &mut DataplaneStatus, msg: &BmpMessage) {
             BmpMessageValue::Termination(term) => {
                 debug!("BMP: termination: {:?}", term);
             }
-            BmpMessageValue::PeerUpNotification(pu) => on_peer_up(status, pu),
-            BmpMessageValue::PeerDownNotification(pd) => on_peer_down(status, pd),
+            BmpMessageValue::PeerUpNotification(pu) => on_peer_up(status, pu, rtr_ctl).await,
+            BmpMessageValue::PeerDownNotification(pd) => on_peer_down(status, pd, rtr_ctl).await,
             BmpMessageValue::RouteMonitoring(rm) => on_route_monitoring(status, rm),
             BmpMessageValue::StatisticsReport(sr) => on_statistics(status, sr),
             _ => {}
@@ -128,8 +151,31 @@ fn post_policy_from_peer_type(pt: BmpPeerType) -> bool {
     }
 }
 
+async fn generate_bgp_event(
+    rtr_ctl: &RouterCtlSender,
+    prev_state: BgpNeighborSessionState,
+    neigh: &BgpNeighborStatus,
+) {
+    if prev_state != neigh.session_state {
+        let ev = BgpNeighEvent::new(
+            neigh.remote_router_id.clone(),
+            neigh.peer_as,
+            prev_state,
+            neigh.session_state,
+            neigh.last_reset_reason.clone(),
+        );
+        if let Err(e) = rtr_ctl.send_bgp_neigh_change(ev).await {
+            error!("Failed to send bgp session event: {e}")
+        }
+    }
+}
+
 #[allow(clippy::map_unwrap_or)]
-fn on_peer_up(status: &mut DataplaneStatus, pu: &PeerUpNotificationMessage) {
+async fn on_peer_up(
+    status: &mut DataplaneStatus,
+    pu: &PeerUpNotificationMessage,
+    rtr_ctl: &RouterCtlSender,
+) {
     let peer = pu.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
         return;
@@ -184,9 +230,16 @@ fn on_peer_up(status: &mut DataplaneStatus, pu: &PeerUpNotificationMessage) {
         neigh.peer_port,
         neigh.remote_router_id,
     );
+
+    // generate event (if status changed)
+    generate_bgp_event(rtr_ctl, prev_state, neigh).await;
 }
 
-fn on_peer_down(status: &mut DataplaneStatus, pd: &PeerDownNotificationMessage) {
+async fn on_peer_down(
+    status: &mut DataplaneStatus,
+    pd: &PeerDownNotificationMessage,
+    rtr_ctl: &RouterCtlSender,
+) {
     let peer = pd.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
         return;
@@ -213,6 +266,9 @@ fn on_peer_down(status: &mut DataplaneStatus, pd: &PeerDownNotificationMessage) 
                     prev_dropped,
                     neigh.connections_dropped
                 );
+
+                // generate event (if status changed)
+                generate_bgp_event(rtr_ctl, prev_state, neigh).await;
             } else {
                 debug!(
                     "BMP: peer-down for unknown neighbor: vrf={} key={}",

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -15,6 +15,9 @@ use config::internal::status::{
     BgpNeighborStatus, BgpStatus, BgpVrfStatus, DataplaneStatus,
 };
 
+use concurrency::sync::Arc;
+use tokio::sync::RwLock;
+
 use crate::RouterCtlSender;
 use netgauze_bmp_pkt::iana::PeerDownReasonCode;
 use tracing::{debug, error};
@@ -49,10 +52,12 @@ impl BgpNeighEvent {
 
 /// Update `DataplaneStatus` from a single BMP message.
 pub async fn handle_bmp_message(
-    status: &mut DataplaneStatus,
+    dp_status: &Arc<RwLock<DataplaneStatus>>,
     msg: &BmpMessage,
     rtr_ctl: &RouterCtlSender,
 ) {
+    let mut status_guard = dp_status.write().await;
+
     match msg {
         BmpMessage::V3(v) => match v {
             // NOTE: NetGauze uses `Initiation`, not `InitiationMessage`
@@ -62,10 +67,26 @@ pub async fn handle_bmp_message(
             BmpMessageValue::Termination(term) => {
                 debug!("BMP: termination: {:?}", term);
             }
-            BmpMessageValue::PeerUpNotification(pu) => on_peer_up(status, pu, rtr_ctl).await,
-            BmpMessageValue::PeerDownNotification(pd) => on_peer_down(status, pd, rtr_ctl).await,
-            BmpMessageValue::RouteMonitoring(rm) => on_route_monitoring(status, rm),
-            BmpMessageValue::StatisticsReport(sr) => on_statistics(status, sr),
+            BmpMessageValue::PeerUpNotification(pu) => {
+                let event = on_peer_up(&mut status_guard, pu);
+                if let Some(ev) = event {
+                    drop(status_guard); // release lock before sending event
+                    if let Err(e) = rtr_ctl.send_bgp_neigh_change(ev).await {
+                        error!("Failed to send bgp event on peer up: {e}");
+                    }
+                }
+            }
+            BmpMessageValue::PeerDownNotification(pd) => {
+                let event = on_peer_down(&mut status_guard, pd);
+                if let Some(ev) = event {
+                    drop(status_guard); // release lock before sending event
+                    if let Err(e) = rtr_ctl.send_bgp_neigh_change(ev).await {
+                        error!("Failed to send bgp event on peer down: {e}");
+                    }
+                }
+            }
+            BmpMessageValue::RouteMonitoring(rm) => on_route_monitoring(&mut status_guard, rm),
+            BmpMessageValue::StatisticsReport(sr) => on_statistics(&mut status_guard, sr),
             _ => {}
         },
         // V4 not handled yet
@@ -152,34 +173,33 @@ fn post_policy_from_peer_type(pt: BmpPeerType) -> bool {
     }
 }
 
-async fn generate_bgp_event(
-    rtr_ctl: &RouterCtlSender,
+/// Build and return a `BgpNeighEvent` if the status of a neighbor changed.
+/// Otherwise, return `None`
+fn bgp_event(
     prev_state: BgpNeighborSessionState,
     neigh: &BgpNeighborStatus,
-) {
-    if prev_state != neigh.session_state {
-        let ev = BgpNeighEvent::new(
-            neigh.remote_router_id.clone(),
-            neigh.peer_as,
-            prev_state,
-            neigh.session_state,
-            neigh.last_reset_reason.clone(),
-        );
-        if let Err(e) = rtr_ctl.send_bgp_neigh_change(ev).await {
-            error!("Failed to send bgp session event: {e}");
-        }
+) -> Option<BgpNeighEvent> {
+    if prev_state == neigh.session_state {
+        return None;
     }
+    let ev = BgpNeighEvent::new(
+        neigh.remote_router_id.clone(),
+        neigh.peer_as,
+        prev_state,
+        neigh.session_state,
+        neigh.last_reset_reason.clone(),
+    );
+    Some(ev)
 }
 
 #[allow(clippy::map_unwrap_or)]
-async fn on_peer_up(
+fn on_peer_up(
     status: &mut DataplaneStatus,
     pu: &PeerUpNotificationMessage,
-    rtr_ctl: &RouterCtlSender,
-) {
+) -> Option<BgpNeighEvent> {
     let peer = pu.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
-        return;
+        return None;
     }
 
     let vrf = vrf_from_peer_header(peer);
@@ -233,7 +253,7 @@ async fn on_peer_up(
     );
 
     // generate event (if status changed)
-    generate_bgp_event(rtr_ctl, prev_state, neigh).await;
+    bgp_event(prev_state, neigh)
 }
 
 fn pretty(reason: PeerDownReasonCode) -> String {
@@ -254,14 +274,13 @@ fn pretty(reason: PeerDownReasonCode) -> String {
     }
 }
 
-async fn on_peer_down(
+fn on_peer_down(
     status: &mut DataplaneStatus,
     pd: &PeerDownNotificationMessage,
-    rtr_ctl: &RouterCtlSender,
-) {
+) -> Option<BgpNeighEvent> {
     let peer = pd.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
-        return;
+        return None;
     }
 
     let vrf = vrf_from_peer_header(peer);
@@ -288,13 +307,12 @@ async fn on_peer_down(
                 );
 
                 // generate event (if status changed)
-                generate_bgp_event(rtr_ctl, prev_state, neigh).await;
-            } else {
-                debug!(
-                    "BMP: peer-down for unknown neighbor: vrf={} key={}",
-                    vrf, key
-                );
+                return bgp_event(prev_state, neigh);
             }
+            debug!(
+                "BMP: peer-down for unknown neighbor: vrf={} key={}",
+                vrf, key
+            );
         } else {
             debug!("BMP: peer-down for unknown vrf: vrf={} key={}", vrf, key);
         }
@@ -304,6 +322,7 @@ async fn on_peer_down(
             vrf, key
         );
     }
+    None
 }
 
 fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage) {

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -244,6 +244,13 @@ fn on_peer_up(
         neigh.local_as = u32::from(open.my_as());
     }
 
+    if let BgpMessage::Open(_open) = pu.received_message() {
+        // amend FRR's limitation by increasing the count of opens received
+        // FIXME: this seems to over count the messages received.
+        // TODO: investigate if it is needed
+        // neigh.messages.received.open = neigh.messages.received.open.saturating_add(1);
+    }
+
     debug!(
         "BMP: peer-up vrf={} key={} peer_addr={} prev_state={:?} new_state={:?} peer_as={} local_as={} peer_port={} remote_id={}",
         vrf,

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -21,7 +21,7 @@ use tokio::sync::RwLock;
 
 use crate::RouterCtlSender;
 use netgauze_bmp_pkt::iana::PeerDownReasonCode;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 /// A struct representing a status change of a BGP peering. Most of the information here
 /// comes from `BgpNeighborStatus`.
@@ -304,10 +304,19 @@ fn on_peer_down(
                 let prev_dropped = neigh.connections_dropped;
 
                 set_neighbor_session_state(neigh, BgpNeighborSessionState::Idle);
-                neigh.connections_dropped = neigh.connections_dropped.saturating_add(1);
-                neigh.last_reset_reason = Some(pretty(pd.reason().get_type()));
-                neigh.last_reset_time = Some(std::time::Instant::now());
-
+                if prev_state == BgpNeighborSessionState::Established {
+                    neigh.connections_dropped = neigh.connections_dropped.saturating_add(1);
+                    neigh.last_reset_reason = Some(pretty(pd.reason().get_type()));
+                    neigh.last_reset_time = Some(std::time::Instant::now());
+                } else {
+                    // we should not get to see this message with current FRR and RFC 7854
+                    // Peer down events are only produced when leaving Established state
+                    info!(
+                        "Bgp session with peer {key} (ASN {}) failed to establish: {}",
+                        neigh.peer_as,
+                        pretty(pd.reason().get_type())
+                    );
+                }
                 debug!(
                     "BMP: peer-down vrf={} key={} prev_state={:?} new_state={:?} prev_connections_dropped={} new_connections_dropped={}",
                     vrf,

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -16,6 +16,7 @@ use config::internal::status::{
 };
 
 use crate::RouterCtlSender;
+use netgauze_bmp_pkt::iana::PeerDownReasonCode;
 use tracing::{debug, error};
 
 /// A struct representing a status change of a BGP peering. Most of the information here
@@ -25,7 +26,7 @@ pub struct BgpNeighEvent {
     pub(crate) peer_asn: u32,
     pub(crate) prev: BgpNeighborSessionState, // previous state
     pub(crate) new: BgpNeighborSessionState,  // new state
-    pub(crate) last_reset_reason: String,
+    pub(crate) last_reset_reason: Option<String>,
 }
 impl BgpNeighEvent {
     #[must_use]
@@ -34,7 +35,7 @@ impl BgpNeighEvent {
         peer_asn: u32,
         prev: BgpNeighborSessionState,
         new: BgpNeighborSessionState,
-        last_reset_reason: String,
+        last_reset_reason: Option<String>,
     ) -> Self {
         Self {
             peer,
@@ -165,7 +166,7 @@ async fn generate_bgp_event(
             neigh.last_reset_reason.clone(),
         );
         if let Err(e) = rtr_ctl.send_bgp_neigh_change(ev).await {
-            error!("Failed to send bgp session event: {e}")
+            error!("Failed to send bgp session event: {e}");
         }
     }
 }
@@ -235,6 +236,24 @@ async fn on_peer_up(
     generate_bgp_event(rtr_ctl, prev_state, neigh).await;
 }
 
+fn pretty(reason: PeerDownReasonCode) -> String {
+    match reason {
+        PeerDownReasonCode::LocalSystemClosedNotificationPduFollows
+        | PeerDownReasonCode::LocalSystemClosedFsmEventFollows
+        | PeerDownReasonCode::LocalSystemClosedTlvDataFollows => "Local system closed".to_string(),
+
+        PeerDownReasonCode::RemoteSystemClosedNotificationPduFollows
+        | PeerDownReasonCode::RemoteSystemClosedNoData => "Remote system closed".to_string(),
+
+        PeerDownReasonCode::PeerDeConfigured => "Peer de-configured".to_string(),
+
+        PeerDownReasonCode::Experimental251 => "Experimental 251".to_string(),
+        PeerDownReasonCode::Experimental252 => "Experimental 252".to_string(),
+        PeerDownReasonCode::Experimental253 => "Experimental 253".to_string(),
+        PeerDownReasonCode::Experimental254 => "Experimental 254".to_string(),
+    }
+}
+
 async fn on_peer_down(
     status: &mut DataplaneStatus,
     pd: &PeerDownNotificationMessage,
@@ -256,6 +275,7 @@ async fn on_peer_down(
 
                 set_neighbor_session_state(neigh, BgpNeighborSessionState::Idle);
                 neigh.connections_dropped = neigh.connections_dropped.saturating_add(1);
+                neigh.last_reset_reason = Some(pretty(pd.reason().get_type()));
 
                 debug!(
                     "BMP: peer-down vrf={} key={} prev_state={:?} new_state={:?} prev_connections_dropped={} new_connections_dropped={}",

--- a/routing/src/bmp/handler.rs
+++ b/routing/src/bmp/handler.rs
@@ -16,8 +16,8 @@ pub trait BmpHandler: Send + Sync + 'static {
     async fn on_message(&self, peer: std::net::SocketAddr, msg: BmpMessage);
 
     /// Called when a connection terminates (EOF / error).
-    async fn on_disconnect(&self, _peer: std::net::SocketAddr, _reason: &str) {
-        debug!("BMP: connection to {} disconnected", _peer);
+    async fn on_disconnect(&self, peer: std::net::SocketAddr, _reason: &str) {
+        debug!("BMP: connection to {peer} disconnected");
     }
 }
 

--- a/routing/src/bmp/handler.rs
+++ b/routing/src/bmp/handler.rs
@@ -8,6 +8,7 @@ use netgauze_bmp_pkt::BmpMessage;
 use tokio::sync::RwLock;
 use tracing::debug;
 
+use crate::RouterCtlSender;
 use crate::bmp::bmp_render;
 
 #[async_trait]
@@ -24,12 +25,13 @@ pub trait BmpHandler: Send + Sync + 'static {
 /// Background BMP handler that updates shared dataplane status.
 pub struct StatusHandler {
     dp_status: Arc<RwLock<DataplaneStatus>>,
+    rtr_ctl: RouterCtlSender,
 }
 
 impl StatusHandler {
     #[must_use]
-    pub fn new(dp_status: Arc<RwLock<DataplaneStatus>>) -> Self {
-        Self { dp_status }
+    pub fn new(dp_status: Arc<RwLock<DataplaneStatus>>, rtr_ctl: RouterCtlSender) -> Self {
+        Self { dp_status, rtr_ctl }
     }
 }
 

--- a/routing/src/bmp/handler.rs
+++ b/routing/src/bmp/handler.rs
@@ -38,10 +38,6 @@ impl StatusHandler {
 #[async_trait]
 impl BmpHandler for StatusHandler {
     async fn on_message(&self, _peer: std::net::SocketAddr, msg: BmpMessage) {
-        {
-            let mut guard = self.dp_status.write().await;
-            bmp_render::handle_bmp_message(&mut guard, &msg, &self.rtr_ctl).await;
-        }
-        debug!("BMP: released dataplane status write guard after handling message");
+        bmp_render::handle_bmp_message(&self.dp_status, &msg, &self.rtr_ctl).await;
     }
 }

--- a/routing/src/bmp/handler.rs
+++ b/routing/src/bmp/handler.rs
@@ -40,7 +40,7 @@ impl BmpHandler for StatusHandler {
     async fn on_message(&self, _peer: std::net::SocketAddr, msg: BmpMessage) {
         {
             let mut guard = self.dp_status.write().await;
-            bmp_render::handle_bmp_message(&mut guard, &msg);
+            bmp_render::handle_bmp_message(&mut guard, &msg, &self.rtr_ctl).await;
         }
         debug!("BMP: released dataplane status write guard after handling message");
     }

--- a/routing/src/bmp/mod.rs
+++ b/routing/src/bmp/mod.rs
@@ -5,6 +5,7 @@ pub mod bmp_render;
 pub mod handler;
 pub mod server;
 
+use crate::RouterCtlSender;
 pub use server::{BmpServer, BmpServerConfig};
 
 use concurrency::sync::Arc;
@@ -25,6 +26,7 @@ pub fn spawn_bmp_server(
     handle: &tokio::runtime::Handle,
     bind: std::net::SocketAddr,
     dp_status: Arc<RwLock<DataplaneStatus>>,
+    rtr_ctl: RouterCtlSender,
 ) -> JoinHandle<()> {
     let cancel = mgmt.cancel_token();
     let fut = async move {
@@ -33,7 +35,7 @@ pub fn spawn_bmp_server(
             bind_addr: bind,
             ..Default::default()
         };
-        let srv = BmpServer::new(cfg, handler::StatusHandler::new(dp_status));
+        let srv = BmpServer::new(cfg, handler::StatusHandler::new(dp_status, rtr_ctl));
         tokio::select! {
             () = cancel.cancelled() => {
                 info!("BMP server shutdown requested");

--- a/routing/src/cli/display.rs
+++ b/routing/src/cli/display.rs
@@ -41,6 +41,7 @@ use std::fmt::Display;
 use std::fmt::Write;
 use std::os::unix::net::SocketAddr;
 use std::rc::Rc;
+use std::time::Duration;
 use std::time::Instant;
 
 use tracing::{error, warn};
@@ -219,11 +220,16 @@ impl Display for RouteFlags {
     }
 }
 
-struct Age(Instant);
-impl Display for Age {
+pub struct PrettyDuration(Duration);
+impl PrettyDuration {
+    #[must_use]
+    pub fn new(d: Duration) -> Self {
+        Self(d)
+    }
+}
+impl Display for PrettyDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let duration = self.0.elapsed();
-        let total = duration.as_secs();
+        let total = self.0.as_secs();
         let days = total / 86_400;
         let hours = (total % 86_400) / 3_600;
         let minutes = (total % 3_600) / 60;
@@ -234,6 +240,14 @@ impl Display for Age {
         }
         write!(f, "{hours:02}:{minutes:02}:{seconds:02}")?;
         Ok(())
+    }
+}
+
+struct Age(Instant);
+impl Display for Age {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let duration = self.0.elapsed();
+        PrettyDuration(duration).fmt(f)
     }
 }
 

--- a/routing/src/cli/mod.rs
+++ b/routing/src/cli/mod.rs
@@ -3,5 +3,5 @@
 
 //! Cli
 
-mod display;
+pub(crate) mod display;
 pub(crate) mod handler;

--- a/routing/src/frr/renderer/bgp.rs
+++ b/routing/src/frr/renderer/bgp.rs
@@ -83,6 +83,11 @@ impl Render for BmpOptions {
         }
         cfg += connect;
 
+        // mirror
+        if self.mirror {
+            cfg += " bmp mirror";
+        }
+
         // monitors
         if self.monitor_ipv4_pre {
             cfg += " bmp monitor ipv4 unicast pre-policy";

--- a/routing/src/frr/test.rs
+++ b/routing/src/frr/test.rs
@@ -146,7 +146,7 @@ pub mod tests {
         let router_subsystem =
             lifecycle::Subsystem::new("router", lifecycle::CancellationToken::new());
         let mut router = Router::new(&router_subsystem, router_params, None).unwrap();
-        let mut ctl = router.get_ctl_tx();
+        let ctl = router.get_ctl_tx();
 
         /* start fake frr agent */
         let frr_agent_path = router.get_frr_agent_path().to_str().expect("Bad path");

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -16,6 +16,7 @@ use tokio::task;
 use tracing::{debug, error, info, warn};
 
 use crate::RouterError;
+use crate::bmp::bmp_render::BgpNeighEvent;
 use crate::config::RouterConfig;
 use crate::frr::frrmi::FrrAppliedConfig;
 use crate::interfaces::interface::IfState;
@@ -59,6 +60,7 @@ pub(crate) enum RouterCtlMsg {
     Config(Arc<ValidatedGwConfig>),
     ConfigHistory(Arc<Vec<GwConfigMeta>>),
     IfEvent(EthEvent),
+    BgpNeighStatus(BgpNeighEvent),
 }
 
 /// Object to send control messages to the router
@@ -169,6 +171,10 @@ impl RouterCtlSender {
         let msg = RouterCtlMsg::IfEvent(ev);
         self.send_and_wake(msg).await
     }
+    pub async fn send_bgp_neigh_change(&mut self, ev: BgpNeighEvent) -> Result<(), RouterError> {
+        let msg = RouterCtlMsg::BgpNeighStatus(ev);
+        self.send_and_wake(msg).await
+    }
 }
 
 /// Handle a lock request for the indicated CPI
@@ -276,6 +282,14 @@ fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
     iftw.set_iface_oper_state(ifindex, oper_state);
 }
 
+fn handle_bgp_peer_status_change(bgp_ev: BgpNeighEvent) {
+    info!(
+        "BGP session with {} (ASN {}) changed {} -> {}",
+        bgp_ev.peer, bgp_ev.peer_asn, bgp_ev.prev, bgp_ev.new
+    );
+    revent!(RouterEvent::BgpNeighStateChange(bgp_ev));
+}
+
 /// Handle requests from the control channel. Since the channel is integrated with the poll loop via a `Waker`
 /// and the `Waker` coalesce multiple readiness events, we drain completely on each call with a loop.
 pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
@@ -293,6 +307,7 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
             Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
             Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
             Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
+            Ok(RouterCtlMsg::BgpNeighStatus(bgp_ev)) => handle_bgp_peer_status_change(bgp_ev),
             Err(TryRecvError::Empty) => break,
             Err(e) => {
                 error!("Error receiving from ctl channel {e:?}");

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -282,8 +282,8 @@ fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
 
 fn handle_bgp_peer_status_change(bgp_ev: BgpNeighEvent) {
     info!(
-        "BGP session with {} (ASN {}) changed {} -> {}",
-        bgp_ev.peer, bgp_ev.peer_asn, bgp_ev.prev, bgp_ev.new
+        "BGP session with {} (id:{} ASN:{}) changed {} -> {}",
+        bgp_ev.peer_key, bgp_ev.peer_router_id, bgp_ev.peer_asn, bgp_ev.prev, bgp_ev.new
     );
     revent!(RouterEvent::BgpNeighStateChange(bgp_ev));
 }

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -82,7 +82,7 @@ impl RouterCtlSender {
             waker: Arc::clone(&self.waker),
         }
     }
-    async fn send_and_wake(&mut self, msg: RouterCtlMsg) -> Result<(), RouterError> {
+    async fn send_and_wake(&self, msg: RouterCtlMsg) -> Result<(), RouterError> {
         self.tx
             .send(msg)
             .await
@@ -95,7 +95,7 @@ impl RouterCtlSender {
         Ok(())
     }
 
-    pub async fn lock(&mut self) -> Result<LockGuard, RouterError> {
+    pub async fn lock(&self) -> Result<LockGuard, RouterError> {
         debug!("Requesting CPI lock...");
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::Lock(reply_tx);
@@ -111,7 +111,7 @@ impl RouterCtlSender {
         Ok(self.as_lock_guard())
     }
     #[allow(unused)]
-    pub async fn unlock(&mut self) -> Result<(), RouterError> {
+    pub async fn unlock(&self) -> Result<(), RouterError> {
         debug!("Requesting CPI unlock...");
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::Unlock(reply_tx);
@@ -125,7 +125,7 @@ impl RouterCtlSender {
         };
         result
     }
-    pub async fn configure(&mut self, config: RouterConfig) -> Result<(), RouterError> {
+    pub async fn configure(&self, config: RouterConfig) -> Result<(), RouterError> {
         let genid = config.genid();
         debug!("Requesting router to apply config for gen {genid}...");
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -141,9 +141,7 @@ impl RouterCtlSender {
         };
         result
     }
-    pub async fn get_frr_applied_config(
-        &mut self,
-    ) -> Result<Option<FrrAppliedConfig>, RouterError> {
+    pub async fn get_frr_applied_config(&self) -> Result<Option<FrrAppliedConfig>, RouterError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         let msg = RouterCtlMsg::GetFrrAppliedConfig(reply_tx);
         self.send_and_wake(msg).await?;
@@ -156,22 +154,22 @@ impl RouterCtlSender {
         };
         Ok(frr_cfg)
     }
-    pub async fn send_config(&mut self, config: Arc<ValidatedGwConfig>) -> Result<(), RouterError> {
+    pub async fn send_config(&self, config: Arc<ValidatedGwConfig>) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::Config(config);
         self.send_and_wake(msg).await
     }
     pub async fn send_config_history(
-        &mut self,
+        &self,
         history: Arc<Vec<GwConfigMeta>>,
     ) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::ConfigHistory(history);
         self.send_and_wake(msg).await
     }
-    pub async fn send_ifevent(&mut self, ev: EthEvent) -> Result<(), RouterError> {
+    pub async fn send_ifevent(&self, ev: EthEvent) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::IfEvent(ev);
         self.send_and_wake(msg).await
     }
-    pub async fn send_bgp_neigh_change(&mut self, ev: BgpNeighEvent) -> Result<(), RouterError> {
+    pub async fn send_bgp_neigh_change(&self, ev: BgpNeighEvent) -> Result<(), RouterError> {
         let msg = RouterCtlMsg::BgpNeighStatus(ev);
         self.send_and_wake(msg).await
     }

--- a/routing/src/router/revent.rs
+++ b/routing/src/router/revent.rs
@@ -8,6 +8,7 @@ use crate::bmp::bmp_render::BgpNeighEvent;
 use crate::event::EventLog;
 use crate::router::cpi::CpiStatus;
 use config::GenId;
+use config::internal::status::BgpNeighborSessionState;
 use interface_manager::monitor::EthEvent;
 use std::cell::RefCell;
 use std::fmt::Display;
@@ -84,20 +85,24 @@ impl Display for RouterEvent {
             RouterEvent::BgpNeighStateChange(bgp_ev) => {
                 let peer = &bgp_ev.peer;
                 let peer_asn = bgp_ev.peer_asn;
-                let last_reset_reason = &bgp_ev.last_reset_reason;
                 let prev = bgp_ev.prev;
                 let new = bgp_ev.new;
+
                 write!(
                     f,
-                    "Status of BGP peer {peer} (AS {peer_asn}) changed: {prev} -> {new}. Last reset reason: {last_reset_reason}"
+                    "Status of BGP peer {peer} (AS {peer_asn}) changed: {prev} -> {new}"
                 )?;
+                if new != BgpNeighborSessionState::Established {
+                    let last_reset_reason = bgp_ev.last_reset_reason.as_deref().unwrap_or("none");
+                    write!(f, " reason: {last_reset_reason}")?;
+                }
             }
         }
         Ok(())
     }
 }
 
-make_event_log!(ROUTER_EVENTS, RouterEvent, 1000);
+make_event_log!(ROUTER_EVENTS, RouterEvent, 2000);
 
 macro_rules! revent {
     ($item:expr) => {

--- a/routing/src/router/revent.rs
+++ b/routing/src/router/revent.rs
@@ -83,14 +83,15 @@ impl Display for RouterEvent {
                 )?;
             }
             RouterEvent::BgpNeighStateChange(bgp_ev) => {
-                let peer = &bgp_ev.peer;
+                let peer_key = &bgp_ev.peer_key;
+                let peer_router_id = &bgp_ev.peer_router_id;
                 let peer_asn = bgp_ev.peer_asn;
                 let prev = bgp_ev.prev;
                 let new = bgp_ev.new;
 
                 write!(
                     f,
-                    "Status of BGP peer {peer} (AS {peer_asn}) changed: {prev} -> {new}"
+                    "Status of BGP peer {peer_key} (id:{peer_router_id} ASN:{peer_asn}) changed: {prev} -> {new}"
                 )?;
                 if new != BgpNeighborSessionState::Established {
                     let last_reset_reason = bgp_ev.last_reset_reason.as_deref().unwrap_or("none");

--- a/routing/src/router/revent.rs
+++ b/routing/src/router/revent.rs
@@ -4,6 +4,7 @@
 //! Router events and eventlog
 
 use crate::IfState;
+use crate::bmp::bmp_render::BgpNeighEvent;
 use crate::event::EventLog;
 use crate::router::cpi::CpiStatus;
 use config::GenId;
@@ -30,6 +31,8 @@ pub enum RouterEvent {
 
     IfAdmChange(EthEvent, IfState, IfState),
     IfOperChange(EthEvent, IfState, IfState),
+
+    BgpNeighStateChange(BgpNeighEvent),
 }
 
 impl Display for RouterEvent {
@@ -76,6 +79,17 @@ impl Display for RouterEvent {
                     f,
                     "{ifc}: admin state changed {old} -> {new} (carrier:{:#?}, carrier-up:{} carrier-down:{})",
                     ev.carrier, ev.carrierup, ev.carrierdown
+                )?;
+            }
+            RouterEvent::BgpNeighStateChange(bgp_ev) => {
+                let peer = &bgp_ev.peer;
+                let peer_asn = bgp_ev.peer_asn;
+                let last_reset_reason = &bgp_ev.last_reset_reason;
+                let prev = bgp_ev.prev;
+                let new = bgp_ev.new;
+                write!(
+                    f,
+                    "Status of BGP peer {peer} (AS {peer_asn}) changed: {prev} -> {new}. Last reset reason: {last_reset_reason}"
                 )?;
             }
         }

--- a/routing/src/router/revent.rs
+++ b/routing/src/router/revent.rs
@@ -5,8 +5,10 @@
 
 use crate::IfState;
 use crate::bmp::bmp_render::BgpNeighEvent;
+use crate::cli::display::PrettyDuration;
 use crate::event::EventLog;
 use crate::router::cpi::CpiStatus;
+
 use config::GenId;
 use config::internal::status::BgpNeighborSessionState;
 use interface_manager::monitor::EthEvent;
@@ -96,6 +98,9 @@ impl Display for RouterEvent {
                 if new != BgpNeighborSessionState::Established {
                     let last_reset_reason = bgp_ev.last_reset_reason.as_deref().unwrap_or("none");
                     write!(f, " reason: {last_reset_reason}")?;
+                } else if let Some(downtime) = &bgp_ev.last_downtime {
+                    let downtime = PrettyDuration::new(*downtime);
+                    write!(f, " (downtime of {downtime})")?;
                 }
             }
         }


### PR DESCRIPTION
~~This goes on top of https://github.com/githedgehog/dataplane/pull/1643~~

Log `(info)` events for BGP session changes
``` 
2026-07-18T15:40:24.800367Z  INFO                 routerIO dataplane_routing::router::ctl: 284: BGP session with 7.0.0.2 (ASN 65002) changed Idle -> Established
``` 


Generate events so that all changes get recorded independently of logging and that these include:
 * reason for reset / down
 * downtime

```
dataplane(✔)# show router events
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ROUTER_EVENTS ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 generated: 13 stored: 13 capacity: 2000

 0    2026-07-19T 12:08:40: Started!
 1    2026-07-19T 12:08:40: Connected to frr-agent
 2    2026-07-19T 12:08:46: Router config request received for generation 1
 3    2026-07-19T 12:08:46: Router config request for generation 1 SUCCEEDED
 4    2026-07-19T 12:08:46: Requested FRR configuration for generation 1
 5    2026-07-19T 12:08:46: CPI status changed to Connected
 6    2026-07-19T 12:08:47: FRR configuration for generation 1 SUCCEEDED
 7    2026-07-19T 12:08:57: Status of BGP peer 10.0.0.13 (id:7.0.0.2 ASN:65002) changed: Unset -> Established
 8    2026-07-19T 12:08:57: Status of BGP peer 10.0.1.13 (id:7.0.0.6 ASN:65006) changed: Unset -> Established
 9    2026-07-19T 12:09:08: Status of BGP peer 10.0.0.13 (id:7.0.0.2 ASN:65002) changed: Established -> Idle reason: Remote system closed
 10   2026-07-19T 12:09:10: Status of BGP peer 10.0.0.13 (id:7.0.0.2 ASN:65002) changed: Idle -> Established (downtime: 00:00:02)
 11   2026-07-19T 12:09:50: Status of BGP peer 10.0.1.13 (id:7.0.0.6 ASN:65006) changed: Established -> Idle reason: Local system closed
 12   2026-07-19T 12:10:01: Status of BGP peer 10.0.1.13 (id:7.0.0.6 ASN:65006) changed: Idle -> Established (downtime: 00:00:11)
``` 