### PR TITLE
Pr/fredi/worker liveness check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "axum-server",
  "dataplane-acl-filter",
  "dataplane-args",
+ "dataplane-common",
  "dataplane-concurrency",
  "dataplane-config",
  "dataplane-dpdk",

--- a/cli/bin/cmdtree_dp.rs
+++ b/cli/bin/cmdtree_dp.rs
@@ -299,6 +299,14 @@ fn cmd_show_packet_stats() -> Node {
     root
 }
 
+fn cmd_show_driver_status() -> Node {
+    let mut root = Node::new("driver");
+    root += Node::new("status")
+        .desc("Show the status of the packet driver")
+        .action(CliAction::ShowDriverStatus);
+    root
+}
+
 fn cmd_show_tech() -> Node {
     Node::new("tech")
         .desc("Dump dataplanes state")
@@ -320,6 +328,7 @@ fn cmd_show() -> Node {
     root += cmd_show_gateway();
     root += cmd_show_config_summary();
     root += cmd_show_packet_stats();
+    root += cmd_show_driver_status();
     root += cmd_show_tech();
     root
 }

--- a/cli/src/cliproto.rs
+++ b/cli/src/cliproto.rs
@@ -334,6 +334,9 @@ pub enum CliAction {
     // internal config
     ShowConfigInternal,
 
+    // packet driver status
+    ShowDriverStatus,
+
     ShowTech,
 
     /* == Not supported yet == */

--- a/common/src/cliprovider.rs
+++ b/common/src/cliprovider.rs
@@ -3,7 +3,6 @@
 
 //! A trait for a type that can provide CLI data
 
-use arc_swap::{ArcSwap, ArcSwapOption};
 use concurrency::slot::{Slot, SlotOption};
 use concurrency::sync::Arc;
 use left_right::ReadHandle;
@@ -59,32 +58,6 @@ where
     }
 }
 
-impl<T> CliDataProvider for ArcSwap<T>
-where
-    T: CliDataProvider,
-{
-    fn provide(&self) -> String {
-        self.load().provide()
-    }
-}
-
-impl<T> CliDataProvider for ArcSwapOption<T>
-where
-    T: CliDataProvider,
-{
-    fn provide(&self) -> String {
-        // No type annotation on `p`: `arc_swap::ArcSwapOption` always
-        // yields `std::sync::Arc<T>`, which is not the same type as
-        // `concurrency::sync::Arc<T>` under the `loom` backend.
-        // Letting inference do its job keeps this `impl` compiling on
-        // every backend.
-        self.load()
-            .as_ref()
-            .map(|p| p.provide())
-            .unwrap_or_else(|| "(none)".to_string())
-    }
-}
-
 impl<T> CliDataProvider for Slot<T>
 where
     T: CliDataProvider,
