### PR TITLE
Add VPC and VPC-VPC drop counters

### DIFF
--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -327,7 +327,7 @@ impl ConfigProcessor {
                     dst_vpc: dst_name,
                     packets: fs.ctr.packets,
                     bytes: fs.ctr.bytes,
-                    drops: 0,
+                    drops: fs.drops.packets,
                     pps: fs.rate.pps,
                     bps: fs.rate.bps,
                 },

--- a/stats/src/dpstats.rs
+++ b/stats/src/dpstats.rs
@@ -490,6 +490,19 @@ impl StatsCollector {
                     .add_vpc_drops(src, tx_summary.drops.packets, tx_summary.drops.bytes)
                     .await;
             }
+
+            // Per-pair (VPC->VPC) drops, for the drop matrix.
+            for (&dst, &drops) in tx_summary.pair_drops.iter() {
+                if !self.alive_vpcs.contains(&dst) {
+                    debug!("skipping pair drop stats for removed VPC {dst}");
+                    continue;
+                }
+                if drops.packets != 0 || drops.bytes != 0 {
+                    self.vpc_store
+                        .add_pair_drops(src, dst, drops.packets, drops.bytes)
+                        .await;
+                }
+            }
         }
 
         // Push this *apportioned per-batch* snapshot into the SG window.
