### PR TITLE
augment hash to consider icmp ids

### DIFF
--- a/net/src/packet/hash.rs
+++ b/net/src/packet/hash.rs
@@ -38,7 +38,16 @@ impl<Buf: PacketBufferMut> Packet<Buf> {
                         udp.source().hash(state);
                         udp.destination().hash(state);
                     }
-                    &Transport::Icmp4(_) | &Transport::Icmp6(_) => {}
+                    Transport::Icmp4(icmp4) => {
+                        if let Some(id) = icmp4.identifier() {
+                            id.hash(state);
+                        }
+                    }
+                    Transport::Icmp6(icmp6) => {
+                        if let Some(id) = icmp6.identifier() {
+                            id.hash(state);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Augment the hash method for ip packets to consider the ICMP id field (if present). This adds entropy and allows spraying ICMP traffic over ECMP legs.