### PR TITLE
Ensure we account for dropped packets

### DIFF
--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -160,6 +160,10 @@ impl DriverKernel {
             // check the rx task activity, and watchdog, if we've been told to do so
             let (counters, activity) = ifm.watchdog.check_and_clear(check_watchdog);
 
+            // The counters have been cleared by the read above, so accumulate them whatever
+            // the activity: dropping them here would lose them for good.
+            rx_task_status.accumulate(&counters);
+
             // update the rx task status
             rx_task_status.activity = activity;
             match rx_task_status.activity {
@@ -172,14 +176,6 @@ impl DriverKernel {
                     );
                 }
                 Activity::Active => {
-                    rx_task_status.total_rx += counters.rx;
-                    rx_task_status.total_tx += counters.tx;
-                    rx_task_status.total_ppline_drops += counters.ppline_drops;
-                    rx_task_status.total_tx_drops += counters.tx_drops;
-                    rx_task_status.total_parse_errors += counters.parse_errors;
-                    rx_task_status.total_truncated += counters.truncated;
-                    rx_task_status.total_zero_len += counters.zero_len;
-                    rx_task_status.total_kernel_drops += counters.kernel_drops;
                     rx_task_status.pps = counters.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
                 }
                 Activity::Idle => rx_task_status.pps = 0.0,

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -14,6 +14,7 @@
 
 mod fanout;
 mod kif;
+mod sockstats;
 mod worker;
 
 use std::ops::Add;

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -157,11 +157,11 @@ impl DriverKernel {
             debug_assert_eq!(rx_task_status.ifname, ifm.ifname);
 
             // check the rx task activity, and watchdog, if we've been told to do so
-            let activity = ifm.watchdog.check_and_clear(check_watchdog);
+            let (counters, activity) = ifm.watchdog.check_and_clear(check_watchdog);
 
             // update the rx task status
             rx_task_status.activity = activity;
-            match &rx_task_status.activity {
+            match rx_task_status.activity {
                 Activity::Stuck => {
                     rx_task_status.misses += 1;
                     rx_task_status.pps = 0.0;
@@ -170,12 +170,12 @@ impl DriverKernel {
                         ifm.ifname, monitor.id
                     );
                 }
-                Activity::Active(record) => {
-                    rx_task_status.total_rx += record.rx;
-                    rx_task_status.total_tx += record.tx;
-                    rx_task_status.total_ppline_drops += record.ppline_drops;
-                    rx_task_status.total_tx_drops += record.tx_drops;
-                    rx_task_status.pps = record.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
+                Activity::Active => {
+                    rx_task_status.total_rx += counters.rx;
+                    rx_task_status.total_tx += counters.tx;
+                    rx_task_status.total_ppline_drops += counters.ppline_drops;
+                    rx_task_status.total_tx_drops += counters.tx_drops;
+                    rx_task_status.pps = counters.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
                 }
                 Activity::Idle => rx_task_status.pps = 0.0,
             }

--- a/dataplane/src/drivers/kernel/mod.rs
+++ b/dataplane/src/drivers/kernel/mod.rs
@@ -175,6 +175,10 @@ impl DriverKernel {
                     rx_task_status.total_tx += counters.tx;
                     rx_task_status.total_ppline_drops += counters.ppline_drops;
                     rx_task_status.total_tx_drops += counters.tx_drops;
+                    rx_task_status.total_parse_errors += counters.parse_errors;
+                    rx_task_status.total_truncated += counters.truncated;
+                    rx_task_status.total_zero_len += counters.zero_len;
+                    rx_task_status.total_kernel_drops += counters.kernel_drops;
                     rx_task_status.pps = counters.rx as f64 / f64::from(Self::TASK_POLL_PERIOD);
                 }
                 Activity::Idle => rx_task_status.pps = 0.0,

--- a/dataplane/src/drivers/kernel/sockstats.rs
+++ b/dataplane/src/drivers/kernel/sockstats.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Statistics that the kernel keeps for a packet socket.
+
+use std::os::unix::io::AsFd;
+
+use nix::libc;
+use nix::sys::socket::getsockopt;
+use nix::{getsockopt_impl, sockopt_impl};
+
+sockopt_impl!(
+    PacketStatistics,
+    GetOnly,
+    libc::SOL_PACKET,
+    libc::PACKET_STATISTICS,
+    libc::tpacket_stats
+);
+
+/// Get the number of frames the kernel dropped on the socket, typically because we
+/// did not read them fast enough. The kernel resets its counters when we read them,
+/// so this returns the number of drops since the previous call.
+pub fn get_kernel_drops<Fd: AsFd>(fd: Fd) -> Result<u64, nix::Error> {
+    getsockopt(&fd, PacketStatistics).map(|stats| u64::from(stats.tp_drops))
+}

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -548,7 +548,14 @@ async fn tx_packet(
                     done_reason
                 );
             }
-            None => {} // drop impl of packet meta will log
+            None => {
+                // The drop impl of the packet metadata also logs this, but without context.
+                error!(
+                    worker = id,
+                    rx_intf_name = rx_if_name,
+                    "Dropping packet with no verdict (pipeline bug)"
+                );
+            }
         }
         return false;
     };

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -27,6 +27,7 @@ use pipeline::{DynPipeline, NetworkFunction};
 use crate::drivers::kernel::DriverKernel;
 use crate::drivers::kernel::fanout::{PacketFanoutType, set_packet_fanout};
 use crate::drivers::kernel::kif::Kif;
+use crate::drivers::kernel::sockstats;
 use crate::drivers::kernel::{WorkerIfaceMonitor, WorkerMonitor};
 use crate::drivers::status::WorkerId;
 use crate::drivers::watchdog::{RxCounters, Watchdog};
@@ -527,6 +528,20 @@ async fn read_packets_from_interface(
             }
         },
         Err(_wouldblock) => (),