@@ -501,11 +514,15 @@ impl StatsCollector {
             if !self.alive_vpcs.contains(&src) || !self.alive_vpcs.contains(&dst) {
                 continue;
             }
-            if let Some(metrics) = self.metrics.get(&src)
-                && let Some(action) = metrics.peering.get(&dst)
-            {
-                action.tx.packet.count.metric.set(fs.ctr.packets as f64);
-                action.tx.byte.count.metric.set(fs.ctr.bytes as f64);
+            if let Some(metrics) = self.metrics.get(&src) {
+                if let Some(action) = metrics.peering.get(&dst) {
+                    action.tx.packet.count.metric.set(fs.ctr.packets as f64);
+                    action.tx.byte.count.metric.set(fs.ctr.bytes as f64);
+                }
+                if let Some(action) = metrics.peering_drops.get(&dst) {
+                    action.tx.packet.count.metric.set(fs.drops.packets as f64);
+                    action.tx.byte.count.metric.set(fs.drops.bytes as f64);
+                }
             }
         }
 
@@ -654,6 +671,7 @@ where
 #[derive(Debug, Default, Clone)]
 pub struct TransmitSummary<T> {
     pub drops: PacketAndByte<T>,
+    pub pair_drops: SmallMap<{ SMALL_MAP_CAPACITY }, VpcDiscriminant, PacketAndByte<T>>,
     pub dst: SmallMap<{ SMALL_MAP_CAPACITY }, VpcDiscriminant, PacketAndByte<T>>,
 }
 
@@ -665,6 +683,7 @@ impl<T> TransmitSummary<T> {
     {
         Self {
             drops: PacketAndByte::<T>::default(),
+            pair_drops: SmallMap::new(),
             dst: SmallMap::new(),
         }
     }
@@ -828,55 +847,52 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Stats {
             let is_drop = done_reason != DoneReason::Delivered;
             let bytes: u64 = packet.total_len().into();
 
-            match (sdisc, ddisc) {
-                (Some(src), Some(dst)) => match self.update.vpc.get_mut(&src) {
-                    None => {
-                        let mut tx_summary = TransmitSummary::new();
-                        if is_drop {
-                            tx_summary.drops.packets = 1;
-                            tx_summary.drops.bytes = bytes;
-                        } else {
-                            tx_summary
-                                .dst
-                                .insert(dst, PacketAndByte { packets: 1, bytes });
-                        }
-                        self.update.vpc.insert(src, tx_summary);
+            fn bump(
+                map: &mut SmallMap<{ SMALL_MAP_CAPACITY }, VpcDiscriminant, PacketAndByte<u64>>,
+                key: VpcDiscriminant,
+                bytes: u64,
+            ) {
+                match map.get_mut(&key) {
+                    Some(e) => {
+                        e.packets += 1;
+                        e.bytes += bytes;
                     }
-                    Some(tx_summary) => match tx_summary.dst.get_mut(&dst) {
-                        None => {
-                            if is_drop {
-                                tx_summary.drops.packets += 1;
-                                tx_summary.drops.bytes += bytes;
-                            } else {
-                                tx_summary
-                                    .dst
-                                    .insert(dst, PacketAndByte { packets: 1, bytes });
-                            }
+                    None => {
+                        map.insert(key, PacketAndByte { packets: 1, bytes });
+                    }
+                }
+            }
+
+            match sdisc {
+                Some(src) => {
+                    let tx_summary = self
+                        .update
+                        .vpc
+                        .entry(src)
+                        .or_insert_with(TransmitSummary::new);
+                    if is_drop {
+                        // Per-VPC total drops: covers every drop from this source, including
+                        // those whose destination VPC could not be resolved.
+                        tx_summary.drops.packets += 1;
+                        tx_summary.drops.bytes += bytes;
+                        // Per-pair (VPC->VPC) drop matrix: only when the destination is known.
+                        if let Some(dst) = ddisc {
+                            bump(&mut tx_summary.pair_drops, dst, bytes);
                         }
-                        Some(dst) => {
-                            if is_drop {
-                                tx_summary.drops.packets += 1;
-                                tx_summary.drops.bytes += bytes;
-                            } else {
-                                dst.packets += 1;
-                                dst.bytes += bytes;
-                            }
-                        }
-                    },
-                },
-                (None, Some(ddisc)) => {
-                    warn!(
+                    } else if let Some(dst) = ddisc {
+                        bump(&mut tx_summary.dst, dst, bytes);
+                    } else {
+                        trace!(
+                            "missing dest discriminant for delivered packet with source discriminant: {src:?}"
+                        );
+                    }
+                }
+                None => match ddisc {
+                    Some(ddisc) => warn!(
                         "missing source discriminant for packet with dest discriminant: {ddisc:?}"
-                    );
-                }
-                (Some(sdisc), None) => {
-                    trace!(
-                        "missing dest discriminant for packet with source discriminant: {sdisc:?}"
-                    );
-                }
-                (None, None) => {
-                    trace!("no source or dest discriminants for packet");
-                }
+                    ),
+                    None => trace!("no source or dest discriminants for packet"),
+                },
             }
             packet.meta_mut().set_keep(false); /* no longer disable enforce */
             packet.enforce()
@@ -984,11 +1000,18 @@ mod contract {
         fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
             let mut summary = TransmitSummary {
                 drops: driver.produce()?,
+                pair_drops: SmallMap::default(),
                 dst: SmallMap::default(),
             };
             let num_src = driver.produce::<u8>()? % 16;
             for _ in 0..num_src {
                 summary.dst.insert(driver.produce()?, driver.produce()?);
+            }
+            let num_drops = driver.produce::<u8>()? % 16;
+            for _ in 0..num_drops {
+                summary
+                    .pair_drops
+                    .insert(driver.produce()?, driver.produce()?);
             }
             Some(summary)
         }

--- a/stats/src/dpstats.rs
+++ b/stats/src/dpstats.rs
@@ -49,6 +49,73 @@ fn overlap_nanos(a_start: Instant, a_end: Instant, b_start: Instant, b_end: Inst
     end.duration_since(start).as_nanos()
 }
 
+/// Accumulate a `(packets, bytes)` value into a per-destination `SmallMap` entry.
+#[inline]
+fn add_into_map(
+    map: &mut SmallMap<{ SMALL_MAP_CAPACITY }, VpcDiscriminant, PacketAndByte<u64>>,
+    key: VpcDiscriminant,
+    value: PacketAndByte<u64>,
+) {
+    match map.get_mut(&key) {
+        Some(e) => *e += value,
+        None => {
+            map.insert(key, value);
+        }
+    }
+}
+
+/// Apportion a single `(packets, bytes)` value for `src` across the overlapping outstanding batch
+/// `slices`, using the same integer-safe split as forward-traffic apportionment (the remainder
+/// goes to the last overlapping batch). `apply` places each per-batch share into the appropriate
+/// field of that batch's `TransmitSummary` (e.g. the source drop total, or a per-pair entry).
+fn apportion_into_batches(
+    slices: &mut [&mut BatchSummary<u64>],
+    overlaps: &[u128],
+    total_ov: u128,
+    last_idx: Option<usize>,
+    src: VpcDiscriminant,
+    value: PacketAndByte<u64>,
+    mut apply: impl FnMut(&mut TransmitSummary<u64>, PacketAndByte<u64>),
+) {
+    if (value.packets == 0 && value.bytes == 0) || total_ov == 0 {
+        return;
+    }
+    let mut rem_pkts = value.packets;
+    let mut rem_bytes = value.bytes;
+    for (i, batch) in slices.iter_mut().enumerate() {
+        let ov = overlaps[i];
+        if ov == 0 {
+            continue;
+        }
+        let is_last = Some(i) == last_idx;
+        let pkts_in = if is_last {
+            rem_pkts
+        } else {
+            let v = ((value.packets as u128) * ov / total_ov) as u64;
+            rem_pkts = rem_pkts.saturating_sub(v);
+            v
+        };
+        let bytes_in = if is_last {
+            rem_bytes
+        } else {
+            let v = ((value.bytes as u128) * ov / total_ov) as u64;
+            rem_bytes = rem_bytes.saturating_sub(v);
+            v
+        };
+        if pkts_in == 0 && bytes_in == 0 {
+            continue;
+        }
+        let tx = batch.vpc.entry(src).or_insert_with(TransmitSummary::new);
+        apply(
+            tx,
+            PacketAndByte {
+                packets: pkts_in,
+                bytes: bytes_in,
+            },
+        );
+    }
+}
+
 /// Take a synchronous snapshot of `(disc, name)` pairs from the VPC map reader.
 fn snapshot_vpc_pairs(reader: &VpcMapReader<VpcMapName>) -> Vec<(VpcDiscriminant, String)> {
     match reader.enter() {
@@ -64,40 +131,31 @@ fn snapshot_vpc_pairs(reader: &VpcMapReader<VpcMapName>) -> Vec<(VpcDiscriminant
     }
 }
 
+/// Base id of the per-pair (VPC->VPC) drops metric family. Shared with
+/// [`crate::vpc::VpcMetricsSpec::new`], which registers these gauges under the same base.
+pub(crate) const PAIR_DROPS_METRIC_BASE: &str = "vpc_pair_drops";
+
+/// Zero the four gauges (`{base}_packet_count`, `{base}_packet_rate`, `{base}_byte_count`,
+/// `{base}_byte_rate`) for the given label set. Used to clear series belonging to VPCs/peerings
+/// that have been removed, so they don't export stale values indefinitely.
 #[inline]
-fn vpc_id_packet_count() -> &'static str {
-    "vpc_packet_count"
-}
-#[inline]
-fn vpc_id_packet_rate() -> &'static str {
-    "vpc_packet_rate"
-}
-#[inline]
-fn vpc_id_byte_count() -> &'static str {
-    "vpc_byte_count"
-}
-#[inline]
-fn vpc_id_byte_rate() -> &'static str {
-    "vpc_byte_rate"
+fn set_gauges_to_zero(base: &str, labels: Vec<(String, String)>) {
+    for (suffix, unit) in [
+        ("_packet_count", Unit::Count),
+        ("_packet_rate", Unit::BitsPerSecond),
+        ("_byte_count", Unit::Count),
+        ("_byte_rate", Unit::BitsPerSecond),
+    ] {
+        let gauge: crate::register::Registered<metrics::Gauge> =
+            MetricSpec::new(format!("{base}{suffix}"), unit, labels.clone()).register();
+        gauge.metric.set(0.0);
+    }
 }
 
+/// Zero the `vpc_*` gauge family (per-VPC totals/drops and per-pair traffic) for the given labels.
 #[inline]
 fn set_vpc_gauges_to_zero(labels: Vec<(String, String)>) {
-    let packet_count: crate::register::Registered<metrics::Gauge> =
-        MetricSpec::new(vpc_id_packet_count(), Unit::Count, labels.clone()).register();
-    packet_count.metric.set(0.0);
-
-    let packet_rate: crate::register::Registered<metrics::Gauge> =
-        MetricSpec::new(vpc_id_packet_rate(), Unit::BitsPerSecond, labels.clone()).register();
-    packet_rate.metric.set(0.0);
-
-    let byte_count: crate::register::Registered<metrics::Gauge> =
-        MetricSpec::new(vpc_id_byte_count(), Unit::Count, labels.clone()).register();
-    byte_count.metric.set(0.0);
-
-    let byte_rate: crate::register::Registered<metrics::Gauge> =
-        MetricSpec::new(vpc_id_byte_rate(), Unit::BitsPerSecond, labels).register();
-    byte_rate.metric.set(0.0);
+    set_gauges_to_zero("vpc", labels);
 }
 
 /// A `StatsCollector` is responsible for collecting and aggregating packet statistics for a
@@ -261,16 +319,20 @@ impl StatsCollector {
                 set_vpc_gauges_to_zero(vec![("total".to_string(), removed_name.clone())]);
                 set_vpc_gauges_to_zero(vec![("drops".to_string(), removed_name.clone())]);
 
-                // peering series in both directions
+                // peering series (traffic and per-pair drops) in both directions
                 for other_name in &alive_names {
-                    set_vpc_gauges_to_zero(vec![
+                    let fwd = vec![
                         ("from".to_string(), removed_name.clone()),
                         ("to".to_string(), other_name.clone()),
-                    ]);
-                    set_vpc_gauges_to_zero(vec![
+                    ];
+                    let rev = vec![
                         ("from".to_string(), other_name.clone()),
                         ("to".to_string(), removed_name.clone()),
-                    ]);
+                    ];
+                    set_vpc_gauges_to_zero(fwd.clone());
+                    set_vpc_gauges_to_zero(rev.clone());
+                    set_gauges_to_zero(PAIR_DROPS_METRIC_BASE, fwd);
+                    set_gauges_to_zero(PAIR_DROPS_METRIC_BASE, rev);
                 }
 
                 self.known_names.remove(&disc);
@@ -417,6 +479,47 @@ impl StatsCollector {
                     }
                 });
             });
+
+            // Drops are collected per source (a total that also includes drops whose destination
+            // VPC could not be resolved) and per (src,dst) pair. Neither is rate-smoothed, but both
+            // must reach `submit_expired` via the outstanding batches, so apportion them across the
+            // same overlapping slices as forward traffic.
+            let upd_start = update.summary.start;
+            let upd_end = update.start() + update.duration;
+            let overlaps: Vec<u128> = slices
+                .iter()
+                .map(|b| overlap_nanos(b.start, b.planned_end, upd_start, upd_end))
+                .collect();
+            let total_ov: u128 = overlaps.iter().copied().sum();
+            let last_idx = overlaps
+                .iter()
+                .enumerate()
+                .rfind(|&(_, &ov)| ov > 0)
+                .map(|(i, _)| i);
+
+            update.summary.vpc.iter().for_each(|(src, summary)| {
+                for (dst, drops) in summary.pair_drops.iter() {
+                    let dst = *dst;
+                    apportion_into_batches(
+                        &mut slices,
+                        &overlaps,
+                        total_ov,
+                        last_idx,
+                        *src,
+                        *drops,
+                        |tx, v| add_into_map(&mut tx.pair_drops, dst, v),
+                    );
+                }
+                apportion_into_batches(
+                    &mut slices,
+                    &overlaps,
+                    total_ov,
+                    last_idx,
+                    *src,
+                    summary.drops,
+                    |tx, v| tx.drops += v,
+                );
+            });
         }
 
         let current_time = Instant::now();