@@ -99,7 +72,12 @@ where
     T: CliDataProvider,
 {
     fn provide(&self) -> String {
-        self.load_full()
+        // No type annotation on `p`: `arc_swap::ArcSwapOption` always
+        // yields `std::sync::Arc<T>`, which is not the same type as
+        // `concurrency::sync::Arc<T>` under the `loom` backend.
+        // Letting inference do its job keeps this `impl` compiling on
+        // every backend.
+        self.load()
             .as_ref()
             .map(|p| p.provide())
             .unwrap_or_else(|| "(none)".to_string())

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -18,6 +18,7 @@ args = { workspace = true }
 arrayvec = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 axum-server = { workspace = true }
+common = { workspace = true }
 concurrency = { workspace = true }
 config = { workspace = true }
 dpdk = { workspace = true }

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -53,9 +53,8 @@ impl DriverKernel {
         info!("Spawning {num_workers} workers");
         (0..num_workers)
             .map(|wid| {
-                let builder = thread::Builder::new().name(format!("dp-worker-{wid}"));
                 Worker::new(wid, num_workers, setup_pipeline, workers_subsystem.clone())
-                    .start(scope, builder, interfaces)
+                    .start(scope, interfaces)
             })
             .collect()
     }

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -96,6 +96,92 @@ impl DriverKernel {
         Ok(monitors)
     }
 
+    /// Join a worker given its handle, log how the thread terminated and report the outcome in a `WorkerEndResult`.
+    /// This method should only be called when we know that a worker has ended (or is about to do so due to cancellation).
+    /// Otherwise it would block the supervisor.
+    fn join_worker(
+        id: WorkerId,
+        handle: ScopedJoinHandle<'_, Result<(), std::io::Error>>,
+    ) -> WorkerEndResult {
+        match handle.join() {
+            Ok(Ok(())) => {
+                info!("Worker {id} exited successfully");
+                WorkerEndResult::Ok
+            }
+            Ok(Err(e)) => {
+                error!("Worker {id} exited with error: {e}");
+                WorkerEndResult::Failed(e.to_string())
+            }
+            Err(panic_payload) => {
+                let msg = format!("Worker {id} panicked {panic_payload:?}");
+                error!("Worker {id} panicked: {msg}");
+                WorkerEndResult::Panicked(msg)
+            }
+        }
+    }
+
+    /// Check if the `Subsystem` got cancelled (and we must shutdown). If so,
+    /// join all of the workers. This will wait for all workers to finish.
+    /// Returns `true` if the subsystem was cancelled and `false` otherwise.
+    fn must_run(
+        subsystem: &Subsystem,
+        wk_monitors: &mut Vec<WorkerMonitor<'_>>,
+        wk_status: &mut [WorkerStatus],
+    ) -> bool {
+        // we must run if were not cancelled
+        if !subsystem.is_cancelled() {
+            return true;
+        }
+        info!("Got cancelled. Will join worker(s)");
+        for (pos, monitor) in wk_monitors.iter_mut().enumerate() {
+            if let Some(handle) = monitor.handle.take() {
+                let status = &mut wk_status[pos];
+                status.state = WorkerState::Terminated(Self::join_worker(monitor.id, handle));
+            } else {
+                info!("Not joining worker {} (ended before shutdown)", monitor.id);
+            }
+        }
+        info!("All workers joined. Supervisor should terminate soon...");
+        false
+    }
+
+    /// Check the activity of the rx tasks for a worker (watchdog, if `check_watchdog` is true)
+    /// from its `WorkerMonitor` and update the corresponding `WorkerStatus`
+    fn check_worker_rx_tasks(
+        monitor: &mut WorkerMonitor,
+        wk_status: &mut WorkerStatus,
+        check_watchdog: bool,
+    ) {
+        for (idx, ifm) in monitor.intf.iter().enumerate() {
+            let rx_task_status = &mut wk_status.rx_tasks[idx];
+            debug_assert_eq!(rx_task_status.ifname, ifm.ifname);
+
+            // check the rx task activity, and watchdog, if we've been told to do so
+            let activity = ifm.watchdog.check_and_clear(check_watchdog);
+
+            // update the rx task status
+            rx_task_status.activity = activity;
+            match &rx_task_status.activity {
+                Activity::Stuck => {
+                    rx_task_status.misses += 1;
+                    rx_task_status.pps = 0.0;
+                    error!(
+                        "RX task for interface {} in worker {} did not pat the watchdog",
+                        ifm.ifname, monitor.id
+                    );
+                }
+                Activity::Active(record) => {
+                    rx_task_status.total_rx += record.rx;
+                    rx_task_status.total_tx += record.tx;
+                    rx_task_status.total_ppline_drops += record.ppline_drops;
+                    rx_task_status.total_tx_drops += record.tx_drops;
+                    rx_task_status.pps = record.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
+                }
+                Activity::Idle => rx_task_status.pps = 0.0,
+            }
+        }
+    }
+
     /// Spawn worker threads + supervisor into `scope`. The scope joins
     /// all driver threads on closure return.
     ///
@@ -134,67 +220,46 @@ impl DriverKernel {
         )?;
         debug_assert_eq!(worker_monitors.len(), num_workers);
 
-        let supervisor_subsystem = workers_subsystem.clone();
-
         // The supervisor loops over worker monitors (which include join handles) and
         // just joins-and-logs on termination; worker fatal reporting is handled by
         // the `ExitGuard` inside each worker thread.
         let supervisor_builder =
             thread::Builder::new().name("kernel-worker-supervisor".to_string());
 
-        // closure to join a worker, log its outcome, and report how it ended
-        let join_and_log = |id: WorkerId,
-                            handle: ScopedJoinHandle<'scope, Result<(), std::io::Error>>|
-         -> WorkerEndResult {
-            match handle.join() {
-                Ok(Ok(())) => {
-                    info!("Worker {id} exited successfully");
-                    WorkerEndResult::Ok
-                }
-                Ok(Err(e)) => {
-                    error!("Worker {id} exited with error: {e}");
-                    WorkerEndResult::Failed(e.to_string())
-                }
-                Err(panic_payload) => {
-                    let msg = format!("Worker {id} panicked {panic_payload:?}");
-                    error!("Worker {id} panicked: {msg}");
-                    WorkerEndResult::Panicked(msg)
-                }
-            }
-        };
-
         // the two time intervals that matter for liveness detection
         let check_period = Duration::from_secs(u64::from(Self::TASK_CHECK_PERIOD));
         let poll_period = Duration::from_secs(u64::from(Self::TASK_POLL_PERIOD));
+
+        let subsystem = workers_subsystem.clone();
 
         supervisor_builder.spawn_scoped(scope, move || {
             info!("Worker supervisor started");
 
             // build a vector of worker status from their monitors to expose their state outside of this thread
             // each WorkerStatus contains a list of RxTaskStatus
-            let mut workers_status: Vec<WorkerStatus> = worker_monitors.iter().map(|monitor| {
-                let mut ws = WorkerStatus::new(monitor.id);
-                ws.rx_tasks = monitor.intf.iter().map(|i|RxTaskStatus::new(i.ifname.clone())).collect();
-                ws
-            }).collect();
+            let mut workers_status: Vec<WorkerStatus> = worker_monitors
+                .iter()
+                .map(|monitor| {
+                    let mut ws = WorkerStatus::new(monitor.id);
+                    ws.rx_tasks = monitor
+                        .intf
+                        .iter()
+                        .map(|i| RxTaskStatus::new(i.ifname.clone()))
+                        .collect();
+                    ws
+                })
+                .collect();
 
             // the next instant when the rx tasks watchdogs should be checked.
             let mut next_watchdog_check = Instant::now().add(check_period);
 
             loop {
-                // If we got cancelled (graceful stop), join all workers and break, ending the supervisor
-                if supervisor_subsystem.is_cancelled() {
-                    info!("Got cancelled. Will join {} worker(s)", worker_monitors.len());
-                    for monitor in &mut worker_monitors {
-                        if let Some(handle) = monitor.handle.take() {
-                            join_and_log(monitor.id, handle);
-                        }
-                    }
-                    info!("All workers joined. Worker supervisor should terminate soon.");
+                // check if we must run. Otherwise (got cancelled) join all workers
+                if !Self::must_run(&subsystem, &mut worker_monitors, &mut workers_status) {
                     break;
                 }
 
-                // check time and decide if we should check whether the rx tasks patted the watchdogs.
+                // check the current time and decide if we should check whether the rx tasks patted the watchdogs.
                 // If so, compute the next time we should check them again in the future.
                 let now = Instant::now();
                 let check_watchdog = now >= next_watchdog_check;
@@ -204,6 +269,7 @@ impl DriverKernel {
                     }
                 }
 
+                // check each worker using its monitor
                 let mut any_running = false;
                 for (pos, monitor) in worker_monitors.iter_mut().enumerate() {
                     // get status object for the worker/monitor
@@ -211,48 +277,21 @@ impl DriverKernel {
 
                     if let Some(handle) = monitor.handle.take() {
                         if handle.is_finished() {
-                            let result = join_and_log(monitor.id, handle);
+                            // join the worker
+                            let result = Self::join_worker(monitor.id, handle);
                             wk_status.state = WorkerState::Terminated(result);
-                            wk_status.rx_tasks.iter_mut().for_each(|r|{
-                                    // cosmetic, clear all rx task "instantaneous" state
-                                    r.activity = Activity::Idle;
-                                    r.pps = 0.0;
-                                }
-                            );
+                            wk_status.rx_tasks.iter_mut().for_each(|r| {
+                                r.activity = Activity::Idle;
+                                r.pps = 0.0;
+                            });
                         } else {
-                            // Update the worker state
-                            wk_status.state = WorkerState::Running; // the worker is running
-                            monitor.handle = Some(handle); // restore handle (worker is still running)
-                            any_running = true; // there is at least this worker running
+                            // worker is running, update its `WorkerStatus` and restore its handle
+                            wk_status.state = WorkerState::Running;
+                            monitor.handle = Some(handle);
+                            any_running = true;
 
-                            // check the worker's rx tasks and update the corresponding status. The check can
-                            // be a regular activity check or a watchdog check, which will check and rearm the
-                            // watchdog and complain if the task did not pat it.
-                            for (idx, ifm) in monitor.intf.iter().enumerate() {
-                                let rx_task_status = &mut wk_status.rx_tasks[idx];
-                                debug_assert_eq!(rx_task_status.ifname, ifm.ifname);
-
-                                // check the rx task activity, and watchdog, if we've been told to do so
-                                let activity = ifm.watchdog.check_and_clear(check_watchdog);
-
-                                // update the rx task status
-                                rx_task_status.activity = activity;
-                                match &rx_task_status.activity {
-                                    Activity::Stuck => {
-                                        rx_task_status.misses += 1;
-                                        rx_task_status.pps = 0.0;
-                                        error!("RX task for interface {} in worker {} did not pat the watchdog", ifm.ifname, monitor.id);
-                                    }
-                                    Activity::Active(record) => {
-                                        rx_task_status.total_rx += record.rx;
-                                        rx_task_status.total_tx += record.tx;
-                                        rx_task_status.total_ppline_drops += record.ppline_drops;
-                                        rx_task_status.total_tx_drops += record.tx_drops;
-                                        rx_task_status.pps = record.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
-                                    }
-                                    Activity::Idle => rx_task_status.pps = 0.0,
-                                }
-                            }
+                            // check the worker's rx tasks and update the corresponding status
+                            Self::check_worker_rx_tasks(monitor, wk_status, check_watchdog);
                         }
                     } else {
                         // A worker monitor without a handle means that the worker was joined already
@@ -260,19 +299,27 @@ impl DriverKernel {
                     }
                 }
 
-                // publish the status of the driver
-                status_writer.publish(DriverStatus { workers: workers_status.clone() });
-
-                // No more workers running (unexpectedly, there was no cancellation).
-                // If there was cancellation, we'll notice in the next round and deal with it.
                 if !any_running {
                     error!("No more workers are running!!. Stopping...");
                     break;
                 }
 
+                // publish the status of the driver
+                status_writer.publish(DriverStatus {
+                    workers: workers_status.clone(),
+                });
+
                 // sleep for the poll period
                 thread::sleep(poll_period);
             }
+
+            // update status on termination. This is in case we
+            // want to log the last state
+            let last = DriverStatus {
+                workers: workers_status.clone(),
+            };
+            status_writer.publish(last);
+
             info!("Worker supervisor thread terminated");
         })?;
         info!("Kernel driver started successfully");

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -16,12 +16,14 @@ mod fanout;
 mod kif;
 mod worker;
 
-use worker::WorkerId;
+use std::ops::Add;
+use std::time::{Duration, Instant};
 
 use concurrency::sync::Arc;
 use concurrency::thread;
 #[allow(unused_imports)] // used under loom/shuttle backends
 use concurrency::thread::BuilderExt;
+use concurrency::thread::ScopedJoinHandle;
 use lifecycle::Subsystem;
 use net::buffer::test_buffer::TestBuffer;
 use pipeline::DynPipeline;
@@ -30,6 +32,11 @@ use tracectl::trace_target;
 use tracing::{debug, error, info, trace, warn};
 
 use super::DriverError;
+use super::status::{
+    DriverStatus, DriverStatusWriter, RxTaskStatus, WorkerEndResult, WorkerId, WorkerState,
+    WorkerStatus,
+};
+use super::watchdog::{Activity, Watchdog};
 use kif::{Kif, bring_kifs_up};
 use worker::Worker;
 
@@ -40,6 +47,7 @@ trace_target!("kernel-driver", LevelFilter::INFO, &["driver"]);
 pub struct DriverKernel;
 
 #[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_precision_loss)]
 impl DriverKernel {
     /// How often, in seconds, a worker interface pats its watchdog even if no activity (worst case)
     pub(crate) const TASK_PAT_PERIOD: u16 = 2;
@@ -65,17 +73,27 @@ impl DriverKernel {
         num_workers: usize,
         setup_pipeline: &Arc<dyn Send + Sync + Fn() -> DynPipeline<TestBuffer>>,
         interfaces: &[Kif],
-    ) -> Result<
-        Vec<thread::ScopedJoinHandle<'scope, Result<WorkerId, (WorkerId, std::io::Error)>>>,
-        std::io::Error,
-    > {
+    ) -> Result<Vec<WorkerMonitor<'scope>>, std::io::Error> {
+        let mut monitors: Vec<WorkerMonitor> = Vec::with_capacity(num_workers);
+
         info!("Spawning {num_workers} workers");
-        (0..num_workers)
-            .map(|wid| {
-                Worker::new(wid, num_workers, setup_pipeline, workers_subsystem.clone())
-                    .start(scope, interfaces)
-            })
-            .collect()
+
+        for workerid in 0..num_workers {
+            // create worker
+            let worker = Worker::new(
+                workerid,
+                num_workers,
+                setup_pipeline,
+                workers_subsystem.clone(),
+            );
+            // start worker. We get a `WorkerMonitor` on success, which includes
+            // an interface monitor for each of its rx tasks
+            let wk_monitor = worker.start(scope, interfaces)?;
+
+            // store monitor
+            monitors.push(wk_monitor);
+        }
+        Ok(monitors)
     }
 
     /// Spawn worker threads + supervisor into `scope`. The scope joins
@@ -83,12 +101,14 @@ impl DriverKernel {
     ///
     /// # Errors
     /// Returns [`DriverError`] on interface setup or thread spawn failure.
+    #[allow(clippy::too_many_lines)]
     pub fn start<'scope>(
         scope: &'scope thread::Scope<'scope, '_>,
         workers_subsystem: &Subsystem,
         args: impl IntoIterator<Item = impl AsRef<str> + Clone>,
         num_workers: usize,
         setup_pipeline: &Arc<dyn Send + Sync + Fn() -> DynPipeline<TestBuffer>>,
+        status_writer: DriverStatusWriter,
     ) -> Result<(), DriverError> {
         // A current_thread runtime built inside another tokio runtime
         // panics; catch nesting in debug.
@@ -105,31 +125,193 @@ impl DriverKernel {
             .build()?
             .block_on(bring_kifs_up(interfaces.as_slice()))?;
 
-        let worker_handles = Self::spawn_workers_scoped(
+        let mut worker_monitors = Self::spawn_workers_scoped(
             scope,
             workers_subsystem,
             num_workers,
             setup_pipeline,
             interfaces.as_slice(),
         )?;
-        debug_assert_eq!(worker_handles.len(), num_workers);
+        debug_assert_eq!(worker_monitors.len(), num_workers);
 
-        // The supervisor just joins-and-logs; worker fatal reporting is
-        // handled by the `ExitGuard` inside each worker thread.
+        let supervisor_subsystem = workers_subsystem.clone();
+
+        // The supervisor loops over worker monitors (which include join handles) and
+        // just joins-and-logs on termination; worker fatal reporting is handled by
+        // the `ExitGuard` inside each worker thread.
         let supervisor_builder =
-            thread::Builder::new().name("kernel-driver-supervisor".to_string());
+            thread::Builder::new().name("kernel-worker-supervisor".to_string());
 
-        supervisor_builder.spawn_scoped(scope, move || {
-            for handle in worker_handles.into_iter() {
-                match handle.join() {
-                    Ok(Ok(id)) => info!("Worker {id} exited successfully"),
-                    Ok(Err((id, e))) => error!("Worker {id} exited with error: {e}"),
-                    Err(panic_payload) => error!("Worker panicked: {panic_payload:?}"),
+        // closure to join a worker, log its outcome, and report how it ended
+        let join_and_log = |id: WorkerId,
+                            handle: ScopedJoinHandle<'scope, Result<(), std::io::Error>>|
+         -> WorkerEndResult {
+            match handle.join() {
+                Ok(Ok(())) => {
+                    info!("Worker {id} exited successfully");
+                    WorkerEndResult::Ok
+                }
+                Ok(Err(e)) => {
+                    error!("Worker {id} exited with error: {e}");
+                    WorkerEndResult::Failed(e.to_string())
+                }
+                Err(panic_payload) => {
+                    let msg = format!("Worker {id} panicked {panic_payload:?}");
+                    error!("Worker {id} panicked: {msg}");
+                    WorkerEndResult::Panicked(msg)
                 }
             }
-            info!("All workers joined");
-        })?;
+        };
 
+        // the two time intervals that matter for liveness detection
+        let check_period = Duration::from_secs(u64::from(Self::TASK_CHECK_PERIOD));
+        let poll_period = Duration::from_secs(u64::from(Self::TASK_POLL_PERIOD));
+
+        supervisor_builder.spawn_scoped(scope, move || {
+            info!("Worker supervisor started");
+
+            // build a vector of worker status from their monitors to expose their state outside of this thread
+            // each WorkerStatus contains a list of RxTaskStatus
+            let mut workers_status: Vec<WorkerStatus> = worker_monitors.iter().map(|monitor| {
+                let mut ws = WorkerStatus::new(monitor.id);
+                ws.rx_tasks = monitor.intf.iter().map(|i|RxTaskStatus::new(i.ifname.clone())).collect();
+                ws
+            }).collect();
+
+            // the next instant when the rx tasks watchdogs should be checked.
+            let mut next_watchdog_check = Instant::now().add(check_period);
+
+            loop {
+                // If we got cancelled (graceful stop), join all workers and break, ending the supervisor
+                if supervisor_subsystem.is_cancelled() {
+                    info!("Got cancelled. Will join {} worker(s)", worker_monitors.len());
+                    for monitor in &mut worker_monitors {
+                        if let Some(handle) = monitor.handle.take() {
+                            join_and_log(monitor.id, handle);
+                        }
+                    }
+                    info!("All workers joined. Worker supervisor should terminate soon.");
+                    break;
+                }
+
+                // check time and decide if we should check whether the rx tasks patted the watchdogs.
+                // If so, compute the next time we should check them again in the future.
+                let now = Instant::now();
+                let check_watchdog = now >= next_watchdog_check;
+                if check_watchdog {
+                    while next_watchdog_check <= now {
+                        next_watchdog_check = next_watchdog_check.add(check_period);
+                    }
+                }
+
+                let mut any_running = false;
+                for (pos, monitor) in worker_monitors.iter_mut().enumerate() {
+                    // get status object for the worker/monitor
+                    let wk_status = &mut workers_status[pos];
+
+                    if let Some(handle) = monitor.handle.take() {
+                        if handle.is_finished() {
+                            let result = join_and_log(monitor.id, handle);
+                            wk_status.state = WorkerState::Terminated(result);
+                            wk_status.rx_tasks.iter_mut().for_each(|r|{
+                                    // cosmetic, clear all rx task "instantaneous" state
+                                    r.activity = Activity::Idle;
+                                    r.pps = 0.0;
+                                }
+                            );
+                        } else {
+                            // Update the worker state
+                            wk_status.state = WorkerState::Running; // the worker is running
+                            monitor.handle = Some(handle); // restore handle (worker is still running)
+                            any_running = true; // there is at least this worker running
+
+                            // check the worker's rx tasks and update the corresponding status. The check can
+                            // be a regular activity check or a watchdog check, which will check and rearm the
+                            // watchdog and complain if the task did not pat it.
+                            for (idx, ifm) in monitor.intf.iter().enumerate() {
+                                let rx_task_status = &mut wk_status.rx_tasks[idx];
+                                debug_assert_eq!(rx_task_status.ifname, ifm.ifname);
+
+                                // check the rx task activity, and watchdog, if we've been told to do so
+                                let activity = ifm.watchdog.check_and_clear(check_watchdog);
+
+                                // update the rx task status
+                                rx_task_status.activity = activity;
+                                match &rx_task_status.activity {
+                                    Activity::Stuck => {
+                                        rx_task_status.misses += 1;
+                                        rx_task_status.pps = 0.0;
+                                        error!("RX task for interface {} in worker {} did not pat the watchdog", ifm.ifname, monitor.id);
+                                    }
+                                    Activity::Active(record) => {
+                                        rx_task_status.total_rx += record.rx;
+                                        rx_task_status.total_tx += record.tx;
+                                        rx_task_status.total_ppline_drops += record.ppline_drops;
+                                        rx_task_status.total_tx_drops += record.tx_drops;
+                                        rx_task_status.pps = record.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
+                                    }
+                                    Activity::Idle => rx_task_status.pps = 0.0,
+                                }
+                            }
+                        }
+                    } else {
+                        // A worker monitor without a handle means that the worker was joined already
+                        // We do nothing in this case. The monitor is kept in the list.
+                    }
+                }
+
+                // publish the status of the driver
+                status_writer.publish(DriverStatus { workers: workers_status.clone() });
+
+                // No more workers running (unexpectedly, there was no cancellation).
+                // If there was cancellation, we'll notice in the next round and deal with it.
+                if !any_running {
+                    error!("No more workers are running!!. Stopping...");
+                    break;
+                }
+
+                // sleep for the poll period
+                thread::sleep(poll_period);
+            }
+            info!("Worker supervisor thread terminated");
+        })?;
+        info!("Kernel driver started successfully");
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct WorkerIfaceMonitor {
+    ifname: Arc<str>,
+    watchdog: Watchdog,
+}
+
+impl WorkerIfaceMonitor {
+    #[must_use]
+    fn new(ifname: &str) -> Self {
+        Self {
+            ifname: Arc::from(ifname),
+            watchdog: Watchdog::new(),
+        }
+    }
+}
+
+struct WorkerMonitor<'scope> {
+    id: WorkerId,
+    handle: Option<ScopedJoinHandle<'scope, Result<(), std::io::Error>>>,
+    intf: Vec<WorkerIfaceMonitor>,
+}
+impl<'scope> WorkerMonitor<'scope> {
+    #[must_use]
+    fn new(
+        id: WorkerId,
+        handle: ScopedJoinHandle<'scope, Result<(), std::io::Error>>,
+        intf: Vec<WorkerIfaceMonitor>,
+    ) -> Self {
+        Self {
+            id,
+            handle: Some(handle),
+            intf,
+        }
     }
 }

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -41,6 +41,21 @@ pub struct DriverKernel;
 
 #[allow(clippy::cast_possible_truncation)]
 impl DriverKernel {
+    /// How often, in seconds, a worker interface pats its watchdog even if no activity (worst case)
+    pub(crate) const TASK_PAT_PERIOD: u16 = 2;
+
+    /// Slack, in seconds, on top of the pat period before a missed pat is treated as a deadline miss.
+    pub(crate) const TASK_GRACE_PERIOD: u16 = 4;
+
+    /// Interval, in seconds, at which the supervisor will check rx task watchdogs
+    pub(crate) const TASK_CHECK_PERIOD: u16 = Self::TASK_PAT_PERIOD + Self::TASK_GRACE_PERIOD;
+
+    /// Interval, in seconds, at which the supervisor checks rx task activity, ignoring watchdogs
+    pub(crate) const TASK_POLL_PERIOD: u16 = 1;
+
+    /// Max number of packets that a RX task will attempt to read in one go
+    pub(crate) const MAX_RX_PKT_BATCH: usize = 128;
+
     /// Spawn `num_workers` worker threads into `scope`, each with its own
     /// pipeline. Bails on the first spawn failure; workers that did spawn
     /// drain via the scope join.

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -16,6 +16,8 @@ mod fanout;
 mod kif;
 mod worker;
 
+use worker::WorkerId;
+
 use concurrency::sync::Arc;
 use concurrency::thread;
 #[allow(unused_imports)] // used under loom/shuttle backends
@@ -48,8 +50,10 @@ impl DriverKernel {
         num_workers: usize,
         setup_pipeline: &Arc<dyn Send + Sync + Fn() -> DynPipeline<TestBuffer>>,
         interfaces: &[Kif],
-    ) -> Result<Vec<thread::ScopedJoinHandle<'scope, Result<(), std::io::Error>>>, std::io::Error>
-    {
+    ) -> Result<
+        Vec<thread::ScopedJoinHandle<'scope, Result<WorkerId, (WorkerId, std::io::Error)>>>,
+        std::io::Error,
+    > {
         info!("Spawning {num_workers} workers");
         (0..num_workers)
             .map(|wid| {
@@ -93,18 +97,19 @@ impl DriverKernel {
             setup_pipeline,
             interfaces.as_slice(),
         )?;
+        debug_assert_eq!(worker_handles.len(), num_workers);
 
         // The supervisor just joins-and-logs; worker fatal reporting is
         // handled by the `ExitGuard` inside each worker thread.
         let supervisor_builder =
             thread::Builder::new().name("kernel-driver-supervisor".to_string());
+
         supervisor_builder.spawn_scoped(scope, move || {
-            for (id, handle) in worker_handles.into_iter().enumerate() {
-                info!("Waiting for worker {id} to finish");
+            for handle in worker_handles.into_iter() {
                 match handle.join() {
-                    Ok(Ok(())) => info!("Worker {id} exited successfully"),
-                    Ok(Err(e)) => error!("Worker {id} exited with error: {e}"),
-                    Err(panic_payload) => error!("Worker {id} panicked: {panic_payload:?}"),
+                    Ok(Ok(id)) => info!("Worker {id} exited successfully"),
+                    Ok(Err((id, e))) => error!("Worker {id} exited with error: {e}"),
+                    Err(panic_payload) => error!("Worker panicked: {panic_payload:?}"),
                 }
             }
             info!("All workers joined");

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -150,7 +150,6 @@ impl Worker {
     pub fn start<'scope>(
         &mut self,
         scope: &'scope thread::Scope<'scope, '_>,
-        thread_builder: thread::Builder,
         interfaces: &[Kif],
     ) -> Result<thread::ScopedJoinHandle<'scope, Result<(), io::Error>>, io::Error> {
         let id = self.id;
@@ -160,6 +159,7 @@ impl Worker {
         let cancel = subsystem.cancel_token();
         let interfaces = interfaces.to_vec();
 
+        let thread_builder = thread::Builder::new().name(format!("dp-worker-{id}"));
         let handle_res = thread_builder.spawn_scoped(scope, move || {
             info!(worker = id, "Worker started");
 

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -28,7 +28,7 @@ use crate::drivers::kernel::kif::Kif;
 
 use tracing::{debug, error, info, trace, warn};
 
-type WorkerId = usize;
+pub(crate) type WorkerId = usize;
 
 struct WorkerInterfaceWriter {
     if_name: String,
@@ -148,14 +148,15 @@ impl Worker {
 
     #[allow(clippy::too_many_lines)]
     pub fn start<'scope>(
-        &mut self,
+        self,
         scope: &'scope thread::Scope<'scope, '_>,
         interfaces: &[Kif],
-    ) -> Result<thread::ScopedJoinHandle<'scope, Result<(), io::Error>>, io::Error> {
+    ) -> Result<thread::ScopedJoinHandle<'scope, Result<WorkerId, (WorkerId, io::Error)>>, io::Error>
+    {
         let id = self.id;
         let total_workers = self.total_workers;
-        let setup = self.setup_pipeline.clone();
-        let subsystem = self.subsystem.clone();
+        let setup = self.setup_pipeline;
+        let subsystem = self.subsystem;
         let cancel = subsystem.cancel_token();
         let interfaces = interfaces.to_vec();
 
@@ -168,7 +169,8 @@ impl Worker {
 
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
-                .build_local(tokio::runtime::LocalOptions::default())?;
+                .build_local(tokio::runtime::LocalOptions::default())
+                .map_err(|e| (id, e))?;
 
             let result = rt.block_on(async {
                 let (readers, if_table) =
@@ -271,8 +273,8 @@ impl Worker {
                 guard.disarm();
             }
             info!(worker = id, "worker exited");
-            result?;
-            Ok::<(), io::Error>(())
+            result.map_err(|e| (id, e))?;
+            Ok::<WorkerId, (WorkerId, io::Error)>(id)
         })?;
         Ok(handle_res)
     }

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -17,7 +17,7 @@ use concurrency::sync::Arc;
 use concurrency::thread;
 #[allow(unused_imports)] // used under loom/shuttle backends
 use concurrency::thread::BuilderExt;
-use lifecycle::Subsystem;
+use lifecycle::{CancellationToken, Subsystem};
 use net::buffer::test_buffer::TestBuffer;
 use net::interface::InterfaceIndex;
 use net::packet::{DoneReason, Packet};
@@ -146,7 +146,82 @@ impl Worker {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    /// Spawn a task for a given worker `WorkerId` in the given `JoinSet` to read packets
+    /// from a single interface (`WorkerInterfaceReader`) and process them with a pipeline
+    /// built from `setup`. The task can be cancelled with the provided `CancellationToken`.
+    /// The interface table is used to send packets successfully processed over the right
+    /// interface (`WorkerInterfaceWriter`).
+    fn spawn_worker_interface_reader(
+        id: WorkerId,
+        intf: WorkerInterfaceReader,
+        reader_handles: &mut tokio::task::JoinSet<()>,
+        setup: Arc<dyn Fn() -> DynPipeline<TestBuffer> + Send + Sync>,
+        if_table: Arc<HashMap<InterfaceIndex, Arc<Mutex<WorkerInterfaceWriter>>>>,
+        cancel: CancellationToken,
+    ) {
+        reader_handles.spawn_local(async move {
+            let intf = intf;
+            let mut pipeline = setup();
+            loop {
+                debug!(worker = id, "awaiting packets");
+
+                let packets_vec = tokio::select! {
+                    () = cancel.cancelled() => {
+                        info!(
+                            worker = id,
+                            rx_intf_name = intf.if_name,
+                            "cancellation observed; exiting reader"
+                        );
+                        break;
+                    }
+                    result = read_packets_from_interface(id, &intf) => match result {
+                        Ok(packets) => packets,
+                        Err(e) => {
+                            error!(
+                                worker = id,
+                                rx_intf_name = intf.if_name,
+                                "Error reading packets from interface: {e}"
+                            );
+                            vec![]
+                        }
+                    }
+                };
+
+                debug!(
+                    worker = id,
+                    rx_intf_name = intf.if_name,
+                    "Read {} packets from interface {}",
+                    packets_vec.len(),
+                    intf.if_name
+                );
+
+                let packets = packets_vec.into_iter();
+
+                let mut count = 0;
+                let out_pkts = pipeline
+                    .process(packets.map(|pkt| *pkt))
+                    .collect::<Vec<_>>();
+                for out_pkt in out_pkts {
+                    trace!(
+                        worker = id,
+                        rx_intf_name = intf.if_name,
+                        "Tx packet after pipeline for interface {}",
+                        intf.if_name
+                    );
+                    tx_packet(id, &intf.if_name, &if_table, out_pkt).await;
+                    count += 1;
+                }
+
+                tracing::debug!(
+                    worker = id,
+                    rx_intf_name = intf.if_name,
+                    "processed {count} packets from interface {}",
+                    intf.if_name
+                );
+            }
+        });
+    }
+
     pub fn start<'scope>(
         self,
         scope: &'scope thread::Scope<'scope, '_>,
@@ -167,11 +242,13 @@ impl Worker {
             // create exit guard for this worker
             let mut guard = subsystem.new_exit_guard(format!("worker {id}"), true);
 
+            // each worker has its own tokio runtime
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build_local(tokio::runtime::LocalOptions::default())
                 .map_err(|e| (id, e))?;
 
+            // block on a single task to create and supervise all of this worker's interface readers
             let result = rt.block_on(async {
                 let (readers, if_table) =
                     match build_interface_table(id, total_workers, interfaces.as_slice()) {
@@ -182,77 +259,17 @@ impl Worker {
                         }
                     };
 
-                let setup = setup.clone();
-                let if_table = if_table.clone();
-                let cancel = cancel.clone();
-
+                // spawn a task to read from each interface
                 let mut reader_handles = tokio::task::JoinSet::new();
-
                 for intf in readers {
-                    let setup = setup.clone();
-                    let if_table = if_table.clone();
-                    let cancel = cancel.clone();
-                    reader_handles.spawn_local(async move {
-                        let intf = intf;
-                        let mut pipeline = setup();
-                        loop {
-                            debug!(worker = id, "awaiting packets");
-
-                            let packets_vec = tokio::select! {
-                                () = cancel.cancelled() => {
-                                    info!(
-                                        worker = id,
-                                        rx_intf_name = intf.if_name,
-                                        "cancellation observed; exiting reader"
-                                    );
-                                    break;
-                                }
-                                result = read_packets_from_interface(id, &intf) => match result {
-                                    Ok(packets) => packets,
-                                    Err(e) => {
-                                        error!(
-                                            worker = id,
-                                            rx_intf_name = intf.if_name,
-                                            "Error reading packets from interface: {e}"
-                                        );
-                                        vec![]
-                                    }
-                                }
-                            };
-
-                            debug!(
-                                worker = id,
-                                rx_intf_name = intf.if_name,
-                                "Read {} packets from interface {}",
-                                packets_vec.len(),
-                                intf.if_name
-                            );
-
-                            let packets = packets_vec.into_iter();
-
-                            let mut count = 0;
-                            let out_pkts = pipeline
-                                .process(packets.map(|pkt| *pkt))
-                                .collect::<Vec<_>>();
-                            for out_pkt in out_pkts {
-                                trace!(
-                                    worker = id,
-                                    rx_intf_name = intf.if_name,
-                                    "Tx packet after pipeline for interface {}",
-                                    intf.if_name
-                                );
-                                tx_packet(id, &intf.if_name, &if_table, out_pkt).await;
-                                count += 1;
-                            }
-
-                            tracing::debug!(
-                                worker = id,
-                                rx_intf_name = intf.if_name,
-                                "processed {count} packets from interface {}",
-                                intf.if_name
-                            );
-                        }
-                    });
+                    Self::spawn_worker_interface_reader(
+                        id,
+                        intf,
+                        &mut reader_handles,
+                        setup.clone(),
+                        if_table.clone(),
+                        cancel.clone(),
+                    );
                 }
 
                 // Wait for all reader handles to complete

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -12,6 +12,7 @@ use afpacket::tokio::RawPacketStream;
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncWriteExt, Interest};
 use tokio::sync::Mutex;
+use tokio::time::{Duration, interval};
 
 use concurrency::sync::Arc;
 use concurrency::thread;
@@ -23,12 +24,14 @@ use net::interface::InterfaceIndex;
 use net::packet::{DoneReason, Packet};
 use pipeline::{DynPipeline, NetworkFunction};
 
+use crate::drivers::kernel::DriverKernel;
 use crate::drivers::kernel::fanout::{PacketFanoutType, set_packet_fanout};
 use crate::drivers::kernel::kif::Kif;
+use crate::drivers::kernel::{WorkerIfaceMonitor, WorkerMonitor};
+use crate::drivers::status::WorkerId;
+use crate::drivers::watchdog::Watchdog;
 
 use tracing::{debug, error, info, trace, warn};
-
-pub(crate) type WorkerId = usize;
 
 struct WorkerInterfaceWriter {
     if_name: String,
@@ -41,17 +44,20 @@ struct WorkerInterfaceReader {
     if_name: String,
     if_index: InterfaceIndex,
     read_fd: AsyncFd<std::os::unix::io::OwnedFd>,
+    watchdog: Watchdog,
 }
 
 type WorkerInterfaceReaders = Vec<WorkerInterfaceReader>;
 type WorkerIfTable = HashMap<InterfaceIndex, Arc<Mutex<WorkerInterfaceWriter>>>;
 
 #[allow(unsafe_code)]
+/// This function must be called from a tokio context
 fn create_worker_interface(
     id: WorkerId,
     total_workers: usize,
     if_name: &str,
     if_index: InterfaceIndex,
+    watchdog: Watchdog,
 ) -> io::Result<(WorkerInterfaceWriter, WorkerInterfaceReader)> {
     let mut sock = RawPacketStream::new()?;
     sock.bind(if_name)
@@ -120,6 +126,7 @@ fn create_worker_interface(
             if_name: String::from(if_name),
             if_index,
             read_fd,
+            watchdog,
         },
     ))
 }
@@ -159,9 +166,13 @@ impl Worker {
         if_table: Arc<HashMap<InterfaceIndex, Arc<Mutex<WorkerInterfaceWriter>>>>,
         cancel: CancellationToken,
     ) {
+        // the interval at which we'll pat the watchdog if there is no activity on the socket
+        let pat_period = Duration::from_secs(u64::from(DriverKernel::TASK_PAT_PERIOD));
+
         reader_handles.spawn_local(async move {
             let intf = intf;
             let mut pipeline = setup();
+            let mut ticker = interval(pat_period);
             loop {
                 debug!(worker = id, "awaiting packets");
 
@@ -173,7 +184,7 @@ impl Worker {
                             "cancellation observed; exiting reader"
                         );
                         break;
-                    }
+                    },
                     result = read_packets_from_interface(id, &intf) => match result {
                         Ok(packets) => packets,
                         Err(e) => {
@@ -182,8 +193,14 @@ impl Worker {
                                 rx_intf_name = intf.if_name,
                                 "Error reading packets from interface: {e}"
                             );
-                            vec![]
+                            continue;
                         }
+                    },
+                    // N.B. read_packets_from_interface() MUST be cancel-safe for this wake-up not to
+                    // cause packet loss. It currently is.
+                    _ = ticker.tick() => {
+                        intf.watchdog.pat();
+                        continue;
                     }
                 };
 
@@ -195,29 +212,73 @@ impl Worker {
                     intf.if_name
                 );
 
-                let packets = packets_vec.into_iter();
+                let mut tx_pkts: u64 = 0; // number of packets successfully sent
+                let mut tx_drops: u64 = 0; // number of packets dropped on tx
+                let rx_pkts = packets_vec.len() as u64; // number of packets received
+                if rx_pkts == 0 {
+                    // skip any further processing
+                    continue;
+                }
 
-                let mut count = 0;
+                let packets = packets_vec.into_iter();
                 let out_pkts = pipeline
                     .process(packets.map(|pkt| *pkt))
                     .collect::<Vec<_>>();
+
+                // Computing the number of packets dropped by pipeline.
+                // The pipeline may not return to the driver all of the packets it was fed with,
+                // since it may drop some (e.g. due to routing, filtering, etc.). So, the number of
+                // packets dropped in a batch can be computed as `rx_pkts - out_pkts.len() as u64`.
+                // However, this assumes that the pipeline does not generate new packets.
+                // With the packet injection, it may happen that the pipeline outputs more packets
+                // than it was fed with. So, the injection of N packets could mask the drop of N packets
+                // by the pipeline if computed that way.
+                // The number of packets output by the pipeline in a batch is
+                //    out_pkts = in_pkts + injected_pkts - dropped
+                // So, we can compute the number of packets dropped by the pipeline as
+                //    dropped = in_pkts + injected_pkts - out_pkts
+                //
+                // Now, we can't know, here, the number of packets that were injected and those
+                // packets may be dropped by the pipeline as well. In these stats, we mostly care about
+                // incoming packets that got dropped. So, if `injected_pkts` is the number of injected
+                // packets OBSERVED at the output of the pipeline, then `dropped` is the number of packets
+                // received and dropped by the pipeline.
+                // This requires the ability to tell if an ouput packet was injected, which we'll have
+                // as those packets will be annotated.
+
+                // send each of the packets
+                let mut injected: u64 = 0;
+                let output_by_pipeline: u64 = out_pkts.len() as u64;
                 for out_pkt in out_pkts {
+                    if false {
+                        /* packet was injected by us */
+                        injected += 1;
+                    }
                     trace!(
                         worker = id,
                         rx_intf_name = intf.if_name,
                         "Tx packet after pipeline for interface {}",
                         intf.if_name
                     );
-                    tx_packet(id, &intf.if_name, &if_table, out_pkt).await;
-                    count += 1;
+                    if tx_packet(id, &intf.if_name, &if_table, out_pkt).await {
+                        tx_pkts += 1;
+                    } else {
+                        tx_drops += 1;
+                    }
                 }
+
+                let ppline_drops = rx_pkts + injected - output_by_pipeline;
 
                 tracing::debug!(
                     worker = id,
                     rx_intf_name = intf.if_name,
-                    "processed {count} packets from interface {}",
+                    "processed {tx_pkts} packets from interface {}",
                     intf.if_name
                 );
+
+                // update rx task stats
+                intf.watchdog
+                    .record(rx_pkts, tx_pkts, ppline_drops, tx_drops);
             }
         });
     }
@@ -226,14 +287,24 @@ impl Worker {
         self,
         scope: &'scope thread::Scope<'scope, '_>,
         interfaces: &[Kif],
-    ) -> Result<thread::ScopedJoinHandle<'scope, Result<WorkerId, (WorkerId, io::Error)>>, io::Error>
-    {
+    ) -> Result<WorkerMonitor<'scope>, io::Error> {
         let id = self.id;
         let total_workers = self.total_workers;
         let setup = self.setup_pipeline;
         let subsystem = self.subsystem;
         let cancel = subsystem.cancel_token();
         let interfaces = interfaces.to_vec();
+
+        // Create vector of `WorkerIfaceMonitor` with the watchdogs. We'll hand a watchdog to each
+        // interface reader and pass this vector along with the `WorkerMonitor` returned for this `Worker`
+        // for the supervisor to check. Ideally we'd create the watchdogs in the interface readers and
+        // collect them. However build_interface_table() needs to be called from the worker's tokio runtime
+        let ifmonitors: Vec<_> = interfaces
+            .iter()
+            .map(|kif| WorkerIfaceMonitor::new(&kif.name))
+            .collect();
+
+        let worker_ifmonitors = ifmonitors.clone();
 
         let thread_builder = thread::Builder::new().name(format!("dp-worker-{id}"));
         let handle_res = thread_builder.spawn_scoped(scope, move || {
@@ -245,21 +316,25 @@ impl Worker {
             // each worker has its own tokio runtime
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
-                .build_local(tokio::runtime::LocalOptions::default())
-                .map_err(|e| (id, e))?;
+                .build_local(tokio::runtime::LocalOptions::default())?;
 
             // block on a single task to create and supervise all of this worker's interface readers
             let result = rt.block_on(async {
-                let (readers, if_table) =
-                    match build_interface_table(id, total_workers, interfaces.as_slice()) {
-                        Ok(table) => table,
-                        Err(e) => {
-                            error!(worker = id, "Error building interface table: {}", e);
-                            return Err(e);
-                        }
-                    };
+                // Build readers for interfaces and this worker's interface table
+                let (readers, if_table) = match build_interface_table(
+                    id,
+                    total_workers,
+                    interfaces.as_slice(),
+                    &worker_ifmonitors,
+                ) {
+                    Ok(table) => table,
+                    Err(e) => {
+                        error!(worker = id, "Error building interface table: {}", e);
+                        return Err(e);
+                    }
+                };
 
-                // spawn a task to read from each interface
+                // spawn tasks to read from each interface
                 let mut reader_handles = tokio::task::JoinSet::new();
                 for intf in readers {
                     Self::spawn_worker_interface_reader(
@@ -290,10 +365,11 @@ impl Worker {
                 guard.disarm();
             }
             info!(worker = id, "worker exited");
-            result.map_err(|e| (id, e))?;
-            Ok::<WorkerId, (WorkerId, io::Error)>(id)
+            result?;
+            Ok::<(), io::Error>(())
         })?;
-        Ok(handle_res)
+        let monitor = WorkerMonitor::new(id, handle_res, ifmonitors);
+        Ok(monitor)
     }
 }
 
@@ -301,11 +377,21 @@ fn build_interface_table(
     id: WorkerId,
     total_workers: usize,
     interfaces: &[Kif],
+    ifmonitors: &[WorkerIfaceMonitor],
 ) -> Result<(WorkerInterfaceReaders, Arc<WorkerIfTable>), io::Error> {
     let mut if_table = HashMap::new();
     let mut readers = Vec::new();
     for kif in interfaces {
-        let (writer, reader) = create_worker_interface(id, total_workers, &kif.name, kif.ifindex)?;
+        // find the watchdog for this interface
+        let watchdog = ifmonitors
+            .iter()
+            .find(|ifm| ifm.ifname.as_ref() == kif.name.as_str())
+            .map(|ifm| ifm.watchdog.clone())
+            .ok_or(io::Error::other("Failed to find interface watchdog"))?;
+
+        let (writer, reader) =
+            create_worker_interface(id, total_workers, &kif.name, kif.ifindex, watchdog)?;
+
         if_table.insert(kif.ifindex, Arc::new(Mutex::new(writer)));
         readers.push(reader);
     }
@@ -392,20 +478,23 @@ async fn read_packets_from_interface(
             return Err(e);
         }
     };
+    // pat the watchdog
+    intf.watchdog.pat();
+
     if !guard.ready().is_readable() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::WouldBlock,
             "Would block",
         ));
     }
-    let mut pkts = Vec::with_capacity(128);
+    let mut pkts = Vec::with_capacity(DriverKernel::MAX_RX_PKT_BATCH);
     match guard.try_io(|fd| {
         packet_recv(
             id,
             intf.if_name.as_str(),
             fd.as_raw_fd(),
             intf.if_index,
-            128,
+            DriverKernel::MAX_RX_PKT_BATCH,
             &mut pkts,
         )
         .map_err(std::convert::Into::into)
@@ -441,7 +530,7 @@ async fn tx_packet(
     rx_if_name: &str,
     if_table: &WorkerIfTable,
     pkt: Packet<TestBuffer>,
-) {
+) -> bool {
     // get outgoing interface marking. Should have one, except if packet is to be dropped.
     let Some(oif) = pkt.meta().oif else {
         match pkt.get_done() {
@@ -462,7 +551,7 @@ async fn tx_packet(
             }
             None => {} // drop impl of packet meta will log
         }
-        return;
+        return false;
     };
     // lookup interface
     let Some(outgoing_unlocked) = if_table.get(&oif) else {
@@ -472,7 +561,7 @@ async fn tx_packet(
             "TX drop: unknown oif {} (driver bug)",
             oif
         );
-        return;
+        return false;
     };
 
     // serialize and xmit
@@ -493,14 +582,15 @@ async fn tx_packet(
                     "TX failed for pkt ({len} octets) on interface '{}': {e}",
                     &outgoing.if_name
                 );
-            } else {
-                trace!(
-                    worker = id,
-                    rx_intf_name = rx_if_name,
-                    "TX {len} bytes on interface {}",
-                    &outgoing.if_name
-                );
+                return false;
             }
+            trace!(
+                worker = id,
+                rx_intf_name = rx_if_name,
+                "TX {len} bytes on interface {}",
+                &outgoing.if_name
+            );
+            true
         }
         Err(e) => {
             warn!(
@@ -508,6 +598,7 @@ async fn tx_packet(
                 rx_intf_name = rx_if_name,
                 "Serialize failed: {e:?}"
             );
+            false
         }
     }
 }

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -225,6 +225,9 @@ impl Worker {
                     .process(packets.map(|pkt| *pkt))
                     .collect::<Vec<_>>();
 
+                // number of packets output by pipeline
+                let num_out_pkts: u64 = out_pkts.len() as u64;
+
                 // Computing the number of packets dropped by pipeline.
                 // The pipeline may not return to the driver all of the packets it was fed with,
                 // since it may drop some (e.g. due to routing, filtering, etc.). So, the number of
@@ -234,9 +237,9 @@ impl Worker {
                 // than it was fed with. So, the injection of N packets could mask the drop of N packets
                 // by the pipeline if computed that way.
                 // The number of packets output by the pipeline in a batch is
-                //    out_pkts = in_pkts + injected_pkts - dropped
+                //    num_out_pkts = in_pkts + injected_pkts - dropped
                 // So, we can compute the number of packets dropped by the pipeline as
-                //    dropped = in_pkts + injected_pkts - out_pkts
+                //    dropped = in_pkts + injected_pkts - num_out_pkts
                 //
                 // Now, we can't know, here, the number of packets that were injected and those
                 // packets may be dropped by the pipeline as well. In these stats, we mostly care about
@@ -245,21 +248,18 @@ impl Worker {
                 // received and dropped by the pipeline.
                 // This requires the ability to tell if an ouput packet was injected, which we'll have
                 // as those packets will be annotated.
+                //
+                // An alternative to the above would be to let the pipeline not to drop any packet
+                // (currently, the last stage of stats does the actual drop). But that means that
+                // drivers would get packets that they should not transmit and they should decide.
+
+                let mut injected: u64 = 0;
 
                 // send each of the packets
-                let mut injected: u64 = 0;
-                let output_by_pipeline: u64 = out_pkts.len() as u64;
                 for out_pkt in out_pkts {
                     if false {
-                        /* packet was injected by us */
-                        injected += 1;
+                        injected += 1; // packet wasn't received but injected by pipeline
                     }
-                    trace!(
-                        worker = id,
-                        rx_intf_name = intf.if_name,
-                        "Tx packet after pipeline for interface {}",
-                        intf.if_name
-                    );
                     if tx_packet(id, &intf.if_name, &if_table, out_pkt).await {
                         tx_pkts += 1;
                     } else {
@@ -267,13 +267,12 @@ impl Worker {
                     }
                 }
 
-                let ppline_drops = rx_pkts + injected - output_by_pipeline;
+                let ppline_drops = rx_pkts + injected - num_out_pkts;
 
                 tracing::debug!(
                     worker = id,
                     rx_intf_name = intf.if_name,
-                    "processed {tx_pkts} packets from interface {}",
-                    intf.if_name
+                    "Sent {tx_pkts} packets out of {num_out_pkts}, dropped {tx_drops}",
                 );
 
                 // update rx task stats

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -161,38 +161,10 @@ impl Worker {
         let interfaces = interfaces.to_vec();
 
         let handle_res = thread_builder.spawn_scoped(scope, move || {
-            // Drop-guard so panic-unwind, early-`?`, and unexpected normal
-            // return all reach report_fatal. Disarmed on the graceful path.
-            struct ExitGuard {
-                subsystem: Subsystem,
-                id: WorkerId,
-                armed: bool,
-            }
-            impl ExitGuard {
-                fn disarm(&mut self) {
-                    self.armed = false;
-                }
-            }
-            impl Drop for ExitGuard {
-                fn drop(&mut self) {
-                    if !self.armed || self.subsystem.is_cancelled() {
-                        return;
-                    }
-                    let reason = if std::thread::panicking() {
-                        format!("worker {} panicked", self.id)
-                    } else {
-                        format!("worker {} exited unexpectedly", self.id)
-                    };
-                    self.subsystem.report_fatal(&reason);
-                }
-            }
-
             info!(worker = id, "Worker started");
-            let mut guard = ExitGuard {
-                subsystem: subsystem.clone(),
-                id,
-                armed: true,
-            };
+
+            // create exit guard for this worker
+            let mut guard = subsystem.new_exit_guard(format!("worker {id}"), true);
 
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()

--- a/dataplane/src/drivers/mod.rs
+++ b/dataplane/src/drivers/mod.rs
@@ -4,6 +4,8 @@
 use thiserror::Error;
 
 pub mod kernel;
+pub mod status;
+pub mod watchdog;
 
 #[derive(Error, Debug)]
 pub enum DriverError {

--- a/dataplane/src/drivers/status.rs
+++ b/dataplane/src/drivers/status.rs
@@ -133,7 +133,7 @@ impl Display for WorkerState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             WorkerState::Running => write!(f, "running"),
-            WorkerState::Terminated(res) => write!(f, "Terminated, result: {res}"),
+            WorkerState::Terminated(res) => write!(f, "Terminated({res})"),
         }
     }
 }

--- a/dataplane/src/drivers/status.rs
+++ b/dataplane/src/drivers/status.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Driver status, published by the supervisor
+//! Ideally, these types would not depend on the type of driver.
+//!
+//! The supervisor is the sole writer: once per check it builds a fresh
+//! [`DriverStatus`] and publishes it through a [`DriverStatusWriter`].
+
+use common::cliprovider::{CliDataProvider, Heading};
+use concurrency::slot::Slot;
+use concurrency::sync::Arc;
+
+use std::fmt::Display;
+
+use crate::drivers::kernel::DriverKernel;
+use crate::drivers::watchdog::Activity;
+
+// The unique Id of a worker
+pub(crate) type WorkerId = usize;
+
+/// Liveness/activity of one rx task (a worker's reader for one interface),
+/// as of the supervisor's last check.
+#[derive(Clone)]
+pub struct RxTaskStatus {
+    pub ifname: Arc<str>,
+    pub activity: Activity,
+    pub misses: u64,
+    pub total_rx: u64,
+    pub total_tx: u64,
+    pub total_ppline_drops: u64,
+    pub total_tx_drops: u64,
+    pub pps: f64,
+}
+impl RxTaskStatus {
+    #[must_use]
+    pub fn new(ifname: Arc<str>) -> Self {
+        Self {
+            ifname,
+            activity: Activity::Idle,
+            misses: 0,
+            total_rx: 0,
+            total_tx: 0,
+            total_ppline_drops: 0,
+            total_tx_drops: 0,
+            pps: 0.,
+        }
+    }
+}
+
+/// Whether a worker thread is still running or has been joined.
+#[derive(Clone)]
+pub enum WorkerState {
+    Running,
+    Terminated(WorkerEndResult),
+}
+
+/// How a worker thread ended (result when joined)
+#[derive(Clone)]
+pub enum WorkerEndResult {
+    Ok,
+    Failed(String),
+    Panicked(String),
+}
+
+/// Per-worker status: its thread state plus its rx tasks' activity.
+#[derive(Clone)]
+pub struct WorkerStatus {
+    pub worker: WorkerId,
+    pub state: WorkerState,
+    pub rx_tasks: Vec<RxTaskStatus>,
+}
+impl WorkerStatus {
+    #[must_use]
+    pub fn new(worker: WorkerId) -> Self {
+        Self {
+            worker,
+            state: WorkerState::Running,
+            rx_tasks: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DriverStatus {
+    pub workers: Vec<WorkerStatus>,
+}
+
+// ====== Types for sharing DriverStatus ===== //
+
+pub struct DriverStatusWriter(Arc<Slot<DriverStatus>>);
+impl DriverStatusWriter {
+    pub fn publish(&self, status: DriverStatus) {
+        self.0.store(Arc::new(status));
+    }
+}
+
+#[derive(Clone)]
+pub struct DriverStatusReader(Arc<Slot<DriverStatus>>);
+impl DriverStatusReader {
+    #[must_use]
+    pub fn load(&self) -> Arc<DriverStatus> {
+        self.0.load_full()
+    }
+}
+
+#[must_use]
+pub fn driver_status_access() -> (DriverStatusWriter, DriverStatusReader) {
+    let slot = Arc::new(Slot::from_pointee(DriverStatus::default()));
+    (DriverStatusWriter(slot.clone()), DriverStatusReader(slot))
+}
+
+impl CliDataProvider for DriverStatusReader {
+    fn provide(&self) -> String {
+        let status = self.load();
+        status.to_string()
+    }
+}
+
+// === Display impls === //
+
+impl Display for WorkerEndResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerEndResult::Ok => write!(f, "Ok"),
+            WorkerEndResult::Failed(s) => write!(f, "Failed: {s}"),
+            WorkerEndResult::Panicked(s) => write!(f, "Panicked: {s}"),
+        }
+    }
+}
+
+impl Display for WorkerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerState::Running => write!(f, "running"),
+            WorkerState::Terminated(res) => write!(f, "Terminated, result: {res}"),
+        }
+    }
+}
+
+macro_rules! RX_TASK_TBL_FMT {
+    () => {
+        "   {:<16}  {:<6}  {:>14}  {:>20}  {:>20}  {:>12}  {:>8}  {:>9}"
+    };
+}
+
+fn fmt_rx_task_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            RX_TASK_TBL_FMT!(),
+            "iface", "status", "pps", "pkt-rx", "pkt-tx", "ppline-drops", "tx-drops", "wd-misses"
+        )
+    )
+}
+
+fn fmt_rx_task(f: &mut std::fmt::Formatter<'_>, rx: &RxTaskStatus) -> std::fmt::Result {
+    let pps = format!("{:.1}", rx.pps);
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            RX_TASK_TBL_FMT!(),
+            rx.ifname,
+            rx.activity,
+            pps,
+            rx.total_rx,
+            rx.total_tx,
+            rx.total_ppline_drops,
+            rx.total_tx_drops,
+            rx.misses
+        )
+    )
+}
+
+impl Display for DriverStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Heading("Packet driver status").fmt(f)?;
+        writeln!(f, " max rx batch: {} pkts", DriverKernel::MAX_RX_PKT_BATCH)?;
+        write!(f, " activity poll: {} s", DriverKernel::TASK_POLL_PERIOD)?;
+        write!(f, "  watchdog pat: {} s", DriverKernel::TASK_PAT_PERIOD)?;
+        writeln!(f, "  watchdog check: {} s", DriverKernel::TASK_CHECK_PERIOD)?;
+
+        writeln!(f)?;
+        if self.workers.is_empty() {
+            return writeln!(f, " (no workers)");
+        }
+
+        fmt_rx_task_heading(f)?;
+        for worker in &self.workers {
+            writeln!(f, " worker {}: {}", worker.worker, worker.state)?;
+            for rx in &worker.rx_tasks {
+                fmt_rx_task(f, rx)?;
+            }
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+}

--- a/dataplane/src/drivers/watchdog.rs
+++ b/dataplane/src/drivers/watchdog.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Liveness and activity watchdog for the drivers' rx tasks.
+//!
+//! Each rx task holds a [`Watchdog`] clone and reports on it: [`Watchdog::pat`]
+//! as evidence that its loop was scheduled, [`Watchdog::record`] for the packets
+//! it moved. The driver's supervisor consumes both with
+//! [`Watchdog::check_and_clear`].
+
+#![deny(
+    unsafe_code,
+    clippy::all,
+    clippy::pedantic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+use concurrency::sync::Arc;
+use concurrency::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// The actual state of a `Watchdog`, shared by supervisor and a rx task.
+/// The supervisor arms the `Watchdog`. The rx task pats it and updates the
+/// stats. The stats/armed flag are flushed when read by the supervisor.
+/// So, all of the state in a `Watchdog` is somewhat ephemeral.
+#[derive(Default)]
+struct WatchdogInner {
+    armed: AtomicBool,       // false => watchdog was patted
+    rx: AtomicU64,           // number of packets received by task
+    tx: AtomicU64,           // number of packets sent by task
+    ppline_drops: AtomicU64, // number of packets dropped by task pipeline
+    tx_drops: AtomicU64,     // number of tx failures
+}
+
+/// A lock-free liveness + activity watchdog.
+#[derive(Clone, Default)]
+pub struct Watchdog(Arc<WatchdogInner>);
+
+impl Watchdog {
+    /// Create a new [`Watchdog`] in the "patted, idle" state
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Task: clear the liveness flag, providing evidence the loop was scheduled.
+    pub fn pat(&self) {
+        self.0.armed.store(false, Ordering::Relaxed);
+    }
+
+    /// Task: record packets rx and tx
+    pub fn record(&self, rx: u64, tx: u64, ppline_drops: u64, tx_drops: u64) {
+        if rx > 0 {
+            let _ = self
+                .0
+                .rx
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_add(rx))
+                });
+        }
+        if tx > 0 {
+            let _ = self
+                .0
+                .tx
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_add(tx))
+                });
+        }
+        if ppline_drops > 0 {
+            let _ = self
+                .0
+                .ppline_drops
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_add(ppline_drops))
+                });
+        }
+        if tx_drops > 0 {
+            let _ = self
+                .0
+                .tx_drops
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    Some(v.saturating_add(tx_drops))
+                });
+        }
+    }
+
+    /// Supervisor: check the activity count of a watchdog (and zero it).
+    /// If `check_and_rearm` is true, check if the watchdog was patted and
+    /// re-arm it. The status is abstracted in [`Activity`]. If `check_and_rearm`
+    /// is false, the watchdog check (and re-arm) is omitted, meaning that this
+    /// method will never return `Activity::Stuck` in that case.
+    #[must_use]
+    pub fn check_and_clear(&self, check_and_rearm: bool) -> Activity {
+        let record = ActivityRecord {
+            rx: self.0.rx.swap(0, Ordering::Relaxed),
+            tx: self.0.tx.swap(0, Ordering::Relaxed),
+            ppline_drops: self.0.ppline_drops.swap(0, Ordering::Relaxed),
+            tx_drops: self.0.tx_drops.swap(0, Ordering::Relaxed),
+        };
+        let patted = if check_and_rearm {
+            !self.0.armed.swap(true, Ordering::Relaxed)
+        } else {
+            true // assume it was patted since we don't check/care
+        };
+        if record.rx > 0 {
+            Activity::Active(record)
+        } else if patted {
+            Activity::Idle
+        } else {
+            debug_assert!(check_and_rearm);
+            Activity::Stuck
+        }
+    }
+}
+
+/// The state of a [`Watchdog`] as observed by a supervisor when it checks it [`Watchdog::check_and_clear`].
+#[derive(Clone)]
+pub enum Activity {
+    /// Watchdog was not patted
+    Stuck,
+    /// Watchdog was patted but task reported no work
+    Idle,
+    /// Task reported progress
+    Active(ActivityRecord),
+}
+
+/// An activity record from a workers' rx task
+#[derive(Debug, Clone)]
+pub struct ActivityRecord {
+    /// Pkts received
+    pub rx: u64,
+    /// Pkts successfully tx'ed
+    pub tx: u64,
+    /// Pkts received that the pipeline dropped
+    pub ppline_drops: u64,
+    /// Pkts received dropped on tx
+    pub tx_drops: u64,
+}
+
+impl std::fmt::Display for Activity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(match self {
+            Activity::Stuck => "Stuck!",
+            Activity::Idle => "Idle",
+            Activity::Active(_) => "Active",
+        })
+    }
+}

--- a/dataplane/src/packet_processor/egress.rs
+++ b/dataplane/src/packet_processor/egress.rs
@@ -157,6 +157,9 @@ impl Egress {
             self.get_adj_mac(packet, destination, ifindex)
         } else {
             warn!("{nfi}: could not determine packet destination IP address");
+            // This should be a bug because if a packet was not IP, we'd have
+            // already determined that we could not process it.
+            packet.done(DoneReason::NotIp);
             None
         }
     }

--- a/dataplane/src/packet_processor/mod.rs
+++ b/dataplane/src/packet_processor/mod.rs
@@ -5,6 +5,7 @@ mod egress;
 mod ingress;
 mod ipforward;
 
+use super::drivers::status::DriverStatusReader;
 #[allow(unused)]
 use super::packet_processor::egress::Egress;
 use super::packet_processor::ingress::Ingress;
@@ -53,6 +54,7 @@ where
 pub(crate) fn start_router<Buf: PacketBufferMut>(
     router: &lifecycle::Subsystem,
     params: RouterParams,
+    driver_status: DriverStatusReader,
 ) -> Result<InternalSetup<Buf>, RouterError> {
     let vpcmapw = VpcMapWriter::<VpcMapName>::new();
     let vpc_stats_store: Arc<VpcStatsStore> = VpcStatsStore::new();
@@ -85,6 +87,7 @@ pub(crate) fn start_router<Buf: PacketBufferMut>(
         nat_tables: Some(Box::new(nattabler_factory.handle().inner())),
         masquerade_state: Some(Box::new(natallocator_factory.handle().inner())),
         pkt_stats: Some(Box::new(pkt_stats.clone())),
+        driver_status: Some(Box::new(driver_status)),
     };
 
     // create router

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -6,6 +6,7 @@ use crate::statistics::spawn_metrics;
 use args::{CmdArgs, Parser};
 
 use crate::drivers::kernel::DriverKernel;
+use crate::drivers::status::driver_status_access;
 use lifecycle::{
     CancellationToken, DpSignal, Shutdown, default_deadlines, spawn_shutdown_watchdog,
 };
@@ -239,6 +240,8 @@ pub fn main() {
 
     process_tracing_cmds(&args);
 
+    let (driver_status_writer, driver_status_reader) = driver_status_access();
+
     let shutdown = Shutdown::new();
 
     let mgmt_runtime = tokio::runtime::Builder::new_multi_thread()
@@ -269,7 +272,8 @@ pub fn main() {
     };
 
     // start router
-    let mut setup = start_router(&shutdown.router, router_params).expect("failed to start router");
+    let mut setup = start_router(&shutdown.router, router_params, driver_status_reader)
+        .expect("failed to start router");
 
     // start bmp server if indicated via cmd line. It is fine to start it after the router since no bgp session may be up
     // until a configuration is applied, and the mgmt is not yet up.
@@ -336,6 +340,7 @@ pub fn main() {
                             args.kernel_interfaces(),
                             args.kernel_num_workers(),
                             &pipeline_factory,
+                            driver_status_writer,
                         ))
                     }
                     other => {

--- a/lifecycle/src/lib.rs
+++ b/lifecycle/src/lib.rs
@@ -18,6 +18,9 @@
     clippy::panic
 )]
 
