### PR TITLE
fix(interface-manager): Do not delete interfaces we did not create

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "multi_index_map",
  "n-vm",
  "netdev",
+ "nix 0.31.3",
  "pretty_assertions",
  "rtnetlink",
  "serde",

--- a/interface-manager/src/interface/managed.rs
+++ b/interface-manager/src/interface/managed.rs
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Which network interfaces the dataplane is allowed to manage.
+//!
+//! The dataplane does not own the network namespace it runs in.
+//! It shares that namespace with other network managers: a kubernetes CNI (flannel creates
+//! `flannel.1` and `cni0`), a container runtime (`docker0`), libvirt (`virbr0`), and whatever the
+//! operator set up by hand.
+//!
+//! Reconciliation removes observed interfaces which are absent from the plan, so the dataplane
+//! needs to distinguish "an interface I created for a plan which no longer exists" from "an
+//! interface which was never mine."
+//! It makes that distinction by name: every interface the dataplane creates is named
+//! `<base><suffix>` where the suffix is fixed by the [`ManagedInterfaceKind`] of the interface.
+//! An interface whose name does not fit that scheme is _foreign_, and the dataplane must leave it
+//! strictly alone.
+//!
+//! The naming scheme is defined here (and only here) so that the code which _generates_ these
+//! names and the code which _recognizes_ them cannot drift apart.
+//!
+//! Note that this rule is deliberately asymmetric in its failure modes.
+//! Failing to recognize one of our own interfaces leaks that interface, which is bad but bounded
+//! and self correcting (the next plan which uses that name adopts it).
+//! Mistaking somebody else's interface for one of ours destroys their network, which is much
+//! worse and is not correctable by us at all.
+
+use net::interface::{IllegalInterfaceName, InterfaceName};
+use serde::{Deserialize, Serialize};
+
+/// The kinds of network interface which the dataplane creates, and which it therefore manages.
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum ManagedInterfaceKind {
+    /// A VRF: the routing domain of a VPC.
+    Vrf,
+    /// A bridge: the broadcast domain of a VPC.
+    Bridge,
+    /// A VTEP: the vxlan device which terminates a VPC's tunnels.
+    Vtep,
+    /// A tap device: the kernel's end of an interface which the dataplane proxies.
+    Tap,
+}
+
+impl ManagedInterfaceKind {
+    /// Every kind of network interface which the dataplane manages.
+    pub const ALL: [ManagedInterfaceKind; 4] = [Self::Vrf, Self::Bridge, Self::Vtep, Self::Tap];
+
+    /// The name suffix which marks an interface as being of this kind (and thus as belonging to
+    /// the dataplane).
+    ///
+    /// # Invariant
+    ///
+    /// No suffix may be a suffix of any other suffix; classification would otherwise be ambiguous.
+    #[must_use]
+    pub const fn suffix(self) -> &'static str {
+        match self {
+            ManagedInterfaceKind::Vrf => "-vrf",
+            ManagedInterfaceKind::Bridge => "-bri",
+            ManagedInterfaceKind::Vtep => "-vtp",
+            ManagedInterfaceKind::Tap => "-tap",
+        }
+    }
+
+    /// Classify the interface with this name.
+    ///
+    /// Returns `None` if the interface is foreign, i.e., if the dataplane did not create it and
+    /// therefore must not modify or destroy it.
+    #[must_use]
+    pub fn of(name: &InterfaceName) -> Option<ManagedInterfaceKind> {
+        ManagedInterfaceKind::ALL.into_iter().find(|kind| {
+            name.as_ref()
+                .strip_suffix(kind.suffix())
+                .is_some_and(|base| !base.is_empty())
+        })
+    }
+}
+
+/// The name of a network interface which the dataplane created, and which the dataplane may
+/// therefore modify or destroy.
+///
+/// The only way to get one of these is to build a name from the dataplane's naming scheme, or to
+/// recognize a name as having come from that scheme.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ManagedInterfaceName {
+    name: InterfaceName,
+    kind: ManagedInterfaceKind,
+}
+
+/// An [`InterfaceName`] which does not belong to the dataplane.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, thiserror::Error)]
+#[error("interface {0} is foreign: its name does not follow the dataplane's naming scheme")]
+pub struct ForeignInterfaceName(pub(crate) InterfaceName);
+
+impl ManagedInterfaceName {
+    /// The longest base name which can be extended into a legal managed interface name.
+    ///
+    /// Every suffix is the same length, so this bound does not depend on the
+    /// [`ManagedInterfaceKind`].
+    pub const MAX_BASE_LEN: usize =
+        InterfaceName::MAX_LEN - ManagedInterfaceKind::Vrf.suffix().len();
+
+    /// Name an interface of the supplied `kind` after `base`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `base` is empty, or if `base` extended by the suffix of `kind` is not a
+    /// legal interface name (most commonly because `base` is longer than [`Self::MAX_BASE_LEN`]).
+    pub fn new(kind: ManagedInterfaceKind, base: &str) -> Result<Self, IllegalInterfaceName> {
+        if base.is_empty() {
+            return Err(IllegalInterfaceName::Empty);
+        }
+        let name = InterfaceName::try_from(format!("{base}{suffix}", suffix = kind.suffix()))?;
+        Ok(Self { name, kind })
+    }
+
+    /// The kind of interface this name describes.
+    #[must_use]
+    pub fn kind(&self) -> ManagedInterfaceKind {
+        self.kind
+    }
+
+    /// The interface name proper.
+    #[must_use]
+    pub fn name(&self) -> &InterfaceName {
+        &self.name
+    }
+
+    /// The portion of the name which precedes the [`ManagedInterfaceKind`] suffix.
+    #[must_use]
+    pub fn base(&self) -> &str {
+        self.name
+            .as_ref()
+            .strip_suffix(self.kind.suffix())
+            .unwrap_or_else(|| unreachable!("managed name is missing its suffix"))
+    }
+}
+
+impl TryFrom<&InterfaceName> for ManagedInterfaceName {
+    type Error = ForeignInterfaceName;
+
+    fn try_from(name: &InterfaceName) -> Result<Self, ForeignInterfaceName> {
+        match ManagedInterfaceKind::of(name) {
+            None => Err(ForeignInterfaceName(name.clone())),
+            Some(kind) => Ok(Self {
+                name: name.clone(),
+                kind,
+            }),
+        }
+    }
+}
+
+impl TryFrom<InterfaceName> for ManagedInterfaceName {
+    type Error = ForeignInterfaceName;
+
+    fn try_from(name: InterfaceName) -> Result<Self, ForeignInterfaceName> {
+        match ManagedInterfaceKind::of(&name) {
+            None => Err(ForeignInterfaceName(name)),
+            Some(kind) => Ok(Self { name, kind }),
+        }
+    }
+}
+
+impl From<ManagedInterfaceName> for InterfaceName {
+    fn from(managed: ManagedInterfaceName) -> Self {
+        managed.name
+    }
+}
+
+impl AsRef<InterfaceName> for ManagedInterfaceName {
+    fn as_ref(&self) -> &InterfaceName {
+        &self.name
+    }
+}
+
+impl std::fmt::Display for ManagedInterfaceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.name, f)
+    }
+}
+
+#[cfg(any(test, feature = "bolero"))]
+mod contract {
+    use crate::interface::{ManagedInterfaceKind, ManagedInterfaceName};
+    use bolero::{Driver, TypeGenerator};
+    use net::interface::InterfaceName;
+
+    impl TypeGenerator for ManagedInterfaceKind {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let index = driver.produce::<u8>()? as usize % ManagedInterfaceKind::ALL.len();
+            Some(ManagedInterfaceKind::ALL[index])
+        }
+    }
+
+    impl TypeGenerator for ManagedInterfaceName {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let base = driver.produce::<InterfaceName>()?;
+            let base = &base.as_ref()[..base.as_ref().len().min(Self::MAX_BASE_LEN)];
+            ManagedInterfaceName::new(driver.produce()?, base).ok()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interface::{ForeignInterfaceName, ManagedInterfaceKind, ManagedInterfaceName};
+    use net::interface::InterfaceName;
+
+    /// Names created by network managers which are not us.
+    ///
+    /// The flannel entries are the reason this module exists: flannel's vxlan device parses as a
+    /// perfectly ordinary VTEP and its `cni0` parses as a perfectly ordinary bridge, so nothing
+    /// but the name distinguishes them from interfaces of ours which have fallen out of the plan.
+    const FOREIGN: [&str; 14] = [
+        "flannel.1",
+        "flannel.4096",
+        "flannel-v6.1",
+        "flannel-wg",
+        "cni0",
+        "docker0",
+        "veth3a2b1c9",
+        "vxlan.calico",
+        "kube-ipvs0",
+        "virbr0",
+        "tunl0",
+        "eth0",
+        "enp1s0f0",
+        "lo",
+    ];
+
+    #[test]
+    fn foreign_interfaces_are_not_managed() {
+        for name in FOREIGN {
+            let name = InterfaceName::try_from(name).unwrap_or_else(|e| unreachable!("{e}"));
+            assert_eq!(
+                ManagedInterfaceKind::of(&name),
+                None,
+                "{name} must not be treated as an interface of ours"
+            );
+            assert_eq!(
+                ManagedInterfaceName::try_from(&name),
+                Err(ForeignInterfaceName(name.clone()))
+            );
+        }
+    }
+
+    #[test]
+    fn managed_interfaces_are_classified() {
+        let cases = [
+            ("abcde-vrf", ManagedInterfaceKind::Vrf),
+            ("abcde-bri", ManagedInterfaceKind::Bridge),
+            ("abcde-vtp", ManagedInterfaceKind::Vtep),
+            ("eth0-tap", ManagedInterfaceKind::Tap),
+        ];
+        for (name, expected) in cases {
+            let name = InterfaceName::try_from(name).unwrap_or_else(|e| unreachable!("{e}"));
+            assert_eq!(ManagedInterfaceKind::of(&name), Some(expected));
+            let managed =
+                ManagedInterfaceName::try_from(&name).unwrap_or_else(|e| unreachable!("{e}"));
+            assert_eq!(managed.kind(), expected);
+            assert_eq!(managed.name(), &name);
+        }
+    }
+
+    /// A name which is nothing but a suffix was never generated by us, so it is foreign.
+    #[test]
+    fn bare_suffixes_are_not_managed() {
+        for kind in ManagedInterfaceKind::ALL {
+            let name =
+                InterfaceName::try_from(kind.suffix()).unwrap_or_else(|e| unreachable!("{e}"));
+            assert_eq!(ManagedInterfaceKind::of(&name), None);
+        }
+    }
+
+    /// Classification is only well defined if no suffix ends with another suffix.
+    #[test]
+    fn suffixes_are_unambiguous() {
+        for a in ManagedInterfaceKind::ALL {
+            for b in ManagedInterfaceKind::ALL {
+                if a == b {
+                    continue;
+                }
+                assert!(
+                    !a.suffix().ends_with(b.suffix()),
+                    "{a:?} and {b:?} have ambiguous suffixes"
+                );
+            }
+        }
+    }
+
+    /// `MAX_BASE_LEN` is only correct if every suffix is the same length.
+    #[test]
+    fn suffixes_are_the_same_length() {
+        for kind in ManagedInterfaceKind::ALL {
+            assert_eq!(
+                kind.suffix().len(),
+                InterfaceName::MAX_LEN - ManagedInterfaceName::MAX_BASE_LEN
+            );
+        }
+    }
+
+    /// Every name we generate must be recognized as ours, with the kind and base it was built
+    /// from.
+    #[test]
+    fn generated_names_are_recognized() {
+        bolero::check!().with_type().for_each(
+            |(kind, base): &(ManagedInterfaceKind, InterfaceName)| {
+                let base =
+                    &base.as_ref()[..base.as_ref().len().min(ManagedInterfaceName::MAX_BASE_LEN)];
+                let managed = ManagedInterfaceName::new(*kind, base)
+                    .unwrap_or_else(|e| unreachable!("{base} is a legal base name: {e}"));
+                assert_eq!(managed.kind(), *kind);
+                assert_eq!(managed.base(), base);
+                assert_eq!(ManagedInterfaceKind::of(managed.name()), Some(*kind));
+                assert_eq!(
+                    ManagedInterfaceName::try_from(managed.name()),
+                    Ok(managed.clone())
+                );
+            },
+        );
+    }
+
+    /// Whatever else classification does, it must never claim a name which does not end in one of
+    /// our suffixes.
+    #[test]
+    fn only_our_suffixes_are_claimed() {
+        bolero::check!().with_type().for_each(
+            |name: &InterfaceName| match ManagedInterfaceKind::of(name) {
+                None => {}
+                Some(kind) => {
+                    assert!(name.as_ref().ends_with(kind.suffix()));
+                    assert!(name.as_ref().len() > kind.suffix().len());
+                }
+            },
+        );
+    }
+
+    /// A managed name is exactly its base followed by the suffix of its kind.
+    #[test]
+    fn base_and_suffix_reconstruct_the_name() {
+        bolero::check!()
+            .with_type()
+            .for_each(|managed: &ManagedInterfaceName| {
+                assert_eq!(
+                    format!("{}{}", managed.base(), managed.kind().suffix()),
+                    managed.name().to_string()
+                );
+            });
+    }
+}