@@ -522,6 +625,10 @@ impl StatsCollector {
                 if let Some(action) = metrics.peering_drops.get(&dst) {
                     action.tx.packet.count.metric.set(fs.drops.packets as f64);
                     action.tx.byte.count.metric.set(fs.drops.bytes as f64);
+                    // Drops are count-only; no rate is computed. Pin the rate gauges to 0 so
+                    // the registered `_rate` series never export a stale/misleading value.
+                    action.tx.packet.rate.metric.set(0.0);
+                    action.tx.byte.rate.metric.set(0.0);
                 }
             }
         }
@@ -555,6 +662,10 @@ impl StatsCollector {
                     .count
                     .metric
                     .set(fs.drops.bytes as f64);
+                // Drops are count-only; pin the registered rate gauges to 0 so they never
+                // export a stale/misleading value.
+                metrics.drops.tx.packet.rate.metric.set(0.0);
+                metrics.drops.tx.byte.rate.metric.set(0.0);
             }
         }
 
@@ -1214,5 +1325,109 @@ mod drop_stats_tests {
             s.pair_drops.get(&c).map(|x| (x.packets, x.bytes)),
             Some((1, len))
         );
+    }
+
+    fn batch(offset_secs: u64) -> BatchSummary<u64> {
+        BatchSummary::<u64>::new(Instant::now() + Duration::from_secs(offset_secs))
+    }
+
+    #[test]
+    fn apportion_splits_proportionally_and_preserves_totals() {
+        // Overlaps 1:2:3 across three batches; remainder lands in the last overlapping batch.
+        let (mut b0, mut b1, mut b2) = (batch(1), batch(2), batch(3));
+        let mut slices: Vec<&mut BatchSummary<u64>> = vec![&mut b0, &mut b1, &mut b2];
+        let src = vpcd(7);
+
+        apportion_into_batches(
+            &mut slices,
+            &[1, 2, 3],
+            6,
+            Some(2),
+            src,
+            PacketAndByte {
+                packets: 10,
+                bytes: 100,
+            },
+            |tx, v| tx.drops += v,
+        );
+        drop(slices);
+
+        // 10 -> 1,3,(rem)6 ; 100 -> 16,33,(rem)51
+        assert_eq!(
+            b0.vpc.get(&src).map(|t| (t.drops.packets, t.drops.bytes)),
+            Some((1, 16))
+        );
+        assert_eq!(
+            b1.vpc.get(&src).map(|t| (t.drops.packets, t.drops.bytes)),
+            Some((3, 33))
+        );
+        assert_eq!(
+            b2.vpc.get(&src).map(|t| (t.drops.packets, t.drops.bytes)),
+            Some((6, 51))
+        );
+
+        // No packets or bytes are lost or duplicated across the apportionment.
+        let sum_p: u64 = [&b0, &b1, &b2]
+            .iter()
+            .filter_map(|b| b.vpc.get(&src))
+            .map(|t| t.drops.packets)
+            .sum();
+        let sum_b: u64 = [&b0, &b1, &b2]
+            .iter()
+            .filter_map(|b| b.vpc.get(&src))
+            .map(|t| t.drops.bytes)
+            .sum();
+        assert_eq!((sum_p, sum_b), (10, 100));
+    }
+
+    #[test]
+    fn apportion_pair_drops_into_dst_entry() {
+        let (mut b0, mut b1) = (batch(1), batch(2));
+        let mut slices: Vec<&mut BatchSummary<u64>> = vec![&mut b0, &mut b1];
+        let (src, dst) = (vpcd(1), vpcd(2));
+
+        apportion_into_batches(
+            &mut slices,
+            &[1, 1],
+            2,
+            Some(1),
+            src,
+            PacketAndByte {
+                packets: 4,
+                bytes: 40,
+            },
+            |tx, v| add_into_map(&mut tx.pair_drops, dst, v),
+        );
+        drop(slices);
+
+        let got: u64 = [&b0, &b1]
+            .iter()
+            .filter_map(|b| b.vpc.get(&src))
+            .filter_map(|t| t.pair_drops.get(&dst))
+            .map(|c| c.packets)
+            .sum();
+        assert_eq!(got, 4);
+    }
+
+    #[test]
+    fn apportion_no_overlap_records_nothing() {
+        let mut b0 = batch(1);
+        let mut slices: Vec<&mut BatchSummary<u64>> = vec![&mut b0];
+        let src = vpcd(9);
+
+        apportion_into_batches(
+            &mut slices,
+            &[0],
+            0,
+            None,
+            src,
+            PacketAndByte {
+                packets: 5,
+                bytes: 50,
+            },
+            |tx, v| tx.drops += v,
+        );
+        drop(slices);
+        assert!(b0.vpc.is_empty());
     }
 }

