### PR TITLE
(1)-masquerade: allocate each public pair once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 **.profraw
 **/__fuzz__/**
+# libfuzzer writes one of these per worker into the working directory when
+# `just fuzz` is given -j; the corpus itself lives under __fuzz__.
+fuzz-*.log
 # qemu-user core dumps from SIGABRT under emulated tests.
 **/qemu_*.core
 result*

--- a/concurrency-macros/src/lib.rs
+++ b/concurrency-macros/src/lib.rs
@@ -193,6 +193,89 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 fn shuttle() {
                     #krate::stress(|| #block);
                 }
+
+            }
+        }
+    }
+    .into()
+}
+
+/// Give a test the backend-named module shape of [`macro@test`] without touching its body.
+///
+/// [`macro@test`] wraps the whole body in [`stress`](../dataplane_concurrency/fn.stress.html),
+/// which is what you want when the body *is* the thing being model-checked. It is the wrong shape
+/// when a generator has to be the outer loop:
+///
+/// ```ignore
+/// bolero::check!().with_type().cloned().for_each(|scenario: Scenario| {
+///     concurrency::stress(move || scenario.run());   // one exploration per generated shape
+/// });
+/// ```
+///
+/// Wrapping *that* in `stress` would put the whole generator campaign inside a single
+/// model-checking execution, making the generator's own choices part of the explored state space.
+/// So such tests call `stress` themselves, and until now paid for it by losing the backend-named
+/// leaf that `just features=shuttle test` filters on: the suite compiled under the model checker
+/// and was never selected to run.
+///
+/// This attribute emits the module shape and nothing else, leaving the body verbatim:
+///
+/// ```ignore
+/// #[concurrency::model_test]
+/// fn stress_it() { /* ... calls stress itself ... */ }
+/// ```
+///
+/// becomes `mod stress_it { mod concurrency_model { #[test] fn <backend>() { /* body */ } } }`,
+/// where `<backend>` is `loom`, `shuttle` or `plain`. Unlike [`macro@test`], the wrapper is emitted
+/// on every backend, so the name does not change shape between them; there is no existing flat
+/// name to keep compatible here.
+#[proc_macro_attribute]
+pub fn model_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+
+    let attrs = &func.attrs;
+    let sig = &func.sig;
+    let block = &func.block;
+    let fn_name = &sig.ident;
+
+    if let Some(asyncness) = sig.asyncness {
+        return syn::Error::new_spanned(
+            asyncness,
+            "#[concurrency::model_test] does not support async functions yet",
+        )
+        .to_compile_error()
+        .into();
+    }
+    if !sig.inputs.is_empty() {
+        return syn::Error::new_spanned(
+            &sig.inputs,
+            "#[concurrency::model_test] functions must take no arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    quote! {
+        #[allow(non_snake_case)]
+        mod #fn_name {
+            use super::*;
+            mod concurrency_model {
+                use super::*;
+
+                #[cfg(feature = "loom")]
+                #[::core::prelude::v1::test]
+                #(#attrs)*
+                fn loom() #block
+
+                #[cfg(feature = "shuttle")]
+                #[::core::prelude::v1::test]
+                #(#attrs)*
+                fn shuttle() #block
+
+                #[cfg(not(any(feature = "loom", feature = "shuttle")))]
+                #[::core::prelude::v1::test]
+                #(#attrs)*
+                fn plain() #block
             }
         }
     }

--- a/concurrency/src/macros.rs
+++ b/concurrency/src/macros.rs
@@ -160,4 +160,4 @@ macro_rules! with_std {
     ($($item:item)*) => {};
 }
 
-pub use concurrency_macros::{concurrency_mode, test};
+pub use concurrency_macros::{concurrency_mode, model_test, test};

--- a/development/code/running-tests.md
+++ b/development/code/running-tests.md
@@ -62,8 +62,75 @@ change this.
 The major downside is that these processes are very computationally intensive and can take a long time to run.
 In fact, the [afl] fuzzer runs until you terminate it.
 
+## Running a real fuzzing campaign
+
+To run a target under [libfuzzer], which is coverage guided and explores far deeper than the random
+driver the test suite uses, list the targets and pick one:
+
+```shell
+just fuzz-list -p dataplane-nat
+just fuzz 'masquerade::apalloc::region::bolero_tests::decompose_properties' 10min -p dataplane-nat
+```
+
+The duration defaults to `60s`; anything after it is forwarded to `cargo bolero test`. As a sense of
+the difference, a property that manages a few thousand cases per second under `just test` reaches
+several hundred thousand per minute here, because libfuzzer mutates towards inputs that reach new
+code rather than sampling blindly.
+
+Findings are written to a `__fuzz__` directory beside the test. That directory is gitignored: the
+corpus is a local artifact that seeds later runs on the same machine, not something to commit.
+
+Pass `-j` to spread the campaign over more cores, which is the cheapest way to reach deeper:
+
+```shell
+just fuzz 'some::module::tests::some_property' 10min -p some-package -j 60
+```
+
+Each worker then writes a `fuzz-<n>.log` into the directory you ran from, rather than into
+`__fuzz__`. Those are gitignored too, and are only worth reading when a run reports a crash.
+
+### Sanitizers
+
+`cargo bolero` builds with the `fuzz` profile and links [AddressSanitizer] unless told otherwise, so
+a plain `just fuzz` is already an asan campaign. To swap sanitizers, set the same `sanitize`
+variable the rest of the justfile uses:
+
+```shell
+just sanitize=thread fuzz 'some::module::tests::some_property' 5min -p some-package
+```
+
+[ThreadSanitizer] only reports on a target that actually spawns threads, so it is worth the extra
+cost on a concurrency suite and close to pointless on a single-threaded property. It also takes
+much longer to get going, because thread instrumentation changes the ABI: `just` therefore adds
+`--build-std` for it, since a std left uninstrumented fails the build on a mismatch against `core`.
+
+A sanitizer is not free. Instrumentation costs roughly a factor of four in executions per second,
+so it is worth spending some of a campaign with none at all, reaching deeper into the input space
+in exchange for only catching what the test's own assertions catch:
+
+```shell
+just sanitize=NONE fuzz 'some::module::tests::some_property' 30min -p some-package
+```
+
+The two are complementary: asan for memory errors the assertions cannot see, `NONE` for depth.
+
+The suite as a whole can also be run under either sanitizer with the standard runner, which is what
+CI's `sanitize/fuzz/*` jobs do:
+
+```shell
+just profile=fuzz sanitize=thread test
+just profile=fuzz sanitize=address test
+```
+
+That covers far more code than a single fuzz target, but only with the brief random driver rather
+than a real campaign. The two are complementary.
+
 > [!NOTE]
-> Dedicated `just` recipes for running full fuzz campaigns (with libfuzzer/afl) are planned for a future PR.
+> `just fuzz` passes `--rustc-bootstrap`, because libfuzzer wants a nightly compiler for its
+> sanitizer coverage flags while the pinned toolchain is stable. An [afl] recipe is still to come.
+
+[AddressSanitizer]: https://clang.llvm.org/docs/AddressSanitizer.html
+[ThreadSanitizer]: https://clang.llvm.org/docs/ThreadSanitizer.html
 
 [README.md]: ../../README.md
 [afl]: https://github.com/AFLplusplus/AFLplusplus