--- a/interface-manager/src/interface/mod.rs
+++ b/interface-manager/src/interface/mod.rs
@@ -5,6 +5,7 @@
 
 mod association;
 mod bridge;
+mod managed;
 mod pci;
 mod properties;
 mod tap;
@@ -15,6 +16,8 @@ mod vtep;
 pub use association::*;
 #[allow(unused_imports)] // re-export
 pub use bridge::*;
+#[allow(unused_imports)] // re-export
+pub use managed::*;
 #[allow(unused_imports)] // re-export
 pub use pci::*;
 #[allow(unused_imports)] // re-export

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -71,5 +71,6 @@ test-utils = { workspace = true }
 # external
 bolero = { workspace = true, default-features = false, features = ["alloc"] }
 ipnet = { workspace = true }
+nix = { workspace = true, default-features = false, features = ["sched"] }
 pretty_assertions = { workspace = true, features = ["std"] }
 tracing-subscriber = { workspace = true }

--- a/mgmt/src/processor/confbuild/namegen.rs
+++ b/mgmt/src/processor/confbuild/namegen.rs
@@ -12,6 +12,7 @@
 #![allow(unused)]
 
 use config::external::overlay::vpc::{ValidatedVpc, VpcId};
+use interface_manager::interface::{ManagedInterfaceKind, ManagedInterfaceName};
 use net::interface::InterfaceName;
 
 ////////////////////////////////////////////////////////////////////////