+    }
+
+    // Ask the kernel what it dropped on the socket while we were away. This is
+    // read-and-clear, so it must be polled on each pass or the counts pile up.
+    match sockstats::get_kernel_drops(fd.get_ref()) {
+        Ok(drops) => counters.kernel_drops += drops,
+        Err(e) => {
+            debug!(
+                worker = id,
+                rx_intf_name = intf.if_name,
+                "Unable to read socket statistics on interface {}: {e}",
+                intf.if_name
+            );
+        }
     }
 
     trace!(

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -176,6 +176,8 @@ impl Worker {
             loop {
                 debug!(worker = id, "awaiting packets");
 
+                let mut counters = RxCounters::default();
+
                 let packets_vec = tokio::select! {
                     () = cancel.cancelled() => {
                         info!(
@@ -185,7 +187,7 @@ impl Worker {
                         );
                         break;
                     },
-                    result = read_packets_from_interface(id, &intf) => match result {
+                    result = read_packets_from_interface(id, &intf, &mut counters) => match result {
                         Ok(packets) => packets,
                         Err(e) => {
                             error!(
@@ -193,11 +195,12 @@ impl Worker {
                                 rx_intf_name = intf.if_name,
                                 "Error reading packets from interface: {e}"
                             );
-                            continue;
+                            Vec::new()
                         }
                     },
                     // N.B. read_packets_from_interface() MUST be cancel-safe for this wake-up not to
-                    // cause packet loss. It currently is.
+                    // cause packet loss, nor loss of the counters it fills. It currently is: it only
+                    // awaits before reading anything from the socket.
                     _ = ticker.tick() => {
                         intf.watchdog.pat();
                         continue;
@@ -215,8 +218,10 @@ impl Worker {
                 let mut tx_pkts: u64 = 0; // number of packets successfully sent
                 let mut tx_drops: u64 = 0; // number of packets dropped on tx
                 let rx_pkts = packets_vec.len() as u64; // number of packets received
+                counters.rx = rx_pkts;
                 if rx_pkts == 0 {
-                    // skip any further processing
+                    // nothing to process, but the read may have hit errors worth reporting
+                    intf.watchdog.record(&counters);
                     continue;
                 }
 
@@ -276,13 +281,10 @@ impl Worker {
                 );
 
                 // update rx task stats
-                intf.watchdog.record(&RxCounters {
-                    rx: rx_pkts,
-                    tx: tx_pkts,
-                    ppline_drops,
-                    tx_drops,
-                    ..RxCounters::default()
-                });
+                counters.tx = tx_pkts;
+                counters.ppline_drops = ppline_drops;
+                counters.tx_drops = tx_drops;
+                intf.watchdog.record(&counters);
             }
         });
     }
@@ -411,6 +413,7 @@ fn packet_recv(
     if_index: InterfaceIndex,
     max_to_read: usize,
     pkts: &mut Vec<Box<Packet<TestBuffer>>>,
+    counters: &mut RxCounters,
 ) -> Result<(), nix::Error> {
     let mut raw = [0u8; 9600];
     let mut ret = Ok(());
@@ -441,6 +444,7 @@ fn packet_recv(
                     }
                     Err(e) => {
                         // Parsing errors happen; avoid logspam for loopback
+                        counters.parse_errors += 1;
                         if if_name != "lo" {
                             error!(
                                 worker = id,
@@ -468,6 +472,7 @@ fn packet_recv(
 async fn read_packets_from_interface(
     id: WorkerId,
     intf: &WorkerInterfaceReader,
+    counters: &mut RxCounters,
 ) -> Result<Vec<Box<Packet<TestBuffer>>>, io::Error> {
     let fd = &intf.read_fd;
     let mut guard = match fd.readable().await {
@@ -500,6 +505,7 @@ async fn read_packets_from_interface(
             intf.if_index,
             DriverKernel::MAX_RX_PKT_BATCH,
             &mut pkts,
+            counters,
         )
         .map_err(std::convert::Into::into)
     }) {

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -405,6 +405,48 @@ fn build_interface_table(
     Ok((readers, Arc::new(if_table)))
 }
 
+/// Build a [`Packet`] out of a frame just read from a socket. `bytes` is the length the
+/// kernel reported for the frame, which may be more than what we read into `raw`.
+/// Returns `None` if the frame could not be used, and counts why.
+fn build_packet(
+    id: WorkerId,
+    if_name: &str,
+    raw: &[u8],
+    bytes: usize,
+    if_index: InterfaceIndex,
+    counters: &mut RxCounters,
+) -> Option<Box<Packet<TestBuffer>>> {
+    if raw.len() < bytes {
+        counters.truncated += 1;
+        error!(
+            worker = id,
+            rx_intf_name = if_name,
+            "Received packet with {bytes} bytes on {if_name} but raw buffer is only {} bytes, truncating",
+            raw.len()
+        );
+    }
+    let buf = TestBuffer::from_raw_data(&raw[..std::cmp::min(raw.len(), bytes)]);
+    match Packet::new(buf) {
+        Ok(mut incoming) => {
+            incoming.meta_mut().iif = Some(if_index);
+            Some(Box::new(incoming))
+        }
+        Err(e) => {
+            // Parsing errors happen; avoid logspam for loopback
+            counters.parse_errors += 1;
+            if if_name != "lo" {
+                error!(
+                    worker = id,
+                    rx_intf_name = if_name,
+                    "Failed to parse packet on '{}': {e}",
+                    if_name
+                );
+            }
+            None
+        }
+    }
+}
+
 /// Tries to receive frames from the indicated interface and builds `Packet`s
 /// out of them. Returns a vector of [`Packet`]s.
 fn packet_recv(
@@ -432,34 +474,8 @@ fn packet_recv(
             }
             Ok(bytes) => {
                 trace!("Received packet with {} bytes on {}", bytes, if_name);
-                // build TestBuffer and parse
-                if raw.len() < bytes {
-                    counters.truncated += 1;
-                    error!(
-                        worker = id,
-                        rx_intf_name = if_name,
-                        "Received packet with {bytes} bytes on {if_name} but raw buffer is only {} bytes, truncating",
-                        raw.len()
-                    );
-                }
-                let buf = TestBuffer::from_raw_data(&raw[..std::cmp::min(raw.len(), bytes)]);
-                match Packet::new(buf) {
-                    Ok(mut incoming) => {
-                        incoming.meta_mut().iif = Some(if_index);
-                        pkts.push(Box::new(incoming));
-                    }
-                    Err(e) => {
-                        // Parsing errors happen; avoid logspam for loopback
-                        counters.parse_errors += 1;
-                        if if_name != "lo" {
-                            error!(
-                                worker = id,
-                                rx_intf_name = if_name,
-                                "Failed to parse packet on '{}': {e}",
-                                if_name
-                            );
-                        }
-                    }
+                if let Some(pkt) = build_packet(id, if_name, &raw, bytes, if_index, counters) {
+                    pkts.push(pkt);
                 }
             }
             Err(e) if e == nix::errno::Errno::EWOULDBLOCK => {
@@ -651,5 +667,70 @@ async fn tx_packet(
             );
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{RxCounters, build_packet};
+    use net::buffer::test_buffer::TestBuffer;
+    use net::interface::InterfaceIndex;
+    use net::packet::Packet;
+    use net::packet::test_utils::build_test_ipv4_packet;
+
+    const IF_INDEX: u32 = 1;
+    const IF_NAME: &str = "test0";
+
+    fn if_index() -> InterfaceIndex {
+        InterfaceIndex::try_new(IF_INDEX).expect("bad interface index")
+    }
+
+    fn build_test_frame() -> Packet<TestBuffer> {
+        build_test_ipv4_packet(64).expect("failed to build test packet")
+    }
+
+    /// A frame we can parse is returned, and tagged with the interface it came from.
+    #[test]
+    fn good_frame_is_not_counted_as_an_error() {
+        let packet = build_test_frame();
+        let buf = packet.serialize().expect("failed to serialize test packet");
+        let raw = buf.as_ref();
+
+        let mut counters = RxCounters::default();
+        let built = build_packet(0, IF_NAME, raw, raw.len(), if_index(), &mut counters)
+            .expect("valid frame should be built");
+
+        assert_eq!(built.meta().iif, Some(if_index()));
+        assert_eq!(counters.parse_errors, 0);
+        assert_eq!(counters.truncated, 0);
+    }
+
+    /// A frame we cannot parse is dropped, and counted.
+    #[test]
+    fn unparseable_frame_is_counted() {
+        let raw = [0xffu8; 4];
+
+        let mut counters = RxCounters::default();
+        let built = build_packet(0, IF_NAME, &raw, raw.len(), if_index(), &mut counters);
+
+        assert!(built.is_none());
+        assert_eq!(counters.parse_errors, 1);
+        assert_eq!(counters.truncated, 0);
+    }
+
+    /// A frame longer than what we read is counted, whether or not we can parse it.
+    #[test]
+    fn oversize_frame_is_counted() {
+        let packet = build_test_frame();
+        let buf = packet.serialize().expect("failed to serialize test packet");
+        let raw = buf.as_ref();
+
+        let mut counters = RxCounters::default();
+        // the kernel tells us the frame was longer than what it copied for us
+        let built = build_packet(0, IF_NAME, raw, raw.len() + 1, if_index(), &mut counters);
+
+        assert!(built.is_some());
+        assert_eq!(counters.truncated, 1);
+        assert_eq!(counters.parse_errors, 0);
     }
 }

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -574,14 +574,28 @@ async fn tx_packet(
                 "TXing {len} bytes on interface {}",
                 &outgoing.if_name
             );
-            if let Err(e) = outgoing.sock.write(out.as_ref()).await {
-                warn!(
-                    worker = id,
-                    rx_intf_name = rx_if_name,
-                    "TX failed for pkt ({len} octets) on interface '{}': {e}",
-                    &outgoing.if_name
-                );
-                return false;
+            match outgoing.sock.write(out.as_ref()).await {
+                Ok(written) if written == len => {}
+                Ok(written) => {
+                    // One write is one frame on a packet socket, so we can't complete a partial
+                    // write with a second one: the remainder would go out as its own frame.
+                    warn!(
+                        worker = id,
+                        rx_intf_name = rx_if_name,
+                        "TX wrote {written} of {len} octets on interface '{}'. Dropping packet",
+                        &outgoing.if_name
+                    );
+                    return false;
+                }
+                Err(e) => {
+                    warn!(
+                        worker = id,
+                        rx_intf_name = rx_if_name,
+                        "TX failed for pkt ({len} octets) on interface '{}': {e}",
+                        &outgoing.if_name
+                    );
+                    return false;
+                }
             }
             trace!(
                 worker = id,

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -429,10 +429,11 @@ fn packet_recv(
                 trace!("Received packet with {} bytes on {}", bytes, if_name);
                 // build TestBuffer and parse
                 if raw.len() < bytes {
+                    counters.truncated += 1;
                     error!(
                         worker = id,
                         rx_intf_name = if_name,
-                        "Received packet with {bytes} bytes on {if_name} but raw buffer is only {} bytes, trunctating",
+                        "Received packet with {bytes} bytes on {if_name} but raw buffer is only {} bytes, truncating",
                         raw.len()
                     );
                 }

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -29,7 +29,7 @@ use crate::drivers::kernel::fanout::{PacketFanoutType, set_packet_fanout};
 use crate::drivers::kernel::kif::Kif;
 use crate::drivers::kernel::{WorkerIfaceMonitor, WorkerMonitor};
 use crate::drivers::status::WorkerId;
-use crate::drivers::watchdog::Watchdog;
+use crate::drivers::watchdog::{RxCounters, Watchdog};
 
 use tracing::{debug, error, info, trace, warn};
 
@@ -276,8 +276,12 @@ impl Worker {
                 );
 
                 // update rx task stats
-                intf.watchdog
-                    .record(rx_pkts, tx_pkts, ppline_drops, tx_drops);
+                intf.watchdog.record(&RxCounters {
+                    rx: rx_pkts,
+                    tx: tx_pkts,
+                    ppline_drops,
+                    tx_drops,
+                });
             }
         });
     }

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -424,7 +424,11 @@ fn packet_recv(
             &mut raw,
             nix::sys::socket::MsgFlags::MSG_DONTWAIT | nix::sys::socket::MsgFlags::MSG_TRUNC,
         ) {
-            Ok(0) => break, // no more
+            Ok(0) => {
+                // Treated as "no more to read".
+                counters.zero_len += 1;
+                break;
+            }
             Ok(bytes) => {
                 trace!("Received packet with {} bytes on {}", bytes, if_name);
                 // build TestBuffer and parse

--- a/dataplane/src/drivers/kernel/worker.rs
+++ b/dataplane/src/drivers/kernel/worker.rs
@@ -281,6 +281,7 @@ impl Worker {
                     tx: tx_pkts,
                     ppline_drops,
                     tx_drops,
+                    ..RxCounters::default()
                 });
             }
         });

--- a/dataplane/src/drivers/status.rs
+++ b/dataplane/src/drivers/status.rs
@@ -14,7 +14,7 @@ use concurrency::sync::Arc;
 use std::fmt::Display;
 
 use crate::drivers::kernel::DriverKernel;
-use crate::drivers::watchdog::Activity;
+use crate::drivers::watchdog::{Activity, RxCounters};
 
 // The unique Id of a worker
 pub(crate) type WorkerId = usize;
@@ -53,6 +53,19 @@ impl RxTaskStatus {
             total_kernel_drops: 0,
             pps: 0.,
         }
+    }
+
+    /// Add the counters read from a rx task watchdog to the totals. Reading a watchdog
+    /// clears it, so this must be called for every read, whatever the activity reported.
+    pub fn accumulate(&mut self, counters: &RxCounters) {
+        self.total_rx += counters.rx;
+        self.total_tx += counters.tx;
+        self.total_ppline_drops += counters.ppline_drops;
+        self.total_tx_drops += counters.tx_drops;
+        self.total_parse_errors += counters.parse_errors;
+        self.total_truncated += counters.truncated;
+        self.total_zero_len += counters.zero_len;
+        self.total_kernel_drops += counters.kernel_drops;
     }
 }
 
@@ -247,5 +260,38 @@ impl Display for DriverStatus {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Arc, RxCounters, RxTaskStatus};
+
+    /// Every counter read from a watchdog must make it to the totals.
+    #[test]
+    fn accumulate_keeps_every_counter() {
+        let mut status = RxTaskStatus::new(Arc::from("eth0"));
+        let counters = RxCounters {
+            rx: 1,
+            tx: 2,
+            ppline_drops: 3,
+            tx_drops: 4,
+            parse_errors: 5,
+            truncated: 6,
+            zero_len: 7,
+            kernel_drops: 8,
+        };
+
+        status.accumulate(&counters);
+        status.accumulate(&counters);
+
+        assert_eq!(status.total_rx, 2);
+        assert_eq!(status.total_tx, 4);
+        assert_eq!(status.total_ppline_drops, 6);
+        assert_eq!(status.total_tx_drops, 8);
+        assert_eq!(status.total_parse_errors, 10);
+        assert_eq!(status.total_truncated, 12);
+        assert_eq!(status.total_zero_len, 14);
+        assert_eq!(status.total_kernel_drops, 16);
     }
 }

--- a/dataplane/src/drivers/status.rs
+++ b/dataplane/src/drivers/status.rs
@@ -30,6 +30,10 @@ pub struct RxTaskStatus {
     pub total_tx: u64,
     pub total_ppline_drops: u64,
     pub total_tx_drops: u64,
+    pub total_parse_errors: u64,
+    pub total_truncated: u64,
+    pub total_zero_len: u64,
+    pub total_kernel_drops: u64,
     pub pps: f64,
 }
 impl RxTaskStatus {
@@ -43,6 +47,10 @@ impl RxTaskStatus {
             total_tx: 0,
             total_ppline_drops: 0,
             total_tx_drops: 0,
+            total_parse_errors: 0,
+            total_truncated: 0,
+            total_zero_len: 0,
+            total_kernel_drops: 0,
             pps: 0.,
         }
     }
@@ -140,7 +148,13 @@ impl Display for WorkerState {
 
 macro_rules! RX_TASK_TBL_FMT {
     () => {
-        "   {:<16}  {:<6}  {:>14}  {:>20}  {:>20}  {:>12}  {:>8}  {:>9}"
+        "   {:<16}  {:<6}  {:>14}  {:>20}  {:>20}  {:>9}"
+    };
+}
+
+macro_rules! RX_DROP_TBL_FMT {
+    () => {
+        "   {:<16}  {:>12}  {:>10}  {:>10}  {:>10}  {:>10}  {:>12}"
     };
 }
 
@@ -150,7 +164,7 @@ fn fmt_rx_task_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         "{}",
         format_args!(
             RX_TASK_TBL_FMT!(),
-            "iface", "status", "pps", "pkt-rx", "pkt-tx", "ppline-drops", "tx-drops", "wd-misses"
+            "iface", "status", "pps", "pkt-rx", "pkt-tx", "wd-misses"
         )
     )
 }
@@ -162,14 +176,41 @@ fn fmt_rx_task(f: &mut std::fmt::Formatter<'_>, rx: &RxTaskStatus) -> std::fmt::
         "{}",
         format_args!(
             RX_TASK_TBL_FMT!(),
+            rx.ifname, rx.activity, pps, rx.total_rx, rx.total_tx, rx.misses
+        )
+    )
+}
+
+fn fmt_rx_drop_heading(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            RX_DROP_TBL_FMT!(),
+            "iface",
+            "ppline-drops",
+            "tx-drops",
+            "parse-err",
+            "truncated",
+            "zero-len",
+            "kernel-drops"
+        )
+    )
+}
+
+fn fmt_rx_drop(f: &mut std::fmt::Formatter<'_>, rx: &RxTaskStatus) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}",
+        format_args!(
+            RX_DROP_TBL_FMT!(),
             rx.ifname,
-            rx.activity,
-            pps,
-            rx.total_rx,
-            rx.total_tx,
             rx.total_ppline_drops,
             rx.total_tx_drops,
-            rx.misses
+            rx.total_parse_errors,
+            rx.total_truncated,
+            rx.total_zero_len,
+            rx.total_kernel_drops
         )
     )
 }
@@ -187,13 +228,23 @@ impl Display for DriverStatus {
             return writeln!(f, " (no workers)");
         }
 
+        writeln!(f, " rx tasks")?;
         fmt_rx_task_heading(f)?;
         for worker in &self.workers {
             writeln!(f, " worker {}: {}", worker.worker, worker.state)?;
             for rx in &worker.rx_tasks {
                 fmt_rx_task(f, rx)?;
             }
-            writeln!(f)?;
+        }
+
+        writeln!(f)?;
+        writeln!(f, " rx drops")?;
+        fmt_rx_drop_heading(f)?;
+        for worker in &self.workers {
+            writeln!(f, " worker {}", worker.worker)?;
+            for rx in &worker.rx_tasks {
+                fmt_rx_drop(f, rx)?;
+            }
         }
         Ok(())
     }

--- a/dataplane/src/drivers/watchdog.rs
+++ b/dataplane/src/drivers/watchdog.rs
@@ -49,50 +49,22 @@ impl Watchdog {
         self.0.armed.store(false, Ordering::Relaxed);
     }
 
-    /// Task: record packets rx and tx
-    pub fn record(&self, rx: u64, tx: u64, ppline_drops: u64, tx_drops: u64) {
-        if rx > 0 {
-            let _ = self
-                .0
-                .rx
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_add(rx))
-                });
-        }
-        if tx > 0 {
-            let _ = self
-                .0
-                .tx
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_add(tx))
-                });
-        }
-        if ppline_drops > 0 {
-            let _ = self
-                .0
-                .ppline_drops
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_add(ppline_drops))
-                });
-        }
-        if tx_drops > 0 {
-            let _ = self
-                .0
-                .tx_drops
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
-                    Some(v.saturating_add(tx_drops))
-                });
-        }
+    /// Task: record the counters for a batch
+    pub fn record(&self, counters: &RxCounters) {
+        accumulate(&self.0.rx, counters.rx);
+        accumulate(&self.0.tx, counters.tx);
+        accumulate(&self.0.ppline_drops, counters.ppline_drops);
+        accumulate(&self.0.tx_drops, counters.tx_drops);
     }
 