--- a/flow-entry/src/flow_table/concurrent_fuzz.rs
+++ b/flow-entry/src/flow_table/concurrent_fuzz.rs
@@ -296,7 +296,7 @@ impl Scenario {
 /// Drive one bolero shape per iteration through [`concurrency::stress`]:
 /// a single direct run on the std backend (real OS threads — build with
 /// `just test sanitize=thread`), or the full portfolio under shuttle.
-#[test]
+#[concurrency::model_test]
 fn stress_test_concurrency_model() {
     // Single-threaded runtime is enough: we never need the timer task to
     // run, only a context for `insert`'s `tokio::task::spawn` to succeed.

--- a/justfile
+++ b/justfile
@@ -160,6 +160,32 @@ test package="tests.all" *args: (build (if package == "tests.all" { "tests.all" 
     declare -r target="{{ if package == "tests.all" { "tests.all" } else { "tests.pkg." + package } }}"
     cargo nextest run --archive-file results/${target}/*.tar.zst --workspace-remap $(pwd) {{ filter }}
 
+# List the bolero targets `just fuzz` can run. Args go to `cargo bolero list`
+[script]
+fuzz-list *args="":
+    {{ _just_debuggable_ }}
+    cargo bolero list {{ _cargo_feature_flags }} {{ args }}
+
+# Fuzz one bolero target under libfuzzer. See development/code/running-tests.md
+[script]
+fuzz target time="60s" *args="":
+    {{ _just_debuggable_ }}
+    # libfuzzer wants a nightly compiler for its sanitizer coverage flags, while the
+    # pinned toolchain is stable; --rustc-bootstrap bridges that. cargo-bolero already
+    # builds with the fuzz profile and links AddressSanitizer unless told otherwise, so
+    # a plain `just fuzz` is already an asan run. Findings land in a gitignored
+    # `__fuzz__` directory beside the test.
+    #
+    # `sanitize=thread` additionally rebuilds std: thread instrumentation changes the
+    # ABI, so a std left uninstrumented fails the build on a mismatch against `core`.
+    # asan does not need that, and skipping the std rebuild keeps it far quicker.
+    # `sanitize=NONE` drops instrumentation altogether, which buys roughly four times
+    # the executions per second in exchange for only catching what the test asserts.
+    cargo bolero test '{{ target }}' --rustc-bootstrap -T '{{ time }}' \
+        {{ if sanitize != "" { "--sanitizer " + sanitize } else { "" } }} \
+        {{ if sanitize == "thread" { "--build-std" } else { "" } }} \
+        {{ _cargo_feature_flags }} {{ args }}
+
 # Build and run the criterion benches. The rte_acl benches are gated behind the
 # `dpdk` feature, so run `just features=dpdk bench` to exercise them; a plain
 # `just bench` builds them as empty `main()` and only runs the reference benches.

--- a/nat/src/masquerade/allocation.rs
+++ b/nat/src/masquerade/allocation.rs
@@ -35,6 +35,32 @@ pub enum AllocatorError {
     NoPoolFound,
 }
 
+impl AllocatorError {
+    /// Whether this error says the space simply ran out, rather than that something is wrong.
+    ///
+    /// A caller holding several allocators over disjoint space may move on to the next one when
+    /// this holds, and only then: any other error is about the allocator rather than about how
+    /// full it is, and would be buried by a later success. The classification is the one
+    /// [`DoneReason`] already draws, where exactly these become `NatOutOfResources`.
+    /// The match is exhaustive on purpose: a new error has to be classified here rather than
+    /// silently defaulting to one side of it.
+    #[must_use]
+    pub fn is_exhaustion(&self) -> bool {
+        match self {
+            AllocatorError::NoFreeIp
+            | AllocatorError::NoPortBlock
+            | AllocatorError::NoFreePort(_) => true,
+            AllocatorError::PortAllocationFailed(_)
+            | AllocatorError::PortReservationFailed(_)
+            | AllocatorError::UnsupportedProtocol(_)
+            | AllocatorError::MissingDiscriminant
+            | AllocatorError::InternalIssue(_)
+            | AllocatorError::Denied
+            | AllocatorError::NoPoolFound => false,
+        }
+    }
+}
+
 impl From<&AllocatorError> for DoneReason {
     fn from(error: &AllocatorError) -> Self {
         match error {

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -137,10 +137,17 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         // FIXME: Should we clean up every time??
         self.cleanup_used_ips();
 
-        if let Ok(port) = self.reuse_allocated_ip(allow_null) {
-            return Ok(port);
+        // Drawing a fresh address is what to do when the addresses already in hand have no room,
+        // and only then. `reuse_allocated_ip` distinguishes the two: it walks past an address that
+        // has run out and reports anything else as it found it. Taking only `Ok` here would put
+        // that back, burying an error about the allocator under whatever the fresh address
+        // returns -- the same mistake `PoolSet::allocate` avoids one level up, where trying the
+        // next region on any error would bury it under a success.
+        match self.reuse_allocated_ip(allow_null) {
+            Ok(port) => Ok(port),
+            Err(e) if e.is_exhaustion() => self.allocate_from_new_ip(allow_null),
+            Err(e) => Err(e),
         }
-        self.allocate_from_new_ip(allow_null)
     }
 
     fn get_allocated_ip(&self, ip: I) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
@@ -227,21 +234,26 @@ impl<I: NatIpWithBitmap> PoolSet<I> {
 
     /// Allocate from the first region with room. Regions are ordered so that those the expose has
     /// to itself are tried first, leaving shared space for exposes that have nowhere else to go.
+    ///
+    /// Only a region being full moves on to the next one. Any other error is about the allocator
+    /// rather than about how full that region is, and trying the next region would either bury it
+    /// under a success or replace it with a later region's `NoFreeIp`.
     pub(crate) fn allocate(
         &self,
         allow_null: bool,
     ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
-        let mut last_error = None;
+        let mut exhausted = None;
         for region in &self.regions {
             match region.allocator.allocate(allow_null) {
                 Ok(port) => return Ok(port),
-                Err(e) => {
-                    debug!("Region {:?} could not allocate: {e}", region.range);
-                    last_error = Some(e);
+                Err(e) if e.is_exhaustion() => {
+                    debug!("Region {:?} is out of space: {e}", region.range);
+                    exhausted = Some(e);
                 }
+                Err(e) => return Err(e),
             }
         }
-        Err(last_error.unwrap_or(AllocatorError::NoFreeIp))
+        Err(exhausted.unwrap_or(AllocatorError::NoFreeIp))
     }
 
     /// Reserve a specific address and port, which has to come from the region owning that address.

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -22,7 +22,7 @@ use roaring::RoaringBitmap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, error};
 
 ///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
@@ -467,8 +467,15 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 
     fn deallocate_from_pool(&mut self, ip: I) {
         debug!("Address {ip} was deallocated");
-        let offset = I::try_to_offset(ip, &self.reverse_bitmap_mapping).unwrap();
-        self.bitmap.set_ip_free(offset);
+        // The address was handed out by this pool, so it maps back into it. This runs while an
+        // allocation is being dropped and has nowhere to report a failure, so say so and leave the
+        // address marked in use rather than panicking on the drop path.
+        match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
+            Ok(offset) => {
+                self.bitmap.set_ip_free(offset);
+            }
+            Err(e) => error!("Address {ip} does not map back into the pool it came from: {e}"),
+        }
     }
 
     /// `keep_alive` collects every address upgraded here, for the caller to release once the pool
@@ -626,11 +633,25 @@ pub(crate) fn map_offset(
 }
 
 // Reverse operation from map_offset()
-pub(crate) fn map_address(address: Ipv6Addr, bitmap_mapping: &BTreeMap<u128, u32>) -> u32 {
+//
+// Not every address of a region has an offset. A region may hold more addresses than a u32 can
+// index, in which case the bitmap covers only the first 2^32 of them (see `NatPool::for_range`),
+// and an address beyond that is simply not one this pool can serve. That is reachable from
+// configuration rather than a bug: a flow carried across a config change presents the address it
+// already holds, and the region it falls in may have grown downwards underneath it. Report it as
+// the pool not serving the address, so the flow is dropped like any other that cannot be carried
+// over, rather than panicking in the middle of applying a config.
+pub(crate) fn map_address(
+    address: Ipv6Addr,
+    bitmap_mapping: &BTreeMap<u128, u32>,
+) -> Result<u32, AllocatorError> {
     let (prefix_start_bits, prefix_offset) = bitmap_mapping
         .range(..=address.to_bits())
         .next_back()
-        .expect("This should never fail");
+        .ok_or(AllocatorError::NoPoolFound)?;
 
-    prefix_offset + u32::try_from(address.to_bits() - prefix_start_bits).unwrap()
+    u32::try_from(address.to_bits() - prefix_start_bits)
+        .ok()
+        .and_then(|offset| prefix_offset.checked_add(offset))
+        .ok_or(AllocatorError::NoPoolFound)
 }

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -9,14 +9,15 @@
 //!
 //! See also the architecture diagram at the top of mod.rs.
 
+use super::region::AddrInterval;
 use super::{NatIpWithBitmap, port_alloc};
 use crate::masquerade::allocation::AllocatorError;
 use crate::masquerade::natip::NatIp;
 use crate::port::NatPort;
 use crate::ranges::IpRange;
 use concurrency::sync::{Arc, RwLock, RwLockReadGuard, Weak};
+use lpm::prefix::PortRange;
 use lpm::prefix::range_map::DisjointRangesBTreeMap;
-use lpm::prefix::{IpPrefix, PortRange, Prefix};
 use roaring::RoaringBitmap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv6Addr};
@@ -47,10 +48,6 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
 
     pub(crate) fn read(&self) -> RwLockReadGuard<'_, NatPool<I>> {
         self.pool.read()
-    }
-
-    pub(crate) fn idle_timeout(&self) -> Duration {
-        self.pool.read().idle_timeout()
     }
 
     fn deallocate_ip(&self, ip: I) {
@@ -137,6 +134,94 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
     pub fn get_pool_clone_for_tests(&self) -> (RoaringBitmap, VecDeque<Weak<AllocatedIp<I>>>) {
         let pool = self.pool.read();
         (pool.bitmap.0.clone(), pool.in_use.clone())
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PoolSet
+///////////////////////////////////////////////////////////////////////////////
+
+/// One region of the public address space, and the allocator that owns it.
+#[derive(Debug, Clone)]
+pub(crate) struct PoolRegion<I: NatIpWithBitmap> {
+    range: AddrInterval,
+    allocator: IpAllocator<I>,
+}
+
+impl<I: NatIpWithBitmap> PoolRegion<I> {
+    pub(crate) fn range(&self) -> AddrInterval {
+        self.range
+    }
+
+    pub(crate) fn allocator(&self) -> &IpAllocator<I> {
+        &self.allocator
+    }
+}
+
+/// What a single expose may allocate from: the regions its public range covers, in the order to
+/// try them, plus the settings that belong to the expose rather than to the address space.
+///
+/// An expose's range is exactly the union of its regions, so allocating from any of them yields an
+/// address the expose is configured for, and regions shared with another expose are backed by one
+/// allocator, so no address is handed out twice.
+#[derive(Debug, Clone)]
+pub(crate) struct PoolSet<I: NatIpWithBitmap> {
+    regions: Vec<PoolRegion<I>>,
+    idle_timeout: Duration,
+}
+
+impl<I: NatIpWithBitmap> PoolSet<I> {
+    pub(crate) fn new(idle_timeout: Duration) -> Self {
+        Self {
+            regions: Vec::new(),
+            idle_timeout,
+        }
+    }
+
+    pub(crate) fn push_region(&mut self, range: AddrInterval, allocator: IpAllocator<I>) {
+        self.regions.push(PoolRegion { range, allocator });
+    }
+
+    pub(crate) fn idle_timeout(&self) -> Duration {
+        self.idle_timeout
+    }
+
+    pub(crate) fn regions(&self) -> impl Iterator<Item = &PoolRegion<I>> {
+        self.regions.iter()
+    }
+
+    /// Allocate from the first region with room. Regions are ordered so that those the expose has
+    /// to itself are tried first, leaving shared space for exposes that have nowhere else to go.
+    pub(crate) fn allocate(
+        &self,
+        allow_null: bool,
+    ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
+        let mut last_error = None;
+        for region in &self.regions {
+            match region.allocator.allocate(allow_null) {
+                Ok(port) => return Ok(port),
+                Err(e) => {
+                    debug!("Region {:?} could not allocate: {e}", region.range);
+                    last_error = Some(e);
+                }
+            }
+        }
+        Err(last_error.unwrap_or(AllocatorError::NoFreeIp))
+    }
+
+    /// Reserve a specific address and port, which has to come from the region owning that address.
+    pub(crate) fn reserve(
+        &self,
+        ip: I,
+        port: NatPort,
+    ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
+        let bits = ip.to_addr_bits();
+        let region = self
+            .regions
+            .iter()
+            .find(|region| region.range.contains(bits))
+            .ok_or(AllocatorError::NoPoolFound)?;
+        region.allocator.reserve(ip, port)
     }
 }
 
@@ -235,26 +320,43 @@ pub(crate) struct NatPool<I: NatIpWithBitmap> {
     reverse_bitmap_mapping: BTreeMap<u128, u32>,
     in_use: VecDeque<Weak<AllocatedIp<I>>>,
     reserved_prefixes_ports: Option<DisjointRangesBTreeMap<IpRange, PortRange>>,
-    idle_timeout: Duration,
     exclude_wellknown_ports: bool,
 }
 
 impl<I: NatIpWithBitmap> NatPool<I> {
-    pub(crate) fn new(
-        bitmap: PoolBitmap,
-        bitmap_mapping: BTreeMap<u32, u128>,
-        reverse_bitmap_mapping: BTreeMap<u128, u32>,
+    /// Build the pool covering one contiguous region of the public address space.
+    ///
+    /// Pools own a region rather than an expose's range, because ranges from different exposes
+    /// overlap and a public address may only be handed out by one pool.
+    pub(crate) fn for_range(
+        range: AddrInterval,
         reserved_prefixes_ports: Option<DisjointRangesBTreeMap<IpRange, PortRange>>,
-        idle_timeout: Duration,
         exclude_wellknown_ports: bool,
     ) -> Self {
+        // Index the region from its own start. IPv4 indexes its bitmap by the address bits and
+        // ignores the mapping; IPv6 cannot fit its space in a u32, so indices count from the start
+        // of the region and the mapping carries them back to real addresses. Going through
+        // try_to_offset gets both right without naming either version here.
+        let bitmap_mapping = BTreeMap::from([(0u32, range.start)]);
+        let reverse_bitmap_mapping = BTreeMap::from([(range.start, 0u32)]);
+
+        // A region holding more addresses than the u32 bitmap can index is truncated. We would run
+        // out of memory long before allocating four billion addresses.
+        let span = range.len().saturating_sub(1).min(u128::from(u32::MAX));
+        let to_offset = |bits: u128| {
+            let address = I::try_from_bits(bits).unwrap_or_else(|()| unreachable!());
+            I::try_to_offset(address, &reverse_bitmap_mapping).unwrap_or_else(|_| unreachable!())
+        };
+
         Self {
-            bitmap,
+            bitmap: PoolBitmap::with_offset_range(
+                to_offset(range.start),
+                to_offset(range.start + span),
+            ),
             bitmap_mapping,
             reverse_bitmap_mapping,
             in_use: VecDeque::new(),
             reserved_prefixes_ports,
-            idle_timeout,
             exclude_wellknown_ports,
         }
     }
@@ -265,10 +367,6 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 
     fn cleanup(&mut self) {
         self.in_use.retain(|ip| ip.upgrade().is_some());
-    }
-
-    pub(crate) fn idle_timeout(&self) -> Duration {
-        self.idle_timeout
     }
 
     pub(crate) fn ips_in_use(&self) -> impl Iterator<Item = &Weak<AllocatedIp<I>>> {
@@ -418,8 +516,11 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 pub(crate) struct PoolBitmap(RoaringBitmap);
 
 impl PoolBitmap {
-    pub(crate) fn new() -> Self {
-        Self(RoaringBitmap::new())
+    /// Mark every index in the inclusive range as free.
+    pub(crate) fn with_offset_range(start: u32, end: u32) -> Self {
+        let mut bitmap = RoaringBitmap::new();
+        bitmap.insert_range(start..=end);
+        Self(bitmap)
     }
 
     fn pop_ip(&mut self) -> Result<u32, AllocatorError> {
@@ -434,21 +535,6 @@ impl PoolBitmap {
 
     fn set_ip_free(&mut self, index: u32) -> bool {
         self.0.insert(index)
-    }
-
-    pub(crate) fn add_prefix(&mut self, prefix: &Prefix, bitmap_mapping: &BTreeMap<u128, u32>) {
-        match prefix {
-            Prefix::IPV4(p) => {
-                let start = p.network().to_bits();
-                let end = p.last_address().to_bits();
-                self.0.insert_range(start..=end);
-            }
-            Prefix::IPV6(p) => {
-                let start = map_address(p.network(), bitmap_mapping);
-                let end = map_address(p.last_address(), bitmap_mapping);
-                self.0.insert_range(start..=end);
-            }
-        }
     }
 }
 

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -360,7 +360,7 @@ impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
 /// A [`NatPool`] is a pool of IP addresses that can be allocated from. It contains a bitmap of
 /// available IP addresses, and a list of weak references to [`AllocatedIp`] objects representing
 /// the allocated IPs potentially available for use (if they still have free ports)
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct NatPool<I: NatIpWithBitmap> {
     bitmap: PoolBitmap,
     bitmap_mapping: BTreeMap<u32, u128>,

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -58,25 +58,46 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         &self,
         allow_null: bool,
     ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
-        let allocated_ips = self.pool.read();
-        for ip_weak in allocated_ips.ips_in_use() {
-            let Some(ip) = ip_weak.upgrade() else {
-                continue;
-            };
-            if !ip.has_free_ports() {
-                continue;
-            }
-            match ip.allocate_port_for_ip(allow_null) {
-                Ok(port) => {
-                    debug!("Allocated port {port}");
-                    return Ok(port);
+        // An address upgraded out of the in-use list has to outlive the guard below.
+        //
+        // The list holds weak references; the strong ones belong to the blocks handed out from
+        // each address. Another thread ending the last flow on an address drops the last of those
+        // at any moment, which leaves the reference upgraded here as the only one. Letting it go
+        // while the guard is held runs `AllocatedIp::drop` on this thread, and that takes the same
+        // lock for writing: a self-deadlock that wedges the core for good, on the path every new
+        // flow takes.
+        //
+        // Every upgrade is therefore kept until the guard is gone, and released after it.
+        let mut examined: Vec<Arc<AllocatedIp<I>>> = Vec::new();
+        let outcome = {
+            let allocated_ips = self.pool.read();
+            let mut outcome = Err(AllocatorError::NoFreeIp);
+            for ip_weak in allocated_ips.ips_in_use() {
+                let Some(ip) = ip_weak.upgrade() else {
+                    continue;
+                };
+                examined.push(ip.clone());
+                if !ip.has_free_ports() {
+                    continue;
                 }
-                // If there is no free port left, loop again to try another IP address
-                Err(AllocatorError::NoFreePort(_)) => {}
-                Err(e) => return Err(e),
+                match ip.allocate_port_for_ip(allow_null) {
+                    Ok(port) => {
+                        debug!("Allocated port {port}");
+                        outcome = Ok(port);
+                        break;
+                    }
+                    // If there is no free port left, loop again to try another IP address
+                    Err(AllocatorError::NoFreePort(_)) => {}
+                    Err(e) => {
+                        outcome = Err(e);
+                        break;
+                    }
+                }
             }
-        }
-        Err(AllocatorError::NoFreeIp)
+            outcome
+        };
+        drop(examined);
+        outcome
     }
 
     fn allocate_new_ip_from_pool(&self) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
@@ -97,8 +118,16 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
     }
 
     fn cleanup_used_ips(&self) {
-        let mut allocated_ips = self.pool.write();
-        allocated_ips.cleanup();
+        // Same trap as in `reuse_allocated_ip`, and worse: `cleanup` upgrades each weak reference
+        // to see whether it still resolves, and does it holding the pool's *write* lock. An
+        // upgrade that turns out to be the last strong reference runs `AllocatedIp::drop` on this
+        // thread, which asks for that same lock again.
+        let mut released = Vec::new();
+        {
+            let mut allocated_ips = self.pool.write();
+            allocated_ips.cleanup(&mut released);
+        }
+        drop(released);
     }
 
     pub(crate) fn allocate(
@@ -115,9 +144,15 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
     }
 
     fn get_allocated_ip(&self, ip: I) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
-        self.pool
-            .write()
-            .reserve_from_pool(ip, self.clone(), self.randomize)
+        // The third place that upgrades an in-use entry under the pool lock, and so the third that
+        // must not let the upgrade go while holding it. See `cleanup_used_ips`.
+        let mut examined = Vec::new();
+        let outcome =
+            self.pool
+                .write()
+                .reserve_from_pool(ip, self.clone(), self.randomize, &mut examined);
+        drop(examined);
+        outcome
     }
 
     pub(crate) fn reserve(
@@ -365,8 +400,16 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         self.in_use.push_back(Arc::downgrade(ip));
     }
 
-    fn cleanup(&mut self) {
-        self.in_use.retain(|ip| ip.upgrade().is_some());
+    /// Drop the entries whose addresses are gone, handing the caller every address that is still
+    /// alive so it can release them once the pool lock is no longer held. See `cleanup_used_ips`.
+    fn cleanup(&mut self, keep_alive: &mut Vec<Arc<AllocatedIp<I>>>) {
+        self.in_use.retain(|ip| match ip.upgrade() {
+            Some(alive) => {
+                keep_alive.push(alive);
+                true
+            }
+            None => false,
+        });
     }
 
     pub(crate) fn ips_in_use(&self) -> impl Iterator<Item = &Weak<AllocatedIp<I>>> {
@@ -416,18 +459,23 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         self.bitmap.set_ip_free(offset);
     }
 
+    /// `keep_alive` collects every address upgraded here, for the caller to release once the pool
+    /// lock is gone. See `cleanup_used_ips`.
     fn reserve_from_pool(
         &mut self,
         ip: I,
         ip_allocator: IpAllocator<I>,
         randomize: bool,
+        keep_alive: &mut Vec<Arc<AllocatedIp<I>>>,
     ) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
         let offset = I::try_to_offset(ip, &self.reverse_bitmap_mapping)?;
 
         for ip_weak in self.ips_in_use() {
-            if let Some(ip_arc) = ip_weak.upgrade()
-                && ip_arc.ip() == ip
-            {
+            let Some(ip_arc) = ip_weak.upgrade() else {
+                continue;
+            };
+            keep_alive.push(ip_arc.clone());
+            if ip_arc.ip() == ip {
                 // We found the allocated IP in the list of IPs in use, return it
                 debug!("Reserved ip {ip_arc}");
                 return Ok(ip_arc);

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Concurrent fuzz test for the masquerade pools across a config change.
+//!
+//! One test, [`stress_test_config_change`], drives a bolero-generated [`Scenario`] through
+//! [`concurrency::stress`] on every backend, mirroring the bolero x model-checker layout used for
+//! the flow table (see `flow-entry/src/flow_table/concurrent_fuzz.rs`). bolero is the *outer* loop
+//! and picks the shape: which public ranges the exposes claim, and an op stream per thread. The
+//! backend is the *inner* loop and explores interleavings of that fixed shape:
+//!
+//! * **default (std) backend** — one direct run on real OS threads. Build with
+//!   `just test sanitize=thread` to surface data races inside the allocator.
+//! * **`--features shuttle`** — the full portfolio (Random + PCT [+ DFS]).
+//!
+//! # What is being raced
+//!
+//! Applying a new masquerade config is not atomic from the data plane's point of view. The writer
+//! builds a fresh allocator, carries the surviving flows over into it by re-reserving the address
+//! and port each one holds, and only then publishes it; meanwhile packet threads keep allocating
+//! from whichever allocator is currently published. Every lock and atomic the allocator uses comes
+//! from `concurrency::sync`, so a model checker sees all of it: the `compare_exchange` that claims
+//! a port block, the map of weak references to allocated blocks, the per-thread block hint, and
+//! the pool locks.
+//!
+//! Three properties are asserted:
+//!
+//! * A published allocator never hands out an address and port that was carried over into it. This
+//!   is the safety property of the update: the writer re-reserves before publishing, so a flow that
+//!   survived a config change and a flow created just after it must not collide on the reverse key.
+//! * An address and port is never handed to two live flows drawn from the same allocator. Shapes
+//!   that hold every allocation for the length of the run check this exactly; those that free as
+//!   they go trade that for exercising deallocation. See [`Live`] for why the two differ.
+//! * Neither allocation nor reservation ever reports [`AllocatorError::InternalIssue`]. That is the
+//!   allocator saying its own bookkeeping is inconsistent, and `find_block_for_port` carries a
+//!   standing `FIXME` wondering whether the block it just found non-free can be released before it
+//!   is looked up. Reserving concurrently with allocating is what would show it.
+//!
+//! # No loom
+//!
+//! Gated off under loom, for the same reason `test_alloc`'s concurrency tests are: loom's `Weak`
+//! shim never lets an allocator liveness entry die, so the pool's in-use list never drains and the
+//! run does not model what production does. Shuttle has no such limitation.
+//!
+//! # Why `#[concurrency::model_test]`
+//!
+//! `just features=shuttle test` filters the run down to test names containing `shuttle`, because
+//! under that backend `concurrency::sync` types are shuttle primitives and every other test in the
+//! workspace would fail spuriously on `ExecutionState NotSet`. `#[concurrency::test]` earns its
+//! way past that filter by appending a `concurrency_model::shuttle` leaf, but it also wraps the
+//! whole body in [`concurrency::stress`], which is the wrong shape here: bolero has to be the outer
+//! loop, so `stress` is called once per generated shape from inside it.
+//! [`macro@concurrency::model_test`] emits the same backend-named leaf and leaves the body alone,
+//! which is what lets this suite be selected at all.
+
+#![cfg(test)]
+#![cfg(not(feature = "loom"))]
+
+use super::AllocatedPort;
+use super::alloc::PoolSet;
+use super::region::AddrInterval;
+use super::setup::{PoolSpec, pool_sets_for_specs};
+use crate::masquerade::allocation::AllocatorError;
+use crate::port::NatPort;
+use concurrency::slot::SlotOption;
+use concurrency::sync::{Arc, Mutex};
+use concurrency::thread;
+// `spawn_scoped` is inherent on std's `Builder`, but supplied by `BuilderExt` under shuttle
+#[cfg_attr(not(feature = "shuttle"), allow(unused_imports))]
+use concurrency::thread::BuilderExt;
+use lpm::prefix::PrefixPortsSet;
+use net::ip::NextHeader;
+use std::collections::BTreeSet;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+// 10.1.0.0, over a window narrow enough that generated ranges overlap most of the time and the
+// pools stay cheap to build once per published generation.
+const BASE: u128 = 0x0A01_0000;
+const WINDOW: u128 = 8;
+const MAX_EXPOSES: u8 = 3;
+const MAX_RANGE_LEN: u8 = 4;
+
+// Op streams are kept short: the backend explores interleavings of a fixed shape, so length costs
+// schedule space without buying coverage.
+const MAX_PACKET_OPS: usize = 6;
+const MAX_CONFIG_OPS: usize = 3;
+const PACKET_WORKERS: usize = 2;
+
+const IDLE_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// What a packet thread does. Allocating and freeing model flows starting and ending; reserving
+/// models a flow being carried over, and is the op that races reservation against allocation on
+/// pools that are already published and in use.
+#[derive(Clone, Copy, Debug, bolero::TypeGenerator)]
+enum PacketOp {
+    Allocate,
+    FreeOldest,
+    ReserveExisting,
+}
+
+/// What the config thread does. Production has a single writer, so only this thread republishes.
+#[derive(Clone, Copy, Debug, bolero::TypeGenerator)]
+enum ConfigOp {
+    Republish,
+    Idle,
+}
+
+/// One generated shape: the public ranges each expose claims, and an op stream per thread.
+#[derive(Clone, Debug)]
+struct Scenario {
+    ranges: Vec<Vec<(u8, u8)>>,
+    packet_ops: [Vec<PacketOp>; PACKET_WORKERS],
+    config_ops: Vec<ConfigOp>,
+    /// Whether flows may end while the run is in progress.
+    ///
+    /// Freeing is worth exercising, because it is what returns an address to a pool, but it costs
+    /// the uniqueness oracle its certainty: see [`Live`]. Half the shapes therefore hold every
+    /// allocation for the whole run, which makes the record monotone and the oracle exact.
+    frees_allowed: bool,
+}
+
+impl bolero::TypeGenerator for Scenario {
+    /// Generate a shape, then normalize it so the run always exercises real concurrency.
+    ///
+    /// shuttle's PCT scheduler panics on a body in which two threads are never simultaneously
+    /// runnable. Rather than skip degenerate shapes, every packet stream is given an `Allocate` if
+    /// it has none, and the config stream a `Republish`. The splice position comes from the driver,
+    /// so the normalization stays a deterministic function of the input and a failure still
+    /// reproduces from its seed.
+    fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
+        let expose_count = usize::from(driver.produce::<u8>()? % MAX_EXPOSES + 1);
+        let mut ranges = Vec::with_capacity(expose_count);
+        for _ in 0..expose_count {
+            let offset = driver.produce::<u8>()? % u8::try_from(WINDOW).ok()?;
+            let length = driver.produce::<u8>()? % MAX_RANGE_LEN + 1;
+            ranges.push(vec![(offset, length)]);
+        }
+
+        let mut packet_ops: [Vec<PacketOp>; PACKET_WORKERS] = driver.produce()?;
+        for ops in &mut packet_ops {
+            ops.truncate(MAX_PACKET_OPS);
+            if !ops.iter().any(|op| matches!(op, PacketOp::Allocate)) {
+                let at = driver.produce::<usize>()? % (ops.len() + 1);
+                ops.insert(at, PacketOp::Allocate);
+            }
+        }
+
+        let mut config_ops: Vec<ConfigOp> = driver.produce()?;
+        config_ops.truncate(MAX_CONFIG_OPS);
+        if !config_ops
+            .iter()
+            .any(|op| matches!(op, ConfigOp::Republish))
+        {
+            let at = driver.produce::<usize>()? % (config_ops.len() + 1);
+            config_ops.insert(at, ConfigOp::Republish);
+        }
+
+        Some(Self {
+            ranges,
+            packet_ops,
+            config_ops,
+            frees_allowed: driver.produce()?,
+        })
+    }
+}
+
+/// One generation of published pools, together with the flows carried into it.
+///
+/// The reservations are held for as long as the generation is published, exactly as a surviving
+/// flow holds the allocation it was re-reserved.
+struct Published {
+    generation: u64,
+    pools: Vec<PoolSet<Ipv4Addr>>,
+    carried: BTreeSet<(Ipv4Addr, u16)>,
+    _reservations: Vec<AllocatedPort<Ipv4Addr>>,
+}
+
+impl Published {
+    /// Build the pools for a new config and carry the surviving flows into them before returning,
+    /// so that a generation is only ever published once its survivors hold their addresses again.
+    fn build(
+        specs: &[PoolSpec],
+        generation: u64,
+        survivors: &[(usize, Ipv4Addr, NatPort)],
+    ) -> Self {
+        let pools = pool_sets_for_specs::<Ipv4Addr>(specs, NextHeader::TCP, false);
+        let mut carried = BTreeSet::new();
+        let mut reservations = Vec::new();
+
+        for &(owner, ip, port) in survivors {
+            let Some(pool) = pools.get(owner) else {
+                continue;
+            };
+            match pool.reserve(ip, port) {
+                Ok(reservation) => {
+                    carried.insert((ip, port.as_u16()));
+                    reservations.push(reservation);
+                }
+                Err(AllocatorError::InternalIssue(message)) => {
+                    panic!("re-reserving {ip}:{port} for generation {generation}: {message}")
+                }
+                // The address may no longer be served, or another survivor may already hold it.
+                Err(_) => {}
+            }
+        }
+
+        Self {
+            generation,
+            pools,
+            carried,
+            _reservations: reservations,
+        }
+    }
+}
+
+/// Every address and port currently held by a flow, with the generation it was drawn from.
+///
+/// Shared by all threads: a collision between two of them is the interesting one, and a per-thread
+/// record would not see it. Pairs from *different* generations may legitimately repeat; only what
+/// was carried into a generation is protected, which [`Published::carried`] covers.
+///
+/// The record is written just after the allocator hands a pair out, not as part of it, which keeps
+/// the threads racing on the allocator's locks rather than on this mutex. The cost is that a
+/// duplicate can hide: if two threads are wrongly given the same pair and the first frees it before
+/// the second records it, the insertion succeeds. That interleaving cannot be told apart from
+/// legitimate reuse from any record kept here. Shapes with [`Scenario::frees_allowed`] false --
+/// about half -- free nothing, so their record only grows and catches duplicates with certainty;
+/// the rest trade that for exercising deallocation. Closing the gap outright means recording the
+/// pair inside the allocator.
+struct Live(Mutex<BTreeSet<(u64, Ipv4Addr, u16)>>);
+
+impl Live {
+    fn new() -> Self {
+        Self(Mutex::new(BTreeSet::new()))
+    }
+
+    /// Record a freshly allocated pair, failing if it is already held.
+    fn claim(&self, generation: u64, ip: Ipv4Addr, port: u16) {
+        let mut live = self.0.lock();
+        assert!(
+            live.insert((generation, ip, port)),
+            "generation {generation} handed out {ip}:{port} to two flows at once"
+        );
+    }
+
+    /// Give a pair back, freeing it while the record is still locked so that no other thread can
+    /// claim it before the allocator has actually released it.
+    fn release(&self, generation: u64, allocation: AllocatedPort<Ipv4Addr>) {
+        let mut live = self.0.lock();
+        live.remove(&(generation, allocation.ip(), allocation.port().as_u16()));
+        drop(allocation);
+    }
+}
+
+impl Scenario {
+    fn specs(&self) -> Vec<PoolSpec> {
+        self.ranges
+            .iter()
+            .map(|ranges| PoolSpec {
+                public_ranges: ranges
+                    .iter()
+                    .map(|&(offset, length)| {
+                        let start = u128::from(offset);
+                        let end = (start + u128::from(length) - 1).min(WINDOW - 1);
+                        AddrInterval::new(BASE + start, BASE + end)
+                    })
+                    .collect(),
+                reserved: PrefixPortsSet::new(),
+                idle_timeout: IDLE_TIMEOUT,
+            })
+            .collect()
+    }
+
+    /// Run the scenario: stand up a first generation with a few flows already on it, then let the
+    /// packet threads and the config thread work against the published slot concurrently.
+    fn run(&self) {
+        let specs = self.specs();
+
+        // The flows that already exist when the config change arrives.
+        let initial = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+        let mut existing = Vec::new();
+        let mut survivors = Vec::new();
+        for (owner, pool) in initial.iter().enumerate() {
+            if let Ok(allocation) = pool.allocate(false) {
+                survivors.push((owner, allocation.ip(), allocation.port()));
+                existing.push(allocation);
+            }
+        }
+
+        let slot = Arc::new(SlotOption::new(Some(Arc::new(Published::build(
+            &specs, 0, &survivors,
+        )))));
+        let live = Arc::new(Live::new());
+
+        thread::scope(|scope| {
+            let mut packet_handles = Vec::new();
+
+            for (index, ops) in self.packet_ops.iter().enumerate() {
+                let slot = slot.clone();
+                let live = live.clone();
+                let ops = ops.clone();
+                let survivors = survivors.clone();
+                let frees_allowed = self.frees_allowed;
+                packet_handles.push(
+                    thread::Builder::new()
+                        .name(format!("packet-{index}"))
+                        .spawn_scoped(scope, move || {
+                            packet_worker(&slot, &live, &ops, &survivors, frees_allowed)
+                        })
+                        .expect("spawn packet worker"),
+                );
+            }
+
+            let config_handle = {
+                let slot = slot.clone();
+                let ops = self.config_ops.clone();
+                let specs = specs.clone();
+                let survivors = survivors.clone();
+                thread::Builder::new()
+                    .name("config".to_string())
+                    .spawn_scoped(scope, move || {
+                        let mut generation = 0u64;
+                        for op in ops {
+                            match op {
+                                ConfigOp::Republish => {
+                                    generation += 1;
+                                    let next = Published::build(&specs, generation, &survivors);
+                                    slot.store(Some(Arc::new(next)));
+                                }
+                                ConfigOp::Idle => {}
+                            }
+                            thread::yield_now();
+                        }
+                    })
+                    .expect("spawn config worker")
+            };
+
+            // Collect rather than drop: an allocation released while another thread is still
+            // allocating is one the record cannot reason about, so everything stays held until
+            // every thread has finished.
+            let leftovers: Vec<_> = packet_handles
+                .into_iter()
+                .map(|handle| handle.join().expect("packet worker panicked"))
+                .collect();
+            config_handle.join().expect("config worker panicked");
+            drop(leftovers);
+        });
+
+        drop(existing);
+    }
+}
+
+/// Returns whatever the thread is still holding when its ops run out, rather than releasing it.
+///
+/// Releasing here would free addresses while other threads are still allocating, which is exactly
+/// the ambiguity [`Live`] cannot see through, and it is not needed to keep the record honest: the
+/// pairs stay held, so nothing else can legitimately be given them.
+fn packet_worker(
+    slot: &SlotOption<Published>,
+    live: &Live,
+    ops: &[PacketOp],
+    survivors: &[(usize, Ipv4Addr, NatPort)],
+    frees_allowed: bool,
+) -> Vec<(u64, AllocatedPort<Ipv4Addr>)> {
+    // What this thread is holding, tagged with the generation it was drawn from.
+    let mut held: Vec<(u64, AllocatedPort<Ipv4Addr>)> = Vec::new();
+
+    for (step, op) in ops.iter().enumerate() {
+        let published = slot.load_full().expect("pools are always published");
+
+        match op {
+            PacketOp::Allocate => {
+                let owner = step % published.pools.len();
+                match published.pools[owner].allocate(false) {
+                    Ok(allocation) => {
+                        let pair = (allocation.ip(), allocation.port().as_u16());
+
+                        // The writer re-reserved every survivor before publishing, so a new flow
+                        // must never be handed what a carried-over flow still holds.
+                        assert!(
+                            !published.carried.contains(&pair),
+                            "generation {} handed out {}:{}, which a carried-over flow holds",
+                            published.generation,
+                            pair.0,
+                            pair.1
+                        );
+
+                        live.claim(published.generation, pair.0, pair.1);
+                        held.push((published.generation, allocation));
+                    }
+                    Err(AllocatorError::InternalIssue(message)) => {
+                        panic!(
+                            "allocating from generation {}: {message}",
+                            published.generation
+                        )
+                    }
+                    // Running out of addresses or ports is a legitimate outcome.
+                    Err(_) => {}
+                }
+            }
+            PacketOp::FreeOldest => {
+                if frees_allowed && !held.is_empty() {
+                    let (generation, allocation) = held.remove(0);
+                    live.release(generation, allocation);
+                }
+            }
+            PacketOp::ReserveExisting => {
+                // Race a reservation against the other threads' allocations on pools that are
+                // already published and in use. Failing is fine, claiming inconsistent bookkeeping
+                // is not.
+                if let Some(&(owner, ip, port)) = survivors.get(step % survivors.len().max(1))
+                    && let Some(pool) = published.pools.get(owner)
+                    && let Err(AllocatorError::InternalIssue(message)) = pool.reserve(ip, port)
+                {
+                    panic!(
+                        "reserving {ip}:{port} in generation {}: {message}",
+                        published.generation
+                    );
+                }
+            }
+        }
+
+        // Give the model checker a preemption point between ops; a cheap hint under std.
+        thread::yield_now();
+    }
+
+    held
+}
+
+#[concurrency::model_test]
+fn stress_test_config_change() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|scenario: Scenario| {
+            concurrency::stress(move || {
+                scenario.run();
+            });
+        });
+}

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -439,3 +439,46 @@ fn stress_test_config_change() {
             });
         });
 }
+
+/// Printing the allocator races the last flow on an address ending.
+///
+/// The pool holds weak references to the addresses in use, and printing upgrades each one while
+/// the pool's read guard is held. An address whose last block is released at that moment leaves
+/// the upgrade taken for printing as the only strong reference, and dropping it runs
+/// `AllocatedIp::drop` on the printing thread, which takes the same lock for writing.
+///
+/// This is the same self-deadlock the allocation paths guard against, reached from the management
+/// side: `NatAllocator` is a `CliSource`, so the table is formatted on a thread of its own while
+/// packet threads keep ending flows. A wedged read guard takes the pool with it.
+///
+/// Shuttle names it directly -- "tried to acquire a `RwLock` it already holds" -- so the
+/// assertion is the run completing at all.
+#[concurrency::model_test]
+fn printing_the_pool_does_not_wedge_it_against_a_flow_ending() {
+    concurrency::stress(|| {
+        let specs = vec![PoolSpec {
+            // One address, so the flow that ends is the last holder of the one being printed.
+            public_ranges: vec![AddrInterval::new(BASE, BASE)],
+            reserved: PrefixPortsSet::new(),
+            idle_timeout: IDLE_TIMEOUT,
+        }];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            NextHeader::TCP,
+            false,
+        ));
+
+        let allocation = pools[0].allocate(false).expect("the pool can serve");
+
+        let releaser = thread::spawn(move || drop(allocation));
+        let printer = {
+            let pools = pools.clone();
+            thread::spawn(move || {
+                let _ = format!("{}", pools[0]);
+            })
+        };
+
+        printer.join().expect("the printing thread panicked");
+        releaser.join().expect("the releasing thread panicked");
+    });
+}

--- a/nat/src/masquerade/apalloc/display.rs
+++ b/nat/src/masquerade/apalloc/display.rs
@@ -3,7 +3,7 @@
 
 //! Display implementations for allocator types
 
-use super::alloc::{AllocatedIp, IpAllocator, NatPool};
+use super::alloc::{AllocatedIp, IpAllocator, NatPool, PoolSet};
 use super::port_alloc::PortAllocator;
 use super::{NatAllocator, NatIp, NatIpWithBitmap, PoolTable, PoolTableKey};
 use common::cliprovider::{CliSource, Heading};
@@ -57,9 +57,31 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(
             f,
-            "{} | dest VPC: {}, for IPs: [ {} .. {} ]",
-            self.protocol, self.dst_vpcd, self.addr, self.addr_range_end
+            "{} | source VPC: {}, dest VPC: {}, for IPs: [ {} .. {} ]",
+            self.protocol, self.src_vpcd, self.dst_vpcd, self.addr, self.addr_range_end
         )
+    }
+}
+
+impl<I> Display for PoolSet<I>
+where
+    I: NatIpWithBitmap + Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f, "idle timeout: {:?}", self.idle_timeout())?;
+        let mut empty = true;
+        for region in self.regions() {
+            empty = false;
+            let range = region.range();
+            let start = I::try_from_bits(range.start).map_err(|()| Error)?;
+            let end = I::try_from_bits(range.end).map_err(|()| Error)?;
+            writeln!(f, "region [ {start} .. {end} ]:")?;
+            write!(with_indent!(f), "{}", region.allocator())?;
+        }
+        if empty {
+            writeln!(f, "(no region)")?;
+        }
+        Ok(())
     }
 }
 
@@ -78,8 +100,6 @@ where
     I: NatIpWithBitmap + Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        writeln!(f, "idle timeout: {:?}", self.idle_timeout())?;
-
         if let Some(reserved) = self.reserved_prefixes_ports() {
             writeln!(f, "reserved ranges:")?;
             for (ips, ports) in reserved {

--- a/nat/src/masquerade/apalloc/display.rs
+++ b/nat/src/masquerade/apalloc/display.rs
@@ -7,6 +7,7 @@ use super::alloc::{AllocatedIp, IpAllocator, NatPool, PoolSet};
 use super::port_alloc::PortAllocator;
 use super::{NatAllocator, NatIp, NatIpWithBitmap, PoolTable, PoolTableKey};
 use common::cliprovider::{CliSource, Heading};
+use concurrency::sync::{Arc, Weak};
 use indenter::indented;
 use std::fmt::{Display, Error, Formatter, Result, Write};
 
@@ -90,8 +91,24 @@ where
     I: NatIpWithBitmap + Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let pool = self.read();
-        write!(f, "{pool}")
+        // The same hazard the allocation paths guard against, reached by printing the table.
+        //
+        // The pool holds weak references to the addresses in use; the strong ones belong to the
+        // blocks handed out from each. `NatPool`'s own `fmt` upgrades each weak reference to print
+        // it, and the guard below is held for all of that. Another thread ending the last flow on
+        // an address at that moment leaves one of those upgrades as the only strong reference, and
+        // letting it go runs `AllocatedIp::drop` here, which takes this same lock for writing.
+        //
+        // Holding an upgrade of every address across the guard keeps the ones taken while printing
+        // from ever being last. They are released below, once the guard is gone.
+        let mut examined: Vec<Arc<AllocatedIp<I>>> = Vec::new();
+        let outcome = {
+            let pool = self.read();
+            examined.extend(pool.ips_in_use().filter_map(Weak::upgrade));
+            write!(f, "{pool}")
+        };
+        drop(examined);
+        outcome
     }
 }
 

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -97,6 +97,7 @@ use tracectl::trace_target;
 trace_target!("nat-allocation", LevelFilter::ERROR, &["masquerade"]);
 
 mod alloc;
+mod concurrent_fuzz;
 mod display;
 mod natip_with_bitmap;
 mod pool_fuzz;

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -228,7 +228,7 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// [`Allocation`] is the non-generic object representing an allocation, be it IPv4 or IPv6
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Allocation {
     V4(AllocatedPort<Ipv4Addr>),
     V6(AllocatedPort<Ipv6Addr>),

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -92,18 +92,32 @@ pub use port_alloc::AllocatedPort;
 // PoolTableKey
 ///////////////////////////////////////////////////////////////////////////////
 
+/// Identifies the pool serving a private source address.
+///
+/// A private address only means anything within the VPC it belongs to: two VPCs routinely use the
+/// same private space, which is much of the point of NAT. Both discriminants are therefore part of
+/// the key, and both are ordered before the address, so that the range lookup in
+/// [`PoolTable::get`] scans within a single pair of VPCs.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct PoolTableKey<I: NatIp> {
     protocol: NextHeader,
+    src_vpcd: VpcDiscriminant,
     dst_vpcd: VpcDiscriminant,
     addr: I,
     addr_range_end: I,
 }
 
 impl<I: NatIp> PoolTableKey<I> {
-    fn new(protocol: NextHeader, dst_vpcd: VpcDiscriminant, addr: I, addr_range_end: I) -> Self {
+    fn new(
+        protocol: NextHeader,
+        src_vpcd: VpcDiscriminant,
+        dst_vpcd: VpcDiscriminant,
+        addr: I,
+        addr_range_end: I,
+    ) -> Self {
         Self {
             protocol,
+            src_vpcd,
             dst_vpcd,
             addr,
             addr_range_end,
@@ -132,6 +146,7 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
         match self.0.range(..=key).next_back() {
             Some((k, v))
                 if k.addr_range_end >= key.addr
+                    && k.src_vpcd == key.src_vpcd
                     && k.dst_vpcd == key.dst_vpcd
                     && k.protocol == key.protocol =>
             {
@@ -144,18 +159,19 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
     fn get_entry(
         &self,
         protocol: NextHeader,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         addr: I,
     ) -> Option<&alloc::IpAllocator<J>> {
-        let key = PoolTableKey::new(protocol, dst_vpcd, addr, max_range::<I>());
+        let key = PoolTableKey::new(protocol, src_vpcd, dst_vpcd, addr, max_range::<I>());
         self.get(&key)
     }
 
     fn add_entry(&mut self, key: PoolTableKey<I>, allocator: alloc::IpAllocator<J>) {
         if self.0.contains_key(&key) {
             warn!(
-                "Overwriting NAT pool entry {key:?}: the same private prefix is masqueraded by \
-                 more than one expose towards the same peer VPC"
+                "Overwriting NAT pool entry {key:?}: within one VPC, the same private prefix is \
+                 masqueraded by more than one expose towards the same peer VPC"
             );
         }
         self.0.insert(key, allocator);
@@ -245,6 +261,7 @@ impl NatAllocator {
         for nat_peering in config.iter() {
             allocator.add_peering_addresses(
                 &nat_peering.peering,
+                nat_peering.src_vpcd,
                 nat_peering.dst_vpcd,
                 &mut registries,
             );
@@ -259,44 +276,57 @@ impl NatAllocator {
 
     fn allocate_v4(
         &self,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: Ipv4Addr,
         next_header: NextHeader,
     ) -> Result<AllocationResult<AllocatedPort<Ipv4Addr>>, AllocatorError> {
-        self.allocate_from_tables(src_ip.into(), dst_vpcd, next_header, &self.pools_src44)
+        self.allocate_from_tables(
+            src_ip.into(),
+            src_vpcd,
+            dst_vpcd,
+            next_header,
+            &self.pools_src44,
+        )
     }
 
     fn allocate_v6(
         &self,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: Ipv6Addr,
         next_header: NextHeader,
     ) -> Result<AllocationResult<AllocatedPort<Ipv6Addr>>, AllocatorError> {
-        self.allocate_from_tables(src_ip.into(), dst_vpcd, next_header, &self.pools_src66)
+        self.allocate_from_tables(
+            src_ip.into(),
+            src_vpcd,
+            dst_vpcd,
+            next_header,
+            &self.pools_src66,
+        )
     }
 
     /// Allocate an IP address and port for the given source IP, dispatching on IP version.
     pub(crate) fn allocate(
         &self,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: IpAddr,
         next_header: NextHeader,
     ) -> Result<AllocationResult<Allocation>, AllocatorError> {
         match src_ip {
-            IpAddr::V4(ip) => {
-                self.allocate_v4(dst_vpcd, ip, next_header)
-                    .map(|r| AllocationResult {
-                        allocation: Allocation::V4(r.allocation),
-                        idle_timeout: r.idle_timeout,
-                    })
-            }
-            IpAddr::V6(ip) => {
-                self.allocate_v6(dst_vpcd, ip, next_header)
-                    .map(|r| AllocationResult {
-                        allocation: Allocation::V6(r.allocation),
-                        idle_timeout: r.idle_timeout,
-                    })
-            }
+            IpAddr::V4(ip) => self
+                .allocate_v4(src_vpcd, dst_vpcd, ip, next_header)
+                .map(|r| AllocationResult {
+                    allocation: Allocation::V4(r.allocation),
+                    idle_timeout: r.idle_timeout,
+                }),
+            IpAddr::V6(ip) => self
+                .allocate_v6(src_vpcd, dst_vpcd, ip, next_header)
+                .map(|r| AllocationResult {
+                    allocation: Allocation::V6(r.allocation),
+                    idle_timeout: r.idle_timeout,
+                }),
         }
     }
     fn check_proto(next_header: NextHeader) -> Result<(), AllocatorError> {
@@ -308,6 +338,7 @@ impl NatAllocator {
     fn allocate_from_tables<I: NatIpWithBitmap>(
         &self,
         src_ip: IpAddr,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         next_header: NextHeader,
         pools_src: &PoolTable<I, I>,
@@ -319,6 +350,7 @@ impl NatAllocator {
         let pool = pools_src
             .get_entry(
                 next_header,
+                src_vpcd,
                 dst_vpcd,
                 NatIp::try_from_addr(src_ip).map_err(|()| {
                     AllocatorError::InternalIssue("Failed to convert src IP address".to_string())
@@ -344,34 +376,46 @@ impl NatAllocator {
     fn reserve_ipv4_port(
         &self,
         protocol: NextHeader,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: Ipv4Addr,
         ip: Ipv4Addr,
         port: NatPort,
     ) -> Result<AllocatedPort<Ipv4Addr>, AllocatorError> {
-        let Some(pool) = self.pools_src44.get_entry(protocol, dst_vpcd, src_ip) else {
-            warn!("No pool found for proto:{protocol} dst-vpcd:{dst_vpcd} and src:{src_ip}");
+        let Some(pool) = self
+            .pools_src44
+            .get_entry(protocol, src_vpcd, dst_vpcd, src_ip)
+        else {
+            warn!(
+                "No pool found for proto:{protocol} src-vpcd:{src_vpcd} dst-vpcd:{dst_vpcd} and src:{src_ip}"
+            );
             return Err(AllocatorError::NoPoolFound);
         };
 
-        debug!("Pool found for {protocol} {dst_vpcd} {src_ip}");
+        debug!("Pool found for {protocol} {src_vpcd} {dst_vpcd} {src_ip}");
         pool.reserve(ip, port)
             .inspect_err(|e| error!("Failed to reserve ip {ip} port {port}: {e}"))
     }
     fn reserve_ipv6_port(
         &self,
         protocol: NextHeader,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: Ipv6Addr,
         ip: Ipv6Addr,
         port: NatPort,
     ) -> Result<AllocatedPort<Ipv6Addr>, AllocatorError> {
-        let Some(pool) = self.pools_src66.get_entry(protocol, dst_vpcd, src_ip) else {
-            warn!("No pool found for proto:{protocol} dst-vpcd:{dst_vpcd} and src:{src_ip}");
+        let Some(pool) = self
+            .pools_src66
+            .get_entry(protocol, src_vpcd, dst_vpcd, src_ip)
+        else {
+            warn!(
+                "No pool found for proto:{protocol} src-vpcd:{src_vpcd} dst-vpcd:{dst_vpcd} and src:{src_ip}"
+            );
             return Err(AllocatorError::NoPoolFound);
         };
 
-        debug!("Pool found for {protocol} {dst_vpcd} {src_ip}");
+        debug!("Pool found for {protocol} {src_vpcd} {dst_vpcd} {src_ip}");
         pool.reserve(ip, port)
             .inspect_err(|e| error!("Failed to reserve ip {ip} port {port}: {e}"))
     }
@@ -380,18 +424,19 @@ impl NatAllocator {
     pub(crate) fn reserve_port(
         &self,
         protocol: NextHeader,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         src_ip: IpAddr,
         ip: IpAddr,
         port: NatPort,
     ) -> Result<Allocation, AllocatorError> {
-        debug!("Re-reserving {ip} {protocol}:{port}, dst_vpcd:{dst_vpcd}");
+        debug!("Re-reserving {ip} {protocol}:{port}, src_vpcd:{src_vpcd} dst_vpcd:{dst_vpcd}");
         let mut allocation = match (src_ip, ip) {
             (IpAddr::V4(src), IpAddr::V4(allocated)) => self
-                .reserve_ipv4_port(protocol, dst_vpcd, src, allocated, port)
+                .reserve_ipv4_port(protocol, src_vpcd, dst_vpcd, src, allocated, port)
                 .map(Allocation::V4)?,
             (IpAddr::V6(src), IpAddr::V6(allocated)) => self
-                .reserve_ipv6_port(protocol, dst_vpcd, src, allocated, port)
+                .reserve_ipv6_port(protocol, src_vpcd, dst_vpcd, src, allocated, port)
                 .map(Allocation::V6)?,
             _ => {
                 return Err(AllocatorError::InternalIssue(format!(
@@ -429,6 +474,9 @@ mod tests {
     fn vpcd(vpc_id: u32) -> VpcDiscriminant {
         VpcDiscriminant::VNI(Vni::new_checked(vpc_id).unwrap())
     }
+    fn vpcd1() -> VpcDiscriminant {
+        vpcd(1)
+    }
     fn vpcd2() -> VpcDiscriminant {
         vpcd(2)
     }
@@ -436,20 +484,24 @@ mod tests {
         vpcd(3)
     }
 
-    // Ensure that keys are sorted first by L4 protocol type, then by VPC IDs, and then by IP
-    // address. This is essential to make sure we can lookup for entries associated with prefixes
-    // for a given ID in the pool tables.
+    // Ensure that keys are sorted first by L4 protocol type, then by the source and destination
+    // VPC IDs, and only then by IP address. This is essential to make sure we can lookup for
+    // entries associated with prefixes for a given pair of IDs in the pool tables: the range scan
+    // in PoolTable::get relies on every key of a given (protocol, source, destination) group being
+    // contiguous, and on addresses of another group never falling between them.
     #[allow(clippy::too_many_lines)]
     #[test]
     fn test_key_order() {
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
         );
         let key2 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
@@ -458,12 +510,14 @@ mod tests {
 
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
         );
         let key2 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(255, 255, 255, 255),
@@ -472,12 +526,14 @@ mod tests {
 
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
         );
         let key2 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 2),
             Ipv4Addr::new(255, 255, 255, 255),
@@ -486,12 +542,14 @@ mod tests {
 
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(2, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
         );
         let key2 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 255, 255, 255),
             Ipv4Addr::new(255, 255, 255, 255),
@@ -502,12 +560,14 @@ mod tests {
 
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(255, 255, 255, 255),
         );
         let key2 = PoolTableKey::new(
             NextHeader::UDP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(255, 255, 255, 255),
@@ -516,16 +576,75 @@ mod tests {
 
         let key1 = PoolTableKey::new(
             NextHeader::TCP,
+            vpcd1(),
             vpcd3(),
             Ipv4Addr::new(2, 2, 2, 2),
             Ipv4Addr::new(255, 255, 255, 255),
         );
         let key2 = PoolTableKey::new(
             NextHeader::UDP,
+            vpcd1(),
             vpcd2(),
             Ipv4Addr::new(1, 1, 1, 1),
             Ipv4Addr::new(1, 1, 1, 1),
         );
         assert!(key1 < key2);
+
+        // Mixing source VPCs. The source discriminant outranks both the destination and the
+        // address, so the entries of one source VPC never interleave with those of another.
+
+        let key1 = PoolTableKey::new(
+            NextHeader::TCP,
+            vpcd1(),
+            vpcd3(),
+            Ipv4Addr::new(2, 2, 2, 2),
+            Ipv4Addr::new(255, 255, 255, 255),
+        );
+        let key2 = PoolTableKey::new(
+            NextHeader::TCP,
+            vpcd2(),
+            vpcd2(),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(1, 1, 1, 1),
+        );
+        assert!(key1 < key2);
+
+        // ... but it does not outrank the protocol.
+
+        let key1 = PoolTableKey::new(
+            NextHeader::TCP,
+            vpcd3(),
+            vpcd2(),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(255, 255, 255, 255),
+        );
+        let key2 = PoolTableKey::new(
+            NextHeader::UDP,
+            vpcd1(),
+            vpcd2(),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(255, 255, 255, 255),
+        );
+        assert!(key1 < key2);
+
+        // Two source VPCs using the same private address are distinct keys, which is the whole
+        // point of carrying the source discriminant: a private address only means something
+        // within the VPC it belongs to.
+
+        let key1 = PoolTableKey::new(
+            NextHeader::TCP,
+            vpcd1(),
+            vpcd3(),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(1, 1, 255, 255),
+        );
+        let key2 = PoolTableKey::new(
+            NextHeader::TCP,
+            vpcd2(),
+            vpcd3(),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(1, 1, 255, 255),
+        );
+        assert_ne!(key1, key2);
     }
 }

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -8,31 +8,39 @@
 //! Here is an attempt to visualize the allocator structure:
 //!
 //! ```text
-//! ┌────────────┐
-//! │NatAllocator├────────────────────────────┬──────┬──────┐
-//! └────────┬───┘                            │      │      │
-//!          │                                │      │      │
-//! ┌────────▼────────┐         ┌─────────────▼──────▼──────▼───┐
-//! │PoolTable (src44)│         │PoolTable (src66, dst44, dst66)│
-//! └───────┬─────────┘         └───────────────────────────────┘
-//!         │
-//! ┌───────▼────┐  associates  ┌───────────┐
-//! │PoolTableKey┼──────────────►IpAllocator◄────────────────┐
-//! └────────────┘              └────┬──────┘                │
-//!                                  │                       │
-//!                             ┌────▼──┐                    │
-//!       ┌─────────────────────┤NatPool├───┐                │
-//!       │                     └───────┘   │                │
-//!       │                                 │                │
-//! ┌─────────────────┐           ┌─────────▼──────────┐     │
-//! │<collection>     │           │PoolBitmap          │     │
-//! │(weak references)│           │(map free addresses)│     │
-//! └─────────────────┘           └────────────────────┘     │
-//!       │                                                  │
-//! ┌─────▼─────┐                                            │
-//! │AllocatedIp│────────────────────────────────────────────┘
-//! └─▲─────────┘           back-reference, for deallocation
-//!   │       │
+//!                        ┌────────────┐
+//!                        │NatAllocator│
+//!                        └──────┬─────┘
+//!                 ┌─────────────┴─────────────┐
+//!       ┌─────────▼───────┐         ┌─────────▼───────┐
+//!       │PoolTable (src44)│         │PoolTable (src66)│   one per address family
+//!       └─────────┬───────┘         └─────────────────┘
+//!                 │  keyed by
+//!       ┌─────────▼──┐
+//!       │PoolTableKey│  protocol, source VPC, dest VPC, public range
+//!       └─────────┬──┘
+//!                 │  which an expose may draw from
+//!         ┌───────▼─┐
+//!         │PoolSet  │  the regions this expose's ranges cover, exclusive ones first
+//!         └───────┬─┘
+//!                 │
+//!        ┌────────▼──┐        ┌───────────┐
+//!        │PoolRegion ├────────►AddrInterval│  the slice of public space it owns
+//!        └────────┬──┘        └───────────┘
+//!                 │  one allocator per region, shared by every expose over it
+//!       ┌─────────▼─┐
+//!       │IpAllocator│◄───────────────────────────────┐
+//!       └─────────┬─┘                                │
+//!            ┌────▼──┐                               │
+//!    ┌───────┤NatPool├──────────┐                    │
+//!    │       └───────┘          │                    │
+//! ┌──▼──────────────┐  ┌────────▼───────────┐        │
+//! │<collection>     │  │PoolBitmap          │        │
+//! │(weak references)│  │(map free addresses)│        │
+//! └──┬──────────────┘  └────────────────────┘        │
+//! ┌──▼────────┐                                      │
+//! │AllocatedIp│──────────────────────────────────────┘
+//! └─▲───────┬─┘         back-reference, for deallocation
 //!   │ ┌─────▼───────┐
 //!   │ │PortAllocator│
 //!   │ └─────┬───────┘
@@ -53,6 +61,15 @@
 //! └───────────────┘
 //! Returned object
 //! ```
+//!
+//! The layer worth reading twice is [`PoolSet`](alloc::PoolSet) and
+//! [`PoolRegion`](alloc::PoolRegion). Exposes may claim overlapping public ranges, and two
+//! allocators over the same address would each believe it was theirs to hand out -- which is the
+//! collision the reverse flow key cannot survive, since it carries nothing that says which VPC the
+//! traffic came from. So the space is cut at every point where the set of exposes covering it
+//! changes ([`region`]), one allocator is built per resulting region, and an expose is handed the
+//! regions its own ranges cover. Sharing a region means sharing its allocator, which is what makes
+//! the uniqueness structural rather than a promise from the configuration layer.
 //!
 //! The [`AllocatedPort`](port_alloc::AllocatedPort) has a back-reference to
 //! [`AllocatedPortBlock`](port_alloc::AllocatedPortBlock), to deallocate the ports when the
@@ -82,7 +99,9 @@ trace_target!("nat-allocation", LevelFilter::ERROR, &["masquerade"]);
 mod alloc;
 mod display;
 mod natip_with_bitmap;
+mod pool_fuzz;
 mod port_alloc;
+mod region;
 mod setup;
 mod test_alloc;
 
@@ -131,7 +150,7 @@ impl<I: NatIp> PoolTableKey<I> {
 
 #[derive(Debug)]
 struct PoolTable<I: NatIpWithBitmap, J: NatIpWithBitmap>(
-    BTreeMap<PoolTableKey<I>, alloc::IpAllocator<J>>,
+    BTreeMap<PoolTableKey<I>, alloc::PoolSet<J>>,
 );
 
 impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
@@ -139,7 +158,7 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
         Self(BTreeMap::new())
     }
 
-    fn get(&self, key: &PoolTableKey<I>) -> Option<&alloc::IpAllocator<J>> {
+    fn get(&self, key: &PoolTableKey<I>) -> Option<&alloc::PoolSet<J>> {
         // We need to find the entry with the ID, and the prefix for the corresponding address.
         // Get the range of "lower" entries, the one with the address before ours is the prefix we
         // need, if the ID also matches.
@@ -162,19 +181,19 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
         src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         addr: I,
-    ) -> Option<&alloc::IpAllocator<J>> {
+    ) -> Option<&alloc::PoolSet<J>> {
         let key = PoolTableKey::new(protocol, src_vpcd, dst_vpcd, addr, max_range::<I>());
         self.get(&key)
     }
 
-    fn add_entry(&mut self, key: PoolTableKey<I>, allocator: alloc::IpAllocator<J>) {
+    fn add_entry(&mut self, key: PoolTableKey<I>, pool_set: alloc::PoolSet<J>) {
         if self.0.contains_key(&key) {
             warn!(
                 "Overwriting NAT pool entry {key:?}: within one VPC, the same private prefix is \
                  masqueraded by more than one expose towards the same peer VPC"
             );
         }
-        self.0.insert(key, allocator);
+        self.0.insert(key, pool_set);
     }
 }
 
@@ -254,18 +273,7 @@ impl NatAllocator {
             pools_src66: PoolTable::new(),
             randomize: config.randomize(),
         };
-        // Pools are identified by the public range they allocate from, so that exposes
-        // masquerading onto the same range share one allocator rather than each handing out the
-        // whole range on its own. The registries are only needed while building.
-        let mut registries = setup::PoolRegistries::default();
-        for nat_peering in config.iter() {
-            allocator.add_peering_addresses(
-                &nat_peering.peering,
-                nat_peering.src_vpcd,
-                nat_peering.dst_vpcd,
-                &mut registries,
-            );
-        }
+        allocator.build_pools(&config);
         allocator.config = config;
         allocator
     }

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -158,21 +158,46 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
         Self(BTreeMap::new())
     }
 
+    /// The pool serving a private address: the entry whose prefix covers it and starts nearest to
+    /// it, within the same protocol and pair of VPCs.
+    ///
+    /// Keys sort by address before range end, so walking back from the address reaches the
+    /// prefixes that could cover it in turn. Taking only the first one found is not enough: a
+    /// prefix nested inside another starts nearer to an address than the prefix containing it,
+    /// while covering less of it, so a nested prefix would answer "no pool" for an address of the
+    /// wider one *above* it. The walk therefore continues past an entry that does not cover the
+    /// address, and stops once no later entry can be a better match.
+    ///
+    /// Where several prefixes cover the address the narrowest wins, which is the longest-prefix
+    /// match the rest of the system uses. Nothing in this crate rejects an overlap or reports one:
+    /// [`PoolTable::add_entry`] warns only when two entries have exactly the same bounds. Choosing
+    /// the narrowest is therefore what to do when the configuration layer's guarantee of disjoint
+    /// prefixes is absent, not support for a configuration it would accept.
     fn get(&self, key: &PoolTableKey<I>) -> Option<&alloc::PoolSet<J>> {
-        // We need to find the entry with the ID, and the prefix for the corresponding address.
-        // Get the range of "lower" entries, the one with the address before ours is the prefix we
-        // need, if the ID also matches.
-        match self.0.range(..=key).next_back() {
-            Some((k, v))
-                if k.addr_range_end >= key.addr
-                    && k.src_vpcd == key.src_vpcd
-                    && k.dst_vpcd == key.dst_vpcd
-                    && k.protocol == key.protocol =>
+        let mut best: Option<(&PoolTableKey<I>, &alloc::PoolSet<J>)> = None;
+        for (candidate, pool_set) in self.0.range(..=key).rev() {
+            // The keys of one protocol and pair of VPCs are contiguous, so leaving that run means
+            // there is nothing further back to find.
+            if candidate.protocol != key.protocol
+                || candidate.src_vpcd != key.src_vpcd
+                || candidate.dst_vpcd != key.dst_vpcd
             {
-                Some(v)
+                break;
             }
-            _ => None,
+            // Walking back, prefixes start further from the address as we go. Once one covering it
+            // has been found, only another starting at the same address can be narrower.
+            if let Some((found, _)) = best
+                && candidate.addr < found.addr
+            {
+                break;
+            }
+            if candidate.addr_range_end >= key.addr {
+                // Entries sharing a start address are visited widest first, so a later one is
+                // always the narrower match.
+                best = Some((candidate, pool_set));
+            }
         }
+        best.map(|(_, pool_set)| pool_set)
     }
 
     fn get_entry(
@@ -473,6 +498,138 @@ fn max_range<I: NatIp>() -> I {
 ///////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
+mod bolero_tests {
+    use super::*;
+    use bolero::{Driver, TypeGenerator};
+    use net::vxlan::Vni;
+    use std::time::Duration;
+
+    // Prefixes are drawn from a narrow window so that nesting and overlap are the common case
+    // rather than astronomically unlikely, and so that every address in the window can be checked
+    // rather than a sampled few.
+    const BASE: u32 = 0x0A00_0000; // 10.0.0.0
+    const WINDOW: u32 = 24;
+    const MAX_ENTRIES: u8 = 6;
+    const MAX_LEN: u8 = 12;
+
+    // Which entry a lookup landed on, as a value a `PoolSet` can carry.
+    //
+    // Both bounds, because either alone loses entries. Marking by end made two entries ending
+    // together indistinguishable however far apart they start -- and "nearest start" is half of
+    // the rule under test, so a walk preferring the farther of the two passed.
+    const SPAN: u32 = WINDOW + MAX_LEN as u32 + 1;
+    fn marker(start: u32, end: u32) -> u32 {
+        (start - BASE) * SPAN + (end - start)
+    }
+
+    fn vpcd(id: u32) -> VpcDiscriminant {
+        VpcDiscriminant::VNI(Vni::new_checked(id).unwrap())
+    }
+
+    /// A set of entries, each an offset into the window and a length, and each in one of two
+    /// groups so that the walk's refusal to cross between groups is exercised too.
+    ///
+    /// The foreign group sorts *before* the queried one, which is what makes that last part true:
+    /// keys order by destination VPC before address, so a group sorting after is cut off by
+    /// `range(..=key)` and never reaches the guard at all.
+    #[derive(Debug, Clone)]
+    struct Scenario {
+        entries: Vec<(u8, u8, bool)>,
+    }
+
+    impl TypeGenerator for Scenario {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let count = usize::from(driver.produce::<u8>()? % MAX_ENTRIES + 1);
+            let mut entries = Vec::with_capacity(count);
+            for _ in 0..count {
+                entries.push((
+                    driver.produce::<u8>()? % u8::try_from(WINDOW).ok()?,
+                    driver.produce::<u8>()? % MAX_LEN + 1,
+                    driver.produce::<bool>()?,
+                ));
+            }
+            Some(Self { entries })
+        }
+    }
+
+    impl Scenario {
+        // The entries of the group under test, as inclusive address bounds.
+        fn ranges(&self) -> Vec<(u32, u32)> {
+            self.entries
+                .iter()
+                .filter(|(_, _, other_group)| !other_group)
+                .map(|&(offset, length, _)| {
+                    let start = BASE + u32::from(offset);
+                    (start, start + u32::from(length) - 1)
+                })
+                .collect()
+        }
+
+        fn table(&self) -> PoolTable<Ipv4Addr, Ipv4Addr> {
+            let mut table = PoolTable::new();
+            for &(offset, length, other_group) in &self.entries {
+                let start = BASE + u32::from(offset);
+                let end = start + u32::from(length) - 1;
+                table.add_entry(
+                    PoolTableKey::new(
+                        NextHeader::TCP,
+                        vpcd(1),
+                        // Below the queried group, so the walk has to refuse to enter it.
+                        if other_group { vpcd(2) } else { vpcd(3) },
+                        Ipv4Addr::from(start),
+                        Ipv4Addr::from(end),
+                    ),
+                    alloc::PoolSet::new(Duration::from_secs(u64::from(marker(start, end)))),
+                );
+            }
+            table
+        }
+
+        // The oracle: among the entries covering the address, the one starting nearest to it, and
+        // of those the narrowest. Straight from the inputs, with no walking.
+        fn expected(&self, address: u32) -> Option<u32> {
+            self.ranges()
+                .into_iter()
+                .filter(|&(start, end)| start <= address && address <= end)
+                .min_by_key(|&(start, end)| (std::cmp::Reverse(start), end))
+                .map(|(start, end)| marker(start, end))
+        }
+    }
+
+    /// The lookup answers what the oracle answers, on arbitrary intervals.
+    ///
+    /// Not "longest prefix", which is what this was called: the generator produces intervals of
+    /// any offset and length, and most of them are not CIDR-aligned. Longest-prefix match is only
+    /// defined on prefixes, which nest or stay disjoint; arbitrary intervals may also partially
+    /// overlap, and the oracle here is the rule [`PoolTable::get`] actually implements -- nearest
+    /// start, then narrowest -- which agrees with longest-prefix on the inputs the configuration
+    /// layer can produce and is defined on the ones it cannot.
+    #[test]
+    fn pool_table_lookup_matches_an_interval_oracle() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|scenario: Scenario| {
+                let table = scenario.table();
+                // A margin either side, so addresses below and above every entry are covered.
+                for offset in 0..WINDOW + u32::from(MAX_LEN) + 2 {
+                    let address = BASE + offset;
+                    let found = table
+                        .get_entry(NextHeader::TCP, vpcd(1), vpcd(3), Ipv4Addr::from(address))
+                        .map(|pool_set| u32::try_from(pool_set.idle_timeout().as_secs()).unwrap());
+                    assert_eq!(
+                        found,
+                        scenario.expected(address),
+                        "lookup for {} disagreed with the oracle, entries {:?}",
+                        Ipv4Addr::from(address),
+                        scenario.ranges()
+                    );
+                }
+            });
+    }
+}
+
+#[cfg(test)]
 mod tests {
     #![allow(clippy::ip_constant)]
 
@@ -490,6 +647,142 @@ mod tests {
     }
     fn vpcd3() -> VpcDiscriminant {
         vpcd(3)
+    }
+
+    // A pool set carrying nothing but a distinguishable idle timeout, so a lookup can be told
+    // which entry it landed on.
+    fn marked_pool_set(marker: u64) -> alloc::PoolSet<Ipv4Addr> {
+        alloc::PoolSet::new(std::time::Duration::from_secs(marker))
+    }
+
+    // The group these tests query. Keys sort by protocol, then source VPC, then destination VPC,
+    // and the walk only ever looks *back* from the queried key -- so a group that sorts after this
+    // one is excluded by `range(..=key)` before the walk begins and proves nothing about the guard
+    // that stops it crossing between groups. This group is deliberately not the lowest, leaving
+    // room below it on each of the three components for
+    // [`test_the_walk_does_not_cross_into_another_group`] to put one there.
+    fn queried_group() -> (NextHeader, VpcDiscriminant, VpcDiscriminant) {
+        (NextHeader::TCP, vpcd2(), vpcd3())
+    }
+
+    fn table_with(entries: &[(&str, &str, u64)]) -> PoolTable<Ipv4Addr, Ipv4Addr> {
+        let (protocol, src, dst) = queried_group();
+        let mut table = PoolTable::new();
+        for &(start, end, marker) in entries {
+            table.add_entry(
+                PoolTableKey::new(
+                    protocol,
+                    src,
+                    dst,
+                    start.parse().unwrap(),
+                    end.parse().unwrap(),
+                ),
+                marked_pool_set(marker),
+            );
+        }
+        table
+    }
+
+    fn lookup(table: &PoolTable<Ipv4Addr, Ipv4Addr>, addr: &str) -> Option<u64> {
+        let (protocol, src, dst) = queried_group();
+        table
+            .get_entry(protocol, src, dst, addr.parse().unwrap())
+            .map(|pool_set| pool_set.idle_timeout().as_secs())
+    }
+
+    // A private prefix nested inside another must not hide the addresses of the wider one. The
+    // lookup walks back to the nearest entry starting at or below the address, and a nested prefix
+    // is nearer than the prefix containing it, so stopping at the first one found answered "no
+    // pool" for an address the wider prefix plainly covers. A packet from it is then dropped, and
+    // logged as a bug in the allocator rather than as the configuration it is.
+    #[test]
+    fn test_a_nested_prefix_does_not_hide_the_one_containing_it() {
+        let table = table_with(&[
+            ("10.0.0.0", "10.0.255.255", 16), // 10.0.0.0/16
+            ("10.0.1.0", "10.0.1.255", 24),   // 10.0.1.0/24, nested inside it
+        ]);
+
+        // Below the nested prefix, and inside it: unambiguous either way.
+        assert_eq!(lookup(&table, "10.0.0.5"), Some(16));
+        // Past the nested prefix, but still inside the wider one. This is the case that failed.
+        assert_eq!(
+            lookup(&table, "10.0.2.5"),
+            Some(16),
+            "an address covered by the wider prefix was not served"
+        );
+        // Well past both.
+        assert_eq!(lookup(&table, "10.1.0.1"), None);
+    }
+
+    // Where both cover an address, the more specific prefix serves it, as it does everywhere else
+    // in routing.
+    #[test]
+    fn test_the_most_specific_prefix_wins() {
+        let table = table_with(&[
+            ("10.0.0.0", "10.0.255.255", 16),
+            ("10.0.1.0", "10.0.1.255", 24),
+        ]);
+        assert_eq!(lookup(&table, "10.0.1.5"), Some(24));
+    }
+
+    // Several prefixes nested one inside the next, to check the walk does not stop early.
+    #[test]
+    fn test_deeply_nested_prefixes() {
+        let table = table_with(&[
+            ("10.0.0.0", "10.255.255.255", 8),
+            ("10.0.0.0", "10.0.255.255", 16),
+            ("10.0.0.0", "10.0.0.255", 24),
+        ]);
+        assert_eq!(lookup(&table, "10.0.0.1"), Some(24));
+        assert_eq!(lookup(&table, "10.0.1.1"), Some(16));
+        assert_eq!(lookup(&table, "10.1.0.1"), Some(8));
+        assert_eq!(lookup(&table, "11.0.0.1"), None);
+    }
+
+    // The walk stops at the edge of its own group: an entry belonging to another protocol or
+    // another pair of VPCs never serves an address, however well its prefix covers it.
+    //
+    // Each foreign group here sorts *before* the queried one, on a different component of the key.
+    // That is the whole of the test: a group sorting after is never in `range(..=key)` to begin
+    // with, so putting one there exercises the bound and not the guard. An earlier version of this
+    // test did exactly that -- the guard could be deleted outright and it still passed.
+    #[test]
+    fn test_the_walk_does_not_cross_into_another_group() {
+        let (protocol, src, dst) = queried_group();
+        // One boundary at a time, each a group immediately below the queried one.
+        let foreign = [
+            (NextHeader::ICMP, src, dst),
+            (protocol, vpcd1(), dst),
+            (protocol, src, vpcd2()),
+        ];
+
+        for (index, &(f_protocol, f_src, f_dst)) in foreign.iter().enumerate() {
+            let mut table = table_with(&[("10.0.1.0", "10.0.1.255", 24)]);
+            // A wider prefix, covering everything the queried group's entry does and more, but
+            // reached only by walking out of the queried group.
+            table.add_entry(
+                PoolTableKey::new(
+                    f_protocol,
+                    f_src,
+                    f_dst,
+                    "10.0.0.0".parse().unwrap(),
+                    "10.0.255.255".parse().unwrap(),
+                ),
+                marked_pool_set(99),
+            );
+            // An address only the foreign entry covers is not served at all...
+            assert_eq!(
+                lookup(&table, "10.0.2.5"),
+                None,
+                "foreign group {index} served an address of its own"
+            );
+            // ...and one both cover is served by the queried group's entry.
+            assert_eq!(
+                lookup(&table, "10.0.1.5"),
+                Some(24),
+                "foreign group {index} displaced the entry that should serve"
+            );
+        }
     }
 
     // Ensure that keys are sorted first by L4 protocol type, then by the source and destination

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -152,6 +152,12 @@ impl<I: NatIpWithBitmap, J: NatIpWithBitmap> PoolTable<I, J> {
     }
 
     fn add_entry(&mut self, key: PoolTableKey<I>, allocator: alloc::IpAllocator<J>) {
+        if self.0.contains_key(&key) {
+            warn!(
+                "Overwriting NAT pool entry {key:?}: the same private prefix is masqueraded by \
+                 more than one expose towards the same peer VPC"
+            );
+        }
         self.0.insert(key, allocator);
     }
 }
@@ -232,8 +238,16 @@ impl NatAllocator {
             pools_src66: PoolTable::new(),
             randomize: config.randomize(),
         };
+        // Pools are identified by the public range they allocate from, so that exposes
+        // masquerading onto the same range share one allocator rather than each handing out the
+        // whole range on its own. The registries are only needed while building.
+        let mut registries = setup::PoolRegistries::default();
         for nat_peering in config.iter() {
-            allocator.add_peering_addresses(&nat_peering.peering, nat_peering.dst_vpcd);
+            allocator.add_peering_addresses(
+                &nat_peering.peering,
+                nat_peering.dst_vpcd,
+                &mut registries,
+            );
         }
         allocator.config = config;
         allocator

--- a/nat/src/masquerade/apalloc/natip_with_bitmap.rs
+++ b/nat/src/masquerade/apalloc/natip_with_bitmap.rs
@@ -60,6 +60,6 @@ impl NatIpWithBitmap for Ipv6Addr {
         bitmap_mapping: &BTreeMap<u128, u32>,
     ) -> Result<u32, AllocatorError> {
         // Reverse operation of map_offset()
-        Ok(map_address(address, bitmap_mapping))
+        map_address(address, bitmap_mapping)
     }
 }

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -23,11 +23,12 @@ use super::alloc::PoolSet;
 use super::region::AddrInterval;
 use super::setup::{PoolSpec, pool_sets_for_specs};
 use crate::masquerade::allocation::AllocatorError;
+use crate::port::NatPort;
 use bolero::{Driver, TypeGenerator};
 use lpm::prefix::{PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use std::collections::BTreeSet;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
 // 10.1.0.0, with a window small enough that regions stay cheap to build.
@@ -290,6 +291,75 @@ fn an_exhausted_region_falls_through_to_the_next() {
         Ipv4Addr::from(u32::try_from(free).unwrap_or_else(|_| unreachable!())),
         "allocation did not fall through to the region with room"
     );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// IPv6
+///////////////////////////////////////////////////////////////////////////////
+
+/// A region may hold more addresses than a `u32` can index, in which case the bitmap covers only
+/// the first 2^32 of them. An address past that is inside the region but not servable, which a
+/// flow carried across a config change can present, and which must be an error rather than a panic
+/// part way through applying a config.
+#[test]
+fn an_address_past_the_indexable_span_is_refused_rather_than_panicking() {
+    let start = u128::from(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0));
+    // Far wider than the bitmap can index.
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(start, start + (1u128 << 40))],
+        reserved: PrefixPortsSet::new(),
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let pool_sets = pool_sets_for_specs::<Ipv6Addr>(&specs, NextHeader::TCP, false);
+    let port = NatPort::new_port_checked(4096).unwrap_or_else(|_| unreachable!());
+
+    // Just inside the indexable span: an ordinary carry-over, which must still work.
+    let near = Ipv6Addr::from(start + 1);
+    assert!(
+        pool_sets[0].reserve(near, port).is_ok(),
+        "an address the pool can index was refused"
+    );
+
+    // Past it: refused, and specifically not a panic.
+    let far = Ipv6Addr::from(start + (1u128 << 33));
+    assert_eq!(
+        pool_sets[0].reserve(far, port).unwrap_err(),
+        AllocatorError::NoPoolFound,
+        "an address the pool cannot index should be refused as unserved"
+    );
+}
+
+/// The pools are generic over the address family but every other test here is IPv4. Allocating
+/// from an IPv6 pool goes through the offset mapping that IPv4 skips entirely, so cover it.
+#[test]
+fn ipv6_pools_allocate_within_their_range() {
+    let start = u128::from(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0));
+    let end = start + 3;
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(start, end)],
+        reserved: PrefixPortsSet::new(),
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let pool_sets = pool_sets_for_specs::<Ipv6Addr>(&specs, NextHeader::TCP, false);
+
+    let mut held = Vec::new();
+    let mut seen = BTreeSet::new();
+    for _ in 0..8 {
+        let allocation = pool_sets[0].allocate(false).expect("pool has room");
+        let bits = u128::from(allocation.ip());
+        assert!(
+            (start..=end).contains(&bits),
+            "{} is outside the range the pool was built for",
+            allocation.ip()
+        );
+        assert!(
+            seen.insert((allocation.ip(), allocation.port().as_u16())),
+            "{}:{} was handed out twice",
+            allocation.ip(),
+            allocation.port()
+        );
+        held.push(allocation);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -258,6 +258,40 @@ fn re_reservation_after_a_config_change_is_honoured() {
         });
 }
 
+/// Falling through to the next region is what makes an expose's several regions behave as one
+/// pool. Only exhaustion may do it: any other error is about the allocator rather than about how
+/// full a region is, and a later region's success would bury it.
+///
+/// Exhausting a region by allocating from it would take every port of every address it holds, so
+/// this reserves them instead, which reaches the same state in one step.
+#[test]
+fn an_exhausted_region_falls_through_to_the_next() {
+    // Not adjacent, or the two would merge into a single region.
+    let full = BASE;
+    let free = BASE + 4;
+
+    let every_port = PrefixWithOptionalPorts::new(
+        "10.1.0.0/32".into(),
+        Some(PortRange::new(1024, u16::MAX).unwrap_or_else(|_| unreachable!())),
+    );
+
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(full, full), AddrInterval::new(free, free)],
+        reserved: [every_port].into_iter().collect(),
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+    let allocation = pool_sets[0]
+        .allocate(false)
+        .expect("the second region has room, so allocation must succeed");
+    assert_eq!(
+        allocation.ip(),
+        Ipv4Addr::from(u32::try_from(free).unwrap_or_else(|_| unreachable!())),
+        "allocation did not fall through to the region with room"
+    );
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Reserved ports
 ///////////////////////////////////////////////////////////////////////////////

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Property tests for the pools built over the public address space.
+//!
+//! [`super::region`] tests the cutting on its own; these drive the real construction
+//! ([`pool_sets_for_specs`]) and then allocate through it, so they cover the step where regions
+//! become allocators and the step where a config change re-reserves what the previous config had
+//! handed out.
+//!
+//! The properties are the ones return traffic depends on. A public address and port may only be
+//! live once at a time towards a given peer, because the reverse flow key is built from it and
+//! carries nothing that says which VPC the traffic came from. And an expose may only ever be given
+//! an address its own configuration declares.
+//!
+//! Ranges are drawn from a narrow window so that overlap is the common case rather than
+//! astronomically unlikely, and so that a handful of allocations is enough to make two exposes
+//! collide if the pools let them.
+
+#![cfg(test)]
+
+use super::alloc::PoolSet;
+use super::region::AddrInterval;
+use super::setup::{PoolSpec, pool_sets_for_specs};
+use crate::masquerade::allocation::AllocatorError;
+use bolero::{Driver, TypeGenerator};
+use lpm::prefix::{PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
+use net::ip::NextHeader;
+use std::collections::BTreeSet;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+// 10.1.0.0, with a window small enough that regions stay cheap to build.
+const BASE: u128 = 0x0A01_0000;
+const WINDOW: u128 = 16;
+const MAX_OWNERS: u8 = 4;
+const MAX_RANGES_PER_OWNER: u8 = 2;
+const MAX_RANGE_LEN: u8 = 8;
+// Enough allocations for several exposes to be served repeatedly out of any shared region.
+const ALLOCATIONS: usize = 24;
+
+const IDLE_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// One generated configuration: for each expose, the public ranges it masquerades onto.
+#[derive(Debug, Clone)]
+struct Config {
+    owners: Vec<Vec<(u8, u8)>>,
+}
+
+impl TypeGenerator for Config {
+    fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+        let owner_count = usize::from(driver.produce::<u8>()? % MAX_OWNERS + 1);
+        let mut owners = Vec::with_capacity(owner_count);
+        for _ in 0..owner_count {
+            let range_count = usize::from(driver.produce::<u8>()? % MAX_RANGES_PER_OWNER + 1);
+            let mut ranges = Vec::with_capacity(range_count);
+            for _ in 0..range_count {
+                let offset = driver.produce::<u8>()? % u8::try_from(WINDOW).ok()?;
+                let length = driver.produce::<u8>()? % MAX_RANGE_LEN + 1;
+                ranges.push((offset, length));
+            }
+            owners.push(ranges);
+        }
+        Some(Self { owners })
+    }
+}
+
+impl Config {
+    fn owner_ranges(&self) -> Vec<Vec<AddrInterval>> {
+        self.owners
+            .iter()
+            .map(|ranges| {
+                ranges
+                    .iter()
+                    .map(|&(offset, length)| {
+                        let start = u128::from(offset);
+                        let end = (start + u128::from(length) - 1).min(WINDOW - 1);
+                        AddrInterval::new(BASE + start, BASE + end)
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn specs(&self) -> Vec<PoolSpec> {
+        self.owner_ranges()
+            .into_iter()
+            .map(|public_ranges| PoolSpec {
+                public_ranges,
+                reserved: PrefixPortsSet::new(),
+                idle_timeout: IDLE_TIMEOUT,
+            })
+            .collect()
+    }
+
+    fn pool_sets(&self) -> Vec<PoolSet<Ipv4Addr>> {
+        // No randomization: a failure has to reproduce from its seed alone.
+        pool_sets_for_specs::<Ipv4Addr>(&self.specs(), NextHeader::TCP, false)
+    }
+
+    fn owner_count(&self) -> usize {
+        self.owners.len()
+    }
+}
+
+fn bits(ip: Ipv4Addr) -> u128 {
+    u128::from(ip.to_bits())
+}
+
+fn declares(ranges: &[AddrInterval], ip: Ipv4Addr) -> bool {
+    ranges.iter().any(|range| range.contains(bits(ip)))
+}
+
+/// Allocate round-robin across the exposes, holding every allocation so nothing is freed and
+/// reused mid-run. Returns which expose got what.
+fn allocate_round_robin(
+    pool_sets: &[PoolSet<Ipv4Addr>],
+    count: usize,
+) -> Vec<(usize, super::AllocatedPort<Ipv4Addr>)> {
+    let mut held = Vec::new();
+    for step in 0..count {
+        let owner = step % pool_sets.len();
+        if let Ok(allocation) = pool_sets[owner].allocate(false) {
+            held.push((owner, allocation));
+        }
+    }
+    held
+}
+
+#[test]
+fn allocations_are_unique_and_within_the_declared_ranges() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|config: Config| {
+            let ranges = config.owner_ranges();
+            let pool_sets = config.pool_sets();
+            assert_eq!(pool_sets.len(), config.owner_count());
+
+            let mut seen = BTreeSet::new();
+            for (owner, allocation) in allocate_round_robin(&pool_sets, ALLOCATIONS) {
+                let ip = allocation.ip();
+                let port = allocation.port().as_u16();
+
+                // Two live flows may not share a public address and port, whichever exposes they
+                // belong to: their reverse flow keys would be identical and return traffic for one
+                // would be delivered to the other.
+                assert!(
+                    seen.insert((ip, port)),
+                    "{ip}:{port} was handed out twice, the second time to expose {owner}"
+                );
+
+                // An expose may only be given an address it declares, however the space was cut.
+                assert!(
+                    declares(&ranges[owner], ip),
+                    "expose {owner} was given {ip}, which is outside the ranges it declares"
+                );
+
+                // TCP pools keep off the IANA system range.
+                assert!(port >= 1024, "{ip}:{port} is in the well-known port range");
+            }
+        });
+}
+
+#[test]
+fn freed_allocations_become_available_again() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|config: Config| {
+            let pool_sets = config.pool_sets();
+
+            let first = allocate_round_robin(&pool_sets, ALLOCATIONS);
+            let taken: BTreeSet<_> = first
+                .iter()
+                .map(|(_, allocation)| (allocation.ip(), allocation.port().as_u16()))
+                .collect();
+            assert!(!taken.is_empty(), "a config with ranges allocated nothing");
+            drop(first);
+
+            // Everything was released, so the same space must be servable again. Values need not
+            // repeat, but the pools must not have leaked capacity.
+            let second = allocate_round_robin(&pool_sets, ALLOCATIONS);
+            assert_eq!(
+                second.len(),
+                taken.len(),
+                "the pools served fewer allocations after everything was freed"
+            );
+        });
+}
+
+/// A config update: flows allocated under one config re-reserve their address and port in the
+/// allocator built for the next one, exactly as `check_masquerading_flow` does.
+///
+/// What must hold is that a re-reservation is honoured. If the new pools accept an address and
+/// port, they may not then hand the same pair to a new flow, or the surviving flow and the new one
+/// would collide on the reverse key.
+#[test]
+fn re_reservation_after_a_config_change_is_honoured() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|(before, after): (Config, Config)| {
+            let before_pools = before.pool_sets();
+            let held = allocate_round_robin(&before_pools, ALLOCATIONS);
+
+            let after_ranges = after.owner_ranges();
+            let after_pools = after.pool_sets();
+
+            // Carry each flow over to the new pools, where the new config still has an expose for
+            // it. Flows whose expose is gone would be invalidated instead.
+            let mut carried = Vec::new();
+            let mut reserved = BTreeSet::new();
+            for (owner, allocation) in &held {
+                let Some(pool_set) = after_pools.get(*owner) else {
+                    continue;
+                };
+                let ip = allocation.ip();
+                let port = allocation.port();
+                match pool_set.reserve(ip, port) {
+                    Ok(reservation) => {
+                        // Accepting an address means the expose really does declare it under the
+                        // new config; nothing may be carried over into space it no longer holds.
+                        assert!(
+                            declares(&after_ranges[*owner], ip),
+                            "expose {owner} kept {ip}, which its new config does not declare"
+                        );
+                        assert!(
+                            reserved.insert((ip, port.as_u16())),
+                            "{ip}:{port} was reserved twice across exposes"
+                        );
+                        carried.push(reservation);
+                    }
+                    Err(AllocatorError::NoPoolFound) => {
+                        // The new config dropped that address, so the flow cannot be carried over.
+                        assert!(
+                            !declares(&after_ranges[*owner], ip),
+                            "expose {owner} was refused {ip}, which its new config declares"
+                        );
+                    }
+                    Err(_) => {}
+                }
+            }
+
+            // New flows arriving under the new config must not be given anything a carried-over
+            // flow is still using.
+            for (_, allocation) in allocate_round_robin(&after_pools, ALLOCATIONS) {
+                let pair = (allocation.ip(), allocation.port().as_u16());
+                assert!(
+                    !reserved.contains(&pair),
+                    "{}:{} was allocated although a carried-over flow holds it",
+                    pair.0,
+                    pair.1
+                );
+            }
+
+            drop(carried);
+        });
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Reserved ports
+///////////////////////////////////////////////////////////////////////////////
+
+/// A port range on one public address that port forwarding has claimed, and that masquerade must
+/// therefore not hand out.
+#[derive(Debug, Clone, Copy)]
+struct Reservation {
+    offset: u8,
+    port_lo: u16,
+    port_span: u16,
+}
+
+impl Reservation {
+    fn address(self) -> Ipv4Addr {
+        Ipv4Addr::from(
+            u32::try_from(BASE + u128::from(self.offset % 16)).unwrap_or_else(|_| unreachable!()),
+        )
+    }
+
+    fn ports(self) -> PortRange {
+        let lo = self.port_lo.max(1024);
+        let hi = lo.saturating_add(self.port_span);
+        PortRange::new(lo, hi).unwrap_or_else(|_| unreachable!())
+    }
+
+    fn covers(self, ip: Ipv4Addr, port: u16) -> bool {
+        let ports = self.ports();
+        self.address() == ip && port >= ports.start() && port <= ports.end()
+    }
+
+    fn as_prefix(self) -> PrefixWithOptionalPorts {
+        PrefixWithOptionalPorts::new(
+            format!("{}/32", self.address()).as_str().into(),
+            Some(self.ports()),
+        )
+    }
+}
+
+/// A config where exposes also carry port-forwarding claims on their public addresses.
+#[derive(Debug, Clone)]
+struct ReservedConfig {
+    config: Config,
+    reservations: Vec<Vec<Reservation>>,
+}
+
+impl TypeGenerator for ReservedConfig {
+    fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+        let config: Config = driver.produce()?;
+        let mut reservations = Vec::with_capacity(config.owner_count());
+        for _ in 0..config.owner_count() {
+            let count = usize::from(driver.produce::<u8>()? % 3);
+            let mut claims = Vec::with_capacity(count);
+            for _ in 0..count {
+                claims.push(Reservation {
+                    offset: driver.produce::<u8>()?,
+                    port_lo: driver.produce::<u16>()?,
+                    port_span: u16::from(driver.produce::<u8>()?),
+                });
+            }
+            reservations.push(claims);
+        }
+        Some(Self {
+            config,
+            reservations,
+        })
+    }
+}
+
+impl ReservedConfig {
+    fn pool_sets(&self) -> Vec<PoolSet<Ipv4Addr>> {
+        let specs: Vec<PoolSpec> = self
+            .config
+            .owner_ranges()
+            .into_iter()
+            .zip(&self.reservations)
+            .map(|(public_ranges, claims)| PoolSpec {
+                public_ranges,
+                reserved: claims.iter().map(|claim| claim.as_prefix()).collect(),
+                idle_timeout: IDLE_TIMEOUT,
+            })
+            .collect();
+        pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false)
+    }
+}
+
+/// Ports that port forwarding has claimed on a public address may not be handed out by
+/// masquerade, whichever expose is allocating.
+///
+/// A region is shared, so it has to honour the claims of every expose that owns it: a claim made
+/// through one expose still has to hold against an allocation made through another, or masquerade
+/// would hand out a port that port forwarding is statically mapping elsewhere.
+///
+/// # Ignored: this does not hold today
+///
+/// A pool keeps at most one reserved port range per public address, so several claims on one
+/// address collapse to whichever was recorded last and the rest are silently handed out. See
+/// [`several_claims_on_one_address_are_all_honoured`] for the minimal case, and the note there for
+/// the two places that need to change. Unignore both once they do.
+#[ignore = "a pool holds one reserved port range per address; see several_claims_on_one_address_are_all_honoured"]
+#[test]
+fn reserved_ports_are_never_allocated() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|reserved_config: ReservedConfig| {
+            let ranges = reserved_config.config.owner_ranges();
+            let pool_sets = reserved_config.pool_sets();
+
+            for (owner, allocation) in allocate_round_robin(&pool_sets, ALLOCATIONS) {
+                let ip = allocation.ip();
+                let port = allocation.port().as_u16();
+
+                // Every expose that declares this address shares the region it came from, so its
+                // claims apply to this allocation too.
+                for (claimant, claims) in reserved_config.reservations.iter().enumerate() {
+                    if !declares(&ranges[claimant], ip) {
+                        continue;
+                    }
+                    for claim in claims {
+                        assert!(
+                            !claim.covers(ip, port),
+                            "expose {owner} was allocated {ip}:{port}, which expose {claimant} \
+                             has claimed for port forwarding ({:?})",
+                            claim.ports()
+                        );
+                    }
+                }
+            }
+        });
+}
+
+/// The minimal shape behind [`reserved_ports_are_never_allocated`]: one public address carrying
+/// two port-forwarding claims.
+///
+/// # Ignored: this does not hold today
+///
+/// `build_reserved_prefixes_ports` records the claims in a `DisjointRangesBTreeMap` keyed by
+/// address range, so two claims on one address are inserted under the same key and the second
+/// replaces the first. Even with that fixed, `NatPool::use_new_ip` resolves a single
+/// `Option<PortRange>` per address and `PortAllocator` stores one `reserved_port_range`, so the
+/// data model cannot hold more than one claim per address either. Both need to take a set of
+/// ranges.
+///
+/// This is not a consequence of allocating from regions; the same collapse existed when each
+/// expose had its own pool. It stays latent in production only because the claims are currently
+/// computed from private prefixes and never match the public address they are looked up by, which
+/// is the separate defect noted on `find_masquerade_portfw_overlap`. Fixing that without fixing
+/// this would turn an inert path into a wrong one.
+#[ignore = "a pool holds one reserved port range per address, so the earlier claim is dropped"]
+#[test]
+fn several_claims_on_one_address_are_all_honoured() {
+    let address: u128 = BASE;
+    let claim = |start: u16, end: u16| {
+        PrefixWithOptionalPorts::new(
+            "10.1.0.0/32".into(),
+            Some(PortRange::new(start, end).unwrap_or_else(|_| unreachable!())),
+        )
+    };
+
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(address, address)],
+        reserved: [claim(1024, 1024), claim(2000, 2000)].into_iter().collect(),
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+    let allocated: BTreeSet<u16> = allocate_round_robin(&pool_sets, 4)
+        .iter()
+        .map(|(_, allocation)| allocation.port().as_u16())
+        .collect();
+
+    assert!(
+        !allocated.contains(&1024),
+        "port 1024 was claimed for port forwarding but handed out: {allocated:?}"
+    );
+    assert!(
+        !allocated.contains(&2000),
+        "port 2000 was claimed for port forwarding but handed out: {allocated:?}"
+    );
+}

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -21,7 +21,7 @@ use lpm::prefix::PortRange;
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Display;
 
-use tracing::debug;
+use tracing::{debug, error};
 
 #[concurrency_mode(std)]
 use rand::seq::SliceRandom;
@@ -576,7 +576,7 @@ impl<I: NatIpWithBitmap> Drop for AllocatedPortBlock<I> {
 ///
 /// It contains a back reference to its parent [`AllocatedPortBlock`], to deallocate the port when
 /// the [`AllocatedPort`] is dropped.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AllocatedPort<I: NatIpWithBitmap> {
     port: NatPort,                               // the actual allocated value
     block_allocator: Arc<AllocatedPortBlock<I>>, // block/IP the allocated value belongs to
@@ -612,7 +612,14 @@ impl<I: NatIpWithBitmap> AllocatedPort<I> {
 impl<I: NatIpWithBitmap> Drop for AllocatedPort<I> {
     fn drop(&mut self) {
         debug!("Dropping allocated port {self}...");
-        let _ = self.block_allocator.deallocate_port_from_block(self.port);
+        // Not panicking on a drop path is right; discarding the answer is not. A port that cannot
+        // be given back has either been given back already or was never recorded as taken, and
+        // both mean the bitmap no longer says what is in use -- the same accounting whose silence
+        // let a pair be handed out twice until the error above was made load-bearing. There is
+        // nothing to do about it here, but it should not pass unsaid.
+        if let Err(e) = self.block_allocator.deallocate_port_from_block(self.port) {
+            error!("Failed to give back {self}: {e}");
+        }
     }
 }
 

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -845,27 +845,36 @@ impl Bitmap256 {
         Err(())
     }
 
-    fn set_bitmap_value(&mut self, port_in_block: u8, value: u128) -> Result<(), ()> {
-        if port_in_block < 128 {
-            if self.first_half & (1 << port_in_block) == value {
-                return Err(());
-            }
-            self.first_half |= value << port_in_block;
+    /// Mark a port used or free, failing if it is already in that state.
+    ///
+    /// The error is load-bearing in both directions: it is how reserving a port that has already
+    /// been handed out is refused, rather than the pair going to two flows at once, and how giving
+    /// back a port that was never taken is reported as the bookkeeping mistake it is.
+    fn set_bitmap_value(&mut self, port_in_block: u8, used: bool) -> Result<(), ()> {
+        let (half, bit) = if port_in_block < 128 {
+            (&mut self.first_half, port_in_block)
         } else {
-            if self.second_half & (1 << (port_in_block - 128)) == value {
-                return Err(());
-            }
-            self.second_half |= value << (port_in_block - 128);
+            (&mut self.second_half, port_in_block - 128)
+        };
+        let mask = 1u128 << bit;
+
+        if (*half & mask != 0) == used {
+            return Err(());
+        }
+        if used {
+            *half |= mask;
+        } else {
+            *half &= !mask;
         }
         Ok(())
     }
 
     fn deallocate_port_from_bitmap(&mut self, port_in_block: u8) -> Result<(), ()> {
-        self.set_bitmap_value(port_in_block, 0)
+        self.set_bitmap_value(port_in_block, false)
     }
 
     fn reserve_port_from_bitmap(&mut self, port_in_block: u8) -> Result<(), ()> {
-        self.set_bitmap_value(port_in_block, 1)
+        self.set_bitmap_value(port_in_block, true)
     }
 
     fn set_half_bitmap_range(
@@ -1066,6 +1075,93 @@ mod tests {
         Bitmap256::set_half_bitmap_range(&mut half, 120, 127, 1).unwrap();
         let expected = ((1u128 << 8) - 1) << 120;
         assert_eq!(half, expected);
+    }
+
+    // set_bitmap_value(), through the two operations built on it
+
+    fn port_is_used(bitmap: &Bitmap256, port: u8) -> bool {
+        if port < 128 {
+            bitmap.first_half & (1u128 << port) != 0
+        } else {
+            bitmap.second_half & (1u128 << (port - 128)) != 0
+        }
+    }
+
+    // A port given back is free again. Blocks outlive the ports drawn from them, so a port that
+    // stays marked used is one the block can never hand out again.
+    #[test]
+    fn a_deallocated_port_becomes_free_again() {
+        let mut bitmap = Bitmap256::new();
+        for port in [5u8, 200] {
+            bitmap.reserve_port_from_bitmap(port).unwrap();
+            assert!(
+                port_is_used(&bitmap, port),
+                "port {port} was not marked used"
+            );
+
+            bitmap.deallocate_port_from_bitmap(port).unwrap();
+            assert!(
+                !port_is_used(&bitmap, port),
+                "port {port} is still marked used after being given back"
+            );
+        }
+    }
+
+    // Allocation hands out the lowest free port, so a freed port is the next one out.
+    #[test]
+    fn a_deallocated_port_is_handed_out_again() {
+        let mut bitmap = Bitmap256::new();
+        let first = bitmap.allocate_port_from_bitmap().unwrap();
+        let second = bitmap.allocate_port_from_bitmap().unwrap();
+        assert_eq!((first, second), (0, 1));
+
+        bitmap
+            .deallocate_port_from_bitmap(u8::try_from(first).unwrap())
+            .unwrap();
+        assert_eq!(
+            bitmap.allocate_port_from_bitmap().unwrap(),
+            first,
+            "a freed port was not handed out again"
+        );
+    }
+
+    // Reserving a port already in use has to fail: that is what tells a flow being carried across
+    // a config change that its address and port have been taken, rather than handing the same pair
+    // to two flows.
+    #[test]
+    fn reserving_a_used_port_fails() {
+        for port in [0u8, 7, 128, 201] {
+            let mut bitmap = Bitmap256::new();
+            bitmap.reserve_port_from_bitmap(port).unwrap();
+            assert!(
+                bitmap.reserve_port_from_bitmap(port).is_err(),
+                "reserving port {port} twice was allowed"
+            );
+        }
+    }
+
+    // The same, for a port taken by allocation rather than by an earlier reservation. Port 0 is
+    // skipped deliberately: it is the one bit position a broken guard still gets right, so testing
+    // only the first allocation would pass either way.
+    #[test]
+    fn reserving_an_allocated_port_fails() {
+        let mut bitmap = Bitmap256::new();
+        let mut allocated = 0;
+        for _ in 0..4 {
+            allocated = u8::try_from(bitmap.allocate_port_from_bitmap().unwrap()).unwrap();
+        }
+        assert_ne!(allocated, 0);
+        assert!(
+            bitmap.reserve_port_from_bitmap(allocated).is_err(),
+            "reserving port {allocated}, which is allocated, was allowed"
+        );
+    }
+
+    // Giving back a port that is already free is a bookkeeping error, and says so.
+    #[test]
+    fn deallocating_a_free_port_fails() {
+        let mut bitmap = Bitmap256::new();
+        assert!(bitmap.deallocate_port_from_bitmap(9).is_err());
     }
 
     // set_bitmap_range()

--- a/nat/src/masquerade/apalloc/region.rs
+++ b/nat/src/masquerade/apalloc/region.rs
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Decomposition of the public address space into disjoint regions.
+//!
+//! Several exposes may masquerade onto public ranges that overlap, and they may overlap partially:
+//! `10.0.0.0/24` and `10.0.0.128/25` share half their addresses. Every public `(address, port)`
+//! still has to be handed out at most once, because the reverse flow key that carries return
+//! traffic back is built from the public address and port, the remote endpoint and the peer VPC,
+//! and nothing in it identifies which VPC the traffic came from.
+//!
+//! Rather than give each expose an allocator over its own range, we cut the address space at every
+//! point where the set of exposes covering it changes. That yields maximal intervals over which the
+//! set of owners is constant, and no two of them overlap, so one allocator per interval is enough
+//! to keep allocations unique. Each expose then allocates from the intervals its own range covers,
+//! and only those.
+//!
+//! The decomposition is over addresses only. Public ranges can carry port ranges too, which the
+//! pools do not model yet (see the two `FIXME`s about port ranges in `setup.rs`); when
+//! they do, the same cutting has to happen over the port dimension.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// An inclusive range of addresses, as raw bits, so that IPv4 and IPv6 can be cut the same way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct AddrInterval {
+    pub(crate) start: u128,
+    pub(crate) end: u128,
+}
+
+impl AddrInterval {
+    pub(crate) fn new(start: u128, end: u128) -> Self {
+        debug_assert!(start <= end, "an interval cannot end before it starts");
+        Self { start, end }
+    }
+
+    pub(crate) fn contains(&self, addr: u128) -> bool {
+        self.start <= addr && addr <= self.end
+    }
+
+    /// Number of addresses covered, saturating at [`u128::MAX`] for the whole space.
+    pub(crate) fn len(&self) -> u128 {
+        (self.end - self.start).saturating_add(1)
+    }
+}
+
+/// A stretch of public address space over which the set of exposes entitled to allocate does not
+/// change. Owners are indices into the slice handed to [`decompose`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Region {
+    pub(crate) range: AddrInterval,
+    pub(crate) owners: BTreeSet<usize>,
+}
+
+/// Cut the space covered by `owner_ranges` into maximal disjoint regions, each labelled with the
+/// set of owners covering it. Owners are identified by their index in `owner_ranges`.
+///
+/// The result is ordered by address, covers exactly the union of the inputs, and contains no
+/// overlapping regions. Every input range is exactly the union of some subset of the regions, which
+/// is what lets an expose allocate from whole regions and never from an address outside its range.
+pub(crate) fn decompose(owner_ranges: &[Vec<AddrInterval>]) -> Vec<Region> {
+    // Coverage can only change at the start of a range, or just past the end of one. Cutting at
+    // every such point gives elementary intervals that each range either covers entirely or does
+    // not touch at all, so testing a single address per interval decides ownership.
+    let mut cuts = BTreeSet::new();
+    for ranges in owner_ranges {
+        for range in ranges {
+            cuts.insert(range.start);
+            // A range ending at the top of the space has nothing past it to cut at.
+            if let Some(past_end) = range.end.checked_add(1) {
+                cuts.insert(past_end);
+            }
+        }
+    }
+
+    let cuts: Vec<u128> = cuts.into_iter().collect();
+    let mut regions: Vec<Region> = Vec::new();
+    for (index, &start) in cuts.iter().enumerate() {
+        let end = match cuts.get(index + 1) {
+            Some(&next_cut) => next_cut - 1,
+            None => u128::MAX,
+        };
+        let owners: BTreeSet<usize> = owner_ranges
+            .iter()
+            .enumerate()
+            .filter(|(_, ranges)| ranges.iter().any(|range| range.contains(start)))
+            .map(|(owner, _)| owner)
+            .collect();
+        if owners.is_empty() {
+            // A gap between ranges, or the tail past the last one.
+            continue;
+        }
+        debug_assert!(
+            owner_ranges.iter().enumerate().all(|(owner, ranges)| {
+                owners.contains(&owner) == ranges.iter().any(|range| range.contains(end))
+            }),
+            "an elementary interval must be covered as a whole or not at all"
+        );
+        regions.push(Region {
+            range: AddrInterval::new(start, end),
+            owners,
+        });
+    }
+
+    merge_adjacent(regions)
+}
+
+// Neighbouring elementary intervals with the same owners describe one region. This happens when an
+// expose lists several adjacent prefixes, and keeps the number of allocators down.
+fn merge_adjacent(regions: Vec<Region>) -> Vec<Region> {
+    let mut merged: Vec<Region> = Vec::with_capacity(regions.len());
+    for region in regions {
+        match merged.last_mut() {
+            Some(previous)
+                if previous.range.end.checked_add(1) == Some(region.range.start)
+                    && previous.owners == region.owners =>
+            {
+                previous.range.end = region.range.end;
+            }
+            _ => merged.push(region),
+        }
+    }
+    merged
+}
+
+/// The regions each owner may allocate from, in the order they should be tried.
+///
+/// Regions an owner has to itself come first: allocating there cannot contend with another VPC, and
+/// leaves the shared regions for the exposes that have nowhere else to go.
+pub(crate) fn regions_by_owner(regions: &[Region]) -> BTreeMap<usize, Vec<usize>> {
+    let mut by_owner: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (index, region) in regions.iter().enumerate() {
+        for &owner in &region.owners {
+            by_owner.entry(owner).or_default().push(index);
+        }
+    }
+    for indices in by_owner.values_mut() {
+        indices.sort_by_key(|&index| {
+            // Fewest sharers first, then widest, then by address so the order is deterministic.
+            (
+                regions[index].owners.len(),
+                std::cmp::Reverse(regions[index].range.len()),
+                regions[index].range.start,
+            )
+        });
+    }
+    by_owner
+}
+
+#[cfg(test)]
+mod bolero_tests {
+    use super::*;
+    use bolero::{Driver, TypeGenerator};
+
+    // Ranges are drawn from a small window of the address space. Independently generated u128
+    // ranges would essentially never overlap, and overlap is the whole point; a narrow window
+    // makes it the common case, and makes it cheap enough to check every property against every
+    // address in the window rather than against a sampled few.
+    const WINDOW: u128 = 48;
+    const MAX_OWNERS: u8 = 5;
+    const MAX_RANGES_PER_OWNER: u8 = 3;
+    const MAX_RANGE_LEN: u8 = 12;
+
+    // Where the window sits. Includes both ends of the space, so the cut just past the end of a
+    // range is exercised where it can overflow and where the first address has nothing below it.
+    const BASES: [u128; 4] = [
+        0,
+        1,
+        (u32::MAX as u128) - WINDOW + 1,
+        u128::MAX - WINDOW + 1,
+    ];
+
+    /// A generated set of owner ranges: a window position, and per owner a list of ranges given as
+    /// an offset into the window and a length.
+    #[derive(Debug, Clone)]
+    struct Scenario {
+        base: u128,
+        owners: Vec<Vec<(u8, u8)>>,
+    }
+
+    impl TypeGenerator for Scenario {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let base = BASES[usize::from(driver.produce::<u8>()? % 4)];
+            let owner_count = usize::from(driver.produce::<u8>()? % MAX_OWNERS + 1);
+            let mut owners = Vec::with_capacity(owner_count);
+            for _ in 0..owner_count {
+                let range_count = usize::from(driver.produce::<u8>()? % MAX_RANGES_PER_OWNER + 1);
+                let mut ranges = Vec::with_capacity(range_count);
+                for _ in 0..range_count {
+                    let offset = driver.produce::<u8>()? % u8::try_from(WINDOW).ok()?;
+                    let length = driver.produce::<u8>()? % MAX_RANGE_LEN + 1;
+                    ranges.push((offset, length));
+                }
+                owners.push(ranges);
+            }
+            Some(Self { base, owners })
+        }
+    }
+
+    impl Scenario {
+        // Materialize the ranges, clipped to the window so that every address a region can cover
+        // is one the oracle below walks.
+        fn owner_ranges(&self) -> Vec<Vec<AddrInterval>> {
+            self.owners
+                .iter()
+                .map(|ranges| {
+                    ranges
+                        .iter()
+                        .map(|&(offset, length)| {
+                            let start = u128::from(offset);
+                            let end = (start + u128::from(length) - 1).min(WINDOW - 1);
+                            AddrInterval::new(self.base + start, self.base + end)
+                        })
+                        .collect()
+                })
+                .collect()
+        }
+
+        fn addresses(&self) -> impl Iterator<Item = u128> + '_ {
+            (0..WINDOW).map(move |offset| self.base + offset)
+        }
+
+        // The oracle: who covers this address, straight from the inputs.
+        fn owners_covering(ranges: &[Vec<AddrInterval>], address: u128) -> BTreeSet<usize> {
+            ranges
+                .iter()
+                .enumerate()
+                .filter(|(_, ranges)| ranges.iter().any(|range| range.contains(address)))
+                .map(|(owner, _)| owner)
+                .collect()
+        }
+    }
+
+    #[test]
+    fn decompose_properties() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|scenario: Scenario| {
+                let owner_ranges = scenario.owner_ranges();
+                let regions = decompose(&owner_ranges);
+
+                for region in &regions {
+                    assert!(
+                        region.range.start <= region.range.end,
+                        "region {:?} ends before it starts",
+                        region.range
+                    );
+                    assert!(
+                        !region.owners.is_empty(),
+                        "region {:?} has no owner, so nothing may allocate from it",
+                        region.range
+                    );
+                    assert!(
+                        region.owners.iter().all(|&o| o < owner_ranges.len()),
+                        "region {:?} names an owner that does not exist",
+                        region.range
+                    );
+                }
+
+                // Regions are ordered and never overlap. Overlap is what would let two allocators
+                // hand out the same address.
+                for pair in regions.windows(2) {
+                    assert!(
+                        pair[0].range.end < pair[1].range.start,
+                        "regions {:?} and {:?} overlap or are out of order",
+                        pair[0].range,
+                        pair[1].range
+                    );
+                }
+
+                // The load-bearing property, checked at every address in the window: an address is
+                // covered by exactly the owners that claimed it, no more and no fewer. "No more"
+                // is what keeps an expose from being handed an address it never asked for; "no
+                // fewer" is what keeps two exposes that both claimed it on one allocator.
+                for address in scenario.addresses() {
+                    let expected = Scenario::owners_covering(&owner_ranges, address);
+                    match regions.iter().find(|region| region.range.contains(address)) {
+                        Some(region) => assert_eq!(
+                            region.owners, expected,
+                            "address {address} is owned by {:?} but was claimed by {expected:?}",
+                            region.owners
+                        ),
+                        None => assert!(
+                            expected.is_empty(),
+                            "address {address} was claimed by {expected:?} but is in no region"
+                        ),
+                    }
+                }
+
+                // Regions are maximal: neighbours that touch must differ in their owners, or they
+                // should have been one region.
+                for pair in regions.windows(2) {
+                    if pair[0].range.end.checked_add(1) == Some(pair[1].range.start) {
+                        assert_ne!(
+                            pair[0].owners, pair[1].owners,
+                            "adjacent regions {:?} and {:?} have the same owners",
+                            pair[0].range, pair[1].range
+                        );
+                    }
+                }
+
+                // Building the pools twice for one config must give the same answer.
+                assert_eq!(
+                    decompose(&owner_ranges),
+                    regions,
+                    "decompose is not a function"
+                );
+            });
+    }
+
+    #[test]
+    fn regions_by_owner_properties() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|scenario: Scenario| {
+                let owner_ranges = scenario.owner_ranges();
+                let regions = decompose(&owner_ranges);
+                let by_owner = regions_by_owner(&regions);
+
+                for (owner, _) in owner_ranges.iter().enumerate() {
+                    let listed = by_owner.get(&owner).map_or(&[][..], Vec::as_slice);
+
+                    // An owner is offered exactly the regions it owns: nothing it may not use, and
+                    // nothing it may use left out.
+                    let expected: BTreeSet<usize> = regions
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, region)| region.owners.contains(&owner))
+                        .map(|(index, _)| index)
+                        .collect();
+                    assert_eq!(
+                        listed.iter().copied().collect::<BTreeSet<_>>(),
+                        expected,
+                        "owner {owner} was offered the wrong regions"
+                    );
+
+                    // No region is offered twice, or the same space would be tried repeatedly.
+                    assert_eq!(
+                        listed.len(),
+                        expected.len(),
+                        "owner {owner} was offered a region more than once"
+                    );
+
+                    // Space the owner has to itself comes first.
+                    for pair in listed.windows(2) {
+                        assert!(
+                            regions[pair[0]].owners.len() <= regions[pair[1]].owners.len(),
+                            "owner {owner} is offered shared space before exclusive space"
+                        );
+                    }
+
+                    // Every address the owner claimed is in one of the regions it was offered.
+                    for address in scenario.addresses() {
+                        if owner_ranges[owner]
+                            .iter()
+                            .any(|range| range.contains(address))
+                        {
+                            assert!(
+                                listed
+                                    .iter()
+                                    .any(|&index| regions[index].range.contains(address)),
+                                "owner {owner} claimed address {address} but was offered no region holding it"
+                            );
+                        }
+                    }
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn interval(start: u128, end: u128) -> AddrInterval {
+        AddrInterval::new(start, end)
+    }
+
+    fn owners(indices: &[usize]) -> BTreeSet<usize> {
+        indices.iter().copied().collect()
+    }
+
+    #[test]
+    fn decompose_single_range_is_left_whole() {
+        let regions = decompose(&[vec![interval(10, 20)]]);
+        assert_eq!(
+            regions,
+            vec![Region {
+                range: interval(10, 20),
+                owners: owners(&[0])
+            }]
+        );
+    }
+
+    #[test]
+    fn decompose_disjoint_ranges_stay_separate() {
+        let regions = decompose(&[vec![interval(10, 20)], vec![interval(30, 40)]]);
+        assert_eq!(
+            regions,
+            vec![
+                Region {
+                    range: interval(10, 20),
+                    owners: owners(&[0])
+                },
+                Region {
+                    range: interval(30, 40),
+                    owners: owners(&[1])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn decompose_identical_ranges_share_one_region() {
+        let regions = decompose(&[vec![interval(10, 20)], vec![interval(10, 20)]]);
+        assert_eq!(
+            regions,
+            vec![Region {
+                range: interval(10, 20),
+                owners: owners(&[0, 1])
+            }]
+        );
+    }
+
+    #[test]
+    fn decompose_partial_overlap_splits_into_three() {
+        // 0: [10, 20], 1: [15, 25] -> [10,14] {0}, [15,20] {0,1}, [21,25] {1}
+        let regions = decompose(&[vec![interval(10, 20)], vec![interval(15, 25)]]);
+        assert_eq!(
+            regions,
+            vec![
+                Region {
+                    range: interval(10, 14),
+                    owners: owners(&[0])
+                },
+                Region {
+                    range: interval(15, 20),
+                    owners: owners(&[0, 1])
+                },
+                Region {
+                    range: interval(21, 25),
+                    owners: owners(&[1])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn decompose_nested_range_splits_into_three() {
+        // 1 sits strictly inside 0.
+        let regions = decompose(&[vec![interval(10, 30)], vec![interval(15, 20)]]);
+        assert_eq!(
+            regions,
+            vec![
+                Region {
+                    range: interval(10, 14),
+                    owners: owners(&[0])
+                },
+                Region {
+                    range: interval(15, 20),
+                    owners: owners(&[0, 1])
+                },
+                Region {
+                    range: interval(21, 30),
+                    owners: owners(&[0])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn decompose_three_way_overlap() {
+        // A staircase: every combination of owners shows up.
+        let regions = decompose(&[
+            vec![interval(0, 30)],
+            vec![interval(10, 40)],
+            vec![interval(20, 50)],
+        ]);
+        assert_eq!(
+            regions,
+            vec![
+                Region {
+                    range: interval(0, 9),
+                    owners: owners(&[0])
+                },
+                Region {
+                    range: interval(10, 19),
+                    owners: owners(&[0, 1])
+                },
+                Region {
+                    range: interval(20, 30),
+                    owners: owners(&[0, 1, 2])
+                },
+                Region {
+                    range: interval(31, 40),
+                    owners: owners(&[1, 2])
+                },
+                Region {
+                    range: interval(41, 50),
+                    owners: owners(&[2])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn decompose_adjacent_ranges_of_one_owner_are_merged() {
+        let regions = decompose(&[vec![interval(10, 19), interval(20, 29)]]);
+        assert_eq!(
+            regions,
+            vec![Region {
+                range: interval(10, 29),
+                owners: owners(&[0])
+            }]
+        );
+    }
+
+    #[test]
+    fn decompose_gap_between_ranges_is_not_covered() {
+        let regions = decompose(&[vec![interval(10, 19), interval(30, 39)]]);
+        assert_eq!(
+            regions,
+            vec![
+                Region {
+                    range: interval(10, 19),
+                    owners: owners(&[0])
+                },
+                Region {
+                    range: interval(30, 39),
+                    owners: owners(&[0])
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn decompose_range_reaching_the_top_of_the_space() {
+        let regions = decompose(&[vec![interval(u128::MAX - 1, u128::MAX)]]);
+        assert_eq!(
+            regions,
+            vec![Region {
+                range: interval(u128::MAX - 1, u128::MAX),
+                owners: owners(&[0])
+            }]
+        );
+    }
+
+    #[test]
+    fn decompose_empty_input() {
+        assert_eq!(decompose(&[]), vec![]);
+        assert_eq!(decompose(&[vec![]]), vec![]);
+    }
+
+    // The properties the allocator depends on: regions never overlap, and every owner's range is
+    // covered exactly by the regions it owns.
+    #[test]
+    fn decompose_regions_are_disjoint_and_cover_each_owner_exactly() {
+        let inputs = vec![
+            vec![interval(0, 30), interval(60, 70)],
+            vec![interval(10, 40)],
+            vec![interval(20, 50), interval(65, 80)],
+            vec![interval(100, 100)],
+        ];
+        let regions = decompose(&inputs);
+
+        for pair in regions.windows(2) {
+            assert!(
+                pair[0].range.end < pair[1].range.start,
+                "regions {:?} and {:?} overlap",
+                pair[0].range,
+                pair[1].range
+            );
+        }
+
+        for (owner, ranges) in inputs.iter().enumerate() {
+            for address in 0..=120u128 {
+                let in_owner_range = ranges.iter().any(|range| range.contains(address));
+                let in_owned_region = regions
+                    .iter()
+                    .any(|region| region.owners.contains(&owner) && region.range.contains(address));
+                assert_eq!(
+                    in_owner_range, in_owned_region,
+                    "address {address} disagrees for owner {owner}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn regions_by_owner_prefers_exclusive_regions() {
+        // 0 owns [0,9] alone and shares [10,19] with 1.
+        let regions = decompose(&[vec![interval(0, 19)], vec![interval(10, 19)]]);
+        let by_owner = regions_by_owner(&regions);
+
+        let for_zero = &by_owner[&0];
+        assert_eq!(regions[for_zero[0]].range, interval(0, 9));
+        assert_eq!(regions[for_zero[1]].range, interval(10, 19));
+
+        // 1 only has the shared region.
+        assert_eq!(by_owner[&1].len(), 1);
+        assert_eq!(regions[by_owner[&1][0]].range, interval(10, 19));
+    }
+}

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -25,11 +25,13 @@ impl NatAllocator {
     pub(crate) fn add_peering_addresses(
         &mut self,
         peering: &ValidatedPeering,
+        src_vpc_id: VpcDiscriminant,
         dst_vpc_id: VpcDiscriminant,
         registries: &mut PoolRegistries,
     ) {
         build_nat_pool_generic(
             peering.local(),
+            src_vpc_id,
             dst_vpc_id,
             ValidatedManifest::masquerade_exposes_44,
             ValidatedManifest::port_forwarding_exposes_44,
@@ -41,6 +43,7 @@ impl NatAllocator {
 
         build_nat_pool_generic(
             peering.local(),
+            src_vpc_id,
             dst_vpc_id,
             ValidatedManifest::masquerade_exposes_66,
             ValidatedManifest::port_forwarding_exposes_66,
@@ -195,6 +198,7 @@ pub(crate) struct PoolRegistries {
 #[allow(clippy::too_many_arguments)]
 fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, P, PIter>(
     manifest: &'a ValidatedManifest,
+    src_vpc_id: VpcDiscriminant,
     dst_vpc_id: VpcDiscriminant,
     // A filter to select relevant exposes: those with masquerade, for the relevant IP version
     exposes_filter: F,
@@ -264,6 +268,7 @@ fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, 
         add_pool_entries(
             table,
             expose.ips(),
+            src_vpc_id,
             dst_vpc_id,
             &tcp_ip_allocator,
             &udp_ip_allocator,
@@ -310,16 +315,18 @@ fn find_masquerade_portfw_overlap<'a>(
 fn pool_table_key_for_expose<I: NatIp>(
     prefix: &PrefixWithOptionalPorts,
     protocol: NextHeader,
+    src_vpc_id: VpcDiscriminant,
     dst_vpc_id: VpcDiscriminant,
 ) -> PoolTableKey<I> {
     let (addr, addr_range_end) = prefix_bounds(prefix);
-    PoolTableKey::new(protocol, dst_vpc_id, addr, addr_range_end)
+    PoolTableKey::new(protocol, src_vpc_id, dst_vpc_id, addr, addr_range_end)
 }
 
 #[allow(clippy::too_many_arguments)]
 fn add_pool_entries<I: NatIpWithBitmap, J: NatIpWithBitmap>(
     table: &mut PoolTable<I, J>,
     prefixes: &PrefixPortsSet,
+    src_vpc_id: VpcDiscriminant,
     dst_vpc_id: VpcDiscriminant,
     tcp_allocator: &IpAllocator<J>,
     udp_allocator: &IpAllocator<J>,
@@ -332,9 +339,9 @@ fn add_pool_entries<I: NatIpWithBitmap, J: NatIpWithBitmap>(
         // or for ICMP, the space defined by the combination of IP addresses and L4 ports/id is distinct
         // for each protocol.
 
-        let tcp_key = pool_table_key_for_expose(prefix, NextHeader::TCP, dst_vpc_id);
-        let udp_key = pool_table_key_for_expose(prefix, NextHeader::UDP, dst_vpc_id);
-        let icmp_key = pool_table_key_for_expose(prefix, icmp_proto, dst_vpc_id);
+        let tcp_key = pool_table_key_for_expose(prefix, NextHeader::TCP, src_vpc_id, dst_vpc_id);
+        let udp_key = pool_table_key_for_expose(prefix, NextHeader::UDP, src_vpc_id, dst_vpc_id);
+        let icmp_key = pool_table_key_for_expose(prefix, icmp_proto, src_vpc_id, dst_vpc_id);
 
         table.add_entry(tcp_key, tcp_allocator.clone());
         table.add_entry(udp_key, udp_allocator.clone());

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -200,6 +200,7 @@ fn build_pools_generic<'a, I, J, F, FIter, P, PIter>(
 
 /// What building a pool needs to know about one expose, independent of where it came from. Keeping
 /// this free of config types is what lets the property tests drive the real construction.
+#[derive(Clone)]
 pub(crate) struct PoolSpec {
     pub(crate) public_ranges: Vec<AddrInterval>,
     pub(crate) reserved: PrefixPortsSet,

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -1,54 +1,47 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Open Network Fabric Authors
 
-use super::NatIpWithBitmap;
-use super::alloc::{IpAllocator, NatPool, PoolBitmap};
-use super::{NatAllocator, PoolTable, PoolTableKey};
+//! Construction of the masquerade address and port pools.
+//!
+//! Pools cannot be built one expose at a time, because exposes that masquerade towards the same
+//! peer VPC may claim overlapping public ranges and a public address may only be handed out by one
+//! allocator. Building happens in two passes instead: collect every masquerade expose, group them
+//! by peer VPC, cut the public space each group claims into disjoint regions (see [`super::region`])
+//! and build one allocator per region, then give each expose the regions its own range covers.
+
+use super::alloc::{IpAllocator, NatPool, PoolSet};
+use super::region::{AddrInterval, Region, decompose, regions_by_owner};
+use super::{NatAllocator, NatIpWithBitmap, PoolTable, PoolTableKey};
+use crate::masquerade::allocator_writer::MasqueradeConfig;
 use crate::masquerade::natip::NatIp;
 use crate::ranges::IpRange;
-use config::external::overlay::vpc::ValidatedPeering;
 use config::external::overlay::vpcpeering::{ValidatedExpose, ValidatedManifest};
 use lpm::prefix::range_map::DisjointRangesBTreeMap;
-use lpm::prefix::{
-    IpPrefix, L4Protocol, PortRange, Prefix, PrefixPortsSet, PrefixWithOptionalPorts,
-};
+use lpm::prefix::{L4Protocol, PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use net::packet::VpcDiscriminant;
-use std::collections::{BTreeMap, BTreeSet};
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::collections::BTreeMap;
 use std::time::Duration;
-use tracing::{error, warn};
+use tracing::{debug, error};
 
 const DEFAULT_MASQUERADE_IDLE_TIMEOUT: Duration = Duration::from_mins(2);
 
 impl NatAllocator {
-    pub(crate) fn add_peering_addresses(
-        &mut self,
-        peering: &ValidatedPeering,
-        src_vpc_id: VpcDiscriminant,
-        dst_vpc_id: VpcDiscriminant,
-        registries: &mut PoolRegistries,
-    ) {
-        build_nat_pool_generic(
-            peering.local(),
-            src_vpc_id,
-            dst_vpc_id,
+    pub(crate) fn build_pools(&mut self, config: &MasqueradeConfig) {
+        build_pools_generic(
+            config,
             ValidatedManifest::masquerade_exposes_44,
             ValidatedManifest::port_forwarding_exposes_44,
             &mut self.pools_src44,
-            &mut registries.v4,
             NextHeader::ICMP,
             self.randomize,
         );
 
-        build_nat_pool_generic(
-            peering.local(),
-            src_vpc_id,
-            dst_vpc_id,
+        build_pools_generic(
+            config,
             ValidatedManifest::masquerade_exposes_66,
             ValidatedManifest::port_forwarding_exposes_66,
             &mut self.pools_src66,
-            &mut registries.v6,
             NextHeader::ICMP6,
             self.randomize,
         );
@@ -56,232 +49,236 @@ impl NatAllocator {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// Pool identity and registry
+// Gathering
 ///////////////////////////////////////////////////////////////////////////////
 
-/// Identity of an address and port pool, as seen from the *public* side of the NAT.
-///
-/// What an allocator hands out is a public `(address, port)` pair, so the public range is what
-/// decides whether two exposes describe the same pool. Two allocators built over the same public
-/// range, for the same protocol and towards the same peer VPC, would each believe they owned the
-/// whole range, hand out the same `(address, port)` twice, and produce colliding reverse flow
-/// keys.
-///
-/// Pools are *identified* here by their public range. They are separately *looked up* by the
-/// private prefixes they serve, in [`PoolTable`], because the private source address is all we
-/// have on the first packet of a flow.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct PoolIdentity {
-    protocol: NextHeader,
-    dst_vpc_id: VpcDiscriminant,
-    public_range: PrefixPortsSet,
-}
-
-/// How a pool allocates, as opposed to [`PoolIdentity`], which is what a pool *is*. The policy
-/// plays no part in deciding whether two exposes share a pool.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PoolPolicy {
-    idle_timeout: Duration,
-    reserved: PrefixPortsSet,
-    exclude_wellknown_ports: bool,
-}
-
-#[derive(Debug)]
-struct RegisteredPool<J: NatIpWithBitmap> {
-    allocator: IpAllocator<J>,
-    policy: PoolPolicy,
-}
-
-/// The allocators built for one IP version, keyed by [`PoolIdentity`].
-///
-/// A configuration can describe the same public pool more than once. Exposes are only checked for
-/// collisions against the other exposes of the same manifest, and a manifest belongs to a single
-/// peering, so two VPCs that both peer with the same destination VPC can masquerade onto the same
-/// public range without anything rejecting it. Both reach the allocator under the same protocol
-/// and destination discriminant, and have to share one allocator.
-#[derive(Debug)]
-struct PoolRegistry<J: NatIpWithBitmap> {
-    pools: BTreeMap<PoolIdentity, RegisteredPool<J>>,
-}
-
-impl<J: NatIpWithBitmap> Default for PoolRegistry<J> {
-    fn default() -> Self {
-        Self {
-            pools: BTreeMap::new(),
-        }
-    }
-}
-
-impl<J: NatIpWithBitmap> PoolRegistry<J> {
-    /// Return the allocator that owns `public_range`, building it if this is the first expose to
-    /// claim that range for this protocol and peer VPC. The returned allocator shares its
-    /// underlying pool with every other holder of the same identity.
-    fn get_or_create(
-        &mut self,
-        protocol: NextHeader,
-        dst_vpc_id: VpcDiscriminant,
-        public_range: &PrefixPortsSet,
-        policy: PoolPolicy,
-        randomize: bool,
-    ) -> IpAllocator<J> {
-        let identity = PoolIdentity {
-            protocol,
-            dst_vpc_id,
-            public_range: public_range.clone(),
-        };
-
-        if let Some(registered) = self.pools.get(&identity) {
-            if registered.policy != policy {
-                warn!(
-                    "Public range {public_range:?} is masqueraded onto more than once for \
-                     {protocol} towards {dst_vpc_id}, with differing allocation policies. \
-                     Sharing the pool, and keeping the policy that was declared first."
-                );
-            }
-            return registered.allocator.clone();
-        }
-
-        self.report_partial_overlaps(&identity);
-
-        let allocator = ip_allocator_for_prefixes(
-            public_range,
-            policy.idle_timeout,
-            &policy.reserved,
-            randomize,
-            policy.exclude_wellknown_ports,
-        );
-        self.pools.insert(
-            identity,
-            RegisteredPool {
-                allocator: allocator.clone(),
-                policy,
-            },
-        );
-        allocator
-    }
-
-    // Pools are shared only when their public ranges match exactly. Ranges that merely overlap
-    // still end up with one allocator each, neither aware of what the other hands out, so report
-    // them: that is a configuration we cannot serve correctly.
-    fn report_partial_overlaps(&self, identity: &PoolIdentity) {
-        for existing in self.pools.keys() {
-            if existing.protocol != identity.protocol || existing.dst_vpc_id != identity.dst_vpc_id
-            {
-                continue;
-            }
-            if !existing
-                .public_range
-                .intersection_prefixes_and_ports(&identity.public_range)
-                .is_empty()
-            {
-                error!(
-                    "Public ranges {:?} and {:?} overlap without being identical, for {} towards \
-                     {}. The same address and port may be allocated twice.",
-                    existing.public_range,
-                    identity.public_range,
-                    identity.protocol,
-                    identity.dst_vpc_id,
-                );
-            }
-        }
-    }
-}
-
-/// The [`PoolRegistry`] for each IP version, held only while a [`NatAllocator`] is being built.
-/// The allocators themselves are kept alive afterwards by the pool tables referencing them.
-#[derive(Debug, Default)]
-pub(crate) struct PoolRegistries {
-    v4: PoolRegistry<Ipv4Addr>,
-    v6: PoolRegistry<Ipv6Addr>,
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, P, PIter>(
-    manifest: &'a ValidatedManifest,
+/// One masquerade expose, with everything the pools need from it.
+struct GatheredExpose<'a> {
     src_vpc_id: VpcDiscriminant,
-    dst_vpc_id: VpcDiscriminant,
-    // A filter to select relevant exposes: those with masquerade, for the relevant IP version
-    exposes_filter: F,
-    // A filter to select other exposes with port forwarding, for the relevant IP version
-    port_forwarding_exposes_filter: P,
-    table: &mut PoolTable<I, J>,
-    registry: &mut PoolRegistry<J>,
-    icmp_proto: NextHeader,
-    randomize: bool,
-) where
-    F: FnOnce(&'a ValidatedManifest) -> FIter,
-    FIter: Iterator<Item = &'a ValidatedExpose>,
-    P: FnOnce(&'a ValidatedManifest) -> PIter,
-    PIter: Iterator<Item = &'a ValidatedExpose>,
-{
-    let port_forwarding_exposes: Vec<&'a ValidatedExpose> =
-        port_forwarding_exposes_filter(manifest).collect();
-
-    exposes_filter(manifest).for_each(|expose| {
-        let ReserveSets {
-            tcp: tcp_reserved,
-            udp: udp_reserved,
-        } = find_masquerade_portfw_overlap(&port_forwarding_exposes, expose);
-
-        let idle_timeout = expose
-            .idle_timeout()
-            .unwrap_or(DEFAULT_MASQUERADE_IDLE_TIMEOUT);
-        let public_range = expose.as_range_or_empty();
-
-        // TCP/UDP masquerade allocators should avoid the IANA system/well-known range
-        // (0-1023). ICMP identifiers are allocated independently and are not subject to that
-        // TCP/UDP source-port policy.
-        let tcp_ip_allocator = registry.get_or_create(
-            NextHeader::TCP,
-            dst_vpc_id,
-            public_range,
-            PoolPolicy {
-                idle_timeout,
-                reserved: tcp_reserved,
-                exclude_wellknown_ports: true,
-            },
-            randomize,
-        );
-        let udp_ip_allocator = registry.get_or_create(
-            NextHeader::UDP,
-            dst_vpc_id,
-            public_range,
-            PoolPolicy {
-                idle_timeout,
-                reserved: udp_reserved,
-                exclude_wellknown_ports: true,
-            },
-            randomize,
-        );
-        let icmp_ip_allocator = registry.get_or_create(
-            icmp_proto,
-            dst_vpc_id,
-            public_range,
-            PoolPolicy {
-                idle_timeout,
-                reserved: PrefixPortsSet::default(),
-                exclude_wellknown_ports: false,
-            },
-            randomize,
-        );
-
-        add_pool_entries(
-            table,
-            expose.ips(),
-            src_vpc_id,
-            dst_vpc_id,
-            &tcp_ip_allocator,
-            &udp_ip_allocator,
-            &icmp_ip_allocator,
-            icmp_proto,
-        );
-    });
+    // The private prefixes this expose masquerades, which is what the pool table is keyed by.
+    private_prefixes: &'a PrefixPortsSet,
+    // The public range this expose allocates from, as raw address intervals.
+    public_ranges: Vec<AddrInterval>,
+    idle_timeout: Duration,
+    reserved: ReserveSets,
 }
 
+/// Ports that port forwarding has claimed, and that masquerade must not hand out.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct ReserveSets {
     tcp: PrefixPortsSet,
     udp: PrefixPortsSet,
+}
+
+impl ReserveSets {
+    fn for_protocol(&self, protocol: NextHeader) -> Option<&PrefixPortsSet> {
+        match protocol {
+            NextHeader::TCP => Some(&self.tcp),
+            NextHeader::UDP => Some(&self.udp),
+            // ICMP identifiers are a space of their own, untouched by port forwarding.
+            _ => None,
+        }
+    }
+}
+
+// Collect the masquerade exposes of every peering, grouped by the VPC they masquerade towards.
+// Grouping by peer VPC is what matters, because return traffic is only told apart by the peer it
+// comes back from: exposes towards different peers can safely claim the same public range.
+fn gather_exposes<'a, J, F, FIter, P, PIter>(
+    config: &'a MasqueradeConfig,
+    exposes_filter: &F,
+    port_forwarding_exposes_filter: &P,
+) -> BTreeMap<VpcDiscriminant, Vec<GatheredExpose<'a>>>
+where
+    J: NatIp,
+    F: Fn(&'a ValidatedManifest) -> FIter,
+    FIter: Iterator<Item = &'a ValidatedExpose>,
+    P: Fn(&'a ValidatedManifest) -> PIter,
+    PIter: Iterator<Item = &'a ValidatedExpose>,
+{
+    let mut groups: BTreeMap<VpcDiscriminant, Vec<GatheredExpose<'a>>> = BTreeMap::new();
+
+    for nat_peering in config.iter() {
+        let manifest = nat_peering.peering.local();
+        let port_forwarding_exposes: Vec<&'a ValidatedExpose> =
+            port_forwarding_exposes_filter(manifest).collect();
+
+        for expose in exposes_filter(manifest) {
+            let public_ranges = public_intervals::<J>(expose.as_range_or_empty());
+            if public_ranges.is_empty() {
+                // A masquerade expose is validated to have a non-empty as_range, so this only
+                // happens if none of its prefixes are of the version we are building.
+                continue;
+            }
+            groups
+                .entry(nat_peering.dst_vpcd)
+                .or_default()
+                .push(GatheredExpose {
+                    src_vpc_id: nat_peering.src_vpcd,
+                    private_prefixes: expose.ips(),
+                    public_ranges,
+                    idle_timeout: expose
+                        .idle_timeout()
+                        .unwrap_or(DEFAULT_MASQUERADE_IDLE_TIMEOUT),
+                    reserved: find_masquerade_portfw_overlap(&port_forwarding_exposes, expose),
+                });
+        }
+    }
+
+    groups
+}
+
+// Convert a set of public prefixes into raw address intervals, dropping any that are not of the
+// version being built.
+fn public_intervals<J: NatIp>(ranges: &PrefixPortsSet) -> Vec<AddrInterval> {
+    ranges
+        .iter()
+        .filter_map(|prefix| {
+            // FIXME: Account for port ranges. A public range may be restricted to a port range,
+            // which the pools do not model, so the whole port space of the address is used.
+            let start = J::try_from_addr(prefix.prefix().as_address()).ok()?;
+            let end = J::try_from_addr(prefix.prefix().last_address()).ok()?;
+            Some(AddrInterval::new(start.to_addr_bits(), end.to_addr_bits()))
+        })
+        .collect()
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Building
+///////////////////////////////////////////////////////////////////////////////
+
+fn build_pools_generic<'a, I, J, F, FIter, P, PIter>(
+    config: &'a MasqueradeConfig,
+    exposes_filter: F,
+    port_forwarding_exposes_filter: P,
+    table: &mut PoolTable<I, J>,
+    icmp_proto: NextHeader,
+    randomize: bool,
+) where
+    I: NatIpWithBitmap,
+    J: NatIpWithBitmap,
+    F: Fn(&'a ValidatedManifest) -> FIter,
+    FIter: Iterator<Item = &'a ValidatedExpose>,
+    P: Fn(&'a ValidatedManifest) -> PIter,
+    PIter: Iterator<Item = &'a ValidatedExpose>,
+{
+    let groups =
+        gather_exposes::<J, _, _, _, _>(config, &exposes_filter, &port_forwarding_exposes_filter);
+
+    for (dst_vpc_id, exposes) in groups {
+        // Allocations for TCP, for example, do not affect allocations for UDP or for ICMP: the
+        // space made of addresses and L4 ports or identifiers is distinct for each protocol. So
+        // each region backs one allocator per protocol, over the same addresses.
+        for protocol in [NextHeader::TCP, NextHeader::UDP, icmp_proto] {
+            let specs: Vec<PoolSpec> = exposes
+                .iter()
+                .map(|expose| PoolSpec {
+                    public_ranges: expose.public_ranges.clone(),
+                    reserved: expose
+                        .reserved
+                        .for_protocol(protocol)
+                        .cloned()
+                        .unwrap_or_default(),
+                    idle_timeout: expose.idle_timeout,
+                })
+                .collect();
+
+            let pool_sets = pool_sets_for_specs::<J>(&specs, protocol, randomize);
+            for (expose, pool_set) in exposes.iter().zip(pool_sets) {
+                add_pool_entries(
+                    table,
+                    expose.private_prefixes,
+                    expose.src_vpc_id,
+                    dst_vpc_id,
+                    protocol,
+                    &pool_set,
+                );
+            }
+        }
+    }
+}
+
+/// What building a pool needs to know about one expose, independent of where it came from. Keeping
+/// this free of config types is what lets the property tests drive the real construction.
+pub(crate) struct PoolSpec {
+    pub(crate) public_ranges: Vec<AddrInterval>,
+    pub(crate) reserved: PrefixPortsSet,
+    pub(crate) idle_timeout: Duration,
+}
+
+/// Cut the space the given exposes claim into disjoint regions, build one allocator per region,
+/// and return the pools each expose may allocate from, in the same order as `specs`.
+///
+/// This is where the guarantee lives: exposes sharing a region share its allocator, so a public
+/// address and port cannot be handed out twice, and an expose is only ever offered regions its own
+/// ranges cover.
+pub(crate) fn pool_sets_for_specs<J: NatIpWithBitmap>(
+    specs: &[PoolSpec],
+    protocol: NextHeader,
+    randomize: bool,
+) -> Vec<PoolSet<J>> {
+    let owner_ranges: Vec<Vec<AddrInterval>> = specs
+        .iter()
+        .map(|spec| spec.public_ranges.clone())
+        .collect();
+    let regions = decompose(&owner_ranges);
+    debug!(
+        "Public space cut into {} region(s) for {} expose(s) ({protocol})",
+        regions.len(),
+        specs.len()
+    );
+
+    let allocators = build_region_allocators::<J>(&regions, specs, protocol, randomize);
+    let by_owner = regions_by_owner(&regions);
+
+    specs
+        .iter()
+        .enumerate()
+        .map(|(owner, spec)| {
+            let mut pool_set = PoolSet::new(spec.idle_timeout);
+            for &region_index in by_owner.get(&owner).map_or(&[][..], Vec::as_slice) {
+                pool_set.push_region(
+                    regions[region_index].range,
+                    allocators[region_index].clone(),
+                );
+            }
+            pool_set
+        })
+        .collect()
+}
+
+// One allocator per region. Every expose owning a region shares that allocator, which is what
+// keeps a public address and port from being handed out twice.
+fn build_region_allocators<J: NatIpWithBitmap>(
+    regions: &[Region],
+    specs: &[PoolSpec],
+    protocol: NextHeader,
+    randomize: bool,
+) -> Vec<IpAllocator<J>> {
+    // TCP and UDP masquerade allocators should avoid the IANA system/well-known range (0-1023).
+    // ICMP identifiers are allocated independently and are not subject to that policy.
+    let exclude_wellknown_ports = matches!(protocol, NextHeader::TCP | NextHeader::UDP);
+
+    regions
+        .iter()
+        .map(|region| {
+            // A region is shared, so it must honour every claim on it: reserve what port
+            // forwarding has taken from any of its owners.
+            let reserved = region
+                .owners
+                .iter()
+                .fold(PrefixPortsSet::new(), |accumulated, &owner| {
+                    accumulated.union_prefixes_and_ports(&specs[owner].reserved)
+                });
+
+            let pool = NatPool::for_range(
+                region.range,
+                build_reserved_prefixes_ports(&reserved),
+                exclude_wellknown_ports,
+            );
+            IpAllocator::new(pool, randomize)
+        })
+        .collect()
 }
 
 fn find_masquerade_portfw_overlap<'a>(
@@ -312,94 +309,6 @@ fn find_masquerade_portfw_overlap<'a>(
     reserve_sets
 }
 
-fn pool_table_key_for_expose<I: NatIp>(
-    prefix: &PrefixWithOptionalPorts,
-    protocol: NextHeader,
-    src_vpc_id: VpcDiscriminant,
-    dst_vpc_id: VpcDiscriminant,
-) -> PoolTableKey<I> {
-    let (addr, addr_range_end) = prefix_bounds(prefix);
-    PoolTableKey::new(protocol, src_vpc_id, dst_vpc_id, addr, addr_range_end)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn add_pool_entries<I: NatIpWithBitmap, J: NatIpWithBitmap>(
-    table: &mut PoolTable<I, J>,
-    prefixes: &PrefixPortsSet,
-    src_vpc_id: VpcDiscriminant,
-    dst_vpc_id: VpcDiscriminant,
-    tcp_allocator: &IpAllocator<J>,
-    udp_allocator: &IpAllocator<J>,
-    icmp_allocator: &IpAllocator<J>,
-    icmp_proto: NextHeader,
-) {
-    for prefix in prefixes {
-        // We insert three times the entry, once for TCP, once for UDP and once for ICMP (v4 or v6
-        // depending on the case). Allocations for TCP, for example, do not affect allocations for UDP
-        // or for ICMP, the space defined by the combination of IP addresses and L4 ports/id is distinct
-        // for each protocol.
-
-        let tcp_key = pool_table_key_for_expose(prefix, NextHeader::TCP, src_vpc_id, dst_vpc_id);
-        let udp_key = pool_table_key_for_expose(prefix, NextHeader::UDP, src_vpc_id, dst_vpc_id);
-        let icmp_key = pool_table_key_for_expose(prefix, icmp_proto, src_vpc_id, dst_vpc_id);
-
-        table.add_entry(tcp_key, tcp_allocator.clone());
-        table.add_entry(udp_key, udp_allocator.clone());
-        table.add_entry(icmp_key, icmp_allocator.clone());
-    }
-}
-
-fn ip_allocator_for_prefixes<J: NatIpWithBitmap>(
-    prefixes: &PrefixPortsSet,
-    idle_timeout: Duration,
-    prefixes_and_ports_to_exclude_from_pools: &PrefixPortsSet,
-    randomize: bool,
-    exclude_wellknown_ports: bool,
-) -> IpAllocator<J> {
-    let pool = create_natpool(
-        prefixes,
-        prefixes_and_ports_to_exclude_from_pools,
-        idle_timeout,
-        exclude_wellknown_ports,
-    );
-    IpAllocator::new(pool, randomize)
-}
-
-fn create_natpool<J: NatIpWithBitmap>(
-    prefixes: &PrefixPortsSet,
-    prefixes_and_ports_to_exclude_from_pools: &PrefixPortsSet,
-    idle_timeout: Duration,
-    exclude_wellknown_ports: bool,
-) -> NatPool<J> {
-    // Build mappings for IPv6 <-> u32 bitmap translation
-    let (bitmap_mapping, reverse_bitmap_mapping) = create_ipv6_bitmap_mappings(
-        &prefixes
-            .iter()
-            // FIXME: Add port range, too
-            .map(PrefixWithOptionalPorts::prefix)
-            .collect::<BTreeSet<Prefix>>(),
-    );
-
-    // Mark all addresses as available (free) in bitmap
-    let mut bitmap = PoolBitmap::new();
-    prefixes
-        .iter()
-        // FIXME: Add port range, too
-        .for_each(|prefix| bitmap.add_prefix(&prefix.prefix(), &reverse_bitmap_mapping));
-
-    let reserved_prefixes_ports =
-        build_reserved_prefixes_ports(prefixes_and_ports_to_exclude_from_pools);
-
-    NatPool::new(
-        bitmap,
-        bitmap_mapping,
-        reverse_bitmap_mapping,
-        reserved_prefixes_ports,
-        idle_timeout,
-        exclude_wellknown_ports,
-    )
-}
-
 fn build_reserved_prefixes_ports(
     prefixes_and_ports_to_exclude_from_pools: &PrefixPortsSet,
 ) -> Option<DisjointRangesBTreeMap<IpRange, PortRange>> {
@@ -418,47 +327,36 @@ fn build_reserved_prefixes_ports(
     Some(reserved_prefixes_ports)
 }
 
+fn pool_table_key_for_expose<I: NatIp>(
+    prefix: &PrefixWithOptionalPorts,
+    protocol: NextHeader,
+    src_vpc_id: VpcDiscriminant,
+    dst_vpc_id: VpcDiscriminant,
+) -> PoolTableKey<I> {
+    let (addr, addr_range_end) = prefix_bounds(prefix);
+    PoolTableKey::new(protocol, src_vpc_id, dst_vpc_id, addr, addr_range_end)
+}
+
+fn add_pool_entries<I: NatIpWithBitmap, J: NatIpWithBitmap>(
+    table: &mut PoolTable<I, J>,
+    prefixes: &PrefixPortsSet,
+    src_vpc_id: VpcDiscriminant,
+    dst_vpc_id: VpcDiscriminant,
+    protocol: NextHeader,
+    pool_set: &PoolSet<J>,
+) {
+    for prefix in prefixes {
+        let key = pool_table_key_for_expose(prefix, protocol, src_vpc_id, dst_vpc_id);
+        table.add_entry(key, pool_set.clone());
+    }
+}
+
 fn prefix_bounds<I: NatIp>(prefix: &PrefixWithOptionalPorts) -> (I, I) {
     let addr = I::try_from_addr(prefix.prefix().as_address()).unwrap_or_else(|()| unreachable!());
     let addr_range_end =
         I::try_from_addr(prefix.prefix().last_address()).unwrap_or_else(|()| unreachable!());
     // FIXME: Account for port ranges
     (addr, addr_range_end)
-}
-
-// The allocator's bitmap contains u32 only. For IPv4, it maps well to the address space. For IPv6,
-// we need some mapping to associate IPv6 addresses with u32 indices. This also means that we cannot
-// use more than 2^32 addresses for one expose, for NAT. If the prefixes we get contain more, we'll
-// just ignore the remaining addresses. Hardware limitations are such that working with 4 billion
-// allocated addresses is unreallistic anyway.
-#[allow(clippy::type_complexity)]
-fn create_ipv6_bitmap_mappings(
-    prefixes: &BTreeSet<Prefix>,
-) -> (BTreeMap<u32, u128>, BTreeMap<u128, u32>) {
-    let mut bitmap_mapping = BTreeMap::new();
-    let mut reverse_bitmap_mapping = BTreeMap::new();
-    let mut index = 0;
-
-    for prefix in prefixes {
-        if let Prefix::IPV6(p) = prefix {
-            let start_address = p.network().to_bits();
-            bitmap_mapping.insert(index, start_address);
-            reverse_bitmap_mapping.insert(start_address, index);
-            if p.size() + u128::from(index) >= 2_u128.pow(32) {
-                break;
-            }
-            let Ok(psize) = u128::try_from(p.size()) else {
-                error!("Failed to get u128 from prefix {:#?}", p.size());
-                continue;
-            };
-            let Ok(psize_u32) = u32::try_from(psize) else {
-                error!("Failed to convert {psize} to u32");
-                continue;
-            };
-            index += psize_u32;
-        }
-    }
-    (bitmap_mapping, reverse_bitmap_mapping)
 }
 
 #[cfg(test)]

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -15,8 +15,9 @@ use lpm::prefix::{
 use net::ip::NextHeader;
 use net::packet::VpcDiscriminant;
 use std::collections::{BTreeMap, BTreeSet};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
-use tracing::error;
+use tracing::{error, warn};
 
 const DEFAULT_MASQUERADE_IDLE_TIMEOUT: Duration = Duration::from_mins(2);
 
@@ -25,6 +26,7 @@ impl NatAllocator {
         &mut self,
         peering: &ValidatedPeering,
         dst_vpc_id: VpcDiscriminant,
+        registries: &mut PoolRegistries,
     ) {
         build_nat_pool_generic(
             peering.local(),
@@ -32,6 +34,7 @@ impl NatAllocator {
             ValidatedManifest::masquerade_exposes_44,
             ValidatedManifest::port_forwarding_exposes_44,
             &mut self.pools_src44,
+            &mut registries.v4,
             NextHeader::ICMP,
             self.randomize,
         );
@@ -42,10 +45,151 @@ impl NatAllocator {
             ValidatedManifest::masquerade_exposes_66,
             ValidatedManifest::port_forwarding_exposes_66,
             &mut self.pools_src66,
+            &mut registries.v6,
             NextHeader::ICMP6,
             self.randomize,
         );
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Pool identity and registry
+///////////////////////////////////////////////////////////////////////////////
+
+/// Identity of an address and port pool, as seen from the *public* side of the NAT.
+///
+/// What an allocator hands out is a public `(address, port)` pair, so the public range is what
+/// decides whether two exposes describe the same pool. Two allocators built over the same public
+/// range, for the same protocol and towards the same peer VPC, would each believe they owned the
+/// whole range, hand out the same `(address, port)` twice, and produce colliding reverse flow
+/// keys.
+///
+/// Pools are *identified* here by their public range. They are separately *looked up* by the
+/// private prefixes they serve, in [`PoolTable`], because the private source address is all we
+/// have on the first packet of a flow.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct PoolIdentity {
+    protocol: NextHeader,
+    dst_vpc_id: VpcDiscriminant,
+    public_range: PrefixPortsSet,
+}
+
+/// How a pool allocates, as opposed to [`PoolIdentity`], which is what a pool *is*. The policy
+/// plays no part in deciding whether two exposes share a pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PoolPolicy {
+    idle_timeout: Duration,
+    reserved: PrefixPortsSet,
+    exclude_wellknown_ports: bool,
+}
+
+#[derive(Debug)]
+struct RegisteredPool<J: NatIpWithBitmap> {
+    allocator: IpAllocator<J>,
+    policy: PoolPolicy,
+}
+
+/// The allocators built for one IP version, keyed by [`PoolIdentity`].
+///
+/// A configuration can describe the same public pool more than once. Exposes are only checked for
+/// collisions against the other exposes of the same manifest, and a manifest belongs to a single
+/// peering, so two VPCs that both peer with the same destination VPC can masquerade onto the same
+/// public range without anything rejecting it. Both reach the allocator under the same protocol
+/// and destination discriminant, and have to share one allocator.
+#[derive(Debug)]
+struct PoolRegistry<J: NatIpWithBitmap> {
+    pools: BTreeMap<PoolIdentity, RegisteredPool<J>>,
+}
+
+impl<J: NatIpWithBitmap> Default for PoolRegistry<J> {
+    fn default() -> Self {
+        Self {
+            pools: BTreeMap::new(),
+        }
+    }
+}
+
+impl<J: NatIpWithBitmap> PoolRegistry<J> {
+    /// Return the allocator that owns `public_range`, building it if this is the first expose to
+    /// claim that range for this protocol and peer VPC. The returned allocator shares its
+    /// underlying pool with every other holder of the same identity.
+    fn get_or_create(
+        &mut self,
+        protocol: NextHeader,
+        dst_vpc_id: VpcDiscriminant,
+        public_range: &PrefixPortsSet,
+        policy: PoolPolicy,
+        randomize: bool,
+    ) -> IpAllocator<J> {
+        let identity = PoolIdentity {
+            protocol,
+            dst_vpc_id,
+            public_range: public_range.clone(),
+        };
+
+        if let Some(registered) = self.pools.get(&identity) {
+            if registered.policy != policy {
+                warn!(
+                    "Public range {public_range:?} is masqueraded onto more than once for \
+                     {protocol} towards {dst_vpc_id}, with differing allocation policies. \
+                     Sharing the pool, and keeping the policy that was declared first."
+                );
+            }
+            return registered.allocator.clone();
+        }
+
+        self.report_partial_overlaps(&identity);
+
+        let allocator = ip_allocator_for_prefixes(
+            public_range,
+            policy.idle_timeout,
+            &policy.reserved,
+            randomize,
+            policy.exclude_wellknown_ports,
+        );
+        self.pools.insert(
+            identity,
+            RegisteredPool {
+                allocator: allocator.clone(),
+                policy,
+            },
+        );
+        allocator
+    }
+
+    // Pools are shared only when their public ranges match exactly. Ranges that merely overlap
+    // still end up with one allocator each, neither aware of what the other hands out, so report
+    // them: that is a configuration we cannot serve correctly.
+    fn report_partial_overlaps(&self, identity: &PoolIdentity) {
+        for existing in self.pools.keys() {
+            if existing.protocol != identity.protocol || existing.dst_vpc_id != identity.dst_vpc_id
+            {
+                continue;
+            }
+            if !existing
+                .public_range
+                .intersection_prefixes_and_ports(&identity.public_range)
+                .is_empty()
+            {
+                error!(
+                    "Public ranges {:?} and {:?} overlap without being identical, for {} towards \
+                     {}. The same address and port may be allocated twice.",
+                    existing.public_range,
+                    identity.public_range,
+                    identity.protocol,
+                    identity.dst_vpc_id,
+                );
+            }
+        }
+    }
+}
+
+/// The [`PoolRegistry`] for each IP version, held only while a [`NatAllocator`] is being built.
+/// The allocators themselves are kept alive afterwards by the pool tables referencing them.
+#[derive(Debug, Default)]
+pub(crate) struct PoolRegistries {
+    v4: PoolRegistry<Ipv4Addr>,
+    v6: PoolRegistry<Ipv6Addr>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -57,6 +201,7 @@ fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, 
     // A filter to select other exposes with port forwarding, for the relevant IP version
     port_forwarding_exposes_filter: P,
     table: &mut PoolTable<I, J>,
+    registry: &mut PoolRegistry<J>,
     icmp_proto: NextHeader,
     randomize: bool,
 ) where
@@ -69,36 +214,51 @@ fn build_nat_pool_generic<'a, I: NatIpWithBitmap, J: NatIpWithBitmap, F, FIter, 
         port_forwarding_exposes_filter(manifest).collect();
 
     exposes_filter(manifest).for_each(|expose| {
-        let prefixes_and_ports_to_exclude_from_pools =
-            find_masquerade_portfw_overlap(&port_forwarding_exposes, expose);
+        let ReserveSets {
+            tcp: tcp_reserved,
+            udp: udp_reserved,
+        } = find_masquerade_portfw_overlap(&port_forwarding_exposes, expose);
 
         let idle_timeout = expose
             .idle_timeout()
             .unwrap_or(DEFAULT_MASQUERADE_IDLE_TIMEOUT);
+        let public_range = expose.as_range_or_empty();
 
         // TCP/UDP masquerade allocators should avoid the IANA system/well-known range
         // (0-1023). ICMP identifiers are allocated independently and are not subject to that
         // TCP/UDP source-port policy.
-        let tcp_ip_allocator = ip_allocator_for_prefixes(
-            expose.as_range_or_empty(),
-            idle_timeout,
-            &prefixes_and_ports_to_exclude_from_pools.tcp,
+        let tcp_ip_allocator = registry.get_or_create(
+            NextHeader::TCP,
+            dst_vpc_id,
+            public_range,
+            PoolPolicy {
+                idle_timeout,
+                reserved: tcp_reserved,
+                exclude_wellknown_ports: true,
+            },
             randomize,
-            true,
         );
-        let udp_ip_allocator = ip_allocator_for_prefixes(
-            expose.as_range_or_empty(),
-            idle_timeout,
-            &prefixes_and_ports_to_exclude_from_pools.udp,
+        let udp_ip_allocator = registry.get_or_create(
+            NextHeader::UDP,
+            dst_vpc_id,
+            public_range,
+            PoolPolicy {
+                idle_timeout,
+                reserved: udp_reserved,
+                exclude_wellknown_ports: true,
+            },
             randomize,
-            true,
         );
-        let icmp_ip_allocator = ip_allocator_for_prefixes(
-            expose.as_range_or_empty(),
-            idle_timeout,
-            &PrefixPortsSet::default(),
+        let icmp_ip_allocator = registry.get_or_create(
+            icmp_proto,
+            dst_vpc_id,
+            public_range,
+            PoolPolicy {
+                idle_timeout,
+                reserved: PrefixPortsSet::default(),
+                exclude_wellknown_ports: false,
+            },
             randomize,
-            false,
         );
 
         add_pool_entries(

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -9,7 +9,7 @@ use concurrency::concurrency_mode;
 // by tests in other modules. These helpers are not to be used outside of tests.
 mod context {
     use crate::masquerade::allocator_writer::MasqueradeConfig;
-    use crate::masquerade::apalloc::alloc::IpAllocator;
+    use crate::masquerade::apalloc::alloc::{IpAllocator, PoolSet};
     use crate::masquerade::apalloc::{NatAllocator, PoolTable, PoolTableKey};
     use config::external::overlay::vpc::{Peering, ValidatedVpcTable, Vpc, VpcTable};
     use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
@@ -68,14 +68,28 @@ mod context {
         protocol: NextHeader,
         src_ip: Ipv4Addr,
     ) -> &IpAllocator<Ipv4Addr> {
-        pool.get(&PoolTableKey::new(
-            protocol,
-            src_vpcd,
-            dst_vpcd,
-            src_ip,
-            Ipv4Addr::from_str("255.255.255.255").unwrap(),
-        ))
-        .unwrap()
+        let pool_set = pool
+            .get(&PoolTableKey::new(
+                protocol,
+                src_vpcd,
+                dst_vpcd,
+                src_ip,
+                Ipv4Addr::from_str("255.255.255.255").unwrap(),
+            ))
+            .unwrap();
+        sole_region(pool_set)
+    }
+
+    // The public ranges in most of these fixtures do not overlap, so each expose owns exactly one
+    // region and the tests can look straight at its allocator.
+    pub fn sole_region(pool_set: &PoolSet<Ipv4Addr>) -> &IpAllocator<Ipv4Addr> {
+        let mut regions = pool_set.regions();
+        let region = regions.next().expect("expose has no region");
+        assert!(
+            regions.next().is_none(),
+            "expose was cut into more than one region"
+        );
+        region.allocator()
     }
 
     fn build_context() -> ValidatedVpcTable {
@@ -258,6 +272,80 @@ mod context {
         let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
         NatAllocator::new(config)
     }
+
+    // Two VPCs peering with the same destination VPC, masquerading onto public ranges that overlap
+    // *partially*: VPC-1 takes 10.1.0.0/30 (.0 through .3) and VPC-2 takes 10.1.0.2/31 (.2 and
+    // .3). Neither range contains the other, so no single range identifies the shared space.
+    fn build_context_partial_overlap() -> ValidatedVpcTable {
+        let masquerade_manifest = |name: &str, private: &str, public: &str| {
+            VpcManifest::with_exposes(
+                name,
+                vec![
+                    VpcExpose::empty()
+                        .make_masquerade(None)
+                        .unwrap()
+                        .ip(private.into())
+                        .as_range(public.into())
+                        .unwrap(),
+                ],
+            )
+        };
+        let remote =
+            VpcManifest::with_exposes("VPC-3", vec![VpcExpose::empty().ip("3.0.0.0/24".into())]);
+
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
+        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2().as_u32()).unwrap();
+        let vpc3 = Vpc::new("VPC-3", "11111", vni3().as_u32()).unwrap();
+
+        vpc1.peerings.push(Peering {
+            name: "partial_peering1".into(),
+            local: masquerade_manifest("VPC-1", "1.1.0.0/16", "10.1.0.0/30"),
+            remote: remote.clone(),
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+        vpc2.peerings.push(Peering {
+            name: "partial_peering2".into(),
+            local: masquerade_manifest("VPC-2", "2.1.0.0/16", "10.1.0.2/31"),
+            remote,
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+
+        let mut vpctable = VpcTable::new();
+        vpctable.add(vpc1).unwrap();
+        vpctable.add(vpc2).unwrap();
+        vpctable.add(vpc3).unwrap();
+
+        vpctable.validate().unwrap()
+    }
+
+    pub fn build_allocator_partial_overlap() -> NatAllocator {
+        let vpc_table = build_context_partial_overlap();
+        let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
+        NatAllocator::new(config)
+    }
+
+    pub fn get_pool_set_v4(
+        pool: &PoolTable<Ipv4Addr, Ipv4Addr>,
+        src_vpcd: VpcDiscriminant,
+        dst_vpcd: VpcDiscriminant,
+        protocol: NextHeader,
+        src_ip: Ipv4Addr,
+    ) -> &PoolSet<Ipv4Addr> {
+        pool.get(&PoolTableKey::new(
+            protocol,
+            src_vpcd,
+            dst_vpcd,
+            src_ip,
+            Ipv4Addr::from_str("255.255.255.255").unwrap(),
+        ))
+        .unwrap()
+    }
 }
 
 mod tests {
@@ -317,6 +405,7 @@ mod tests {
 mod std_tests {
     use super::context::*;
     use crate::masquerade::apalloc::PoolTableKey;
+    use crate::masquerade::apalloc::alloc::PoolRegion;
     use net::ip::NextHeader;
 
     #[test]
@@ -363,7 +452,7 @@ mod std_tests {
 
         assert_eq!(allocator.pools_src66.0.len(), 0);
 
-        let ip_allocator = allocator
+        let pool_set = allocator
             .pools_src44
             .get(&PoolTableKey::new(
                 NextHeader::TCP,
@@ -373,7 +462,7 @@ mod std_tests {
                 addr_v4("255.255.255.255"),
             ))
             .unwrap();
-        let (bitmap, in_use) = ip_allocator.get_pool_clone_for_tests();
+        let (bitmap, in_use) = sole_region(pool_set).get_pool_clone_for_tests();
 
         assert!(bitmap.contains_range(addr_v4_bits("10.1.0.0")..=addr_v4_bits("10.1.0.2")));
         assert_eq!(bitmap.len(), 3);
@@ -598,6 +687,124 @@ mod std_tests {
             addr_v4("10.2.0.0"),
             "traffic from VPC-2 was not masqueraded onto the range VPC-2 exposes"
         );
+    }
+
+    // Partially overlapping public ranges are cut so that the shared part becomes a region of its
+    // own. VPC-1 keeps an exclusive region for the half only it claims, plus the shared one;
+    // VPC-2 only ever sees the shared one.
+    #[test]
+    fn test_partial_overlap_is_cut_into_regions() {
+        let allocator = build_allocator_partial_overlap();
+
+        let for_vpc1 = get_pool_set_v4(
+            &allocator.pools_src44,
+            vpcd1(),
+            vpcd3(),
+            NextHeader::TCP,
+            addr_v4("1.1.0.1"),
+        );
+        let vpc1_ranges: Vec<_> = for_vpc1.regions().map(PoolRegion::range).collect();
+        assert_eq!(vpc1_ranges.len(), 2, "VPC-1 should own two regions");
+        // The exclusive region is offered first.
+        assert_eq!(vpc1_ranges[0].start, u128::from(addr_v4_bits("10.1.0.0")));
+        assert_eq!(vpc1_ranges[0].end, u128::from(addr_v4_bits("10.1.0.1")));
+        assert_eq!(vpc1_ranges[1].start, u128::from(addr_v4_bits("10.1.0.2")));
+        assert_eq!(vpc1_ranges[1].end, u128::from(addr_v4_bits("10.1.0.3")));
+
+        let for_vpc2 = get_pool_set_v4(
+            &allocator.pools_src44,
+            vpcd2(),
+            vpcd3(),
+            NextHeader::TCP,
+            addr_v4("2.1.0.1"),
+        );
+        let vpc2_ranges: Vec<_> = for_vpc2.regions().map(PoolRegion::range).collect();
+        assert_eq!(
+            vpc2_ranges.len(),
+            1,
+            "VPC-2 should only own the shared region"
+        );
+        assert_eq!(vpc2_ranges[0].start, u128::from(addr_v4_bits("10.1.0.2")));
+        assert_eq!(vpc2_ranges[0].end, u128::from(addr_v4_bits("10.1.0.3")));
+    }
+
+    // The shared region is one allocator, not a copy per VPC: an address VPC-2 takes from it is no
+    // longer free in the view VPC-1 has of that same region. This is what stops the two from
+    // handing out the same public address and port.
+    #[test]
+    fn test_partial_overlap_shares_one_allocator_for_the_shared_region() {
+        let allocator = build_allocator_partial_overlap();
+
+        let taken = allocator
+            .allocate_v4(vpcd2(), vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
+            .unwrap();
+        // VPC-2 can only allocate from the shared region.
+        assert_eq!(taken.allocation.ip(), addr_v4("10.1.0.2"));
+
+        let for_vpc1 = get_pool_set_v4(
+            &allocator.pools_src44,
+            vpcd1(),
+            vpcd3(),
+            NextHeader::TCP,
+            addr_v4("1.1.0.1"),
+        );
+        let shared = for_vpc1.regions().nth(1).expect("no shared region");
+        let (bitmap, in_use) = shared.allocator().get_pool_clone_for_tests();
+        assert!(
+            !bitmap.contains(addr_v4_bits("10.1.0.2")),
+            "VPC-1 still sees an address VPC-2 has taken from the shared region"
+        );
+        assert_eq!(in_use.len(), 1);
+    }
+
+    // Allocation prefers space a VPC has to itself, so the shared region stays available for the
+    // VPC that has nowhere else to go.
+    #[test]
+    fn test_partial_overlap_prefers_exclusive_space() {
+        let allocator = build_allocator_partial_overlap();
+
+        let from_vpc1 = allocator
+            .allocate_v4(vpcd1(), vpcd3(), addr_v4("1.1.0.1"), NextHeader::TCP)
+            .unwrap();
+        assert_eq!(
+            from_vpc1.allocation.ip(),
+            addr_v4("10.1.0.0"),
+            "VPC-1 should have drawn from the region it does not share"
+        );
+
+        let from_vpc2 = allocator
+            .allocate_v4(vpcd2(), vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
+            .unwrap();
+        assert_ne!(
+            (
+                from_vpc1.allocation.ip(),
+                from_vpc1.allocation.port().as_u16()
+            ),
+            (
+                from_vpc2.allocation.ip(),
+                from_vpc2.allocation.port().as_u16()
+            ),
+        );
+    }
+
+    // Whichever region it draws from, a VPC may only ever be given an address its own expose
+    // declares.
+    #[test]
+    fn test_partial_overlap_never_allocates_outside_the_configured_range() {
+        let allocator = build_allocator_partial_overlap();
+
+        let mut held = Vec::new();
+        for _ in 0..16 {
+            let allocation = allocator
+                .allocate_v4(vpcd2(), vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
+                .unwrap();
+            let ip = allocation.allocation.ip();
+            assert!(
+                ip == addr_v4("10.1.0.2") || ip == addr_v4("10.1.0.3"),
+                "VPC-2 was given {ip}, which is outside the range it exposes"
+            );
+            held.push(allocation);
+        }
     }
 
     // Both VPCs keep their own entry, rather than the second overwriting the first.

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -43,7 +43,6 @@ mod context {
     pub fn vni3() -> Vni {
         Vni::new_checked(300).unwrap()
     }
-    #[allow(dead_code)]
     pub fn vpcd1() -> VpcDiscriminant {
         VpcDiscriminant::from_vni(vni1())
     }
@@ -64,12 +63,14 @@ mod context {
 
     pub fn get_ip_allocator_v4(
         pool: &mut PoolTable<Ipv4Addr, Ipv4Addr>,
+        src_vpcd: VpcDiscriminant,
         dst_vpcd: VpcDiscriminant,
         protocol: NextHeader,
         src_ip: Ipv4Addr,
     ) -> &IpAllocator<Ipv4Addr> {
         pool.get(&PoolTableKey::new(
             protocol,
+            src_vpcd,
             dst_vpcd,
             src_ip,
             Ipv4Addr::from_str("255.255.255.255").unwrap(),
@@ -200,6 +201,63 @@ mod context {
         let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
         NatAllocator::new(config)
     }
+
+    // Two VPCs using the *same* private prefix, each peering with the same destination VPC and
+    // masquerading onto a public range of its own. Tenants reusing private address space is
+    // ordinary, and is much of what NAT is for, so both are entitled to their own pool.
+    fn build_context_overlapping_private_prefixes() -> ValidatedVpcTable {
+        let masquerade_manifest = |name: &str, public: &str| {
+            VpcManifest::with_exposes(
+                name,
+                vec![
+                    VpcExpose::empty()
+                        .make_masquerade(None)
+                        .unwrap()
+                        .ip("192.168.0.0/16".into())
+                        .as_range(public.into())
+                        .unwrap(),
+                ],
+            )
+        };
+        let remote =
+            VpcManifest::with_exposes("VPC-3", vec![VpcExpose::empty().ip("3.0.0.0/24".into())]);
+
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
+        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2().as_u32()).unwrap();
+        let vpc3 = Vpc::new("VPC-3", "11111", vni3().as_u32()).unwrap();
+
+        vpc1.peerings.push(Peering {
+            name: "overlapping_peering1".into(),
+            local: masquerade_manifest("VPC-1", "10.1.0.0/30"),
+            remote: remote.clone(),
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+        vpc2.peerings.push(Peering {
+            name: "overlapping_peering2".into(),
+            local: masquerade_manifest("VPC-2", "10.2.0.0/30"),
+            remote,
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+
+        let mut vpctable = VpcTable::new();
+        vpctable.add(vpc1).unwrap();
+        vpctable.add(vpc2).unwrap();
+        vpctable.add(vpc3).unwrap();
+
+        vpctable.validate().unwrap()
+    }
+
+    pub fn build_allocator_overlapping_private_prefixes() -> NatAllocator {
+        let vpc_table = build_context_overlapping_private_prefixes();
+        let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
+        NatAllocator::new(config)
+    }
 }
 
 mod tests {
@@ -220,17 +278,17 @@ mod tests {
 
         handles.push(thread::spawn(move || {
             let _allocation1 = allocator1
-                .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+                .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
                 .unwrap();
         }));
         handles.push(thread::spawn(move || {
             let _allocation2 = allocator2
-                .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+                .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
                 .unwrap();
         }));
         handles.push(thread::spawn(move || {
             let _allocation3 = allocator3
-                .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+                .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
                 .unwrap();
         }));
 
@@ -244,6 +302,7 @@ mod tests {
         let mut allocator_again = Arc::try_unwrap(allocator_arc).unwrap();
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator_again.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -308,6 +367,7 @@ mod std_tests {
             .pools_src44
             .get(&PoolTableKey::new(
                 NextHeader::TCP,
+                vpcd1(),
                 vpcd2(),
                 addr_v4("1.1.0.0"),
                 addr_v4("255.255.255.255"),
@@ -328,6 +388,7 @@ mod std_tests {
         let mut allocator = build_allocator();
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -337,7 +398,7 @@ mod std_tests {
         assert_eq!(in_use.len(), 0); // None allocated yet
 
         let alloc_result = allocator
-            .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+            .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
             .unwrap();
         println!("{alloc_result}");
 
@@ -345,6 +406,7 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -358,6 +420,7 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -374,6 +437,7 @@ mod std_tests {
         let mut allocator = build_allocator();
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -384,6 +448,7 @@ mod std_tests {
 
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -394,13 +459,14 @@ mod std_tests {
 
         // Allocate for TCP
         let tcp_allocation = allocator
-            .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+            .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
             .unwrap();
         println!("{tcp_allocation}");
 
         // Check number of allocated IPs for TCP after we have allocated for TCP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -412,6 +478,7 @@ mod std_tests {
         // Check number of allocated IPs for UDP after we have allocated for TCP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -422,13 +489,14 @@ mod std_tests {
 
         // Allocate for UDP
         let udp_allocation = allocator
-            .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::UDP)
+            .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::UDP)
             .unwrap();
         println!("{udp_allocation}");
 
         // Check number of allocated IPs for TCP after we have allocated for UDP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::TCP,
             addr_v4("1.1.0.0"),
@@ -440,6 +508,7 @@ mod std_tests {
         // Check number of allocated IPs for UDP after we have allocated for UDP
         let (bitmap, in_use) = get_ip_allocator_v4(
             &mut allocator.pools_src44,
+            vpcd1(),
             vpcd2(),
             NextHeader::UDP,
             addr_v4("1.1.0.0"),
@@ -457,10 +526,10 @@ mod std_tests {
         let allocator = build_allocator_shared_public_range();
 
         let alloc_a = allocator
-            .allocate_v4(vpcd3(), addr_v4("1.1.0.1"), NextHeader::TCP)
+            .allocate_v4(vpcd1(), vpcd3(), addr_v4("1.1.0.1"), NextHeader::TCP)
             .unwrap();
         let alloc_b = allocator
-            .allocate_v4(vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
+            .allocate_v4(vpcd2(), vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
             .unwrap();
 
         assert_ne!(
@@ -488,12 +557,13 @@ mod std_tests {
             .count();
         assert_eq!(tcp_entries, 2);
 
-        for src in ["1.1.0.1", "2.1.0.1"] {
+        for (src_vpcd, src) in [(vpcd1(), "1.1.0.1"), (vpcd2(), "2.1.0.1")] {
             assert!(
                 allocator
                     .pools_src44
                     .get(&PoolTableKey::new(
                         NextHeader::TCP,
+                        src_vpcd,
                         vpcd3(),
                         addr_v4(src),
                         addr_v4("255.255.255.255"),
@@ -502,6 +572,46 @@ mod std_tests {
                 "no pool found for private source {src}"
             );
         }
+    }
+
+    // Two VPCs may use the same private address space, so a private prefix on its own does not
+    // identify a pool. Each VPC has to be masqueraded onto the public range its own expose
+    // declares, rather than whichever expose happened to be registered last.
+    #[test]
+    fn test_overlapping_private_prefixes_use_their_own_pool() {
+        let allocator = build_allocator_overlapping_private_prefixes();
+
+        let from_vpc1 = allocator
+            .allocate_v4(vpcd1(), vpcd3(), addr_v4("192.168.0.1"), NextHeader::TCP)
+            .unwrap();
+        let from_vpc2 = allocator
+            .allocate_v4(vpcd2(), vpcd3(), addr_v4("192.168.0.1"), NextHeader::TCP)
+            .unwrap();
+
+        assert_eq!(
+            from_vpc1.allocation.ip(),
+            addr_v4("10.1.0.0"),
+            "traffic from VPC-1 was not masqueraded onto the range VPC-1 exposes"
+        );
+        assert_eq!(
+            from_vpc2.allocation.ip(),
+            addr_v4("10.2.0.0"),
+            "traffic from VPC-2 was not masqueraded onto the range VPC-2 exposes"
+        );
+    }
+
+    // Both VPCs keep their own entry, rather than the second overwriting the first.
+    #[test]
+    fn test_overlapping_private_prefixes_keep_separate_entries() {
+        let allocator = build_allocator_overlapping_private_prefixes();
+
+        let tcp_entries = allocator
+            .pools_src44
+            .0
+            .keys()
+            .filter(|k| k.protocol == NextHeader::TCP && k.dst_vpcd == vpcd3())
+            .count();
+        assert_eq!(tcp_entries, 2);
     }
 }
 
@@ -522,12 +632,12 @@ mod concurrency_tests {
 
         let t1 = thread::spawn(move || {
             let _allocation1 = allocator1
-                .allocate_v4(vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
+                .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.1.0.0"), NextHeader::TCP)
                 .unwrap();
         });
         let t2 = thread::spawn(move || {
             let _allocation2 = allocator2
-                .allocate_v4(vpcd2(), addr_v4("1.2.0.0"), NextHeader::TCP)
+                .allocate_v4(vpcd1(), vpcd2(), addr_v4("1.2.0.0"), NextHeader::TCP)
                 .unwrap();
         });
         t1.join().unwrap();

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -40,6 +40,7 @@ mod context {
     pub fn vni2() -> Vni {
         Vni::new_checked(200).unwrap()
     }
+    #[allow(dead_code)]
     pub fn vni3() -> Vni {
         Vni::new_checked(300).unwrap()
     }
@@ -49,6 +50,7 @@ mod context {
     pub fn vpcd2() -> VpcDiscriminant {
         VpcDiscriminant::from_vni(vni2())
     }
+    #[allow(dead_code)]
     pub fn vpcd3() -> VpcDiscriminant {
         VpcDiscriminant::from_vni(vni3())
     }
@@ -160,6 +162,7 @@ mod context {
     // exposes across VPCs: collisions are only checked between the exposes of a single manifest.
     // Both peerings therefore reach the allocator with the same destination discriminant and the
     // same public range, which is one pool described twice.
+    #[allow(dead_code)]
     fn build_context_shared_public_range() -> ValidatedVpcTable {
         let masquerade_manifest = |name: &str, private: &str| {
             VpcManifest::with_exposes(
@@ -208,6 +211,7 @@ mod context {
         vpctable.validate().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn build_allocator_shared_public_range() -> NatAllocator {
         let vpc_table = build_context_shared_public_range();
         // Without randomization the first port block picked is deterministic, so two pools that
@@ -219,6 +223,7 @@ mod context {
     // Two VPCs using the *same* private prefix, each peering with the same destination VPC and
     // masquerading onto a public range of its own. Tenants reusing private address space is
     // ordinary, and is much of what NAT is for, so both are entitled to their own pool.
+    #[allow(dead_code)]
     fn build_context_overlapping_private_prefixes() -> ValidatedVpcTable {
         let masquerade_manifest = |name: &str, public: &str| {
             VpcManifest::with_exposes(
@@ -267,6 +272,7 @@ mod context {
         vpctable.validate().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn build_allocator_overlapping_private_prefixes() -> NatAllocator {
         let vpc_table = build_context_overlapping_private_prefixes();
         let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
@@ -276,6 +282,7 @@ mod context {
     // Two VPCs peering with the same destination VPC, masquerading onto public ranges that overlap
     // *partially*: VPC-1 takes 10.1.0.0/30 (.0 through .3) and VPC-2 takes 10.1.0.2/31 (.2 and
     // .3). Neither range contains the other, so no single range identifies the shared space.
+    #[allow(dead_code)]
     fn build_context_partial_overlap() -> ValidatedVpcTable {
         let masquerade_manifest = |name: &str, private: &str, public: &str| {
             VpcManifest::with_exposes(
@@ -324,12 +331,14 @@ mod context {
         vpctable.validate().unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn build_allocator_partial_overlap() -> NatAllocator {
         let vpc_table = build_context_partial_overlap();
         let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
         NatAllocator::new(config)
     }
 
+    #[allow(dead_code)]
     pub fn get_pool_set_v4(
         pool: &PoolTable<Ipv4Addr, Ipv4Addr>,
         src_vpcd: VpcDiscriminant,

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -40,12 +40,18 @@ mod context {
     pub fn vni2() -> Vni {
         Vni::new_checked(200).unwrap()
     }
+    pub fn vni3() -> Vni {
+        Vni::new_checked(300).unwrap()
+    }
     #[allow(dead_code)]
     pub fn vpcd1() -> VpcDiscriminant {
         VpcDiscriminant::from_vni(vni1())
     }
     pub fn vpcd2() -> VpcDiscriminant {
         VpcDiscriminant::from_vni(vni2())
+    }
+    pub fn vpcd3() -> VpcDiscriminant {
+        VpcDiscriminant::from_vni(vni3())
     }
 
     #[allow(unused)]
@@ -131,6 +137,67 @@ mod context {
     pub fn build_allocator() -> NatAllocator {
         let vpc_table = build_context();
         let config = MasqueradeConfig::new(&vpc_table, 1);
+        NatAllocator::new(config)
+    }
+
+    // Two *different* VPCs, each peering with the same destination VPC, and each masquerading
+    // onto the same public range. A VPC may not peer twice with the same peer, but nothing checks
+    // exposes across VPCs: collisions are only checked between the exposes of a single manifest.
+    // Both peerings therefore reach the allocator with the same destination discriminant and the
+    // same public range, which is one pool described twice.
+    fn build_context_shared_public_range() -> ValidatedVpcTable {
+        let masquerade_manifest = |name: &str, private: &str| {
+            VpcManifest::with_exposes(
+                name,
+                vec![
+                    VpcExpose::empty()
+                        .make_masquerade(None)
+                        .unwrap()
+                        .ip(private.into())
+                        .as_range("10.1.0.0/30".into())
+                        .unwrap(),
+                ],
+            )
+        };
+        let remote =
+            VpcManifest::with_exposes("VPC-3", vec![VpcExpose::empty().ip("3.0.0.0/24".into())]);
+
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
+        let mut vpc2 = Vpc::new("VPC-2", "12345", vni2().as_u32()).unwrap();
+        let vpc3 = Vpc::new("VPC-3", "11111", vni3().as_u32()).unwrap();
+
+        vpc1.peerings.push(Peering {
+            name: "shared_peering1".into(),
+            local: masquerade_manifest("VPC-1", "1.1.0.0/16"),
+            remote: remote.clone(),
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+        vpc2.peerings.push(Peering {
+            name: "shared_peering2".into(),
+            local: masquerade_manifest("VPC-2", "2.1.0.0/16"),
+            remote,
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+
+        let mut vpctable = VpcTable::new();
+        vpctable.add(vpc1).unwrap();
+        vpctable.add(vpc2).unwrap();
+        vpctable.add(vpc3).unwrap();
+
+        vpctable.validate().unwrap()
+    }
+
+    pub fn build_allocator_shared_public_range() -> NatAllocator {
+        let vpc_table = build_context_shared_public_range();
+        // Without randomization the first port block picked is deterministic, so two pools that
+        // wrongly believe they each own the whole public range collide on their first allocation.
+        let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
         NatAllocator::new(config)
     }
 }
@@ -380,6 +447,61 @@ mod std_tests {
         .get_pool_clone_for_tests();
         assert_eq!(bitmap.len(), 2); // 2 free IP addresses left to NAT 1.1.0.0 (UDP)
         assert_eq!(in_use.len(), 1); // 1 allocated, in use
+    }
+
+    // Two VPCs masquerading onto the same public range towards the same destination VPC describe
+    // one pool, not two, and must therefore share a single allocator. Allocating for a source in
+    // each VPC in turn may not yield the same public address and port twice.
+    #[test]
+    fn test_shared_public_range_is_allocated_once() {
+        let allocator = build_allocator_shared_public_range();
+
+        let alloc_a = allocator
+            .allocate_v4(vpcd3(), addr_v4("1.1.0.1"), NextHeader::TCP)
+            .unwrap();
+        let alloc_b = allocator
+            .allocate_v4(vpcd3(), addr_v4("2.1.0.1"), NextHeader::TCP)
+            .unwrap();
+
+        assert_ne!(
+            (alloc_a.allocation.ip(), alloc_a.allocation.port().as_u16()),
+            (alloc_b.allocation.ip(), alloc_b.allocation.port().as_u16()),
+            "the same public address and port was handed out to two different flows"
+        );
+
+        // Sharing the pool means the second allocation reuses the address the first one took,
+        // and simply draws the next port from it.
+        assert_eq!(alloc_a.allocation.ip(), alloc_b.allocation.ip());
+    }
+
+    // Sharing a pool must not collapse the private-side lookups: each private prefix keeps its own
+    // entry, since that is how the first packet of a flow finds its pool.
+    #[test]
+    fn test_shared_public_range_keeps_both_private_entries() {
+        let allocator = build_allocator_shared_public_range();
+
+        let tcp_entries = allocator
+            .pools_src44
+            .0
+            .keys()
+            .filter(|k| k.protocol == NextHeader::TCP && k.dst_vpcd == vpcd3())
+            .count();
+        assert_eq!(tcp_entries, 2);
+
+        for src in ["1.1.0.1", "2.1.0.1"] {
+            assert!(
+                allocator
+                    .pools_src44
+                    .get(&PoolTableKey::new(
+                        NextHeader::TCP,
+                        vpcd3(),
+                        addr_v4(src),
+                        addr_v4("255.255.255.255"),
+                    ))
+                    .is_some(),
+                "no pool found for private source {src}"
+            );
+        }
     }
 }
 

--- a/nat/src/masquerade/flows.rs
+++ b/nat/src/masquerade/flows.rs
@@ -60,12 +60,15 @@ fn re_reserve_ip_and_port(
 ) -> Result<(), ()> {
     let flow_key = flow_info.flowkey();
     let proto = flow_key.proto();
+    // Only the forward flow of a pair holds an allocation, and this is only reached for flows that
+    // have one, so the flow key's source really is the VPC the masqueraded traffic originates in.
+    let src_vpcd = flow_key.src_vpcd().unwrap_or_else(|| unreachable!());
     let dst_vpcd = flow_info.get_dst_vpcd().unwrap_or_else(|| unreachable!());
     let src_ip = *flow_key.src_ip();
     let port_u16 = port.as_u16();
     debug!("Attempting to re-reserve {ip} {proto}:{port_u16} for flow {flow_key}");
 
-    match new_allocator.reserve_port(proto, dst_vpcd, src_ip, ip, port) {
+    match new_allocator.reserve_port(proto, src_vpcd, dst_vpcd, src_ip, ip, port) {
         Ok(alloc) => {
             debug!("Successfully re-reserved ip {ip} port/Id {port_u16} ({proto})");
             let mut guard = flow_info.locked.write();

--- a/nat/src/masquerade/natip.rs
+++ b/nat/src/masquerade/natip.rs
@@ -31,6 +31,10 @@ pub trait NatIp:
     // Convert from a 128-bit integer to a `NatIp`, if possible
     fn try_from_bits(bits: u128) -> Result<Self, ()>;
 
+    // Convert to a 128-bit integer. Named to avoid colliding with the inherent `to_bits` of
+    // `Ipv4Addr`, which yields a `u32` and would silently win method resolution.
+    fn to_addr_bits(&self) -> u128;
+
     // Convert from an `IpAddr` object to a `NatIp`, if possible
     fn try_from_addr(addr: IpAddr) -> Result<Self, ()>;
 }
@@ -58,6 +62,9 @@ impl NatIp for Ipv4Addr {
     }
     fn try_from_bits(bits: u128) -> Result<Self, ()> {
         Ok(Self::from(u32::try_from(bits).map_err(|_| ())?))
+    }
+    fn to_addr_bits(&self) -> u128 {
+        u128::from(self.to_bits())
     }
     fn try_from_addr(addr: IpAddr) -> Result<Self, ()> {
         if let IpAddr::V4(addr) = addr {
@@ -88,6 +95,9 @@ impl NatIp for Ipv6Addr {
     }
     fn try_from_bits(bits: u128) -> Result<Self, ()> {
         Ok(Self::from(bits))
+    }
+    fn to_addr_bits(&self) -> u128 {
+        self.to_bits()
     }
     fn try_from_addr(addr: IpAddr) -> Result<Self, ()> {
         if let IpAddr::V6(addr) = addr {

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -373,6 +373,7 @@ impl Masquerade {
             return Err(MasqueradeError::IntendedDrop("TCP without SYN"));
         }
 
+        let src_vpcd = packet.meta().src_vpcd.unwrap_or_else(|| unreachable!());
         let dst_vpcd = packet.meta().dst_vpcd.unwrap_or_else(|| unreachable!());
 
         // Extract flow key for the current packet
@@ -392,7 +393,7 @@ impl Masquerade {
         // Create a new session and translate the address
         let src_ip = *initial_flow_key.src_ip();
         let alloc = allocator
-            .allocate(dst_vpcd, src_ip, initial_flow_key.proto())
+            .allocate(src_vpcd, dst_vpcd, src_ip, initial_flow_key.proto())
             .map_err(MasqueradeError::AllocationFailure)?;
 
         // Forbid addresses we won't know how to translate. This is a work around of a larger change

--- a/nat/src/masquerade/state.rs
+++ b/nat/src/masquerade/state.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 use std::net::IpAddr;
 use std::time::Duration;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MasqueradeState {
     pub(crate) status: AtomicNatFlowStatus,
     action: NatAction,

--- a/nat/src/masquerade/test.rs
+++ b/nat/src/masquerade/test.rs
@@ -1420,17 +1420,20 @@ fn nat_flow_status(packet: &Packet<TestBuffer>) -> Option<NatFlowStatus> {
         .map(|state| state.status.load())
 }
 
-fn masquerade_state(packet: &Packet<TestBuffer>) -> Option<MasqueradeState> {
-    packet
-        .meta()
-        .flow_info
-        .as_ref()?
-        .locked
-        .read()
+// Read something out of a flow's masquerade state, under the lock.
+//
+// Deliberately not a clone of the state: it owns the allocation, and a copy of it is a second
+// owner of the same public address and port. Nothing in a test needs that.
+fn with_masquerade_state<T>(
+    packet: &Packet<TestBuffer>,
+    read: impl FnOnce(&MasqueradeState) -> T,
+) -> Option<T> {
+    let locked = packet.meta().flow_info.as_ref()?.locked.read();
+    let state = locked
         .nat_state
-        .as_ref()
-        .and_then(|s| s.extract_ref::<MasqueradeState>())
-        .cloned()
+        .as_ref()?
+        .extract_ref::<MasqueradeState>()?;
+    Some(read(state))
 }
 
 fn build_reply(packet: &Packet<TestBuffer>) -> Packet<TestBuffer> {
@@ -1502,7 +1505,7 @@ fn establish_tcp_connection(pipeline: &mut DynPipeline<TestBuffer>) {
     assert_eq!(nat_flow_status(&output), Some(NatFlowStatus::Established));
 
     // configured timeout for the flow
-    let timeout = masquerade_state(&output).unwrap().idle_timeout();
+    let timeout = with_masquerade_state(&output, MasqueradeState::idle_timeout).unwrap();
 
     // check that flow timeouts "match" the ones configured, allowing for 5 second error (for the test)
     let flow_info_ack = output.meta().flow_info.as_ref().unwrap();
@@ -1539,8 +1542,9 @@ async fn test_masquerade_check() {
     let out = process_packet(&mut pipeline, packet);
 
     // packet hit flow with SRC nat rule
-    let state = masquerade_state(&out).expect("Must have flow info w/ masquerade state");
-    assert_eq!(state.action(), NatAction::SrcNat);
+    let action = with_masquerade_state(&out, MasqueradeState::action)
+        .expect("Must have flow info w/ masquerade state");
+    assert_eq!(action, NatAction::SrcNat);
 
     test_case("Process packet masquerade dest nat");
     // process packet in dst nat direction
@@ -1548,8 +1552,9 @@ async fn test_masquerade_check() {
     let out = process_packet(&mut pipeline, reply);
 
     // packet hit flow with dst nat rule
-    let state = masquerade_state(&out).expect("Must have flow info w/ masquerade state");
-    assert_eq!(state.action(), NatAction::DstNat);
+    let action = with_masquerade_state(&out, MasqueradeState::action)
+        .expect("Must have flow info w/ masquerade state");
+    assert_eq!(action, NatAction::DstNat);
     assert_eq!(nat_flow_status(&out).unwrap(), NatFlowStatus::Established);
     assert_eq!(flow_status(&out).unwrap(), FlowStatus::Active);
 
@@ -1582,8 +1587,9 @@ async fn test_masquerade_tcp_reset() {
     let reply_out = process_packet(&mut pipeline, reply);
 
     // packet hits flow with dst nat rule. Nat flow status becomes reset and flow is cancelled
-    let state = masquerade_state(&reply_out).expect("Must have flow info w/ masquerade state");
-    assert_eq!(state.action(), NatAction::DstNat);
+    let action = with_masquerade_state(&reply_out, MasqueradeState::action)
+        .expect("Must have flow info w/ masquerade state");
+    assert_eq!(action, NatAction::DstNat);
     assert_eq!(nat_flow_status(&out).unwrap(), NatFlowStatus::Reset);
     assert_eq!(flow_status(&reply_out).unwrap(), FlowStatus::Cancelled);
 


### PR DESCRIPTION
Masquerade hands out a public `(address, port)` pair, and return traffic is matched on a
reverse flow key built from that pair, the remote endpoint and the peer VPC. Nothing in that
key says which VPC the traffic came from, so two flows that collide on it are
indistinguishable and one tenant's return traffic can be delivered into another's VPC.

This branch fixes three ways the allocator could produce such a collision, and builds the
test machinery to show it does not.

- **Pools identified by their public range.** Exposes sharing a public range each got their
  own allocator, so each believed it owned the whole range.
- **Pools keyed by source VPC.** A private address only means something inside its own VPC.
  Two VPCs using the same private space produced one key, and the second silently replaced
  the first.
- **Allocation from disjoint regions.** Public ranges may overlap only partially, where
  neither contains the other. The public space is now cut at every point where the set of
  exposes covering it changes, giving maximal intervals with one allocator each.

It also carries, as its first commit, the `set_bitmap_value` fix that used to sit in #1699:
freeing a port was an OR with zero and never freed, and the guard against reserving a port already
taken compared the wrong two values, so a pair another flow held could be handed out again. That is
a fourth collision vector, and it belongs here because everything above depends on it -- in
particular the concurrent model checker, which cannot assert that a held pair is refused until the
guard works. Its pool-level test needs machinery introduced later and stays in #1699.

Fixing the bitmap turned a dormant hazard into a live one, so that is fixed here too: an
`AllocatedPort` frees its port on drop and was also `Clone`, so every copy freed the same port.
Dropping a copy released a pair its original still held, and the allocator would hand that pair to
a second flow. Dormant only because a drop that does nothing is harmless to repeat. `Clone` comes
off the allocation, and off `Allocation` and `MasqueradeState` with it -- the data plane never
wanted it, and the one caller was a test helper cloning live state to read two fields.

Then the testing those rest on: a bolero x model-checker suite over a config change, `just`
recipes for real libfuzzer campaigns, and two follow-on fixes found while writing them (a
non-exhaustion error being masked by region fallback, and a panic on an IPv6 address a pool
cannot index).

Every commit passes `cargo nextest run` on its own.

## The allocator can deadlock against its own pool lock

Moved here from the top of the stack. It predates the stack and depends on nothing in it, and at
the top it left every PR below it running with the hang -- which is not hypothetical: it wedged a
thread-sanitizer CI job for six hours before it was understood.

The pool holds weak references to the addresses in use; the strong ones belong to the blocks handed
out from each. Upgrading one under the pool guard and then letting it go can run
`AllocatedIp::drop` on the same thread, and that takes the same lock for writing. Another thread
ending the last flow on an address at that moment is all it takes. Four sites did it:
`reuse_allocated_ip`, `cleanup`, `reserve_from_pool`, and -- found by review of this PR, after the
first three were fixed -- `IpAllocator::fmt`, which reaches it from the management side, since
`NatAllocator` is a `CliSource` and the table is formatted on its own thread.

Each now keeps every upgrade alive until the guard is gone. Two Shuttle regressions come with it;
both deadlock in a single execution without the fix, and Shuttle names it directly: "tried to
acquire a `RwLock` it already holds".