+pub mod utils;
+pub use utils::ExitGuard;
+
 use concurrency::sync::Arc;
 use concurrency::sync::atomic::{AtomicBool, Ordering};
 use std::future::Future;

--- a/lifecycle/src/utils.rs
+++ b/lifecycle/src/utils.rs
@@ -4,7 +4,6 @@
 //! Utils for task lifecycle management
 
 use super::Subsystem;
-use tracing::error;
 
 /// Drop-guard so panic-unwind, early-`?`, and unexpected normal return
 /// all reach [`Subsystem::report_fatal`]. The guard can be disarmed by calling
@@ -39,6 +38,7 @@ impl ExitGuard {
         self.armed = false;
     }
 }
+
 impl Drop for ExitGuard {
     fn drop(&mut self) {
         if !self.armed || self.subsystem.is_cancelled() {
@@ -49,7 +49,6 @@ impl Drop for ExitGuard {
         } else {
             format!("{} ({}) exited unexpectedly", self.id, self.subsystem.name)
         };
-        error!("{reason}. Reporting...");
         self.subsystem.report_fatal(&reason);
     }
 }

--- a/lifecycle/src/utils.rs
+++ b/lifecycle/src/utils.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Utils for task lifecycle management
+
+use super::Subsystem;
+use tracing::error;
+
+/// Drop-guard so panic-unwind, early-`?`, and unexpected normal return
+/// all reach [`Subsystem::report_fatal`]. The guard can be disarmed by calling
+/// `Self::disarm`  on graceful shutdown paths.
+pub struct ExitGuard {
+    subsystem: Subsystem,
+    id: String,
+    armed: bool,
+}
+
+impl Subsystem {
+    /// Get an [`ExitGuard`] bound to a [`Subsystem`]
+    #[must_use]
+    pub fn new_exit_guard(&self, id: String, armed: bool) -> ExitGuard {
+        ExitGuard::new(self.clone(), id, armed)
+    }
+}
+
+impl ExitGuard {
+    /// Create an [`ExitGuard`]
+    #[must_use]
+    fn new(subsystem: Subsystem, id: String, armed: bool) -> Self {
+        Self {
+            subsystem,
+            id,
+            armed,
+        }
+    }
+    /// Disarm an [`ExitGuard`], which inhibits the report
+    /// of a fatal error if the guard is dropped.
+    pub fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        if !self.armed || self.subsystem.is_cancelled() {
+            return;
+        }
+        let reason = if std::thread::panicking() {
+            format!("{} ({}) panicked", self.id, self.subsystem.name)
+        } else {
+            format!("{} ({}) exited unexpectedly", self.id, self.subsystem.name)
+        };
+        error!("{reason}. Reporting...");
+        self.subsystem.report_fatal(&reason);
+    }
+}