-    /// Supervisor: check the activity count of a watchdog (and zero it).
-    /// If `check_and_rearm` is true, check if the watchdog was patted and
-    /// re-arm it. The status is abstracted in [`Activity`]. If `check_and_rearm`
-    /// is false, the watchdog check (and re-arm) is omitted, meaning that this
-    /// method will never return `Activity::Stuck` in that case.
+    /// Supervisor: read the counters of a watchdog (and zero them), along with the
+    /// activity they denote. If `check_and_rearm` is true, check if the watchdog was
+    /// patted and re-arm it. If it is false, the watchdog check (and re-arm) is
+    /// omitted, meaning that this method will never return `Activity::Stuck` in that
+    /// case.
     #[must_use]
-    pub fn check_and_clear(&self, check_and_rearm: bool) -> Activity {
-        let record = ActivityRecord {
+    pub fn check_and_clear(&self, check_and_rearm: bool) -> (RxCounters, Activity) {
+        let counters = RxCounters {
             rx: self.0.rx.swap(0, Ordering::Relaxed),
             tx: self.0.tx.swap(0, Ordering::Relaxed),
             ppline_drops: self.0.ppline_drops.swap(0, Ordering::Relaxed),
@@ -103,31 +75,42 @@ impl Watchdog {
         } else {
             true // assume it was patted since we don't check/care
         };
-        if record.rx > 0 {
-            Activity::Active(record)
+        let activity = if counters.rx > 0 {
+            Activity::Active
         } else if patted {
             Activity::Idle
         } else {
             debug_assert!(check_and_rearm);
             Activity::Stuck
-        }
+        };
+        (counters, activity)
+    }
+}
+
+/// Add `val` to `counter`, saturating instead of wrapping.
+fn accumulate(counter: &AtomicU64, val: u64) {
+    if val > 0 {
+        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+            Some(v.saturating_add(val))
+        });
     }
 }
 
 /// The state of a [`Watchdog`] as observed by a supervisor when it checks it [`Watchdog::check_and_clear`].
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum Activity {
     /// Watchdog was not patted
     Stuck,
     /// Watchdog was patted but task reported no work
     Idle,
     /// Task reported progress
-    Active(ActivityRecord),
+    Active,
 }
 