@@ -28,14 +29,26 @@ where
 }
 impl VpcInterfacesNames for VpcId {
     fn vrf_name(&self) -> InterfaceName {
-        InterfaceName::try_from(format!("{self}-vrf")).unwrap_or_else(|_| unreachable!())
+        managed_name(self, ManagedInterfaceKind::Vrf)
     }
     fn bridge_name(&self) -> InterfaceName {
-        InterfaceName::try_from(format!("{self}-bri")).unwrap_or_else(|_| unreachable!())
+        managed_name(self, ManagedInterfaceKind::Bridge)
     }
     fn vtep_name(&self) -> InterfaceName {
-        InterfaceName::try_from(format!("{self}-vtp")).unwrap_or_else(|_| unreachable!())
+        managed_name(self, ManagedInterfaceKind::Vtep)
     }
+}
+
+/// Name an interface of the supplied kind after this VPC.
+///
+/// Names are generated through [`ManagedInterfaceName`] so that the reconciler recognizes these
+/// interfaces as ours (and, just as importantly, does not mistake anybody else's interfaces for
+/// ours).
+fn managed_name(id: &VpcId, kind: ManagedInterfaceKind) -> InterfaceName {
+    // A `VpcId` is a short, legal, non-empty interface name fragment, so this can't fail.
+    ManagedInterfaceName::new(kind, &id.to_string())
+        .unwrap_or_else(|_| unreachable!())
+        .into()
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/mgmt/src/vpc_manager/mod.rs
+++ b/mgmt/src/vpc_manager/mod.rs
@@ -12,9 +12,9 @@ use futures::TryStreamExt;
 use interface_manager::Manager;
 use interface_manager::interface::{
     BridgePropertiesSpec, InterfaceAssociationSpec, InterfacePropertiesSpec, InterfaceSpecBuilder,
-    MultiIndexInterfaceAssociationSpecMap, MultiIndexInterfaceSpecMap,
-    MultiIndexVrfPropertiesSpecMap, MultiIndexVtepPropertiesSpecMap, TryFromLinkMessage,
-    VrfPropertiesSpec, VtepPropertiesSpec,
+    ManagedInterfaceKind, ManagedInterfaceName, MultiIndexInterfaceAssociationSpecMap,
+    MultiIndexInterfaceSpecMap, MultiIndexVrfPropertiesSpecMap, MultiIndexVtepPropertiesSpecMap,
+    TryFromLinkMessage, VrfPropertiesSpec, VtepPropertiesSpec,
 };
 use multi_index_map::MultiIndexMap;
 use net::eth::ethtype::EthType;
@@ -30,7 +30,7 @@ use rekon::{Observe, Op, Reconcile, Remove};
 use rtnetlink::Handle;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 #[derive(Clone, Debug)]
 pub struct VpcManager<R> {
@@ -51,6 +51,16 @@ impl<T, U> From<&VpcManager<T>> for VpcManager<U> {
     fn from(handle: &VpcManager<T>) -> Self {
         Self::new(handle.handle.clone())
     }
+}
+
+/// Tell if the interface with this name is one the dataplane created and may therefore manage.
+///
+/// The dataplane shares its network namespace with other network managers (most notably a
+/// kubernetes CNI such as flannel, which creates a vxlan device and a bridge of its own).  Those
+/// interfaces are indistinguishable from ours by type: only the naming scheme tells them apart.
+/// See [`ManagedInterfaceName`] for the reasoning.
+fn is_ours(name: &InterfaceName) -> bool {
+    ManagedInterfaceKind::of(name).is_some()
 }
 
 #[derive(
@@ -126,27 +136,32 @@ impl Observe for VpcManager<RequiredInformationBase> {
                 }
             }
         }
