### PR TITLE
bmp msg stats

### DIFF
--- a/config/src/converters/k8s/status/bgp.rs
+++ b/config/src/converters/k8s/status/bgp.rs
@@ -90,11 +90,7 @@ impl TryFrom<&BgpNeighborStatus> for GatewayAgentStatusStateBgpVrfsNeighbors {
     type Error = ToK8sConversionError;
 
     fn try_from(n: &BgpNeighborStatus) -> Result<Self, Self::Error> {
-        let messages = n
-            .messages
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessages::try_from)
-            .transpose()?;
+        let messages = GatewayAgentStatusStateBgpVrfsNeighborsMessages::try_from(&n.messages)?;
 
         let ipv4_unicast_prefixes = n
             .ipv4_unicast_prefixes
@@ -120,7 +116,7 @@ impl TryFrom<&BgpNeighborStatus> for GatewayAgentStatusStateBgpVrfsNeighbors {
             l2_vpnevpn_prefixes,
             last_reset_reason: n.last_reset_reason.clone(),
             local_as: Some(n.local_as),
-            messages,
+            messages: Some(messages),
             peer_as: Some(n.peer_as),
             remote_router_id: (!n.remote_router_id.is_empty()).then(|| n.remote_router_id.clone()),
             session_state: Some(n.session_state.into()),
@@ -132,16 +128,13 @@ impl TryFrom<&BgpMessages> for GatewayAgentStatusStateBgpVrfsNeighborsMessages {
     type Error = ToK8sConversionError;
 
     fn try_from(m: &BgpMessages) -> Result<Self, Self::Error> {
-        let received = m
-            .received
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessagesReceived::from);
-        let sent = m
-            .sent
-            .as_ref()
-            .map(GatewayAgentStatusStateBgpVrfsNeighborsMessagesSent::from);
+        let received = GatewayAgentStatusStateBgpVrfsNeighborsMessagesReceived::from(&m.received);
+        let sent = GatewayAgentStatusStateBgpVrfsNeighborsMessagesSent::from(&m.sent);
 
-        Ok(GatewayAgentStatusStateBgpVrfsNeighborsMessages { received, sent })
+        Ok(GatewayAgentStatusStateBgpVrfsNeighborsMessages {
+            received: Some(received),
+            sent: Some(sent),
+        })
     }
 }
 
@@ -222,8 +215,8 @@ mod tests {
         };
 
         let messages = BgpMessages {
-            received: Some(msg_counters.clone()),
-            sent: Some(msg_counters),
+            received: msg_counters.clone(),
+            sent: msg_counters,
         };
 
         let prefixes = BgpNeighborPrefixes {
@@ -244,7 +237,7 @@ mod tests {
             established_transitions: 8,
             last_reset_reason: None,
             last_reset_time: None,
-            messages: Some(messages),
+            messages,
             ipv4_unicast_prefixes: Some(prefixes.clone()),
             ipv6_unicast_prefixes: Some(prefixes.clone()),
             l2vpn_evpn_prefixes: Some(prefixes),

--- a/config/src/internal/routing/bmp.rs
+++ b/config/src/internal/routing/bmp.rs
@@ -47,6 +47,9 @@ pub struct BmpOptions {
     pub monitor_ipv6_pre: bool,
     pub monitor_ipv6_post: bool,
 
+    /// Route mirroring
+    pub mirror: bool,
+
     /// VRFs/views to import into the default BMP instance:
     /// renders as multiple `bmp import-vrf-view <vrf>`
     pub import_vrf_views: Vec<String>,
@@ -66,6 +69,7 @@ impl Default for BmpOptions {
             monitor_ipv4_post: true,
             monitor_ipv6_pre: false,
             monitor_ipv6_post: false,
+            mirror: false,
             import_vrf_views: Vec::new(),
         }
     }
@@ -122,6 +126,12 @@ impl BmpOptions {
     pub fn monitor_ipv6(mut self, pre: bool, post: bool) -> Self {
         self.monitor_ipv6_pre = pre;
         self.monitor_ipv6_post = post;
+        self
+    }
+
+    #[must_use]
+    pub fn mirror(mut self, value: bool) -> Self {
+        self.mirror = value;
         self
     }
 

--- a/config/src/internal/status/mod.rs
+++ b/config/src/internal/status/mod.rs
@@ -278,8 +278,8 @@ impl BgpMessageCounters {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BgpMessages {
-    pub received: Option<BgpMessageCounters>,
-    pub sent: Option<BgpMessageCounters>,
+    pub received: BgpMessageCounters,
+    pub sent: BgpMessageCounters,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -302,7 +302,7 @@ pub struct BgpNeighborStatus {
     pub established_transitions: u64,
     pub last_reset_reason: Option<String>,
     pub last_reset_time: Option<std::time::Instant>, // not in model
-    pub messages: Option<BgpMessages>,
+    pub messages: BgpMessages,
     pub ipv4_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub ipv6_unicast_prefixes: Option<BgpNeighborPrefixes>,
     pub l2vpn_evpn_prefixes: Option<BgpNeighborPrefixes>,

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -119,7 +119,8 @@ fn parse_bmp_params(args: &CmdArgs) -> (Option<BmpServerParams>, Option<BmpOptio
         let client = BmpOptions::new("bmp1", host, port)
             .set_retry(interval, interval.saturating_mul(4u32))
             .set_stats_interval(interval)
-            .monitor_ipv4(true, true);
+            .monitor_ipv4(true, true)
+            .mirror(true);
 
         (Some(server), Some(client))
     } else {

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -5,14 +5,14 @@
 
 use netgauze_bgp_pkt::BgpMessage;
 use netgauze_bmp_pkt::v3::{
-    BmpMessageValue, PeerDownNotificationMessage, PeerUpNotificationMessage,
-    RouteMonitoringMessage, StatisticsReportMessage,
+    BmpMessageValue, MirroredBgpMessage, PeerDownNotificationMessage, PeerUpNotificationMessage,
+    RouteMirroringMessage, RouteMirroringValue, RouteMonitoringMessage, StatisticsReportMessage,
 };
 use netgauze_bmp_pkt::{BmpMessage, BmpPeerType};
 
 use config::internal::status::{
-    BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus, BgpVrfStatus,
-    DataplaneStatus,
+    BgpMessages, BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus,
+    BgpVrfStatus, DataplaneStatus,
 };
 
 use concurrency::sync::Arc;
@@ -94,6 +94,7 @@ pub async fn handle_bmp_message(
             }
             BmpMessageValue::RouteMonitoring(rm) => on_route_monitoring(&mut status_guard, rm),
             BmpMessageValue::StatisticsReport(sr) => on_statistics(&mut status_guard, sr),
+            BmpMessageValue::RouteMirroring(rm) => on_route_mirroring(&mut status_guard, rm),
             _ => {}
         },
         // V4 not handled yet
@@ -339,12 +340,43 @@ fn on_peer_down(
     None
 }
 
+fn update_msg_counts_from_neigh(msgs: &mut BgpMessages, rm: &RouteMirroringMessage) {
+    let rcv = &mut msgs.received;
+    let mirrored = rm.mirrored();
+    for value in mirrored {
+        if let RouteMirroringValue::BgpMessage(msg) = value
+            && let MirroredBgpMessage::Parsed(m) = msg
+        {
+            match m {
+                // FIXME: FRR docs say "route mirroring is fully implemented,
+                // however BGP OPEN messages are not currently included in route mirroring messages.
+                // Their contents can be extracted from the “peer up” notification for sessions that established successfully."
+                BgpMessage::Open(_) => rcv.open = rcv.open.saturating_add(1),
+
+                // FIXME: we're just counting updates here, but an update may contain many
+                // NLRIs and withdrawn routes.
+                BgpMessage::Update(_) => rcv.update = rcv.update.saturating_add(1),
+
+                BgpMessage::KeepAlive => rcv.keepalive = rcv.keepalive.saturating_add(1),
+                BgpMessage::RouteRefresh(_) => {
+                    rcv.route_refresh = rcv.route_refresh.saturating_add(1);
+                }
+
+                // FIXME: we only count notification messages, ignoring the reason for the
+                // notification, which could provide important info.
+                BgpMessage::Notification(_) => {
+                    rcv.notification = rcv.notification.saturating_add(1);
+                }
+            }
+        }
+    }
+}
+
 fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage) {
     let peer = rm.peer_header();
     if !is_real_bgp_neighbor(peer.peer_type()) {
         return;
     }
-
     let post = post_policy_from_peer_type(peer.peer_type());
     if post {
         return;
@@ -375,6 +407,28 @@ fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage
         "BMP: route-monitoring vrf={} key={} post_policy={} ipv4_received={} ipv4_received_pre={}",
         vrf, key, post, pref.received, pref.received_pre_policy,
     );
+}
+
+fn on_route_mirroring(status: &mut DataplaneStatus, rm: &RouteMirroringMessage) {
+    let peer = rm.peer_header();
+    if !is_real_bgp_neighbor(peer.peer_type()) {
+        return;
+    }
+    let post = post_policy_from_peer_type(peer.peer_type());
+    if post {
+        return;
+    }
+
+    let vrf = vrf_from_peer_header(peer);
+    let key = key_from_peer_header(peer);
+
+    let bgp = ensure_bgp(status);
+    let vrf_s = ensure_vrf(bgp, &vrf);
+    let neigh = ensure_neighbor(vrf_s, &key);
+
+    // count messages received. Mirroring mirrors bgp messages received by the BGP speaker.
+    // RFC 8671 defines adj-rib-out mirroring, but FRR does not implement it.
+    update_msg_counts_from_neigh(&mut neigh.messages, rm);
 }
 
 fn on_statistics(status: &mut DataplaneStatus, sr: &StatisticsReportMessage) {

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -11,8 +11,8 @@ use netgauze_bmp_pkt::v3::{
 use netgauze_bmp_pkt::{BmpMessage, BmpPeerType};
 
 use config::internal::status::{
-    BgpMessageCounters, BgpMessages, BgpNeighborPrefixes, BgpNeighborSessionState,
-    BgpNeighborStatus, BgpStatus, BgpVrfStatus, DataplaneStatus,
+    BgpNeighborPrefixes, BgpNeighborSessionState, BgpNeighborStatus, BgpStatus, BgpVrfStatus,
+    DataplaneStatus,
 };
 
 use concurrency::sync::Arc;
@@ -243,13 +243,6 @@ fn on_peer_up(
         neigh.local_as = u32::from(open.my_as());
     }
 
-    if neigh.messages.is_none() {
-        neigh.messages = Some(BgpMessages {
-            received: Some(BgpMessageCounters::new()),
-            sent: Some(BgpMessageCounters::new()),
-        });
-    }
-
     debug!(
         "BMP: peer-up vrf={} key={} peer_addr={} prev_state={:?} new_state={:?} peer_as={} local_as={} peer_port={} remote_id={}",
         vrf,
@@ -364,16 +357,10 @@ fn on_route_monitoring(status: &mut DataplaneStatus, rm: &RouteMonitoringMessage
     let vrf_s = ensure_vrf(bgp, &vrf);
     let neigh = ensure_neighbor(vrf_s, &key);
 
-    let msgs = neigh.messages.get_or_insert_with(|| BgpMessages {
-        received: Some(BgpMessageCounters::new()),
-        sent: Some(BgpMessageCounters::new()),
-    });
-
     // Count UPDATE messages received (best-effort)
     if let BgpMessage::Update(_) = rm.update_message() {
-        if let Some(rcv) = msgs.received.as_mut() {
-            rcv.update = rcv.update.saturating_add(1);
-        }
+        let rcv = &mut neigh.messages.received;
+        rcv.update = rcv.update.saturating_add(1);
     }
 
     // Minimal prefix counters placeholder (per RM message) — can be upgraded later to real NLRI counting.
@@ -401,12 +388,7 @@ fn on_statistics(status: &mut DataplaneStatus, sr: &StatisticsReportMessage) {
 
     let bgp = ensure_bgp(status);
     let vrf_s = ensure_vrf(bgp, &vrf);
-    let neigh = ensure_neighbor(vrf_s, &key);
-
-    let _ = neigh.messages.get_or_insert_with(|| BgpMessages {
-        received: Some(BgpMessageCounters::new()),
-        sent: Some(BgpMessageCounters::new()),
-    });
+    let _neigh = ensure_neighbor(vrf_s, &key);
 
     debug!(
         "BMP: statistics-report vrf={} key={} (TODO: decode stats later)",

--- a/routing/src/bmp/bmp_render.rs
+++ b/routing/src/bmp/bmp_render.rs
@@ -244,6 +244,13 @@ fn on_peer_up(
         neigh.local_as = u32::from(open.my_as());
     }
 
+    if let BgpMessage::Open(_open) = pu.received_message() {
+        // amend FRR's limitation by increasing the count of opens received
+        // FIXME: this seems to over count the messages received.
+        // TODO: investigate if it is needed
+        // neigh.messages.received.open = neigh.messages.received.open.saturating_add(1);
+    }
+
     debug!(
         "BMP: peer-up vrf={} key={} peer_addr={} prev_state={:?} new_state={:?} peer_as={} local_as={} peer_port={} remote_id={}",
         vrf,

--- a/routing/src/frr/renderer/bgp.rs
+++ b/routing/src/frr/renderer/bgp.rs
@@ -83,6 +83,11 @@ impl Render for BmpOptions {
         }
         cfg += connect;
 
+        // mirror
+        if self.mirror {
+            cfg += " bmp mirror";
+        }
+
         // monitors
         if self.monitor_ipv4_pre {
             cfg += " bmp monitor ipv4 unicast pre-policy";


### PR DESCRIPTION
This goes on top of https://github.com/githedgehog/dataplane/pull/1645

* Improve bgp message statistics
* Currently, we only supported update messages.
* Enable bmp mirroring to account for other message types (opens, notifications, keepalives) which better show the state of a session.

**Note:** 
* only received messages from a peer are supported.
* Sent messages are not supported by frr.
* The stats are at message level. In case of updates, these may contain many routes packed, which are not reflected in the stats.