--- a/stats/src/dpstats.rs
+++ b/stats/src/dpstats.rs
@@ -1055,3 +1055,164 @@ mod contract {
         }
     }
 }
+
+#[cfg(test)]
+mod drop_stats_tests {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::packet::test_utils::build_test_ipv4_packet;
+    use net::vxlan::Vni;
+
+    fn vpcd(vni: u32) -> VpcDiscriminant {
+        VpcDiscriminant::from_vni(Vni::new_checked(vni).expect("valid vni"))
+    }
+
+    /// Length (in bytes) of every packet produced by `mk_packet` / `build_test_ipv4_packet(64)`.
+    /// All test packets are identical in size, so per-packet byte totals are exact multiples.
+    fn packet_len() -> u64 {
+        build_test_ipv4_packet(64)
+            .expect("build packet")
+            .total_len()
+            .into()
+    }
+
+    fn mk_packet(
+        src: Option<VpcDiscriminant>,
+        dst: Option<VpcDiscriminant>,
+        done: Option<DoneReason>,
+    ) -> Packet<TestBuffer> {
+        let mut p = build_test_ipv4_packet(64).expect("build packet");
+        p.meta_mut().src_vpcd = src;
+        p.meta_mut().dst_vpcd = dst;
+        if let Some(reason) = done {
+            p.done(reason);
+        }
+        p
+    }
+
+    /// A `Stats` NF whose batch will never auto-flush during a test (far-future schedule),
+    /// so the accumulated `update.vpc` can be inspected directly.
+    fn new_stats() -> Stats {
+        let (s, _r) = kanal::bounded(16);
+        Stats::with_delivery_schedule("test", PacketStatsWriter(s), Duration::from_secs(3600))
+    }
+
+    /// Drive packets through the NF and drop the (lazy) output so accumulation runs and the
+    /// mutable borrow of `stats` ends.
+    fn run(stats: &mut Stats, packets: Vec<Packet<TestBuffer>>) {
+        let _drained: Vec<_> = stats.process(packets.into_iter()).collect();
+    }
+
+    #[test]
+    fn delivered_pair_counts_forward_only() {
+        let (a, b) = (vpcd(100), vpcd(200));
+        let mut stats = new_stats();
+        run(
+            &mut stats,
+            vec![mk_packet(Some(a), Some(b), Some(DoneReason::Delivered))],
+        );
+
+        let s = stats.update.vpc.get(&a).expect("src summary present");
+        assert_eq!(s.dst.get(&b).map(|c| c.packets), Some(1));
+        assert_eq!(s.dst.get(&b).map(|c| c.bytes), Some(packet_len()));
+        assert_eq!(s.drops.packets, 0);
+        assert!(s.pair_drops.get(&b).is_none());
+    }
+
+    #[test]
+    fn dropped_known_dst_counts_both_axes() {
+        let (a, b) = (vpcd(100), vpcd(200));
+        let mut stats = new_stats();
+        run(
+            &mut stats,
+            vec![mk_packet(Some(a), Some(b), Some(DoneReason::Filtered))],
+        );
+
+        let s = stats.update.vpc.get(&a).expect("src summary present");
+        // No forward traffic recorded for a drop.
+        assert!(s.dst.get(&b).is_none());
+        // Per-VPC total drops and per-pair drops both incremented.
+        assert_eq!(s.drops.packets, 1);
+        assert_eq!(s.drops.bytes, packet_len());
+        assert_eq!(s.pair_drops.get(&b).map(|c| c.packets), Some(1));
+        assert_eq!(s.pair_drops.get(&b).map(|c| c.bytes), Some(packet_len()));
+    }
+
+    #[test]
+    fn dropped_unknown_dst_counts_per_vpc_only() {
+        let a = vpcd(100);
+        let mut stats = new_stats();
+        run(
+            &mut stats,
+            vec![mk_packet(Some(a), None, Some(DoneReason::Filtered))],
+        );
+
+        let s = stats.update.vpc.get(&a).expect("src summary present");
+        // Attributed to the source VPC total, but placed in no (src->dst) cell.
+        assert_eq!(s.drops.packets, 1);
+        assert!(s.pair_drops.is_empty());
+        assert!(s.dst.is_empty());
+    }
+
+    #[test]
+    fn missing_verdict_is_counted_as_drop() {
+        // A packet reaching the Stats stage without a done reason is a bug elsewhere; it must be
+        // accounted as a drop rather than panicking or being lost.
+        let (a, b) = (vpcd(100), vpcd(200));
+        let mut stats = new_stats();
+        run(&mut stats, vec![mk_packet(Some(a), Some(b), None)]);
+
+        let s = stats.update.vpc.get(&a).expect("src summary present");
+        assert_eq!(s.drops.packets, 1);
+        assert_eq!(s.pair_drops.get(&b).map(|c| c.packets), Some(1));
+    }
+
+    #[test]
+    fn missing_src_records_nothing() {
+        let b = vpcd(200);
+        let mut stats = new_stats();
+        run(
+            &mut stats,
+            vec![mk_packet(None, Some(b), Some(DoneReason::Filtered))],
+        );
+        assert!(stats.update.vpc.is_empty());
+    }
+
+    #[test]
+    fn mixed_batch_accumulates() {
+        let (a, b, c) = (vpcd(1), vpcd(2), vpcd(3));
+        let len = packet_len();
+        let mut stats = new_stats();
+
+        let mut pkts = Vec::new();
+        for _ in 0..2 {
+            pkts.push(mk_packet(Some(a), Some(b), Some(DoneReason::Delivered)));
+        }
+        for _ in 0..3 {
+            pkts.push(mk_packet(Some(a), Some(b), Some(DoneReason::Filtered)));
+        }
+        pkts.push(mk_packet(Some(a), Some(c), Some(DoneReason::RouteDrop)));
+        pkts.push(mk_packet(Some(a), None, Some(DoneReason::RouteDrop)));
+        run(&mut stats, pkts);
+
+        let s = stats.update.vpc.get(&a).expect("src summary present");
+        // Forward traffic: only the 2 delivered a->b packets.
+        assert_eq!(
+            s.dst.get(&b).map(|x| (x.packets, x.bytes)),
+            Some((2, 2 * len))
+        );
+        assert!(s.dst.get(&c).is_none());
+        // Per-VPC total drops: 3 (a->b) + 1 (a->c) + 1 (a->unknown) = 5.
+        assert_eq!(s.drops.packets, 5);
+        assert_eq!(s.drops.bytes, 5 * len);
+        // Per-pair drop matrix: known destinations only.
+        assert_eq!(
+            s.pair_drops.get(&b).map(|x| (x.packets, x.bytes)),
+            Some((3, 3 * len))
+        );
+        assert_eq!(
+            s.pair_drops.get(&c).map(|x| (x.packets, x.bytes)),
+            Some((1, len))
+        );
+    }
+}