-/// An activity record from a workers' rx task
-#[derive(Debug, Clone)]
-pub struct ActivityRecord {
+/// The counters a worker's rx task reports on its [`Watchdog`], and that the
+/// supervisor reads back from it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RxCounters {
     /// Pkts received
     pub rx: u64,
     /// Pkts successfully tx'ed
@@ -143,7 +126,7 @@ impl std::fmt::Display for Activity {
         f.pad(match self {
             Activity::Stuck => "Stuck!",
             Activity::Idle => "Idle",
-            Activity::Active(_) => "Active",
+            Activity::Active => "Active",
         })
     }
 }

--- a/dataplane/src/drivers/watchdog.rs
+++ b/dataplane/src/drivers/watchdog.rs
@@ -159,3 +159,70 @@ impl std::fmt::Display for Activity {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{Activity, RxCounters, Watchdog};
+
+    /// A watchdog reports the counters it holds, whatever the activity it denotes.
+    /// Anything it does not report is lost, since reading clears them.
+    #[test]
+    fn counters_are_reported_when_not_active() {
+        // tx drops, but nothing received: this is not activity for the task
+        let watchdog = Watchdog::new();
+        watchdog.pat();
+        watchdog.record(&RxCounters {
+            tx_drops: 7,
+            kernel_drops: 3,
+            ..RxCounters::default()
+        });
+
+        let (counters, activity) = watchdog.check_and_clear(true);
+        assert!(matches!(activity, Activity::Idle));
+        assert_eq!(counters.tx_drops, 7);
+        assert_eq!(counters.kernel_drops, 3);
+
+        // same, for a task that failed to pat the watchdog
+        watchdog.record(&RxCounters {
+            ppline_drops: 5,
+            ..RxCounters::default()
+        });
+        let (counters, activity) = watchdog.check_and_clear(true);
+        assert!(matches!(activity, Activity::Stuck));
+        assert_eq!(counters.ppline_drops, 5);
+    }
+
+    /// Reading the counters clears them.
+    #[test]
+    fn counters_are_cleared_when_read() {
+        let watchdog = Watchdog::new();
+        watchdog.record(&RxCounters {
+            rx: 4,
+            parse_errors: 2,
+            ..RxCounters::default()
+        });
+
+        let (counters, _) = watchdog.check_and_clear(false);
+        assert_eq!(counters.rx, 4);
+        assert_eq!(counters.parse_errors, 2);
+
+        let (counters, _) = watchdog.check_and_clear(false);
+        assert_eq!(counters.rx, 0);
+        assert_eq!(counters.parse_errors, 0);
+    }
+
+    /// Frames we could not parse mean the task is busy, not idle.
+    #[test]
+    fn parse_errors_count_as_activity() {
+        let watchdog = Watchdog::new();
+        watchdog.pat();
+        watchdog.record(&RxCounters {
+            parse_errors: 9,
+            ..RxCounters::default()
+        });
+
+        let (counters, activity) = watchdog.check_and_clear(true);
+        assert!(matches!(activity, Activity::Active));
+        assert_eq!(counters.parse_errors, 9);
+    }
+}