--- a/routing/src/cli/handler.rs
+++ b/routing/src/cli/handler.rs
@@ -527,6 +527,7 @@ fn do_handle_cli_request(
         CliAction::ShowStaticNat => show_provider(request, sources.nat_tables.as_deref()),
         CliAction::ShowMasquerading => show_provider(request, sources.masquerade_state.as_deref()),
         CliAction::ShowPacketStats => show_provider(request, sources.pkt_stats.as_deref()),
+        CliAction::ShowDriverStatus => show_provider(request, sources.driver_status.as_deref()),
         _ => Err(CliError::NotSupported("Not implemented yet".to_string()))?,
     };
     Ok(response)

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -64,6 +64,7 @@ pub struct CliSources {
     pub nat_tables: Option<Box<dyn CliDataProvider + Send>>,
     pub masquerade_state: Option<Box<dyn CliDataProvider + Send>>,
     pub pkt_stats: Option<Box<dyn CliDataProvider + Send>>,
+    pub driver_status: Option<Box<dyn CliDataProvider + Send>>,
 }
 
 impl Display for RouterParams {

--- a/routing/src/router/mod.rs
+++ b/routing/src/router/mod.rs
@@ -14,7 +14,7 @@ use common::cliprovider::CliDataProvider;
 use derive_builder::Builder;
 use std::fmt::Display;
 use std::path::PathBuf;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 // sockets
 use std::net::SocketAddr;
@@ -159,7 +159,7 @@ impl Router {
         }
         self.resolver.stop();
 
-        debug!("Router '{}' is now stopped", self.name);
+        info!("Router '{}' is now stopped", self.name);
     }
 
     #[must_use]

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -402,25 +402,6 @@ impl Rio {
     }
 }
 
