### PR TITLE
fix(acl): bound the layout stride from above, not just below

### DIFF
--- a/acl/src/dpdk/install.rs
+++ b/acl/src/dpdk/install.rs
@@ -7,7 +7,7 @@ use match_action::MatchKey;
 
 use crate::dpdk::dyn_table::{DynInstallError, DynRuleSpec, dispatch_build_classifier};
 use crate::dpdk::layout::{LayoutError, plan_layout};
-use crate::dpdk::lookup::{DpdkAclLookup, MAX_USER_KEY_BYTES, StrideTooSmall};
+use crate::dpdk::lookup::{DpdkAclLookup, MAX_USER_KEY_BYTES, StrideError};
 use crate::dpdk::rule::RuleSpec;
 
 /// Install a typed ACL table.
@@ -57,5 +57,5 @@ pub enum InstallError {
     #[error(transparent)]
     Build(#[from] DynInstallError),
     #[error(transparent)]
-    Stride(#[from] StrideTooSmall),
+    Stride(#[from] StrideError),
 }

--- a/acl/src/dpdk/layout.rs
+++ b/acl/src/dpdk/layout.rs
@@ -252,7 +252,26 @@ fn chunk_shape_checked(size: usize, user_index: usize) -> Result<(u32, usize), L
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dpdk::lookup::MAX_USER_KEY_BYTES;
     use dpdk::acl::AclBuildConfig;
+
+    /// No layout this planner can emit can outgrow the lookup path's key buffers.
+    ///
+    /// `DpdkAclLookup::new` rejects such a layout, so this is not the thing standing between us
+    /// and an out-of-bounds access -- it is what keeps that rejection unreachable. The margin is
+    /// zero (`4 * MAX_FIELDS == MAX_USER_KEY_BYTES` exactly), so raising `MAX_FIELDS` or lowering
+    /// `MAX_USER_KEY_BYTES` by any amount starts failing table builds at runtime. Fail here
+    /// instead, at the constants, where the fix is obvious.
+    #[test]
+    fn planner_can_never_outgrow_the_lookup_key_buffers() {
+        // Every def advances the stride by at most 4 bytes, and there are at most MAX_FIELDS defs.
+        let worst_case_stride = 4 * MAX_FIELDS;
+        assert!(
+            worst_case_stride <= MAX_USER_KEY_BYTES,
+            "a maximal layout ({worst_case_stride} bytes) would exceed the lookup key buffer \
+             ({MAX_USER_KEY_BYTES} bytes): raise MAX_USER_KEY_BYTES to match 4 * MAX_FIELDS",
+        );
+    }
 
     fn spec(name: &'static str, kind: FieldKind, size: usize, offset: usize) -> FieldSpec {
         FieldSpec {

--- a/acl/src/dpdk/lookup.rs
+++ b/acl/src/dpdk/lookup.rs
@@ -51,22 +51,39 @@ where
     /// Construct a lookup table from a built classifier, its action table, and
     /// the planned layout.
     ///
-    /// Returns [`StrideTooSmall`] if `layout.stride` is smaller than the
-    /// classifier's `min_input_size`. This is the keystone invariant: once it
-    /// holds, packing a key into a `stride`-sized buffer always yields at least
-    /// `min_input_size` valid bytes, which is what makes the `unsafe` classify
-    /// calls below sound (see `development/code/unsafe-code.md` -- `unsafe` used
-    /// only to build a safe abstraction with local reasoning).
+    /// Bounds `layout.stride` from both sides, which is what every buffer on the
+    /// lookup path relies on:
+    ///
+    /// - Not below the classifier's `min_input_size`, so packing a key into a
+    ///   `stride`-sized buffer always yields at least `min_input_size` valid
+    ///   bytes. That is what makes the `unsafe` classify calls below sound (see
+    ///   `development/code/unsafe-code.md` -- `unsafe` used only to build a safe
+    ///   abstraction with local reasoning).
+    /// - Not above [`MAX_USER_KEY_BYTES`], so `ZEROS[..stride]` is in bounds and
+    ///   neither the single-key buffer nor the batch arena can overflow.
+    ///
+    /// The upper bound holds today by construction -- `plan_layout` emits at
+    /// most `MAX_FIELDS` defs of at most 4 bytes, and `4 * MAX_FIELDS` is
+    /// exactly `MAX_USER_KEY_BYTES` -- but with no margin whatsoever, and the
+    /// buffers that depend on it are two files away from the constant that
+    /// grants it. Checking here fails the build of a table that could not be
+    /// looked up, rather than panicking on the hot path once per packet.
     pub fn new(
         classifier: Arc<dyn DynClassifier>,
         actions: Vec<A>,
         layout: DpdkLayout,
-    ) -> Result<Self, StrideTooSmall> {
+    ) -> Result<Self, StrideError> {
         let required = classifier.min_input_size();
         if layout.stride < required {
-            return Err(StrideTooSmall {
+            return Err(StrideError::TooSmall {
                 stride: layout.stride,
                 required,
+            });
+        }
+        if layout.stride > MAX_USER_KEY_BYTES {
+            return Err(StrideError::TooLarge {
+                stride: layout.stride,
+                limit: MAX_USER_KEY_BYTES,
             });
         }
         Ok(Self {
@@ -207,11 +224,14 @@ where
     }
 }
 
+/// A planned layout whose stride cannot back a sound lookup. See [`DpdkAclLookup::new`].
 #[derive(Debug, thiserror::Error)]
-#[error(
-    "DpdkAclLookup layout stride={stride} is smaller than the context's min_input_size={required}"
-)]
-pub struct StrideTooSmall {
-    pub stride: usize,
-    pub required: usize,
+pub enum StrideError {
+    #[error(
+        "DpdkAclLookup layout stride={stride} is smaller than the context's \
+         min_input_size={required}"
+    )]
+    TooSmall { stride: usize, required: usize },
+    #[error("DpdkAclLookup layout stride={stride} exceeds MAX_USER_KEY_BYTES={limit}")]
+    TooLarge { stride: usize, limit: usize },
 }


### PR DESCRIPTION
Fix for theoretical bug but may as well assert rather than malfunction severely