--- a/dataplane/src/drivers/watchdog.rs
+++ b/dataplane/src/drivers/watchdog.rs
@@ -87,7 +87,7 @@ impl Watchdog {
         } else {
             true // assume it was patted since we don't check/care
         };
-        let activity = if counters.rx > 0 {
+        let activity = if counters.saw_frames() {
             Activity::Active
         } else if patted {
             Activity::Idle
@@ -139,6 +139,15 @@ pub struct RxCounters {
     pub zero_len: u64,
     /// Frames the kernel dropped on the socket before we could read them
     pub kernel_drops: u64,
+}
+
+impl RxCounters {
+    /// Tell if the task saw any frame, including ones it could not make use of.
+    /// Frames dropped by the kernel don't count: the task never saw them.
+    #[must_use]
+    pub fn saw_frames(&self) -> bool {
+        self.rx > 0 || self.parse_errors > 0 || self.truncated > 0 || self.zero_len > 0
+    }
 }
 
 impl std::fmt::Display for Activity {

--- a/dataplane/src/drivers/watchdog.rs
+++ b/dataplane/src/drivers/watchdog.rs
@@ -31,6 +31,10 @@ struct WatchdogInner {
     tx: AtomicU64,           // number of packets sent by task
     ppline_drops: AtomicU64, // number of packets dropped by task pipeline
     tx_drops: AtomicU64,     // number of tx failures
+    parse_errors: AtomicU64, // number of frames we failed to parse
+    truncated: AtomicU64,    // number of frames larger than the rx buffer
+    zero_len: AtomicU64,     // number of zero-length reads
+    kernel_drops: AtomicU64, // number of frames the kernel dropped on the socket
 }
 
 /// A lock-free liveness + activity watchdog.
@@ -55,6 +59,10 @@ impl Watchdog {
         accumulate(&self.0.tx, counters.tx);
         accumulate(&self.0.ppline_drops, counters.ppline_drops);
         accumulate(&self.0.tx_drops, counters.tx_drops);
+        accumulate(&self.0.parse_errors, counters.parse_errors);
+        accumulate(&self.0.truncated, counters.truncated);
+        accumulate(&self.0.zero_len, counters.zero_len);
+        accumulate(&self.0.kernel_drops, counters.kernel_drops);
     }
 
     /// Supervisor: read the counters of a watchdog (and zero them), along with the
@@ -69,6 +77,10 @@ impl Watchdog {
             tx: self.0.tx.swap(0, Ordering::Relaxed),
             ppline_drops: self.0.ppline_drops.swap(0, Ordering::Relaxed),
             tx_drops: self.0.tx_drops.swap(0, Ordering::Relaxed),
+            parse_errors: self.0.parse_errors.swap(0, Ordering::Relaxed),
+            truncated: self.0.truncated.swap(0, Ordering::Relaxed),
+            zero_len: self.0.zero_len.swap(0, Ordering::Relaxed),
+            kernel_drops: self.0.kernel_drops.swap(0, Ordering::Relaxed),
         };
         let patted = if check_and_rearm {
             !self.0.armed.swap(true, Ordering::Relaxed)
@@ -119,6 +131,14 @@ pub struct RxCounters {
     pub ppline_drops: u64,
     /// Pkts received dropped on tx
     pub tx_drops: u64,
+    /// Frames received but that we failed to parse
+    pub parse_errors: u64,
+    /// Frames received but larger than the rx buffer
+    pub truncated: u64,
+    /// Zero-length reads on the socket
+    pub zero_len: u64,
+    /// Frames the kernel dropped on the socket before we could read them
+    pub kernel_drops: u64,
 }
 
 impl std::fmt::Display for Activity {


### PR DESCRIPTION
This is an effort to add missing logs and counts for dropped frames, in particular in the kernel driver.

Mostly written by Claude; it seems reasonable, but don't hesitate to put the changes in question if they look suspicious to you.

Fixes: #1682