--- a/stats/src/vpc.rs
+++ b/stats/src/vpc.rs
@@ -158,7 +158,13 @@ impl VpcMetricsSpec {
                                 let mut labels = labels.clone();
                                 labels.push(("from".to_string(), src_name.clone()));
                                 labels.push(("to".to_string(), dst_name.clone()));
-                                (*dst_disc, BasicActionSpec::new("vpc_pair_drops", labels))
+                                (
+                                    *dst_disc,
+                                    BasicActionSpec::new(
+                                        crate::dpstats::PAIR_DROPS_METRIC_BASE,
+                                        labels,
+                                    ),
+                                )
                             })
                             .collect(),
                     },
@@ -251,13 +257,5 @@ impl RegisteredVpcMetrics {
 
     pub fn peers(&self) -> impl Iterator<Item = (&VpcDiscriminant, &RegisteredBasicAction)> {
         self.peering.iter()
-    }
-
-    pub fn peer_drops(&self, disc: &VpcDiscriminant) -> Option<&RegisteredBasicAction> {
-        self.peering_drops.get(disc)
-    }
-
-    pub fn peers_drops(&self) -> impl Iterator<Item = (&VpcDiscriminant, &RegisteredBasicAction)> {
-        self.peering_drops.iter()
     }
 }

--- a/stats/src/vpc.rs
+++ b/stats/src/vpc.rs
@@ -122,6 +122,7 @@ pub struct VpcMetricsSpec {
     pub total: BasicActionSpec,
     pub drops: BasicActionSpec,
     pub peering: HashMap<VpcDiscriminant, BasicActionSpec>,
+    pub peering_drops: HashMap<VpcDiscriminant, BasicActionSpec>,
 }
 
 impl VpcMetricsSpec {
@@ -151,6 +152,15 @@ impl VpcMetricsSpec {
                                 (*dst_disc, BasicActionSpec::new("vpc", labels))
                             })
                             .collect(),