+        // Index the properties of the interfaces we manage so that collisions between them can be
+        // detected.
+        //
+        // A collision is reported and nothing else: the observed interface map is the reconciler's
+        // whole view of reality, so an interface dropped from it is invisible to both passes of
+        // `reconcile`.  A stale interface hidden this way can never be collected, and a live one
+        // is create-looped against a device which is plainly already there.  Whatever a duplicate
+        // means, refusing to look at it is not the answer.
         let mut vtep_properties = MultiIndexVtepPropertiesMap::default();
         let mut vrf_properties = MultiIndexVrfPropertiesMap::default();
-        let mut indexes_to_remove = vec![];
         for (_, observation) in observations.iter() {
+            if !is_ours(&observation.name) {
+                // Foreign interfaces are not ours to collide with.  Flannel defaults to vni 1,
+                // which a VPC of ours may legitimately also use (on our own port), and reporting
+                // that as a collision would be both wrong and unactionable.
+                continue;
+            }
             match &observation.properties {
                 InterfaceProperties::Vtep(properties) => {
-                    match vtep_properties.try_insert(properties.clone()) {
-                        Ok(_) => {}
-                        Err(err) => {
-                            error!("{err:?}");
-                            indexes_to_remove.push(observation.index);
-                        }
+                    if let Err(err) = vtep_properties.try_insert(properties.clone()) {
+                        error!("{err:?}");
                     }
                 }
                 InterfaceProperties::Vrf(properties) => {
-                    match vrf_properties.try_insert(properties.clone()) {
-                        Ok(_) => {}
-                        Err(err) => {
-                            error!("{err:?}");
-                            indexes_to_remove.push(observation.index);
-                        }
+                    if let Err(err) = vrf_properties.try_insert(properties.clone()) {
+                        error!("{err:?}");
                     }
                 }
                 InterfaceProperties::Other
@@ -154,9 +169,6 @@ impl Observe for VpcManager<RequiredInformationBase> {
                 | InterfaceProperties::Pci(_)
                 | InterfaceProperties::Bridge(_) => { /* nothing to index */ }
             }
-        }
-        for sliced in indexes_to_remove {
-            observations.remove_by_index(&sliced);
         }
         match ob
             .interfaces(observations)
@@ -220,6 +232,12 @@ impl Reconcile for VpcManager<RequiredInformationBase> {
         let iface_handle = Manager::<Interface>::new(self.handle.clone());
         for (_, interface) in observation.interfaces.iter() {
             match requirement.interfaces.get_by_name(&interface.name) {
+                None if !is_ours(&interface.name) => {
+                    // Somebody else's interface (a CNI's vxlan device or bridge, a container
+                    // runtime's bridge, an operator's own device).  It is absent from the plan
+                    // because it was never in the plan, so leave it strictly alone.
+                    trace!("leaving foreign interface {} alone", interface.name);
+                }
                 None => match interface.properties {
                     InterfaceProperties::Other | InterfaceProperties::Pci(_) => {}
                     _ => {
@@ -306,9 +324,9 @@ fn add_interface_specs(interfaces: &mut MultiIndexInterfaceSpecMap, ifaces: &Int
         match &iface.iftype {
             InterfaceType::Ethernet(eth) => {
                 let mut tap = InterfaceSpecBuilder::default();
-                match InterfaceName::try_from(format!("{}-tap", iface.name.as_str())) {
+                match ManagedInterfaceName::new(ManagedInterfaceKind::Tap, iface.name.as_str()) {
                     Ok(name) => {
-                        tap.name(name);
+                        tap.name(name.into());
                     }
                     Err(e) => {
                         error!("{e}");
@@ -525,9 +543,29 @@ mod contract {
     use crate::vpc_manager::{RequiredInformationBase, Vpc, VpcDiscriminant};
     use bolero::{Driver, TypeGenerator};
     use interface_manager::interface::{
-        InterfaceAssociationSpec, InterfacePropertiesSpec, InterfaceSpec,
+        InterfaceAssociationSpec, InterfacePropertiesSpec, InterfaceSpec, ManagedInterfaceKind,
+        ManagedInterfaceName,
     };
-    use net::interface::AdminState;
+    use net::interface::{AdminState, InterfaceName};
+
+    /// Rename `interface` into the dataplane's own naming scheme, as the config builder does.
+    ///
+    /// Interfaces named any other way are foreign, and the reconciler (correctly) refuses to
+    /// destroy them, so a generator which produced such names would leave interfaces behind for
+    /// the next generated requirement to trip over.
+    fn managed_name(interface: &InterfaceSpec) -> Option<InterfaceName> {
+        let kind = match &interface.properties {
+            InterfacePropertiesSpec::Bridge(_) => ManagedInterfaceKind::Bridge,
+            InterfacePropertiesSpec::Vtep(_) => ManagedInterfaceKind::Vtep,
+            InterfacePropertiesSpec::Vrf(_) => ManagedInterfaceKind::Vrf,
+            InterfacePropertiesSpec::Tap => ManagedInterfaceKind::Tap,
+            // pci netdev names come from the hardware, not from us
+            InterfacePropertiesSpec::Pci(_) => return None,
+        };
+        let base = interface.name.as_ref();
+        let base = &base[..base.len().min(ManagedInterfaceName::MAX_BASE_LEN)];
+        ManagedInterfaceName::new(kind, base).ok().map(Into::into)
+    }
 
     impl TypeGenerator for VpcDiscriminant {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
@@ -562,6 +600,10 @@ mod contract {
                 let mut interface: InterfaceSpec = driver.produce()?;
                 interface.controller = None;
                 interface.admin_state = AdminState::Up;
+                let Some(name) = managed_name(&interface) else {
+                    continue;
+                };
+                interface.name = name;
                 match &interface.properties {
                     InterfacePropertiesSpec::Bridge(_) => {
                         if let Ok(bridge) = requirements.interfaces.try_insert(interface) {

--- a/mgmt/tests/reconcile.rs
+++ b/mgmt/tests/reconcile.rs
@@ -15,10 +15,14 @@ use interface_manager::interface::{
 };
 use mgmt::vpc_manager::{RequiredInformationBase, RequiredInformationBaseBuilder, VpcManager};
 use net::eth::ethtype::EthType;
-use net::interface::AdminState;
+use net::interface::{AdminState, InterfaceName, InterfaceProperties};
 use net::vxlan::Vxlan;
+use nix::sched::CloneFlags;
 use rekon::{Observe, Reconcile};
+use rtnetlink::packet_route::link::{InfoData, InfoVxlan};
 use rtnetlink::sys::AsyncSocket;
+use rtnetlink::{LinkBridge, LinkVxlan};
+use std::future::Future;
 use std::net::Ipv4Addr;
 use std::time::Duration;
 use test_utils::with_caps;
@@ -82,6 +86,205 @@ fn reconcile_fuzz() {
         });
 }
 
+/// Run `exec` in a network namespace of this test's own.
+///
+/// Reconciliation destroys interfaces which are absent from the plan, so a test which creates
+/// devices named after somebody else's software has no business doing so in a namespace shared
+/// with a real deployment of that software.
+fn in_private_netns<Exec, Fut, Out>(exec: Exec) -> Out
+where
+    Exec: (FnOnce() -> Fut) + Send + 'static,
+    Fut: Future<Output = Out>,
+    Out: Send + 'static,
+{
+    std::thread::Builder::new()
+        .name("private-netns".to_string())
+        .spawn(move || {
+            nix::sched::unshare(CloneFlags::CLONE_NEWNET).unwrap_or_else(|err| {
+                panic!("failed to create a private network namespace: {err}")
+            });
+            tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .unwrap_or_else(|err| panic!("failed to build tokio runtime: {err}"))
+                .block_on(exec())
+        })
+        .unwrap_or_else(|err| panic!("failed to spawn netns thread: {err}"))
+        .join()
+        .unwrap_or_else(|err| std::panic::resume_unwind(err))
+}
+
+/// The network devices created by a CNI must survive reconciliation.
+///
+/// Flannel's vxlan backend creates a vxlan device (`flannel.1`) and a bridge (`cni0`).  Both parse
+/// as perfectly ordinary interfaces of kinds we manage, so nothing but the naming scheme
+/// distinguishes them from interfaces of ours which have dropped out of the plan.  Removing them
+/// severs pod networking on the node.
+///
+/// The flannel VTEP here deliberately shares a VNI with a VPC of ours (flannel defaults to vni 1)
+/// while terminating on flannel's own UDP port.  That is legal in the kernel, and the reconciler
+/// must not confuse the two.
+#[test]
+#[wrap(with_caps([Capability::CAP_NET_ADMIN, Capability::CAP_SYS_ADMIN]))]
+#[cfg_attr(not(emulated), traced_test)]
+fn foreign_cni_devices_are_not_removed() {
+    const FLANNEL_VTEP: &str = "flannel.1";
+    const FLANNEL_BRIDGE: &str = "cni0";
+    const FLANNEL_VNI: u32 = 1;
+    const FLANNEL_PORT: u16 = 8472;
+    /// An interface of ours, left over from a plan which no longer mentions it.
+    const STALE: &str = "vpc9-vtp";
+
+    in_private_netns(|| async {
+        let Ok((connection, handle, _)) = rtnetlink::new_connection() else {
+            panic!("failed to create connection");
+        };
+        tokio::spawn(connection);
+        let handle = Arc::new(handle);
+
+        handle
+            .link()
+            .add(
+                LinkVxlan::new(FLANNEL_VTEP, FLANNEL_VNI)
+                    .set_info_data(InfoData::Vxlan(vec![
+                        InfoVxlan::Id(FLANNEL_VNI),
+                        InfoVxlan::Port(FLANNEL_PORT),
+                        InfoVxlan::Local(Ipv4Addr::new(10, 42, 0, 0)),
+                        InfoVxlan::Ttl(0),
+                    ]))
+                    .build(),
+            )
+            .execute()
+            .await
+            .unwrap();
+        handle
+            .link()
+            .add(LinkBridge::new(FLANNEL_BRIDGE).build())
+            .execute()
+            .await
+            .unwrap();
+        handle
+            .link()
+            .add(
+                LinkVxlan::new(STALE, 9)
+                    .set_info_data(InfoData::Vxlan(vec![
+                        InfoVxlan::Id(9),
+                        InfoVxlan::Port(Vxlan::PORT.as_u16()),
+                        InfoVxlan::Local(Ipv4Addr::new(192, 168, 5, 155)),
+                        InfoVxlan::Ttl(64),
+                    ]))
+                    .build(),
+            )
+            .execute()
+            .await
+            .unwrap();
+
+        let mut interfaces = MultiIndexInterfaceSpecMap::default();
+        let mut vteps = MultiIndexVtepPropertiesSpecMap::default();
+        let mut vrfs = MultiIndexVrfPropertiesSpecMap::default();
+        let mut associations = MultiIndexInterfaceAssociationSpecMap::default();
+
+        let vtep_props = VtepPropertiesSpec {
+            // the same vni flannel is using, on our own port
+            vni: FLANNEL_VNI.try_into().unwrap(),
+            local: "192.168.5.155"
+                .parse::<Ipv4Addr>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            ttl: 64,
+            port: Vxlan::PORT,
+        };
+        let vrf_props = VrfPropertiesSpec {
+            route_table_id: 1.try_into().unwrap(),
+        };
+        vteps.try_insert(vtep_props.clone()).unwrap();
+        vrfs.try_insert(vrf_props.clone()).unwrap();
+        for interface in [
+            InterfaceSpecBuilder::default()
+                .name("vpc1-vrf".try_into().unwrap())
+                .admin_state(AdminState::Up)
+                .properties(InterfacePropertiesSpec::Vrf(vrf_props))
+                .build()
+                .unwrap(),
+            InterfaceSpecBuilder::default()
+                .name("vpc1-bri".try_into().unwrap())
+                .admin_state(AdminState::Up)
+                .properties(InterfacePropertiesSpec::Bridge(BridgePropertiesSpec {
+                    vlan_protocol: EthType::VLAN,
+                    vlan_filtering: false,
+                }))
+                .build()
+                .unwrap(),
+            InterfaceSpecBuilder::default()
+                .name("vpc1-vtp".try_into().unwrap())
+                .admin_state(AdminState::Up)
+                .properties(InterfacePropertiesSpec::Vtep(vtep_props))
+                .build()
+                .unwrap(),
+        ] {
+            interfaces.try_insert(interface).unwrap();
+        }
+        for (name, controller) in [("vpc1-bri", "vpc1-vrf"), ("vpc1-vtp", "vpc1-bri")] {
+            associations
+                .try_insert(InterfaceAssociationSpec {
+                    name: name.try_into().unwrap(),
+                    controller_name: Some(controller.try_into().unwrap()),
+                })
+                .unwrap();
+        }
+
+        let mut required = RequiredInformationBaseBuilder::default()
+            .interfaces(interfaces)
+            .vteps(vteps)
+            .vrfs(vrfs)
+            .associations(associations)
+            .build()
+            .unwrap();
+
+        let vpcs = VpcManager::<RequiredInformationBase>::new(handle);
+        let mut passes = 0;
+        while !vpcs
+            .reconcile(&mut required, &vpcs.observe().await.unwrap())
+            .await
+        {
+            passes += 1;
+            assert!(passes < 30, "reconciliation did not converge");
+        }
+
+        let observed = vpcs.observe().await.unwrap();
+        let get = |name: &str| {
+            observed
+                .interfaces
+                .get_by_name(&InterfaceName::try_from(name).unwrap())
+        };
+
+        let flannel_vtep = get(FLANNEL_VTEP)
+            .unwrap_or_else(|| panic!("{FLANNEL_VTEP} was removed by the reconciler"));
+        assert!(
+            matches!(flannel_vtep.properties, InterfaceProperties::Vtep(_)),
+            "{FLANNEL_VTEP} was replaced by something else: {flannel_vtep:?}"
+        );
+        let flannel_bridge = get(FLANNEL_BRIDGE)
+            .unwrap_or_else(|| panic!("{FLANNEL_BRIDGE} was removed by the reconciler"));
+        assert!(
+            matches!(flannel_bridge.properties, InterfaceProperties::Bridge(_)),
+            "{FLANNEL_BRIDGE} was replaced by something else: {flannel_bridge:?}"
+        );
+
+        // ... but an interface of ours which the plan no longer mentions is still collected
+        assert!(
+            get(STALE).is_none(),
+            "{STALE} is ours and is absent from the plan, so it should have been removed"
+        );
+
+        for ours in ["vpc1-vrf", "vpc1-bri", "vpc1-vtp"] {
+            assert!(get(ours).is_some(), "{ours} was never created");
+        }
+    });
+}
+
 #[allow(clippy::too_many_lines)] // this is an integration test and is expected to be long
 #[tokio::test]
 #[wrap(with_caps([Capability::CAP_NET_ADMIN]))]
@@ -90,7 +293,7 @@ async fn reconcile_demo() {
     let mut required_interface_map = MultiIndexInterfaceSpecMap::default();
     let interfaces = [
         InterfaceSpecBuilder::default()
-            .name("vrf1".try_into().unwrap())
+            .name("vpc1-vrf".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Vrf(VrfPropertiesSpec {
                 route_table_id: 1.try_into().unwrap(),
@@ -98,7 +301,7 @@ async fn reconcile_demo() {
             .build()
             .unwrap(),
         InterfaceSpecBuilder::default()
-            .name("vrf2".try_into().unwrap())
+            .name("vpc2-vrf".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Vrf(VrfPropertiesSpec {
                 route_table_id: 2.try_into().unwrap(),
@@ -106,7 +309,7 @@ async fn reconcile_demo() {
             .build()
             .unwrap(),
         InterfaceSpecBuilder::default()
-            .name("vtep1".try_into().unwrap())
+            .name("vpc1-vtp".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Vtep(VtepPropertiesSpec {
                 vni: 1.try_into().unwrap(),
@@ -121,7 +324,7 @@ async fn reconcile_demo() {
             .build()
             .unwrap(),
         InterfaceSpecBuilder::default()
-            .name("vtep2".try_into().unwrap())
+            .name("vpc2-vtp".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Vtep(VtepPropertiesSpec {
                 vni: 2.try_into().unwrap(),
@@ -136,7 +339,7 @@ async fn reconcile_demo() {
             .build()
             .unwrap(),
         InterfaceSpecBuilder::default()
-            .name("br1".try_into().unwrap())
+            .name("vpc1-bri".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Bridge(BridgePropertiesSpec {
                 vlan_protocol: EthType::VLAN,
@@ -145,7 +348,7 @@ async fn reconcile_demo() {
             .build()
             .unwrap(),
         InterfaceSpecBuilder::default()
-            .name("br2".try_into().unwrap())
+            .name("vpc2-bri".try_into().unwrap())
             .admin_state(AdminState::Up)
             .properties(InterfacePropertiesSpec::Bridge(BridgePropertiesSpec {
                 vlan_protocol: EthType::VLAN,
@@ -185,26 +388,26 @@ async fn reconcile_demo() {
     let mut associations = MultiIndexInterfaceAssociationSpecMap::default();
     associations
         .try_insert(InterfaceAssociationSpec {
-            name: "vtep1".to_string().try_into().unwrap(),
-            controller_name: Some("br1".to_string().try_into().unwrap()),
+            name: "vpc1-vtp".to_string().try_into().unwrap(),
+            controller_name: Some("vpc1-bri".to_string().try_into().unwrap()),
         })
         .unwrap();
     associations
         .try_insert(InterfaceAssociationSpec {
-            name: "vtep2".to_string().try_into().unwrap(),
-            controller_name: Some("br2".to_string().try_into().unwrap()),
+            name: "vpc2-vtp".to_string().try_into().unwrap(),
+            controller_name: Some("vpc2-bri".to_string().try_into().unwrap()),
         })
         .unwrap();
     associations
         .try_insert(InterfaceAssociationSpec {
-            name: "br1".to_string().try_into().unwrap(),
-            controller_name: Some("vrf1".to_string().try_into().unwrap()),
+            name: "vpc1-bri".to_string().try_into().unwrap(),
+            controller_name: Some("vpc1-vrf".to_string().try_into().unwrap()),
         })
         .unwrap();
     associations
         .try_insert(InterfaceAssociationSpec {
-            name: "br2".to_string().try_into().unwrap(),
-            controller_name: Some("vrf2".to_string().try_into().unwrap()),
+            name: "vpc2-bri".to_string().try_into().unwrap(),
+            controller_name: Some("vpc2-vrf".to_string().try_into().unwrap()),
         })
         .unwrap();
 
@@ -229,7 +432,7 @@ async fn reconcile_demo() {
     let inject_new_requirements = move |req: &mut RequiredInformationBase| {
         let interfaces = [
             InterfaceSpecBuilder::default()
-                .name("vtep3".try_into().unwrap())
+                .name("vpc3-vtp".try_into().unwrap())
                 .admin_state(AdminState::Up)
                 .controller(None)
                 .properties(InterfacePropertiesSpec::Vtep(VtepPropertiesSpec {
@@ -245,7 +448,7 @@ async fn reconcile_demo() {
                 .build()
                 .unwrap(),
             InterfaceSpecBuilder::default()
-                .name("br3".try_into().unwrap())
+                .name("vpc3-bri".try_into().unwrap())
                 .admin_state(AdminState::Up)
                 .controller(None)
                 .properties(InterfacePropertiesSpec::Bridge(BridgePropertiesSpec {
@@ -255,7 +458,7 @@ async fn reconcile_demo() {
                 .build()
                 .unwrap(),
             InterfaceSpecBuilder::default()
-                .name("vrf3".try_into().unwrap())
+                .name("vpc3-vrf".try_into().unwrap())
                 .admin_state(AdminState::Up)
                 .controller(None)
                 .properties(InterfacePropertiesSpec::Vrf(VrfPropertiesSpec {
@@ -280,33 +483,33 @@ async fn reconcile_demo() {
         }
         req.associations
             .try_insert(InterfaceAssociationSpec {
-                name: "br3".to_string().try_into().unwrap(),
-                controller_name: Some("vrf3".to_string().try_into().unwrap()),
+                name: "vpc3-bri".to_string().try_into().unwrap(),
+                controller_name: Some("vpc3-vrf".to_string().try_into().unwrap()),
             })
             .unwrap();
         req.associations
             .try_insert(InterfaceAssociationSpec {
-                name: "vtep3".to_string().try_into().unwrap(),
-                controller_name: Some("br3".to_string().try_into().unwrap()),
+                name: "vpc3-vtp".to_string().try_into().unwrap(),
+                controller_name: Some("vpc3-bri".to_string().try_into().unwrap()),
             })
             .unwrap();
     };
 
     let remove_some_requirement = move |req: &mut RequiredInformationBase| {
         req.interfaces
-            .remove_by_name(&"br1".to_string().try_into().unwrap())
+            .remove_by_name(&"vpc1-bri".to_string().try_into().unwrap())
             .unwrap();
         req.interfaces
-            .remove_by_name(&"vrf1".to_string().try_into().unwrap())
+            .remove_by_name(&"vpc1-vrf".to_string().try_into().unwrap())
             .unwrap();
         req.interfaces
-            .remove_by_name(&"vtep1".to_string().try_into().unwrap())
+            .remove_by_name(&"vpc1-vtp".to_string().try_into().unwrap())
             .unwrap();
         req.associations
-            .remove_by_name(&"br1".to_string().try_into().unwrap())
+            .remove_by_name(&"vpc1-bri".to_string().try_into().unwrap())
             .unwrap();
         req.associations
-            .remove_by_name(&"vtep1".to_string().try_into().unwrap())
+            .remove_by_name(&"vpc1-vtp".to_string().try_into().unwrap())
             .unwrap();
     };
 


### PR DESCRIPTION
The reconciler garbage collected every observed interface which was absent from the plan, exempting only interfaces of kinds it does not understand.  The dataplane does not own the network namespace it runs in, so this destroyed other people's devices: flannel's vxlan device parses as an ordinary VTEP and its `cni0` parses as an ordinary bridge, and both were removed on the first reconciliation pass, severing pod networking on the node.

Ownership is now decided by name.  `ManagedInterfaceName` defines the dataplane's naming scheme (`-vrf`, `-bri`, `-vtp`, `-tap`) in one place, and both the code which generates those names and the code which recognizes them go through it, so the two cannot drift apart.  An interface whose name does not fit the scheme is foreign: the reconciler leaves it strictly alone.

The rule is deliberately asymmetric.  Failing to recognize one of our own interfaces leaks it, which is bounded and self correcting. Mistaking somebody else's interface for one of ours destroys their network, which is neither.

Foreign interfaces are also excluded from the observed vtep and vrf property indexes.  Those indexes are keyed uniquely by vni and route table id in order to detect collisions between interfaces we manage, and a colliding foreign interface (flannel defaults to vni 1) evicted a legitimate observation of ours from the map, leaving the reconciler to conclude that its own interface was missing and to try, and fail, to recreate it until the config apply gave up.

The new integration test builds a flannel-like vxlan device and bridge in a private network namespace, gives a VPC the same vni flannel is using, and asserts that flannel's devices survive while a stale interface of ours is still collected.