-// Drop-guard so panic-unwind or unexpected loop exit trips
-// report_fatal.
-struct ExitGuard {
-    subsystem: Subsystem,
-}
-impl Drop for ExitGuard {
-    fn drop(&mut self) {
-        if self.subsystem.is_cancelled() {
-            return;
-        }
-        let reason = if std::thread::panicking() {
-            "RIO thread panicked"
-        } else {
-            "RIO thread exited unexpectedly"
-        };
-        self.subsystem.report_fatal(reason);
-    }
-}
-
 #[allow(clippy::missing_errors_doc, clippy::too_many_lines)]
 pub(crate) fn start_rio(
     subsystem: &Subsystem,
@@ -441,9 +422,7 @@ pub(crate) fn start_rio(
     /* router IO loop */
     let rio_loop = move || {
         // drop-guard to detect loop termination
-        let _guard = ExitGuard {
-            subsystem: guard_subsystem,
-        };
+        let _guard = guard_subsystem.new_exit_guard("RIO".to_string(), true);
 
         info!("CPI: Listening at {}.", &rio.cp_sock_path);
         info!("CLI: Listening at {}.", &rio.cli_sock_path);
@@ -575,6 +554,7 @@ pub(crate) fn start_rio(
                 db.vrftable.refresh_fibs_by_vni(&vnis, &db.rmac_store);
             }
         }
+        info!("RIO is now exiting");
     };
     let handle = thread::Builder::new()
         .name("routerIO".to_string())

--- a/stats/src/dpstats.rs
+++ b/stats/src/dpstats.rs
@@ -812,8 +812,20 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Stats {
         input.filter_map(|mut packet| {
             let sdisc = packet.meta().src_vpcd;
             let ddisc = packet.meta().dst_vpcd;
-            let is_drop =
-                !(packet.get_done().unwrap_or_else(|| unreachable!()) == DoneReason::Delivered);
+            // A packet must always carry a verdict by the time it reaches this stage. If it does
+            // not, a previous stage is buggy. Mark it as an internal failure, which will account
+            // it as a drop, instead of panicking. Packets not accounted as a drop may still be
+            // dropped by the driver
+            let done_reason = match packet.get_done() {
+                Some(reason) => reason,
+                None => {
+                    error!("Found packet without Done reason. This is a bug");
+                    packet.done(DoneReason::InternalFailure);
+                    DoneReason::InternalFailure
+                }
+            };
+
+            let is_drop = done_reason != DoneReason::Delivered;
             let bytes: u64 = packet.total_len().into();
 
             match (sdisc, ddisc) {


### PR DESCRIPTION
Fixes https://github.com/githedgehog/dataplane/issues/1653

* Adds infra to periodically check the status of dataplane workers and their rx tasks
* Adds a watchdog per worker rx task such that, if not patted in time, an error log is issued.
* Since logs are gone with the wind, the state of the workers and their RX tasks is exposed through the cli, with current and past stats that can help diagnosing.
* **Note**: the state of a worker observed will always be **"running"** since the process shutdowns as soon as a thread panics.

Sample cli output

For each task, it shows the status (stuck|idle|Active) and
  * pps: packets per second received in last sample
  * total pkts received / sent by the task
  * total drops by pipeline (per task)
  * total drops due to xmit (and serialization).
  * the number of times the task missed to pat its watchdog in time.


``` 
dataplane(✔)# show driver status
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Packet driver status ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 max rx batch: 128 pkts
 activity poll: 1 s  watchdog pat: 2 s  watchdog check: 6 s

   iface             status             pps                pkt-rx                pkt-tx  ppline-drops  tx-drops  wd-misses
 worker 0: running
   eth0              Idle               0.0                     0                     0             0         0          0
   eth1              Idle               0.0                     0                     0             0         0          0
   eth2              Idle               0.0                     0                     0             0         0          0

 worker 1: running
   eth0              Idle               0.0                     0                     0             0         0          0
   eth1              Idle               0.0                     0                     0             0         0          0
   eth2              Idle               0.0                     0                     0             0         0          0

 worker 2: running
   eth0              Idle               0.0                     0                     0             0         0          0
   eth1              Idle               0.0                     0                     0             0         0          0
   eth2              Idle               0.0                     0                     0             0         0          0

[..]

 worker 9: running
   eth0              Active         16658.0               1262725               1262551           174         0          0
   eth1              Idle               0.0                    14                     0            14         0          0
   eth2              Active             4.0                   175                     0           175         0          0

```