+                        peering_drops: vpc_data
+                            .iter()
+                            .map(|(dst_disc, dst_name, labels)| {
+                                let mut labels = labels.clone();
+                                labels.push(("from".to_string(), src_name.clone()));
+                                labels.push(("to".to_string(), dst_name.clone()));
+                                (*dst_disc, BasicActionSpec::new("vpc_pair_drops", labels))
+                            })
+                            .collect(),
                     },
                 )
             })
@@ -163,6 +173,7 @@ pub struct RegisteredVpcMetrics {
     pub total: RegisteredBasicAction,
     pub drops: RegisteredBasicAction,
     pub peering: BTreeMap<VpcDiscriminant, RegisteredBasicAction>,
+    pub peering_drops: BTreeMap<VpcDiscriminant, RegisteredBasicAction>,
 }
 
 #[derive(Debug, Serialize)]
@@ -170,6 +181,7 @@ pub struct VpcMetrics<T> {
     pub total: BasicAction<T>,
     pub drops: BasicAction<T>,
     pub peering: BTreeMap<VpcDiscriminant, BasicAction<T>>,
+    pub peering_drops: BTreeMap<VpcDiscriminant, BasicAction<T>>,
 }
 
 impl Specification for VpcMetricsSpec {
@@ -181,6 +193,11 @@ impl Specification for VpcMetricsSpec {
             drops: self.drops.build(),
             peering: self
                 .peering
+                .into_iter()
+                .map(|(disc, spec)| (disc, spec.build()))
+                .collect(),
+            peering_drops: self
+                .peering_drops
                 .into_iter()
                 .map(|(disc, spec)| (disc, spec.build()))
                 .collect(),
@@ -234,5 +251,13 @@ impl RegisteredVpcMetrics {
 
     pub fn peers(&self) -> impl Iterator<Item = (&VpcDiscriminant, &RegisteredBasicAction)> {
         self.peering.iter()
+    }
+
+    pub fn peer_drops(&self, disc: &VpcDiscriminant) -> Option<&RegisteredBasicAction> {
+        self.peering_drops.get(disc)
+    }
+
+    pub fn peers_drops(&self) -> impl Iterator<Item = (&VpcDiscriminant, &RegisteredBasicAction)> {
+        self.peering_drops.iter()
     }
 }


### PR DESCRIPTION
VPC-VPC stats added as `VpcPeeringStatus.drops` in the `GatewayAgentStatus` and counters reflected in the Prometheus.