### PR TITLE
(2)-masquerade: port forwarding claims

### DIFF
--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -30,7 +30,7 @@ use tracing::{debug, error};
 /// ordinary case, where the first address serves, and an address that cannot serve is taken out of
 /// the pool as it is found, so a run of them is worked through over successive packets rather than
 /// being walked again each time.
-const MAX_ADDRESSES_PER_ALLOCATION: usize = 8;
+pub(super) const MAX_ADDRESSES_PER_ALLOCATION: usize = 8;
 
 ///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
@@ -410,6 +410,16 @@ impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
 #[derive(Debug)]
 pub(crate) struct NatPool<I: NatIpWithBitmap> {
     bitmap: PoolBitmap,
+    /// Offsets that may never be handed out, however often they are given back.
+    ///
+    /// Distinct from being absent from `bitmap`, which only says an address is in use at the
+    /// moment. An address lands here either because port forwarding has claimed every port
+    /// masquerade could draw on it, which is known when the pool is built, or because it was found
+    /// to have nothing to give while serving. Either way it must not come back:
+    /// `deallocate_from_pool` runs on the drop path and would otherwise return it to the pool the
+    /// first time a flow holding it ends, which for a carried-over flow is moments after the pool
+    /// was built.
+    unusable: RoaringBitmap,
     bitmap_mapping: BTreeMap<u32, u128>,
     reverse_bitmap_mapping: BTreeMap<u128, u32>,
     in_use: VecDeque<Weak<AllocatedIp<I>>>,
@@ -437,16 +447,41 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         // A region holding more addresses than the u32 bitmap can index is truncated. We would run
         // out of memory long before allocating four billion addresses.
         let span = range.len().saturating_sub(1).min(u128::from(u32::MAX));
+        let indexable = AddrInterval::new(range.start, range.start + span);
         let to_offset = |bits: u128| {
             let address = I::try_from_bits(bits).unwrap_or_else(|()| unreachable!());
             I::try_to_offset(address, &reverse_bitmap_mapping).unwrap_or_else(|_| unreachable!())
         };
 
+        let mut bitmap =
+            PoolBitmap::with_offset_range(to_offset(indexable.start), to_offset(indexable.end));
+
+        // An address port forwarding has taken every usable port on can serve masquerade nothing,
+        // and which addresses those are is known now rather than discovered a packet at a time.
+        // Left in the pool, such an address is drawn because it is the lowest one free, found
+        // useless, and taken out -- but only eight of them may be worked through before the
+        // allocation gives up, so a run of them costs a dropped packet for every eight, on flows
+        // the region had ample room for. And it costs them again after every config change, since
+        // a new allocator starts with a fresh pool. Keeping them out from the start costs one
+        // sweep over the claims when the pool is built.
+        let mut unusable = RoaringBitmap::new();
+        for interval in reserved_ports.unusable_within::<I>(indexable, exclude_wellknown_ports) {
+            let (first, last) = (to_offset(interval.start), to_offset(interval.end));
+            unusable.insert_range(first..=last);
+            bitmap.remove_offset_range(first, last);
+        }
+        if !unusable.is_empty() {
+            debug!(
+                "Pool over {} address(es) keeps {} of them out: port forwarding has claimed every \
+                 port masquerade could use there",
+                indexable.len(),
+                unusable.len()
+            );
+        }
+
         Self {
-            bitmap: PoolBitmap::with_offset_range(
-                to_offset(range.start),
-                to_offset(range.start + span),
-            ),
+            bitmap,
+            unusable,
             bitmap_mapping,
             reverse_bitmap_mapping,
             in_use: VecDeque::new(),
@@ -509,6 +544,7 @@ impl<I: NatIpWithBitmap> NatPool<I> {
     fn retire_from_pool(&mut self, ip: I) {
         match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
             Ok(offset) => {
+                self.unusable.insert(offset);
                 self.bitmap.set_ip_allocated(offset);
             }
             Err(e) => error!("Address {ip} cannot be retired from its pool: {e}"),
@@ -522,7 +558,15 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         // address marked in use rather than panicking on the drop path.
         match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
             Ok(offset) => {
-                self.bitmap.set_ip_free(offset);
+                // An address that can never serve does not come back, whoever is giving it up.
+                // Reserving reaches addresses the pool never draws, so a flow carried across a
+                // config change onto an address the new configuration has claimed would otherwise
+                // put it into the pool on its way out.
+                if self.unusable.contains(offset) {
+                    debug!("Address {ip} stays out of its pool: it can serve nothing");
+                } else {
+                    self.bitmap.set_ip_free(offset);
+                }
             }
             Err(e) => error!("Address {ip} does not map back into the pool it came from: {e}"),
         }
@@ -656,6 +700,11 @@ impl PoolBitmap {
 
     fn set_ip_free(&mut self, index: u32) -> bool {
         self.0.insert(index)
+    }
+
+    /// Take an inclusive range of indices out of the pool.
+    fn remove_offset_range(&mut self, start: u32, end: u32) {
+        self.0.remove_range(start..=end);
     }
 }
 

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -10,6 +10,7 @@
 //! See also the architecture diagram at the top of mod.rs.
 
 use super::region::AddrInterval;
+use super::reserved::{PortClaims, ReservedPorts};
 use super::{NatIpWithBitmap, port_alloc};
 use crate::masquerade::allocation::AllocatorError;
 use crate::masquerade::natip::NatIp;
@@ -17,7 +18,6 @@ use crate::port::NatPort;
 use crate::ranges::IpRange;
 use concurrency::sync::{Arc, RwLock, RwLockReadGuard, Weak};
 use lpm::prefix::PortRange;
-use lpm::prefix::range_map::DisjointRangesBTreeMap;
 use roaring::RoaringBitmap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::{IpAddr, Ipv6Addr};
@@ -291,14 +291,14 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
     fn new(
         ip: I,
         ip_allocator: IpAllocator<I>,
-        reserved_port_range: Option<PortRange>,
+        reserved_ports: PortClaims,
         randomize: bool,
         exclude_wellknown_ports: bool,
     ) -> Self {
         Self {
             ip,
             port_allocator: port_alloc::PortAllocator::new(
-                reserved_port_range,
+                reserved_ports,
                 randomize,
                 exclude_wellknown_ports,
             ),
@@ -366,7 +366,7 @@ pub(crate) struct NatPool<I: NatIpWithBitmap> {
     bitmap_mapping: BTreeMap<u32, u128>,
     reverse_bitmap_mapping: BTreeMap<u128, u32>,
     in_use: VecDeque<Weak<AllocatedIp<I>>>,
-    reserved_prefixes_ports: Option<DisjointRangesBTreeMap<IpRange, PortRange>>,
+    reserved_ports: ReservedPorts,
     exclude_wellknown_ports: bool,
 }
 
@@ -377,7 +377,7 @@ impl<I: NatIpWithBitmap> NatPool<I> {
     /// overlap and a public address may only be handed out by one pool.
     pub(crate) fn for_range(
         range: AddrInterval,
-        reserved_prefixes_ports: Option<DisjointRangesBTreeMap<IpRange, PortRange>>,
+        reserved_ports: ReservedPorts,
         exclude_wellknown_ports: bool,
     ) -> Self {
         // Index the region from its own start. IPv4 indexes its bitmap by the address bits and
@@ -403,7 +403,7 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             bitmap_mapping,
             reverse_bitmap_mapping,
             in_use: VecDeque::new(),
-            reserved_prefixes_ports,
+            reserved_ports,
             exclude_wellknown_ports,
         }
     }
@@ -429,15 +429,11 @@ impl<I: NatIpWithBitmap> NatPool<I> {
     }
 
     // Used for Display
-    pub(crate) fn reserved_prefixes_ports(
-        &self,
-    ) -> Option<impl Iterator<Item = (IpRange, PortRange)>> {
-        Some(
-            self.reserved_prefixes_ports
-                .as_ref()?
-                .iter()
-                .map(|(&r, &p)| (r, p)),
-        )
+    pub(crate) fn reserved_ports(&self) -> Option<impl Iterator<Item = (IpRange, PortRange)>> {
+        if self.reserved_ports.is_empty() {
+            return None;
+        }
+        Some(self.reserved_ports.iter())
     }
 
     fn use_new_ip(
@@ -450,16 +446,13 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 
         let ip = I::try_from_offset(offset, &self.bitmap_mapping)?;
 
-        // Check if the IP is in a reserved prefix, retrieve the reserved port range if any
-        let reserved_port_range = self
-            .reserved_prefixes_ports
-            .as_ref()
-            .and_then(|ranges| ranges.lookup(&ip.to_ip_addr()).map(|(_, range)| *range));
+        // Every port range port forwarding has claimed on this address, not just one of them.
+        let claims = self.reserved_ports.for_address(ip.to_ip_addr());
 
         Ok(AllocatedIp::new(
             ip,
             ip_allocator,
-            reserved_port_range,
+            claims,
             randomize,
             self.exclude_wellknown_ports,
         ))
@@ -512,7 +505,11 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         let arc_ip = Arc::new(AllocatedIp::new(
             ip,
             ip_allocator,
-            None,
+            // An address entering the pool this way serves later allocations exactly as one that
+            // arrived through allocate(), so it has to carry the same claims. Passing none here
+            // let a flow carried across a config change bring an address in unencumbered, after
+            // which masquerade could hand out the ports port forwarding had taken on it.
+            self.reserved_ports.for_address(ip.to_ip_addr()),
             randomize,
             // Keep the low-port exclusion policy for explicitly reserved IPs as well, so
             // reserve() follows the same TCP/UDP allocation rules as allocate().

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -24,6 +24,14 @@ use std::net::{IpAddr, Ipv6Addr};
 use std::time::Duration;
 use tracing::{debug, error};
 
+/// How many addresses one allocation may draw before giving up.
+///
+/// A data plane cannot search without a bound on the packet path. The bound costs nothing in the
+/// ordinary case, where the first address serves, and an address that cannot serve is taken out of
+/// the pool as it is found, so a run of them is worked through over successive packets rather than
+/// being walked again each time.
+const MAX_ADDRESSES_PER_ALLOCATION: usize = 8;
+
 ///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
 ///////////////////////////////////////////////////////////////////////////////
@@ -109,12 +117,48 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         Ok(arc_ip)
     }
 
+    /// Take an address out of the pool for good.
+    ///
+    /// Only for an address that can never serve, not one that is merely busy.
+    fn retire_ip(&self, ip: I) {
+        self.pool.write().retire_from_pool(ip);
+    }
+
     fn allocate_from_new_ip(
         &self,
         allow_null: bool,
     ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
-        self.allocate_new_ip_from_pool()
-            .and_then(|ip| ip.allocate_port_for_ip(allow_null))
+        let mut exhausted = None;
+        for _ in 0..MAX_ADDRESSES_PER_ALLOCATION {
+            let ip = self.allocate_new_ip_from_pool()?;
+            let address = ip.ip();
+            match ip.allocate_port_for_ip(allow_null) {
+                Ok(port) => return Ok(port),
+                Err(e) if e.is_exhaustion() => {
+                    // The address came fresh out of the pool, so what leaves it with no port is
+                    // almost always fixed for the life of the pool: every port it has is spoken
+                    // for by port forwarding, or by the well-known range. Take it out instead of
+                    // handing it back, or the next allocation stops on it again and the pool
+                    // serves nothing for as long as the address is the lowest one free.
+                    //
+                    // Almost always, because the address joins the in-use list before this runs,
+                    // so another thread could in principle take its every port in between. Losing
+                    // an address that way costs capacity rather than correctness, and needs 64k
+                    // allocations to land in the window.
+                    //
+                    // The allocation attempt consumed the only strong reference we held, so the
+                    // address is already back in the pool by now and taking it out is what sticks.
+                    debug!("Address {address} has no port to give and is taken out of the pool");
+                    self.retire_ip(address);
+                    exhausted = Some(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        // Addresses are only ever tried once, since a useless one is taken out as it is found, so
+        // stopping here spreads the discovery of a large claimed range over several packets rather
+        // than doing all of it on one.
+        Err(exhausted.unwrap_or(AllocatorError::NoFreeIp))
     }
 
     fn cleanup_used_ips(&self) {
@@ -456,6 +500,16 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             randomize,
             self.exclude_wellknown_ports,
         ))
+    }
+
+    // Mark an address used and never give it back, for an address that can never serve.
+    fn retire_from_pool(&mut self, ip: I) {
+        match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
+            Ok(offset) => {
+                self.bitmap.set_ip_allocated(offset);
+            }
+            Err(e) => error!("Address {ip} cannot be retired from its pool: {e}"),
+        }
     }
 
     fn deallocate_from_pool(&mut self, ip: I) {

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -94,8 +94,11 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
                         outcome = Ok(port);
                         break;
                     }
-                    // If there is no free port left, loop again to try another IP address
-                    Err(AllocatorError::NoFreePort(_)) => {}
+                    // This address has nothing left, whether it ran out of ports in a block or of
+                    // blocks altogether. Either way the next address in hand may still have room,
+                    // and giving up here would draw a fresh address while those sat with ports to
+                    // spare.
+                    Err(e) if e.is_exhaustion() => {}
                     Err(e) => {
                         outcome = Err(e);
                         break;

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -184,7 +184,8 @@ impl Published {
         generation: u64,
         survivors: &[(usize, Ipv4Addr, NatPort)],
     ) -> Self {
-        let pools = pool_sets_for_specs::<Ipv4Addr>(specs, NextHeader::TCP, false);
+        let pools =
+            pool_sets_for_specs::<Ipv4Addr>(specs, &PrefixPortsSet::new(), NextHeader::TCP, false);
         let mut carried = BTreeSet::new();
         let mut reservations = Vec::new();
 
@@ -266,7 +267,6 @@ impl Scenario {
                         AddrInterval::new(BASE + start, BASE + end)
                     })
                     .collect(),
-                reserved: PrefixPortsSet::new(),
                 idle_timeout: IDLE_TIMEOUT,
             })
             .collect()
@@ -278,7 +278,8 @@ impl Scenario {
         let specs = self.specs();
 
         // The flows that already exist when the config change arrives.
-        let initial = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+        let initial =
+            pool_sets_for_specs::<Ipv4Addr>(&specs, &PrefixPortsSet::new(), NextHeader::TCP, false);
         let mut existing = Vec::new();
         let mut survivors = Vec::new();
         for (owner, pool) in initial.iter().enumerate() {
@@ -459,11 +460,11 @@ fn printing_the_pool_does_not_wedge_it_against_a_flow_ending() {
         let specs = vec![PoolSpec {
             // One address, so the flow that ends is the last holder of the one being printed.
             public_ranges: vec![AddrInterval::new(BASE, BASE)],
-            reserved: PrefixPortsSet::new(),
             idle_timeout: IDLE_TIMEOUT,
         }];
         let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
             &specs,
+            &PrefixPortsSet::new(),
             NextHeader::TCP,
             false,
         ));

--- a/nat/src/masquerade/apalloc/display.rs
+++ b/nat/src/masquerade/apalloc/display.rs
@@ -117,7 +117,7 @@ where
     I: NatIpWithBitmap + Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        if let Some(reserved) = self.reserved_prefixes_ports() {
+        if let Some(reserved) = self.reserved_ports() {
             writeln!(f, "reserved ranges:")?;
             for (ips, ports) in reserved {
                 writeln!(with_indent!(f), "{ips}:{ports}")?;
@@ -164,8 +164,12 @@ where
     I: NatIpWithBitmap + Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        if let Some(reserved) = self.reserved_port_range() {
-            writeln!(f, "reserved port range: {reserved}")?;
+        let reserved = self.reserved_ports();
+        if !reserved.is_empty() {
+            writeln!(f, "reserved port ranges:")?;
+            for ports in reserved.iter() {
+                writeln!(with_indent!(f), "{ports}")?;
+            }
         }
 
         writeln!(f, "allocated ports:")?;

--- a/nat/src/masquerade/apalloc/mod.rs
+++ b/nat/src/masquerade/apalloc/mod.rs
@@ -103,6 +103,7 @@ mod natip_with_bitmap;
 mod pool_fuzz;
 mod port_alloc;
 mod region;
+mod reserved;
 mod setup;
 mod test_alloc;
 

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -88,7 +88,6 @@ impl Config {
             .into_iter()
             .map(|public_ranges| PoolSpec {
                 public_ranges,
-                reserved: PrefixPortsSet::new(),
                 idle_timeout: IDLE_TIMEOUT,
             })
             .collect()
@@ -96,7 +95,12 @@ impl Config {
 
     fn pool_sets(&self) -> Vec<PoolSet<Ipv4Addr>> {
         // No randomization: a failure has to reproduce from its seed alone.
-        pool_sets_for_specs::<Ipv4Addr>(&self.specs(), NextHeader::TCP, false)
+        pool_sets_for_specs::<Ipv4Addr>(
+            &self.specs(),
+            &PrefixPortsSet::new(),
+            NextHeader::TCP,
+            false,
+        )
     }
 
     fn owner_count(&self) -> usize {
@@ -278,11 +282,11 @@ fn an_exhausted_region_falls_through_to_the_next() {
 
     let specs = vec![PoolSpec {
         public_ranges: vec![AddrInterval::new(full, full), AddrInterval::new(free, free)],
-        reserved: [every_port].into_iter().collect(),
         idle_timeout: IDLE_TIMEOUT,
     }];
 
-    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+    let claimed = PrefixPortsSet::from([every_port]);
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
     let allocation = pool_sets[0]
         .allocate(false)
         .expect("the second region has room, so allocation must succeed");
@@ -307,10 +311,10 @@ fn an_address_past_the_indexable_span_is_refused_rather_than_panicking() {
     // Far wider than the bitmap can index.
     let specs = vec![PoolSpec {
         public_ranges: vec![AddrInterval::new(start, start + (1u128 << 40))],
-        reserved: PrefixPortsSet::new(),
         idle_timeout: IDLE_TIMEOUT,
     }];
-    let pool_sets = pool_sets_for_specs::<Ipv6Addr>(&specs, NextHeader::TCP, false);
+    let pool_sets =
+        pool_sets_for_specs::<Ipv6Addr>(&specs, &PrefixPortsSet::new(), NextHeader::TCP, false);
     let port = NatPort::new_port_checked(4096).unwrap_or_else(|_| unreachable!());
 
     // Just inside the indexable span: an ordinary carry-over, which must still work.
@@ -337,10 +341,10 @@ fn ipv6_pools_allocate_within_their_range() {
     let end = start + 3;
     let specs = vec![PoolSpec {
         public_ranges: vec![AddrInterval::new(start, end)],
-        reserved: PrefixPortsSet::new(),
         idle_timeout: IDLE_TIMEOUT,
     }];
-    let pool_sets = pool_sets_for_specs::<Ipv6Addr>(&specs, NextHeader::TCP, false);
+    let pool_sets =
+        pool_sets_for_specs::<Ipv6Addr>(&specs, &PrefixPortsSet::new(), NextHeader::TCP, false);
 
     let mut held = Vec::new();
     let mut seen = BTreeSet::new();
@@ -437,14 +441,20 @@ impl ReservedConfig {
             .config
             .owner_ranges()
             .into_iter()
-            .zip(&self.reservations)
-            .map(|(public_ranges, claims)| PoolSpec {
+            .map(|public_ranges| PoolSpec {
                 public_ranges,
-                reserved: claims.iter().map(|claim| claim.as_prefix()).collect(),
                 idle_timeout: IDLE_TIMEOUT,
             })
             .collect();
-        pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false)
+        // A claim binds the public space towards a peer, whichever expose declared it, so the
+        // claims of every expose apply to every pool built over that space.
+        let claimed: PrefixPortsSet = self
+            .reservations
+            .iter()
+            .flatten()
+            .map(|claim| claim.as_prefix())
+            .collect();
+        pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false)
     }
 }
 
@@ -456,8 +466,8 @@ impl ReservedConfig {
 /// would hand out a port that port forwarding is statically mapping elsewhere.
 ///
 /// This is a property of the pools, which are given claims already expressed in public space.
-/// Computing those claims from the configuration is a separate step, and gets the address space
-/// wrong; see the note on `find_masquerade_portfw_overlap`.
+/// Translating a configuration into those claims is a separate step, covered by the tests on
+/// `ReserveSets` in `setup.rs` and end to end by `test_forwarded_ports_are_not_masqueraded_onto`.
 #[test]
 fn reserved_ports_are_never_allocated() {
     bolero::check!()
@@ -507,11 +517,11 @@ fn several_claims_on_one_address_are_all_honoured() {
 
     let specs = vec![PoolSpec {
         public_ranges: vec![AddrInterval::new(address, address)],
-        reserved: [claim(1024, 1024), claim(2000, 2000)].into_iter().collect(),
         idle_timeout: IDLE_TIMEOUT,
     }];
 
-    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+    let claimed = PrefixPortsSet::from([claim(1024, 1024), claim(2000, 2000)]);
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
     let allocated: BTreeSet<u16> = allocate_round_robin(&pool_sets, 4)
         .iter()
         .map(|(_, allocation)| allocation.port().as_u16())

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -455,32 +455,27 @@ impl ReservedConfig {
 /// through one expose still has to hold against an allocation made through another, or masquerade
 /// would hand out a port that port forwarding is statically mapping elsewhere.
 ///
-/// # Ignored: this does not hold today
-///
-/// A pool keeps at most one reserved port range per public address, so several claims on one
-/// address collapse to whichever was recorded last and the rest are silently handed out. See
-/// [`several_claims_on_one_address_are_all_honoured`] for the minimal case, and the note there for
-/// the two places that need to change. Unignore both once they do.
-#[ignore = "a pool holds one reserved port range per address; see several_claims_on_one_address_are_all_honoured"]
+/// This is a property of the pools, which are given claims already expressed in public space.
+/// Computing those claims from the configuration is a separate step, and gets the address space
+/// wrong; see the note on `find_masquerade_portfw_overlap`.
 #[test]
 fn reserved_ports_are_never_allocated() {
     bolero::check!()
         .with_type()
         .cloned()
         .for_each(|reserved_config: ReservedConfig| {
-            let ranges = reserved_config.config.owner_ranges();
             let pool_sets = reserved_config.pool_sets();
 
             for (owner, allocation) in allocate_round_robin(&pool_sets, ALLOCATIONS) {
                 let ip = allocation.ip();
                 let port = allocation.port().as_u16();
 
-                // Every expose that declares this address shares the region it came from, so its
-                // claims apply to this allocation too.
+                // A claim binds the public space it names, whoever made it. The pool is built
+                // from the union of every claim, so the oracle unions them too: gating on the
+                // claimant's own ranges here would let a claim made through one expose go
+                // unchecked against an allocation made through another, which is the case the
+                // property exists to state.
                 for (claimant, claims) in reserved_config.reservations.iter().enumerate() {
-                    if !declares(&ranges[claimant], ip) {
-                        continue;
-                    }
                     for claim in claims {
                         assert!(
                             !claim.covers(ip, port),
@@ -495,23 +490,11 @@ fn reserved_ports_are_never_allocated() {
 }
 
 /// The minimal shape behind [`reserved_ports_are_never_allocated`]: one public address carrying
-/// two port-forwarding claims.
+/// two port-forwarding claims, both of which have to be honoured.
 ///
-/// # Ignored: this does not hold today
-///
-/// `build_reserved_prefixes_ports` records the claims in a `DisjointRangesBTreeMap` keyed by
-/// address range, so two claims on one address are inserted under the same key and the second
-/// replaces the first. Even with that fixed, `NatPool::use_new_ip` resolves a single
-/// `Option<PortRange>` per address and `PortAllocator` stores one `reserved_port_range`, so the
-/// data model cannot hold more than one claim per address either. Both need to take a set of
-/// ranges.
-///
-/// This is not a consequence of allocating from regions; the same collapse existed when each
-/// expose had its own pool. It stays latent in production only because the claims are currently
-/// computed from private prefixes and never match the public address they are looked up by, which
-/// is the separate defect noted on `find_masquerade_portfw_overlap`. Fixing that without fixing
-/// this would turn an inert path into a wrong one.
-#[ignore = "a pool holds one reserved port range per address, so the earlier claim is dropped"]
+/// This used to hold only the last claim recorded on an address, at three points in a row: the
+/// claims were collected into a map keyed by address range, the pool resolved one range per
+/// address out of it, and the port allocator stored one range. Each now carries the whole set.
 #[test]
 fn several_claims_on_one_address_are_all_honoured() {
     let address: u128 = BASE;

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -298,6 +298,130 @@ fn an_exhausted_region_falls_through_to_the_next() {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Exhaustion
+///////////////////////////////////////////////////////////////////////////////
+
+// Claiming every port masquerade could hand out on an address, which is how a test reaches
+// address exhaustion without making 64k allocations.
+fn claim_whole_address(offset: u128) -> PrefixWithOptionalPorts {
+    let address = Ipv4Addr::from(u32::try_from(BASE + offset).unwrap_or_else(|_| unreachable!()));
+    PrefixWithOptionalPorts::new(
+        format!("{address}/32").as_str().into(),
+        Some(PortRange::new(1024, u16::MAX).unwrap_or_else(|_| unreachable!())),
+    )
+}
+
+/// An address with nothing left to give is passed over, and the next one serves.
+///
+/// Allocation draws the lowest free address and, finding no port on it, used to hand it straight
+/// back. The same address was lowest next time, so the pool served nothing at all for as long as
+/// it stayed there: one address fully claimed by port forwarding took a whole region out of
+/// service. Claims on a later address never showed it, since allocation stopped before reaching
+/// them.
+#[test]
+fn an_address_with_no_free_port_is_passed_over() {
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(BASE, BASE + 2)],
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let claimed = PrefixPortsSet::from([claim_whole_address(0)]);
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+
+    // Repeatedly, so that an address taken out of the pool stays out.
+    let mut held = Vec::new();
+    for _ in 0..4 {
+        let allocation = pool_sets[0]
+            .allocate(false)
+            .expect("two addresses of the region are free");
+        assert_ne!(
+            allocation.ip(),
+            Ipv4Addr::from(u32::try_from(BASE).unwrap()),
+            "an address whose ports are all claimed was handed out"
+        );
+        held.push(allocation);
+    }
+}
+
+/// With every address claimed the pool has nothing to give, and says so rather than looping.
+#[test]
+fn a_fully_claimed_region_reports_exhaustion() {
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(BASE, BASE + 2)],
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let claimed: PrefixPortsSet = (0..3).map(claim_whole_address).collect();
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+
+    let error = pool_sets[0]
+        .allocate(false)
+        .expect_err("no address in the region can serve");
+    assert!(
+        error.is_exhaustion(),
+        "a region with nothing to give reported {error} rather than being out of space"
+    );
+}
+
+/// An expose falls through to a region it shares once the region it has to itself is used up.
+///
+/// The ordinary tests never reach this: a region is only given up when every port of every address
+/// in it is taken, and allocation stays on one address for 64k ports, so a handful of allocations
+/// never leaves the first address of the first region. Claiming the exclusive region away is how
+/// the fallback gets exercised at all.
+#[test]
+fn an_expose_falls_back_to_shared_space_when_its_own_is_used_up() {
+    // Owner 0 has BASE..=BASE+1 to itself and shares BASE+2 with owner 1.
+    let specs = vec![
+        PoolSpec {
+            public_ranges: vec![AddrInterval::new(BASE, BASE + 2)],
+            idle_timeout: IDLE_TIMEOUT,
+        },
+        PoolSpec {
+            public_ranges: vec![AddrInterval::new(BASE + 2, BASE + 2)],
+            idle_timeout: IDLE_TIMEOUT,
+        },
+    ];
+    // Claim the exclusive region away, leaving owner 0 only the shared one.
+    let claimed: PrefixPortsSet = (0..2).map(claim_whole_address).collect();
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+
+    let allocation = pool_sets[0]
+        .allocate(false)
+        .expect("the shared region still has room");
+    assert_eq!(
+        allocation.ip(),
+        Ipv4Addr::from(u32::try_from(BASE + 2).unwrap()),
+        "the expose did not fall back to the region it shares"
+    );
+}
+
+/// Addresses are used up in turn, and every address of a region is reachable.
+///
+/// Claims stand in for the 64k allocations it would otherwise take to move off an address, so the
+/// walk over addresses is exercised at every depth rather than only at the first one.
+#[test]
+fn every_address_of_a_region_can_be_reached() {
+    const ADDRESSES: u128 = 6;
+    for claimed_count in 0..ADDRESSES {
+        let specs = vec![PoolSpec {
+            public_ranges: vec![AddrInterval::new(BASE, BASE + ADDRESSES - 1)],
+            idle_timeout: IDLE_TIMEOUT,
+        }];
+        // Claim a prefix of the region away, so the first address left is the one after it.
+        let claimed: PrefixPortsSet = (0..claimed_count).map(claim_whole_address).collect();
+        let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+
+        let allocation = pool_sets[0].allocate(false).unwrap_or_else(|e| {
+            panic!("{claimed_count} addresses claimed, allocation failed: {e}")
+        });
+        assert_eq!(
+            allocation.ip(),
+            Ipv4Addr::from(u32::try_from(BASE + claimed_count).unwrap()),
+            "with {claimed_count} addresses claimed the next one should serve"
+        );
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // IPv6
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -421,6 +421,56 @@ fn every_address_of_a_region_can_be_reached() {
     }
 }
 
+/// An address that still has room is reused, rather than a fresh one being drawn.
+///
+/// Reuse walks the addresses already in hand and skips those with nothing left. The skip is
+/// decided by a count of blocks still free, and a block that port forwarding has claimed used to
+/// be marked unusable without being taken off that count. The count then said an address had room
+/// when it had none; the attempt failed with "no port block", and the walk gave up on that error
+/// rather than trying the next address in hand. Every allocation after that drew a fresh address
+/// while addresses already in hand sat with tens of thousands of free ports, until the region ran
+/// out of addresses altogether.
+#[test]
+fn an_address_with_room_is_reused_before_a_fresh_one_is_drawn() {
+    const ADDRESSES: u128 = 4;
+    // Everything above the first block, so the first address has exactly one block: 1024..=1279.
+    let claim = PrefixWithOptionalPorts::new(
+        format!("{}/32", Ipv4Addr::from(u32::try_from(BASE).unwrap()))
+            .as_str()
+            .into(),
+        Some(PortRange::new(1280, u16::MAX).unwrap_or_else(|_| unreachable!())),
+    );
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(BASE, BASE + ADDRESSES - 1)],
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(
+        &specs,
+        &PrefixPortsSet::from([claim]),
+        NextHeader::TCP,
+        false,
+    );
+
+    // One block on the first address, then a handful more that the second address can serve
+    // many times over.
+    let mut held = Vec::new();
+    let mut used = BTreeSet::new();
+    for step in 0..(256 + 4) {
+        let allocation = pool_sets[0]
+            .allocate(false)
+            .unwrap_or_else(|e| panic!("allocation {step} failed: {e}"));
+        used.insert(allocation.ip());
+        held.push(allocation);
+    }
+
+    assert_eq!(
+        used.len(),
+        2,
+        "the region spent {} addresses on what two can serve: {used:?}",
+        used.len()
+    );
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // IPv6
 ///////////////////////////////////////////////////////////////////////////////

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -19,7 +19,7 @@
 
 #![cfg(test)]
 
-use super::alloc::PoolSet;
+use super::alloc::{MAX_ADDRESSES_PER_ALLOCATION, PoolSet};
 use super::region::AddrInterval;
 use super::setup::{PoolSpec, pool_sets_for_specs};
 use crate::masquerade::allocation::AllocatorError;
@@ -114,6 +114,10 @@ fn bits(ip: Ipv4Addr) -> u128 {
 
 fn declares(ranges: &[AddrInterval], ip: Ipv4Addr) -> bool {
     ranges.iter().any(|range| range.contains(bits(ip)))
+}
+
+fn port(value: u16) -> NatPort {
+    NatPort::new_port_checked(value).unwrap_or_else(|_| unreachable!())
 }
 
 /// Allocate round-robin across the exposes, holding every allocation so nothing is freed and
@@ -419,6 +423,93 @@ fn every_address_of_a_region_can_be_reached() {
             "with {claimed_count} addresses claimed the next one should serve"
         );
     }
+}
+
+/// A run of claimed addresses costs nothing, however long it is.
+///
+/// Allocation draws the lowest free address, so a port-forwarded prefix at the bottom of a region
+/// is what it meets first. Those addresses used to sit in the pool and be discovered one at a
+/// time, and since an allocation gives up after `MAX_ADDRESSES_PER_ALLOCATION` of them, a run shed
+/// a dropped packet for every bound's worth -- sixteen for a claimed `/25` -- and shed them again
+/// after every config change. They are excluded when the pool is built now.
+#[test]
+fn a_run_of_claimed_addresses_costs_no_allocations() {
+    let bound = u128::try_from(MAX_ADDRESSES_PER_ALLOCATION).unwrap_or_else(|_| unreachable!());
+
+    // Around the old cliff, and then well past it: the last of these used to cost three packets.
+    for claimed_count in [0, 1, bound - 1, bound, bound + 1, 3 * bound + 5] {
+        let specs = vec![PoolSpec {
+            // One address past the claimed run, which is the one that has to serve.
+            public_ranges: vec![AddrInterval::new(BASE, BASE + claimed_count)],
+            idle_timeout: IDLE_TIMEOUT,
+        }];
+        let claimed: PrefixPortsSet = (0..claimed_count).map(claim_whole_address).collect();
+        let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+
+        let allocation = pool_sets[0].allocate(false).unwrap_or_else(|e| {
+            panic!("a run of {claimed_count} claimed addresses cost the first allocation: {e}")
+        });
+        assert_eq!(
+            allocation.ip(),
+            Ipv4Addr::from(u32::try_from(BASE + claimed_count).unwrap_or_else(|_| unreachable!())),
+            "the address past a run of {claimed_count} claimed ones should be the one that serves"
+        );
+    }
+}
+
+/// An address the pool may never draw is not put into it by a flow that fails to carry over.
+///
+/// Reserving reaches addresses allocation never touches. A flow that survives a config change
+/// presents the address it already holds, and the pool takes that address into use in order to try
+/// to give the port back. Where the new configuration has claimed every port on it the reservation
+/// fails, as it must -- but the address has been through the pool by then, and releasing it on the
+/// way out used to hand it to the bitmap. The exclusion would undo itself on the first config
+/// change that needed it, which is also the first one that could produce such a flow.
+#[test]
+fn a_failed_carry_over_does_not_put_a_claimed_address_into_the_pool() {
+    const ADDRESSES: u128 = 4;
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(BASE, BASE + ADDRESSES - 1)],
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    // The lowest two addresses are claimed end to end, so neither may ever be handed out.
+    let claimed: PrefixPortsSet = (0..2).map(claim_whole_address).collect();
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, &claimed, NextHeader::TCP, false);
+    let claimed_address = Ipv4Addr::from(u32::try_from(BASE).unwrap_or_else(|_| unreachable!()));
+
+    let free_offsets = || {
+        let region = pool_sets[0]
+            .regions()
+            .next()
+            .expect("the specs describe one region");
+        let (bitmap, _) = region.allocator().get_pool_clone_for_tests();
+        bitmap
+    };
+    assert!(
+        !free_offsets().contains(claimed_address.to_bits()),
+        "a fully claimed address was in the pool to begin with"
+    );
+
+    // Carry a flow over onto it. Refused, and the address goes back where it came from.
+    assert!(
+        pool_sets[0].reserve(claimed_address, port(5000)).is_err(),
+        "a port on a fully claimed address was carried over"
+    );
+
+    assert!(
+        !free_offsets().contains(claimed_address.to_bits()),
+        "a fully claimed address was put into the pool by a carry-over that failed on it"
+    );
+
+    // And allocation still goes straight to the first address that can serve.
+    let allocation = pool_sets[0]
+        .allocate(false)
+        .expect("the region has addresses that can serve");
+    assert_eq!(
+        allocation.ip(),
+        Ipv4Addr::from(u32::try_from(BASE + 2).unwrap_or_else(|_| unreachable!())),
+        "allocation did not go straight past the claimed addresses"
+    );
 }
 
 /// An address that still has room is reused, rather than a fresh one being drawn.

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -10,7 +10,7 @@
 
 use super::NatIpWithBitmap;
 use super::alloc::AllocatedIp;
-use super::reserved::PortClaims;
+use super::reserved::{IANA_WELLKNOWN_PORT_LIMIT, PortClaims};
 use crate::masquerade::allocation::AllocatorError;
 use crate::port::NatPort;
 use concurrency::concurrency_mode;
@@ -90,10 +90,6 @@ pub(crate) struct PortAllocator<I: NatIpWithBitmap> {
     exclude_wellknown_ports: bool,
 }
 
-/// Ports 0..=1023 cover the IANA system/well-known range and should not be
-/// allocated by masquerade NAT for TCP or UDP.
-const IANA_WELLKNOWN_PORT_LIMIT: u16 = 1024;
-
 impl<I: NatIpWithBitmap> PortAllocator<I> {
     pub(crate) fn new(
         reserved_ports: PortClaims,
@@ -116,9 +112,7 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
             // well-known range (0-1023) for TCP and UDP, and any block port forwarding has claimed
             // in full. Deciding this once, here, is what keeps the count of usable blocks honest:
             // a block ruled out later would be marked non-free without ever being counted out.
-            if (exclude_wellknown_ports && base < IANA_WELLKNOWN_PORT_LIMIT)
-                || (!reserved_ports.is_empty() && reserved_ports.covers_block(base))
-            {
+            if reserved_ports.block_is_unusable(base, exclude_wellknown_ports) {
                 block
                     .free
                     .store(false, concurrency::sync::atomic::Ordering::Relaxed);
@@ -359,8 +353,8 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
     // recognized here is taken for a live allocation that has gone missing.
     fn block_is_excluded(&self, port: NatPort) -> bool {
         let base = (port.as_u16() / 256) * 256;
-        (self.exclude_wellknown_ports && base < IANA_WELLKNOWN_PORT_LIMIT)
-            || self.reserved_ports.covers_block(base)
+        self.reserved_ports
+            .block_is_unusable(base, self.exclude_wellknown_ports)
     }
 
     fn find_block_for_port(

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -10,6 +10,7 @@
 
 use super::NatIpWithBitmap;
 use super::alloc::AllocatedIp;
+use super::reserved::PortClaims;
 use crate::masquerade::allocation::AllocatorError;
 use crate::port::NatPort;
 use concurrency::concurrency_mode;
@@ -85,7 +86,7 @@ pub(crate) struct PortAllocator<I: NatIpWithBitmap> {
     current_alloc_index: AtomicUsize,
     thread_blocks: ThreadPortMap,
     allocated_blocks: AllocatedPortBlockMap<I>,
-    reserved_port_range: Option<PortRange>,
+    reserved_ports: PortClaims,
     exclude_wellknown_ports: bool,
 }
 
@@ -98,7 +99,7 @@ const IANA_WELLKNOWN_BLOCKS: u16 = IANA_WELLKNOWN_PORT_LIMIT / 256;
 
 impl<I: NatIpWithBitmap> PortAllocator<I> {
     pub(crate) fn new(
-        reserved_port_range: Option<PortRange>,
+        reserved_ports: PortClaims,
         randomize: bool,
         exclude_wellknown_ports: bool,
     ) -> Self {
@@ -133,17 +134,17 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
             current_alloc_index: AtomicUsize::new(0),
             thread_blocks: ThreadPortMap::new(),
             allocated_blocks: AllocatedPortBlockMap::new(),
-            reserved_port_range,
+            reserved_ports,
             exclude_wellknown_ports,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn new_no_randomness(
-        reserved_port_range: Option<PortRange>,
+        reserved_ports: PortClaims,
         exclude_wellknown_ports: bool,
     ) -> Self {
-        Self::new(reserved_port_range, false, exclude_wellknown_ports)
+        Self::new(reserved_ports, false, exclude_wellknown_ports)
     }
 
     #[concurrency_mode(std)]
@@ -227,25 +228,11 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
                     return false;
                 }
 
-                // Check if this block is fully contained in the reserved range
-                if let Some(reserved_range) = self.reserved_port_range
-                    && reserved_range.len() >= 255
-                {
-                    // Corner case: reserved_range is 1-255+, but 0 cannot be allocated so
-                    // reserved_range effectively renders the block unusable (except maybe for ICMP
-                    // but never mind)
-                    let adjusted_reserved_range = if reserved_range.start() == 1 {
-                        PortRange::new(0, reserved_range.end()).unwrap_or_else(|_| unreachable!())
-                    } else {
-                        reserved_range
-                    };
-
-                    let block_range = PortRange::from(*block);
-                    if adjusted_reserved_range.covers(block_range) {
-                        return false;
-                    }
-                }
-                true
+                // Skip a block port forwarding has claimed in full: there is nothing left in it to
+                // hand out. Several claims may cover a block between them while no single one of
+                // them does, so this asks the claims as a whole rather than testing them one by
+                // one.
+                !self.reserved_ports.covers_block(block.to_port_number())
             })
             .ok_or(AllocatorError::NoPortBlock)?;
         Ok((index, block.to_port_number()))
@@ -269,20 +256,12 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         self.usable_blocks
             .fetch_sub(1, concurrency::sync::atomic::Ordering::Relaxed);
 
-        let reserved_port_range_for_block = self.reserved_port_range.and_then(|range| {
-            range.intersection(
-                PortRange::new(base_port_index, base_port_index + 255)
-                    .unwrap_or_else(|_| unreachable!()),
-            )
-        });
+        // Clip the claims to this block before they reach its bitmap, which indexes ports modulo
+        // 256 and cannot represent a range reaching past the block's end.
+        let reserved_for_block: Vec<PortRange> =
+            self.reserved_ports.within_block(base_port_index).collect();
 
-        AllocatedPortBlock::new(
-            ip,
-            index,
-            base_port_index,
-            reserved_port_range_for_block,
-            allow_null,
-        )
+        AllocatedPortBlock::new(ip, index, base_port_index, &reserved_for_block, allow_null)
     }
 
     pub(crate) fn allocate_port(
@@ -341,11 +320,16 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
     ) -> Result<Arc<AllocatedPortBlock<I>>, AllocatorError> {
         self.usable_blocks
             .fetch_sub(1, concurrency::sync::atomic::Ordering::Relaxed);
+        let base_port_index = (port.as_u16() / 256) * 256; // discard the offset within the block
+        // A block entering the allocator through a reservation serves later allocations like any
+        // other, so it carries the same claims, clipped to it.
+        let reserved_for_block: Vec<PortRange> =
+            self.reserved_ports.within_block(base_port_index).collect();
         let block = Arc::new(AllocatedPortBlock::new(
             ip,
             index,
-            (port.as_u16() / 256) * 256, // port block base index, discard offset within block
-            None,
+            base_port_index,
+            &reserved_for_block,
             allow_null,
         )?);
         self.allocated_blocks
@@ -391,8 +375,8 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         block.reserve_port_from_block(port)
     }
 
-    pub(crate) fn reserved_port_range(&self) -> Option<PortRange> {
-        self.reserved_port_range
+    pub(crate) fn reserved_ports(&self) -> &PortClaims {
+        &self.reserved_ports
     }
 
     // Used for Display
@@ -427,7 +411,7 @@ impl<I: NatIpWithBitmap> AllocatedPortBlock<I> {
         ip: Arc<AllocatedIp<I>>,
         index: usize,
         base_port_idx: u16,
-        reserved_port_range: Option<PortRange>,
+        reserved_ports: &[PortRange],
         allow_null: bool,
     ) -> Result<Self, AllocatorError> {
         let block = Self {
@@ -438,8 +422,7 @@ impl<I: NatIpWithBitmap> AllocatedPortBlock<I> {
         };
         // Port 0 may be reserved, in which case we don't want to use it, so we mark it as not free.
         let reserve_zero = !allow_null && block.base_port_idx == 0;
-        let reserve_range = reserved_port_range.is_some();
-        if reserve_zero || reserve_range {
+        if reserve_zero || !reserved_ports.is_empty() {
             let mut mutex_guard = block.usage_bitmap.lock();
             if reserve_zero {
                 mutex_guard.reserve_port_from_bitmap(0).map_err(|()| {
@@ -448,12 +431,11 @@ impl<I: NatIpWithBitmap> AllocatedPortBlock<I> {
                     )
                 })?;
             }
-            if reserve_range {
+            // Reserving in the bitmap is an OR, so claims that overlap each other, or that
+            // overlap port 0 reserved just above, are harmless in any order.
+            for claim in reserved_ports {
                 mutex_guard
-                    .reserve_port_range_from_bitmap(
-                        // We just check that reserved_port_range.is_some()
-                        reserved_port_range.unwrap_or_else(|| unreachable!()),
-                    )
+                    .reserve_port_range_from_bitmap(*claim)
                     .map_err(|()| {
                         AllocatorError::InternalIssue(
                             "Failed to reserve port range from new block".to_string(),
@@ -1257,7 +1239,7 @@ mod tests {
 
     #[test]
     fn pick_available_block_no_reserved_range() {
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(None, false);
+        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(PortClaims::default(), false);
         let (index, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(index, 0);
         assert_eq!(base_port, 0);
@@ -1267,7 +1249,8 @@ mod tests {
     fn pick_available_block_reserved_range_covers_first_block() {
         // Reserve 0..=255 (entire first block) → should skip to block 1 (ports 256-511)
         let reserved = PortRange::new(0, 255).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         let (index, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(index, 1);
         assert_eq!(base_port, 256);
@@ -1279,7 +1262,8 @@ mod tests {
         // be allocated anyway, so the block is effectively unusable. The code adjusts the
         // reserved range to start at 0, causing the block to be skipped.
         let reserved = PortRange::new(1, 255).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         let (index, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(index, 1);
         assert_eq!(base_port, 256);
@@ -1289,7 +1273,8 @@ mod tests {
     fn pick_available_block_reserved_range_covers_multiple_blocks() {
         // Reserve 0..=511 (first two blocks) → should skip to block 2 (ports 512-767)
         let reserved = PortRange::new(0, 511).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         let (index, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(index, 2);
         assert_eq!(base_port, 512);
@@ -1299,7 +1284,8 @@ mod tests {
     fn pick_available_block_reserved_range_does_not_cover_other_blocks() {
         // Reserve 0..=255 only covers block 0, block 1 is unaffected
         let reserved = PortRange::new(0, 255).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         // First pick skips block 0, gets block 1
         let (_, base_port1) = allocator.pick_available_block().unwrap();
         assert_eq!(base_port1, 256);
@@ -1313,7 +1299,8 @@ mod tests {
         // Reserve 1..=200 (len 200 < 255) → block is NOT skipped entirely, individual ports
         // are reserved within the block instead
         let reserved = PortRange::new(1, 200).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         let (index, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(index, 0);
         assert_eq!(base_port, 0);
@@ -1323,7 +1310,8 @@ mod tests {
     fn pick_available_block_reserved_middle_block() {
         // Reserve 256..=511 (block 1 only) → block 0 is fine, block 1 is skipped
         let reserved = PortRange::new(256, 511).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         // First pick: block 0
         let (_, base_port1) = allocator.pick_available_block().unwrap();
         assert_eq!(base_port1, 0);
@@ -1336,7 +1324,8 @@ mod tests {
     fn pick_available_block_all_blocks_reserved() {
         // Reserve 0..=65535 (all blocks) → NoPortBlock error
         let reserved = PortRange::new(0, 65535).unwrap();
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), false);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), false);
         assert!(allocator.pick_available_block().is_err());
     }
 
@@ -1467,7 +1456,7 @@ mod tests {
     fn exclude_wellknown_ports_first_available_block_is_1024() {
         // With no randomness and IANA exclusion, blocks 0-3 (ports 0-1023) are pre-marked
         // non-free, so the first block handed out should start at port 1024.
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(None, true);
+        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(PortClaims::default(), true);
         let (_, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(base_port, 1024);
     }
@@ -1476,7 +1465,7 @@ mod tests {
     fn exclude_wellknown_ports_all_252_blocks_are_above_1023() {
         // Exactly 252 blocks (256 - 4 IANA blocks) should be allocatable; every one should
         // start at port >= 1024. The 253rd attempt should fail with NoPortBlock.
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(None, true);
+        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(PortClaims::default(), true);
         for _ in 0..252 {
             let (_, base_port) = allocator.pick_available_block().unwrap();
             assert!(
@@ -1490,7 +1479,7 @@ mod tests {
     #[test]
     fn exclude_wellknown_ports_disabled_starts_at_port_zero() {
         // Sanity check: without the flag, block 0 (port 0) is returned first.
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(None, false);
+        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(PortClaims::default(), false);
         let (_, base_port) = allocator.pick_available_block().unwrap();
         assert_eq!(base_port, 0);
     }
@@ -1498,7 +1487,8 @@ mod tests {
     #[test]
     fn exclude_wellknown_ports_combined_with_reserved_range() {
         let reserved = PortRange::new(2048, 2303).unwrap(); // entire block 8
-        let allocator = PortAllocator::<Ipv4Addr>::new_no_randomness(Some(reserved), true);
+        let allocator =
+            PortAllocator::<Ipv4Addr>::new_no_randomness([reserved].into_iter().collect(), true);
 
         let (_, b0) = allocator.pick_available_block().unwrap();
         assert_eq!(b0, 1024); // block 4

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -352,6 +352,17 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         Ok(block)
     }
 
+    // Whether the block holding this port is one masquerade may never draw from, and so was marked
+    // non-free when the allocator was built without ever having been allocated.
+    //
+    // Mirrors the condition in `new`, and has to keep mirroring it: a block ruled out there but not
+    // recognized here is taken for a live allocation that has gone missing.
+    fn block_is_excluded(&self, port: NatPort) -> bool {
+        let base = (port.as_u16() / 256) * 256;
+        (self.exclude_wellknown_ports && base < IANA_WELLKNOWN_PORT_LIMIT)
+            || self.reserved_ports.covers_block(base)
+    }
+
     fn find_block_for_port(
         &self,
         ip: Arc<AllocatedIp<I>>,
@@ -362,16 +373,30 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         if block_was_free {
             return self.allocate_block_for_reservation(ip, index, port, allow_null);
         }
-        self.allocated_blocks
-            .search_for_block(port)
-            // Block was not free but is not in the list of allocated blocks either??
-            //
-            // FIXME: This can legitimately happen if the block was released just after we checked
-            // whether it was free? (Not observed in shuttle tests so far.) Do we need an additional
-            // lock around the PortAllocator?
-            .ok_or(AllocatorError::InternalIssue(
-                "Block not free, although absent from list of allocated blocks".to_string(),
-            ))
+        if let Some(block) = self.allocated_blocks.search_for_block(port) {
+            return Ok(block);
+        }
+        // A block masquerade may never draw from never joins the list of allocated blocks, so its
+        // absence from that list says nothing about the bookkeeping. Port forwarding claiming a
+        // block in full is the way to reach this from a configuration: a flow carried across a
+        // config change may hold a port in a block the new configuration has claimed.
+        //
+        // Answer as a claim on part of the same block does, where the block is allocatable and its
+        // own bitmap refuses the port. How much of a block an operator happened to claim is not
+        // something the caller should be able to tell apart, and it is certainly not the difference
+        // between a policy conflict and a broken allocator.
+        if self.block_is_excluded(port) {
+            debug!("Port {port} lies in a block that port forwarding has claimed in full");
+            return Err(AllocatorError::PortReservationFailed(port.as_u16()));
+        }
+        // Block was not free but is not in the list of allocated blocks either??
+        //
+        // FIXME: This can legitimately happen if the block was released just after we checked
+        // whether it was free? (Not observed in shuttle tests so far.) Do we need an additional
+        // lock around the PortAllocator?
+        Err(AllocatorError::InternalIssue(
+            "Block not free, although absent from list of allocated blocks".to_string(),
+        ))
     }
 
     pub(crate) fn reserve_port(

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -94,9 +94,6 @@ pub(crate) struct PortAllocator<I: NatIpWithBitmap> {
 /// allocated by masquerade NAT for TCP or UDP.
 const IANA_WELLKNOWN_PORT_LIMIT: u16 = 1024;
 
-/// Number of 256-port blocks covering the IANA well-known port range (0-1023).
-const IANA_WELLKNOWN_BLOCKS: u16 = IANA_WELLKNOWN_PORT_LIMIT / 256;
-
 impl<I: NatIpWithBitmap> PortAllocator<I> {
     pub(crate) fn new(
         reserved_ports: PortClaims,
@@ -112,22 +109,34 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         if randomize {
             Self::shuffle_slice(&mut base_ports);
         }
-        let blocks = std::array::from_fn(|i| {
+        let blocks: [AllocatorPortBlock; 256] = std::array::from_fn(|i| {
             let block = AllocatorPortBlock::new(base_ports[i]);
-            // Pre-mark IANA well-known port blocks (0-1023) as permanently non-free so they are
-            // never handed out by masquerade NAT for TCP or UDP.
-            if exclude_wellknown_ports && block.to_port_number() < IANA_WELLKNOWN_PORT_LIMIT {
+            let base = block.to_port_number();
+            // Mark the blocks masquerade can never draw from as permanently non-free: the IANA
+            // well-known range (0-1023) for TCP and UDP, and any block port forwarding has claimed
+            // in full. Deciding this once, here, is what keeps the count of usable blocks honest:
+            // a block ruled out later would be marked non-free without ever being counted out.
+            if (exclude_wellknown_ports && base < IANA_WELLKNOWN_PORT_LIMIT)
+                || (!reserved_ports.is_empty() && reserved_ports.covers_block(base))
+            {
                 block
                     .free
                     .store(false, concurrency::sync::atomic::Ordering::Relaxed);
             }
             block
         });
-        let usable_blocks = if exclude_wellknown_ports {
-            256 - IANA_WELLKNOWN_BLOCKS
-        } else {
-            256
-        };
+        // Counted from the blocks themselves rather than assumed, so the two cannot disagree.
+        let usable_blocks = u16::try_from(
+            blocks
+                .iter()
+                .filter(|block| {
+                    block
+                        .free
+                        .load(concurrency::sync::atomic::Ordering::Relaxed)
+                })
+                .count(),
+        )
+        .unwrap_or(u16::MAX);
         Self {
             blocks,
             usable_blocks: AtomicU16::new(usable_blocks),
@@ -195,13 +204,19 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         // finding a weak reference that won't upgrade. Removing here would require an additional
         // lookup in the list.
         //
-        // TODO: Should we move usable_blocks and blocks into a lock-protected struct? Or adjust the
-        // ordering for the atomic operations?
+        // TODO: Should we move usable_blocks and blocks into a lock-protected struct?
+        //
+        // The count is given back before the flag, and the order matters. A claimant subtracts
+        // from the count only after winning the flag, so raising the flag first leaves a window in
+        // which the count is still short by this block and someone else's subtraction takes it
+        // below zero -- on a `u16`, to 65535, which says the address has room it does not have.
+        // This way round the count is briefly one too high instead, which only says an address has
+        // room a moment before it truly does.
+        self.usable_blocks
+            .fetch_add(1, concurrency::sync::atomic::Ordering::Relaxed);
         self.blocks[index]
             .free
             .store(true, concurrency::sync::atomic::Ordering::Relaxed);
-        self.usable_blocks
-            .fetch_add(1, concurrency::sync::atomic::Ordering::Relaxed);
     }
 
     fn has_allocated_blocks_with_free_ports(&self) -> bool {
@@ -209,13 +224,17 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
     }
 
     // Find an available block to allocate ports from, and mark it as non-free.
+    //
+    // The blocks masquerade may never draw from, the well-known range and those port forwarding
+    // has claimed in full, were marked non-free when the allocator was built, so taking the first
+    // block whose flag can be claimed is the whole of the decision.
     fn pick_available_block(&self) -> Result<(usize, u16), AllocatorError> {
-        // Find the first free block in the list, starting from the current self.current_alloc_index
+        // Starting from the current self.current_alloc_index, take the first block for which the
+        // atomic compare_exchange succeeds.
         let (index, block) = self
             .cycle_blocks()
             .find(|(_, block)| {
-                // Find the first block for which the atomic compare_exchange succeeds
-                if block
+                block
                     .free
                     .compare_exchange(
                         true,
@@ -223,16 +242,7 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
                         concurrency::sync::atomic::Ordering::Relaxed,
                         concurrency::sync::atomic::Ordering::Relaxed,
                     )
-                    .is_err()
-                {
-                    return false;
-                }
-
-                // Skip a block port forwarding has claimed in full: there is nothing left in it to
-                // hand out. Several claims may cover a block between them while no single one of
-                // them does, so this asks the claims as a whole rather than testing them one by
-                // one.
-                !self.reserved_ports.covers_block(block.to_port_number())
+                    .is_ok()
             })
             .ok_or(AllocatorError::NoPortBlock)?;
         Ok((index, block.to_port_number()))
@@ -261,7 +271,13 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         let reserved_for_block: Vec<PortRange> =
             self.reserved_ports.within_block(base_port_index).collect();
 
+        // Building the block is the last thing that can fail, and by here its flag is taken and
+        // the count is down. Nothing would give either back: no `Arc` exists yet, so no `Drop` is
+        // coming, and the block would sit claimed by nobody for the life of the allocator. Only
+        // reachable through an `InternalIssue` that should not happen, which is exactly the sort
+        // of thing that turns one bad block into a slow leak.
         AllocatedPortBlock::new(ip, index, base_port_index, &reserved_for_block, allow_null)
+            .inspect_err(|_| self.deallocate_block(index))
     }
 
     pub(crate) fn allocate_port(
@@ -325,13 +341,12 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         // other, so it carries the same claims, clipped to it.
         let reserved_for_block: Vec<PortRange> =
             self.reserved_ports.within_block(base_port_index).collect();
-        let block = Arc::new(AllocatedPortBlock::new(
-            ip,
-            index,
-            base_port_index,
-            &reserved_for_block,
-            allow_null,
-        )?);
+        // As in `allocate_block`: the flag is already taken and the count already down, and only
+        // a `Drop` gives them back. There is no `Arc` to drop if this fails.
+        let block = Arc::new(
+            AllocatedPortBlock::new(ip, index, base_port_index, &reserved_for_block, allow_null)
+                .inspect_err(|_| self.deallocate_block(index))?,
+        );
         self.allocated_blocks
             .insert(block.index, Arc::downgrade(&block));
         Ok(block)
@@ -367,7 +382,15 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         // Reject explicit reservations into the IANA system/well-known range up front so callers
         // get a policy-oriented error rather than a misleading resource-exhaustion error from the
         // pre-excluded low-port blocks.
-        if self.exclude_wellknown_ports && port.as_u16() < IANA_WELLKNOWN_PORT_LIMIT {
+        //
+        // The range is a port-number convention, so it says nothing about an ICMP identifier,
+        // which is drawn from the whole 16 bits. Identifiers cannot meet this today -- ICMP pools
+        // are built with the exclusion off -- but that is decided in `setup.rs`, and a reader here
+        // would have to go and find it to know a low identifier is not silently denied.
+        if self.exclude_wellknown_ports
+            && !matches!(port, NatPort::Identifier(_))
+            && port.as_u16() < IANA_WELLKNOWN_PORT_LIMIT
+        {
             debug!("Explicit reservation for well-known port {port} denied by allocator policy");
             return Err(AllocatorError::Denied);
         }

--- a/nat/src/masquerade/apalloc/reserved.rs
+++ b/nat/src/masquerade/apalloc/reserved.rs
@@ -13,9 +13,19 @@
 //! claims on an address are kept as a list and every one of them applies. Holding a single range
 //! per address instead would silently honour whichever was recorded last.
 
+use super::region::AddrInterval;
+use crate::masquerade::natip::NatIp;
 use crate::ranges::IpRange;
 use lpm::prefix::PortRange;
+use std::collections::BTreeSet;
 use std::net::IpAddr;
+
+/// Ports 0..=1023 cover the IANA system/well-known range and should not be
+/// allocated by masquerade NAT for TCP or UDP.
+pub(crate) const IANA_WELLKNOWN_PORT_LIMIT: u16 = 1024;
+
+/// How many 256-port blocks an address is divided into.
+const BLOCKS_PER_ADDRESS: u32 = 256;
 
 /// Ports claimed on public addresses, as a flat list of claims.
 ///
@@ -51,6 +61,69 @@ impl ReservedPorts {
     pub(crate) fn iter(&self) -> impl Iterator<Item = (IpRange, PortRange)> + '_ {
         self.claims.iter().copied()
     }
+
+    /// The stretches of `range` on which masquerade could never hand anything out, because port
+    /// forwarding has claimed every port it is allowed to draw from.
+    ///
+    /// Walks the claims rather than the addresses: a region may hold billions of addresses, while
+    /// there are only as many claims as there are port-forwarding exposes towards one peer.
+    /// Coverage can only change where a claim begins or just past where one ends, so cutting at
+    /// those points gives stretches over which the answer cannot change and a single address
+    /// decides each of them. Adjacent stretches that agree are merged.
+    ///
+    /// `range` must be one every address of which converts to an offset, so callers pass the
+    /// indexable part of a region rather than the whole of it.
+    pub(crate) fn unusable_within<I: NatIp>(
+        &self,
+        range: AddrInterval,
+        exclude_wellknown_ports: bool,
+    ) -> Vec<AddrInterval> {
+        // With nothing claimed there is nothing to find: the well-known range on its own never
+        // uses an address up, since every block above it is still there to draw from.
+        if self.claims.is_empty() {
+            return Vec::new();
+        }
+
+        let mut cuts = BTreeSet::from([range.start]);
+        for (addresses, _) in &self.claims {
+            let Some((start, end)) = claim_bounds::<I>(addresses) else {
+                // A claim of the other address family, which says nothing about this region.
+                continue;
+            };
+            for cut in [Some(start), end.checked_add(1)].into_iter().flatten() {
+                if cut > range.start && cut <= range.end {
+                    cuts.insert(cut);
+                }
+            }
+        }
+
+        let cuts: Vec<u128> = cuts.into_iter().collect();
+        let mut unusable: Vec<AddrInterval> = Vec::new();
+        for (index, &start) in cuts.iter().enumerate() {
+            let end = cuts.get(index + 1).map_or(range.end, |&next| next - 1);
+            let Ok(address) = I::try_from_bits(start) else {
+                continue;
+            };
+            if !self
+                .for_address(address.to_ip_addr())
+                .every_block_is_unusable(exclude_wellknown_ports)
+            {
+                continue;
+            }
+            match unusable.last_mut() {
+                Some(previous) if previous.end.checked_add(1) == Some(start) => previous.end = end,
+                _ => unusable.push(AddrInterval::new(start, end)),
+            }
+        }
+        unusable
+    }
+}
+
+// The bounds of a claim as raw bits, or None if the claim is of another address family.
+fn claim_bounds<I: NatIp>(addresses: &IpRange) -> Option<(u128, u128)> {
+    let start = I::try_from_addr(addresses.start()).ok()?;
+    let end = I::try_from_addr(addresses.end()).ok()?;
+    Some((start.to_addr_bits(), end.to_addr_bits()))
 }
 
 /// The port ranges claimed on one public address.
@@ -79,6 +152,29 @@ impl PortClaims {
         self.0
             .iter()
             .filter_map(move |claim| claim.intersection(block))
+    }
+
+    /// Whether the block at `base` is one masquerade may never draw from, whether because policy
+    /// keeps it off or because port forwarding has taken the whole of it.
+    ///
+    /// This is the decision the port allocator makes when it marks a block permanently non-free,
+    /// and the one [`every_block_is_unusable`](Self::every_block_is_unusable) asks 256 times over.
+    /// Both go through here so that the address-level answer cannot drift from the block-level one:
+    /// an address dropped from a pool while a block of it was still allocatable would be capacity
+    /// silently thrown away.
+    pub(crate) fn block_is_unusable(&self, base: u16, exclude_wellknown_ports: bool) -> bool {
+        (exclude_wellknown_ports && base < IANA_WELLKNOWN_PORT_LIMIT)
+            || (!self.is_empty() && self.covers_block(base))
+    }
+
+    /// Whether no block of the address carrying these claims can be drawn from, so the address can
+    /// serve masquerade nothing at all.
+    pub(crate) fn every_block_is_unusable(&self, exclude_wellknown_ports: bool) -> bool {
+        (0..BLOCKS_PER_ADDRESS)
+            .map(|index| {
+                u16::try_from(index * 256).unwrap_or_else(|_| unreachable!("256 blocks of 256"))
+            })
+            .all(|base| self.block_is_unusable(base, exclude_wellknown_ports))
     }
 
     /// Whether every port the block at `base` could hand out is claimed, so the block is of no use
@@ -121,6 +217,160 @@ impl FromIterator<PortRange> for PortClaims {
 fn block_range(base: u16) -> PortRange {
     // A block is 256 ports wide and based at a multiple of 256, so this cannot overflow.
     PortRange::new(base, base.saturating_add(255)).unwrap_or_else(|_| unreachable!())
+}
+
+#[cfg(test)]
+mod bolero_tests {
+    use super::*;
+    use bolero::{Driver, TypeGenerator};
+    use std::net::Ipv4Addr;
+
+    // A narrow window, so that claims overlap one another as a matter of course and every address
+    // in it can be checked rather than a sampled few.
+    const BASE: u32 = 0x0A01_0000;
+    const WINDOW: u32 = 12;
+    const MAX_CLAIMS: u8 = 4;
+
+    /// A generated set of claims: each an offset and a length into the window, and a port range
+    /// that is either the whole of what masquerade could draw on or some slice of it.
+    #[derive(Debug, Clone)]
+    struct Scenario {
+        claims: Vec<(u8, u8, u8, u16, u16)>,
+    }
+
+    impl TypeGenerator for Scenario {
+        fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+            let count = usize::from(driver.produce::<u8>()? % (MAX_CLAIMS + 1));
+            let mut claims = Vec::with_capacity(count);
+            for _ in 0..count {
+                claims.push((
+                    driver.produce::<u8>()?,
+                    driver.produce::<u8>()?,
+                    // Which shape of port range to draw. Left to chance, a range that happens to
+                    // reach from 1024 to 65535, or to stop exactly on a block boundary, is
+                    // vanishingly rare, and those are the shapes the answer turns on.
+                    driver.produce::<u8>()?,
+                    driver.produce::<u16>()?,
+                    driver.produce::<u16>()?,
+                ));
+            }
+            Some(Self { claims })
+        }
+    }
+
+    impl Scenario {
+        fn reserved(&self) -> ReservedPorts {
+            let mut reserved = ReservedPorts::default();
+            for &(offset, length, shape, port_lo, port_span) in &self.claims {
+                let start = BASE + u32::from(offset) % WINDOW;
+                // Claims may reach past the end of the window, which the clipping has to survive.
+                let end = start + u32::from(length) % WINDOW;
+                let ports = match shape % 3 {
+                    // The whole of what masquerade could draw on, which uses the address up by
+                    // itself.
+                    0 => PortRange::new(IANA_WELLKNOWN_PORT_LIMIT, u16::MAX),
+                    // Up to the end of some block: the shape that decides whether the block a
+                    // claim stops on is judged the same way by the address-level answer and the
+                    // block-level one.
+                    1 => {
+                        let blocks = 1 + u32::from(port_lo) % 255;
+                        let end = (u32::from(IANA_WELLKNOWN_PORT_LIMIT) + blocks * 256 - 1)
+                            .min(u32::from(u16::MAX));
+                        PortRange::new(
+                            IANA_WELLKNOWN_PORT_LIMIT,
+                            u16::try_from(end).unwrap_or_else(|_| unreachable!()),
+                        )
+                    }
+                    // Anywhere at all.
+                    _ => {
+                        let low = port_lo.max(1);
+                        PortRange::new(low, low.saturating_add(port_span))
+                    }
+                }
+                .unwrap_or_else(|_| unreachable!());
+                reserved.claim(
+                    IpRange::new(
+                        IpAddr::V4(Ipv4Addr::from(start)),
+                        IpAddr::V4(Ipv4Addr::from(end)),
+                    ),
+                    ports,
+                );
+            }
+            reserved
+        }
+    }
+
+    #[test]
+    fn unusable_within_matches_a_per_address_oracle() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|scenario: Scenario| {
+                let reserved = scenario.reserved();
+                let range = AddrInterval::new(u128::from(BASE), u128::from(BASE + WINDOW - 1));
+                let unusable = reserved.unusable_within::<Ipv4Addr>(range, true);
+
+                for interval in &unusable {
+                    assert!(
+                        interval.start <= interval.end,
+                        "interval {interval:?} ends before it starts"
+                    );
+                    assert!(
+                        interval.start >= range.start && interval.end <= range.end,
+                        "interval {interval:?} reaches outside the range it was asked about"
+                    );
+                }
+
+                // Ordered, and never touching: two that met should have been reported as one.
+                for pair in unusable.windows(2) {
+                    assert!(
+                        pair[0].end.saturating_add(1) < pair[1].start,
+                        "intervals {:?} and {:?} touch, overlap, or are out of order",
+                        pair[0],
+                        pair[1]
+                    );
+                }
+
+                // The load-bearing property, at every address in the window. An address is kept out
+                // of the pool exactly when no block of it could ever be drawn from: keeping out one
+                // that still had a block is capacity silently thrown away, and leaving in one that
+                // had none is the walk this exists to avoid.
+                for bits in range.start..=range.end {
+                    let address =
+                        Ipv4Addr::from(u32::try_from(bits).unwrap_or_else(|_| unreachable!()));
+                    let has_nothing_to_give =
+                        covers_every_usable_port(&reserved.for_address(IpAddr::V4(address)));
+                    let kept_out = unusable.iter().any(|interval| interval.contains(bits));
+                    assert_eq!(
+                        kept_out, has_nothing_to_give,
+                        "address {address}: kept out of the pool = {kept_out}, but every block \
+                         unusable = {has_nothing_to_give}"
+                    );
+                }
+            });
+    }
+
+    /// The oracle: an address can serve nothing when the claims on it cover every port masquerade
+    /// could hand out, end to end.
+    ///
+    /// Worked out over the port space directly, rather than by asking whether each of the 256
+    /// blocks is covered. That is the whole value of it: the implementation deliberately routes the
+    /// address-level answer and the block-level one through a single predicate so they cannot
+    /// drift, and a test that reused that predicate would be comparing it with itself.
+    fn covers_every_usable_port(claims: &PortClaims) -> bool {
+        let mut ranges: Vec<PortRange> = claims.iter().collect();
+        ranges.sort_by_key(PortRange::start);
+
+        // Everything below the well-known limit is off the table anyway, so coverage starts there.
+        let mut covered_through = IANA_WELLKNOWN_PORT_LIMIT - 1;
+        for range in ranges {
+            if range.start() > covered_through.saturating_add(1) {
+                return false;
+            }
+            covered_through = covered_through.max(range.end());
+        }
+        covered_through == u16::MAX
+    }
 }
 
 #[cfg(test)]

--- a/nat/src/masquerade/apalloc/reserved.rs
+++ b/nat/src/masquerade/apalloc/reserved.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Ports that port forwarding has claimed on public addresses, and that masquerade must not hand
+//! out.
+//!
+//! A public `(address, port)` may only be live once towards a given peer, and port forwarding maps
+//! its own statically, so masquerade allocating a pair port forwarding has taken would send return
+//! traffic to whichever of the two the flow table happened to keep.
+//!
+//! One address can carry several claims. Port forwarding names a public range and a port range per
+//! expose, and nothing stops two exposes naming the same address with different ports, so the
+//! claims on an address are kept as a list and every one of them applies. Holding a single range
+//! per address instead would silently honour whichever was recorded last.
+
+use crate::ranges::IpRange;
+use lpm::prefix::PortRange;
+use std::net::IpAddr;
+
+/// Ports claimed on public addresses, as a flat list of claims.
+///
+/// Kept flat rather than keyed by address, because claims may be made on overlapping address
+/// ranges and every claim covering an address has to be honoured, not just the innermost or the
+/// last recorded.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ReservedPorts {
+    claims: Vec<(IpRange, PortRange)>,
+}
+
+impl ReservedPorts {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.claims.is_empty()
+    }
+
+    pub(crate) fn claim(&mut self, addresses: IpRange, ports: PortRange) {
+        self.claims.push((addresses, ports));
+    }
+
+    /// Every port range claimed on `address`.
+    pub(crate) fn for_address(&self, address: IpAddr) -> PortClaims {
+        PortClaims(
+            self.claims
+                .iter()
+                .filter(|(addresses, _)| addresses.contains(&address))
+                .map(|(_, ports)| *ports)
+                .collect(),
+        )
+    }
+
+    /// The claims, for display.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (IpRange, PortRange)> + '_ {
+        self.claims.iter().copied()
+    }
+}
+
+/// The port ranges claimed on one public address.
+///
+/// The ranges are independent and may overlap; nothing here merges them, because reserving a port
+/// in a bitmap is idempotent and reserving the same port twice is harmless.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PortClaims(Vec<PortRange>);
+
+impl PortClaims {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The claims, for display.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = PortRange> + '_ {
+        self.0.iter().copied()
+    }
+
+    /// The claims that fall in the 256-port block starting at `base`, each clipped to it.
+    ///
+    /// Clipping here is what lets a claim span block boundaries: the bitmap of a block indexes
+    /// ports modulo 256 and cannot represent a range reaching past its end.
+    pub(crate) fn within_block(&self, base: u16) -> impl Iterator<Item = PortRange> + '_ {
+        let block = block_range(base);
+        self.0
+            .iter()
+            .filter_map(move |claim| claim.intersection(block))
+    }
+
+    /// Whether every port the block at `base` could hand out is claimed, so the block is of no use
+    /// to masquerade at all.
+    ///
+    /// Port 0 is never handed out for TCP or UDP, so a claim over the whole of a block bar port 0
+    /// still leaves nothing allocatable. Several claims may cover a block between them while no
+    /// single one of them does, which is why this walks the union rather than testing each claim.
+    pub(crate) fn covers_block(&self, base: u16) -> bool {
+        let block = block_range(base);
+        // Port 0 is never handed out for TCP or UDP, so the first block only has to be covered
+        // from port 1 to be useless.
+        let must_cover_from = if base == 0 { 1 } else { base };
+
+        let mut claims: Vec<PortRange> = self.within_block(base).collect();
+        claims.sort_by_key(PortRange::start);
+
+        let mut covered_through: Option<u16> = None;
+        for claim in claims {
+            match covered_through {
+                // The block has to be covered from its first allocatable port.
+                None if claim.start() > must_cover_from => return false,
+                None => covered_through = Some(claim.end()),
+                // A claim starting more than one port past what is covered leaves a gap, and a
+                // port left in a gap is one masquerade may still hand out.
+                Some(end) if claim.start() > end.saturating_add(1) => return false,
+                Some(end) => covered_through = Some(end.max(claim.end())),
+            }
+        }
+        covered_through.is_some_and(|end| end >= block.end())
+    }
+}
+
+impl FromIterator<PortRange> for PortClaims {
+    fn from_iter<T: IntoIterator<Item = PortRange>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+fn block_range(base: u16) -> PortRange {
+    // A block is 256 ports wide and based at a multiple of 256, so this cannot overflow.
+    PortRange::new(base, base.saturating_add(255)).unwrap_or_else(|_| unreachable!())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ports(start: u16, end: u16) -> PortRange {
+        PortRange::new(start, end).unwrap_or_else(|_| unreachable!())
+    }
+
+    fn claims(ranges: &[(u16, u16)]) -> PortClaims {
+        ranges.iter().map(|&(s, e)| ports(s, e)).collect()
+    }
+
+    #[test]
+    fn no_claims_cover_nothing() {
+        assert!(!PortClaims::default().covers_block(1024));
+        assert!(PortClaims::default().is_empty());
+    }
+
+    #[test]
+    fn a_claim_over_the_whole_block_covers_it() {
+        assert!(claims(&[(1024, 1279)]).covers_block(1024));
+    }
+
+    #[test]
+    fn a_claim_over_part_of_the_block_does_not() {
+        assert!(!claims(&[(1024, 1200)]).covers_block(1024));
+        assert!(!claims(&[(1100, 1279)]).covers_block(1024));
+    }
+
+    // The case a per-claim test gets wrong: neither claim covers the block, but together they do.
+    #[test]
+    fn two_claims_covering_between_them_cover_the_block() {
+        assert!(claims(&[(1024, 1150), (1151, 1279)]).covers_block(1024));
+        assert!(claims(&[(1024, 1150), (1150, 1279)]).covers_block(1024));
+    }
+
+    #[test]
+    fn two_claims_leaving_a_gap_do_not_cover_the_block() {
+        assert!(!claims(&[(1024, 1150), (1152, 1279)]).covers_block(1024));
+    }
+
+    // Port 0 is never allocatable, so covering 1..=255 leaves the first block useless.
+    #[test]
+    fn the_first_block_is_covered_without_port_zero() {
+        assert!(claims(&[(1, 255)]).covers_block(0));
+        assert!(claims(&[(0, 255)]).covers_block(0));
+        assert!(!claims(&[(1, 254)]).covers_block(0));
+    }
+
+    #[test]
+    fn claims_are_clipped_to_the_block() {
+        // A claim spanning two blocks reaches each of them, clipped.
+        let spanning = claims(&[(1000, 1300)]);
+        let in_first: Vec<_> = spanning.within_block(1024).collect();
+        assert_eq!(in_first, vec![ports(1024, 1279)]);
+        let in_second: Vec<_> = spanning.within_block(1280).collect();
+        assert_eq!(in_second, vec![ports(1280, 1300)]);
+        // And not blocks it does not touch.
+        assert_eq!(spanning.within_block(2048).count(), 0);
+    }
+
+    #[test]
+    fn claims_outside_the_block_are_ignored() {
+        assert!(!claims(&[(2048, 2303)]).covers_block(1024));
+    }
+}

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -59,10 +59,17 @@ struct GatheredExpose<'a> {
     // The public range this expose allocates from, as raw address intervals.
     public_ranges: Vec<AddrInterval>,
     idle_timeout: Duration,
-    reserved: ReserveSets,
 }
 
-/// Ports that port forwarding has claimed, and that masquerade must not hand out.
+/// Everything masquerading towards one peer VPC: the exposes that allocate from its public space,
+/// and the public ports port forwarding has already claimed in that same space.
+#[derive(Default)]
+struct GatheredGroup<'a> {
+    exposes: Vec<GatheredExpose<'a>>,
+    claimed: ReserveSets,
+}
+
+/// Public ports that port forwarding has claimed, and that masquerade must not hand out.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct ReserveSets {
     tcp: PrefixPortsSet,
@@ -78,6 +85,22 @@ impl ReserveSets {
             _ => None,
         }
     }
+
+    // Record what a port-forwarding expose has taken, under the protocols it applies to. The claim
+    // is on the public side, which is the space masquerade allocates from and the space a pool is
+    // asked about; the private side describes addresses the pools never see.
+    fn add(&mut self, expose: &ValidatedExpose) {
+        let claimed = expose.as_range_or_empty();
+        let proto = expose.nat().map_or(L4Protocol::Any, |nat| nat.proto);
+        match proto {
+            L4Protocol::Tcp => self.tcp.extend(claimed.clone()),
+            L4Protocol::Udp => self.udp.extend(claimed.clone()),
+            L4Protocol::Any => {
+                self.tcp.extend(claimed.clone());
+                self.udp.extend(claimed.clone());
+            }
+        }
+    }
 }
 
 // Collect the masquerade exposes of every peering, grouped by the VPC they masquerade towards.
@@ -87,7 +110,7 @@ fn gather_exposes<'a, J, F, FIter, P, PIter>(
     config: &'a MasqueradeConfig,
     exposes_filter: &F,
     port_forwarding_exposes_filter: &P,
-) -> BTreeMap<VpcDiscriminant, Vec<GatheredExpose<'a>>>
+) -> BTreeMap<VpcDiscriminant, GatheredGroup<'a>>
 where
     J: NatIp,
     F: Fn(&'a ValidatedManifest) -> FIter,
@@ -95,12 +118,20 @@ where
     P: Fn(&'a ValidatedManifest) -> PIter,
     PIter: Iterator<Item = &'a ValidatedExpose>,
 {
-    let mut groups: BTreeMap<VpcDiscriminant, Vec<GatheredExpose<'a>>> = BTreeMap::new();
+    let mut groups: BTreeMap<VpcDiscriminant, GatheredGroup<'a>> = BTreeMap::new();
 
     for nat_peering in config.iter() {
         let manifest = nat_peering.peering.local();
-        let port_forwarding_exposes: Vec<&'a ValidatedExpose> =
-            port_forwarding_exposes_filter(manifest).collect();
+        let group = groups.entry(nat_peering.dst_vpcd).or_default();
+
+        // Port forwarding claims public space towards this peer whichever VPC declared it, because
+        // the public space towards a peer is shared: return traffic carries nothing that says
+        // which VPC it belongs to. Claims are therefore collected per peer VPC rather than per
+        // manifest, so a claim made by one VPC is honoured by another VPC's pools, and a peering
+        // that port-forwards without masquerading still has its claims respected.
+        for pf_expose in port_forwarding_exposes_filter(manifest) {
+            group.claimed.add(pf_expose);
+        }
 
         for expose in exposes_filter(manifest) {
             let public_ranges = public_intervals::<J>(expose.as_range_or_empty());
@@ -109,18 +140,14 @@ where
                 // happens if none of its prefixes are of the version we are building.
                 continue;
             }
-            groups
-                .entry(nat_peering.dst_vpcd)
-                .or_default()
-                .push(GatheredExpose {
-                    src_vpc_id: nat_peering.src_vpcd,
-                    private_prefixes: expose.ips(),
-                    public_ranges,
-                    idle_timeout: expose
-                        .idle_timeout()
-                        .unwrap_or(DEFAULT_MASQUERADE_IDLE_TIMEOUT),
-                    reserved: find_masquerade_portfw_overlap(&port_forwarding_exposes, expose),
-                });
+            group.exposes.push(GatheredExpose {
+                src_vpc_id: nat_peering.src_vpcd,
+                private_prefixes: expose.ips(),
+                public_ranges,
+                idle_timeout: expose
+                    .idle_timeout()
+                    .unwrap_or(DEFAULT_MASQUERADE_IDLE_TIMEOUT),
+            });
         }
     }
 
@@ -164,26 +191,27 @@ fn build_pools_generic<'a, I, J, F, FIter, P, PIter>(
     let groups =
         gather_exposes::<J, _, _, _, _>(config, &exposes_filter, &port_forwarding_exposes_filter);
 
-    for (dst_vpc_id, exposes) in groups {
+    for (dst_vpc_id, group) in groups {
         // Allocations for TCP, for example, do not affect allocations for UDP or for ICMP: the
         // space made of addresses and L4 ports or identifiers is distinct for each protocol. So
         // each region backs one allocator per protocol, over the same addresses.
         for protocol in [NextHeader::TCP, NextHeader::UDP, icmp_proto] {
-            let specs: Vec<PoolSpec> = exposes
+            let specs: Vec<PoolSpec> = group
+                .exposes
                 .iter()
                 .map(|expose| PoolSpec {
                     public_ranges: expose.public_ranges.clone(),
-                    reserved: expose
-                        .reserved
-                        .for_protocol(protocol)
-                        .cloned()
-                        .unwrap_or_default(),
                     idle_timeout: expose.idle_timeout,
                 })
                 .collect();
 
-            let pool_sets = pool_sets_for_specs::<J>(&specs, protocol, randomize);
-            for (expose, pool_set) in exposes.iter().zip(pool_sets) {
+            let claimed = group
+                .claimed
+                .for_protocol(protocol)
+                .cloned()
+                .unwrap_or_default();
+            let pool_sets = pool_sets_for_specs::<J>(&specs, &claimed, protocol, randomize);
+            for (expose, pool_set) in group.exposes.iter().zip(pool_sets) {
                 add_pool_entries(
                     table,
                     expose.private_prefixes,
@@ -202,7 +230,6 @@ fn build_pools_generic<'a, I, J, F, FIter, P, PIter>(
 #[derive(Clone)]
 pub(crate) struct PoolSpec {
     pub(crate) public_ranges: Vec<AddrInterval>,
-    pub(crate) reserved: PrefixPortsSet,
     pub(crate) idle_timeout: Duration,
 }
 
@@ -214,6 +241,7 @@ pub(crate) struct PoolSpec {
 /// ranges cover.
 pub(crate) fn pool_sets_for_specs<J: NatIpWithBitmap>(
     specs: &[PoolSpec],
+    claimed: &PrefixPortsSet,
     protocol: NextHeader,
     randomize: bool,
 ) -> Vec<PoolSet<J>> {
@@ -228,7 +256,7 @@ pub(crate) fn pool_sets_for_specs<J: NatIpWithBitmap>(
         specs.len()
     );
 
-    let allocators = build_region_allocators::<J>(&regions, specs, protocol, randomize);
+    let allocators = build_region_allocators::<J>(&regions, claimed, protocol, randomize);
     let by_owner = regions_by_owner(&regions);
 
     specs
@@ -251,7 +279,7 @@ pub(crate) fn pool_sets_for_specs<J: NatIpWithBitmap>(
 // keeps a public address and port from being handed out twice.
 fn build_region_allocators<J: NatIpWithBitmap>(
     regions: &[Region],
-    specs: &[PoolSpec],
+    claimed: &PrefixPortsSet,
     protocol: NextHeader,
     randomize: bool,
 ) -> Vec<IpAllocator<J>> {
@@ -259,54 +287,19 @@ fn build_region_allocators<J: NatIpWithBitmap>(
     // ICMP identifiers are allocated independently and are not subject to that policy.
     let exclude_wellknown_ports = matches!(protocol, NextHeader::TCP | NextHeader::UDP);
 
+    // The claims cover the whole public space towards this peer VPC, so every region gets the
+    // same set and each pool keeps only what covers an address when it hands one out. A region is
+    // shared between exposes, and a claim binds the space rather than the expose that declared it,
+    // so there is nothing per-owner to work out here.
+    let reserved = build_reserved_ports(claimed);
+
     regions
         .iter()
         .map(|region| {
-            // A region is shared, so it must honour every claim on it: reserve what port
-            // forwarding has taken from any of its owners.
-            let reserved = region
-                .owners
-                .iter()
-                .fold(PrefixPortsSet::new(), |accumulated, &owner| {
-                    accumulated.union_prefixes_and_ports(&specs[owner].reserved)
-                });
-
-            let pool = NatPool::for_range(
-                region.range,
-                build_reserved_ports(&reserved),
-                exclude_wellknown_ports,
-            );
+            let pool = NatPool::for_range(region.range, reserved.clone(), exclude_wellknown_ports);
             IpAllocator::new(pool, randomize)
         })
         .collect()
-}
-
-fn find_masquerade_portfw_overlap<'a>(
-    port_forwarding_exposes: &Vec<&'a ValidatedExpose>,
-    expose: &'a ValidatedExpose,
-) -> ReserveSets {
-    let expose_nat = expose.nat().unwrap_or_else(|| unreachable!());
-    let mut reserve_sets = ReserveSets::default();
-
-    for pf_expose in port_forwarding_exposes {
-        let pf_nat = pf_expose.nat().unwrap_or_else(|| unreachable!());
-        let Some(relevant_proto) = expose_nat.proto.intersection(&pf_nat.proto) else {
-            // No overlap on L4 protocols, so no overlap for prefixes and ports.
-            continue;
-        };
-        let ranges_intersection = pf_expose
-            .ips()
-            .intersection_prefixes_and_ports(expose.ips());
-        match relevant_proto {
-            L4Protocol::Tcp => reserve_sets.tcp.extend(ranges_intersection),
-            L4Protocol::Udp => reserve_sets.udp.extend(ranges_intersection),
-            L4Protocol::Any => {
-                reserve_sets.tcp.extend(ranges_intersection.clone());
-                reserve_sets.udp.extend(ranges_intersection);
-            }
-        }
-    }
-    reserve_sets
 }
 
 // Every claim is kept, including several on one address: a set of claims is not a map from
@@ -360,7 +353,7 @@ fn prefix_bounds<I: NatIp>(prefix: &PrefixWithOptionalPorts) -> (I, I) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ReserveSets, find_masquerade_portfw_overlap};
+    use super::ReserveSets;
     use config::external::overlay::vpcpeering::VpcExpose;
     use lpm::prefix::{L4Protocol, PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
 
@@ -368,145 +361,83 @@ mod tests {
         PrefixWithOptionalPorts::new(s.into(), Some(PortRange::new(start, end).unwrap()))
     }
 
-    // tests for find_masquerade_portfw_overlap()
+    // A port-forwarding expose, mapping a private range onto a public one.
+    fn port_forwarding(private: &str, public: &str, proto: Option<L4Protocol>) -> VpcExpose {
+        VpcExpose::empty()
+            .make_port_forwarding(None, proto)
+            .unwrap()
+            .ip(prefix_with_ports(private, 8080, 8090))
+            .as_range(prefix_with_ports(public, 8080, 8090))
+            .unwrap()
+    }
 
+    fn claims_of(exposes: &[VpcExpose]) -> ReserveSets {
+        let mut sets = ReserveSets::default();
+        for expose in exposes {
+            sets.add(&expose.clone().validate().unwrap());
+        }
+        sets
+    }
+
+    // The claim is on the public address and ports, because that is what masquerade allocates and
+    // what a pool is asked about. Recording the private side instead described a space the pools
+    // never look in, so nothing was ever actually reserved.
     #[test]
-    fn find_masquerade_portfw_overlap_multiple_pf_exposes() {
-        let expose = VpcExpose::empty()
-            .make_masquerade(None)
-            .unwrap()
-            .ip("10.0.0.0/16".into())
-            .ip("172.16.0.0/16".into())
-            .as_range("192.168.0.0/16".into())
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose1 = VpcExpose::empty()
-            .make_port_forwarding(None, None)
-            .unwrap()
-            .ip(prefix_with_ports("10.0.1.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose2 = VpcExpose::empty()
-            .make_port_forwarding(None, None)
-            .unwrap()
-            .ip(prefix_with_ports("172.16.5.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.2.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_exposes_vec = vec![&pf_expose1, &pf_expose2];
-        let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
+    fn a_claim_is_recorded_on_the_public_range() {
+        let claims = claims_of(&[port_forwarding("10.0.0.0/24", "192.168.1.0/24", None)]);
+        let expected = PrefixPortsSet::from([prefix_with_ports("192.168.1.0/24", 8080, 8090)]);
         assert_eq!(
-            result,
+            claims,
             ReserveSets {
-                tcp: PrefixPortsSet::from([
-                    prefix_with_ports("10.0.1.0/24", 8080, 8090),
-                    prefix_with_ports("172.16.5.0/24", 8080, 8090),
-                ]),
-                udp: PrefixPortsSet::from([
-                    prefix_with_ports("10.0.1.0/24", 8080, 8090),
-                    prefix_with_ports("172.16.5.0/24", 8080, 8090),
-                ]),
+                tcp: expected.clone(),
+                udp: expected,
             }
         );
     }
 
     #[test]
-    fn find_masquerade_portfw_overlap_with_ports() {
-        let expose = VpcExpose::empty()
-            .make_masquerade(None)
-            .unwrap()
-            .ip("10.0.0.0/24".into())
-            .as_range("192.168.0.0/24".into())
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose = VpcExpose::empty()
-            .make_port_forwarding(None, None)
-            .unwrap()
-            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_exposes_vec = vec![&pf_expose];
-        let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
+    fn a_protocol_specific_claim_only_binds_that_protocol() {
+        let claims = claims_of(&[port_forwarding(
+            "10.0.0.0/24",
+            "192.168.1.0/24",
+            Some(L4Protocol::Tcp),
+        )]);
         assert_eq!(
-            result,
+            claims,
             ReserveSets {
-                tcp: PrefixPortsSet::from([prefix_with_ports("10.0.0.0/24", 8080, 8090)]),
-                udp: PrefixPortsSet::from([prefix_with_ports("10.0.0.0/24", 8080, 8090)]),
+                tcp: PrefixPortsSet::from([prefix_with_ports("192.168.1.0/24", 8080, 8090)]),
+                udp: PrefixPortsSet::default(),
             }
         );
     }
 
     #[test]
-    fn find_masquerade_portfw_overlap_with_ports_tcp() {
-        let expose = VpcExpose::empty()
-            .make_masquerade(None)
-            .unwrap()
-            .ip("10.0.0.0/24".into())
-            .as_range("192.168.0.0/24".into())
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose = VpcExpose::empty()
-            .make_port_forwarding(None, Some(L4Protocol::Tcp)) // TCP only
-            .unwrap()
-            .ip(prefix_with_ports("10.0.0.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_exposes_vec = vec![&pf_expose];
-        let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
+    fn claims_from_several_exposes_accumulate() {
+        let claims = claims_of(&[
+            port_forwarding("10.0.1.0/24", "192.168.1.0/24", None),
+            port_forwarding("172.16.5.0/24", "192.168.2.0/24", None),
+        ]);
+        let expected = PrefixPortsSet::from([
+            prefix_with_ports("192.168.1.0/24", 8080, 8090),
+            prefix_with_ports("192.168.2.0/24", 8080, 8090),
+        ]);
         assert_eq!(
-            result,
+            claims,
             ReserveSets {
-                tcp: PrefixPortsSet::from([prefix_with_ports("10.0.0.0/24", 8080, 8090)]),
-                udp: PrefixPortsSet::default()
+                tcp: expected.clone(),
+                udp: expected,
             }
         );
     }
 
+    // Two exposes forwarding different private ranges onto one public range describe one claim.
     #[test]
-    fn find_masquerade_portfw_overlap_duplicates_collapsed() {
-        // Two port-forwarding exposes with the same prefix should produce one entry
-        let expose = VpcExpose::empty()
-            .make_masquerade(None)
-            .unwrap()
-            .ip("10.0.0.0/16".into())
-            .as_range("192.168.0.0/24".into())
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose1 = VpcExpose::empty()
-            .make_port_forwarding(None, None)
-            .unwrap()
-            .ip(prefix_with_ports("10.0.1.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_expose2 = VpcExpose::empty()
-            .make_port_forwarding(None, None)
-            .unwrap()
-            .ip(prefix_with_ports("10.0.1.0/24", 8080, 8090))
-            .as_range(prefix_with_ports("192.168.1.0/24", 8080, 8090))
-            .unwrap()
-            .validate()
-            .unwrap();
-        let pf_exposes_vec = vec![&pf_expose1, &pf_expose2];
-        let result = find_masquerade_portfw_overlap(&pf_exposes_vec, &expose);
-        assert_eq!(
-            result,
-            ReserveSets {
-                tcp: PrefixPortsSet::from([prefix_with_ports("10.0.1.0/24", 8080, 8090)]),
-                udp: PrefixPortsSet::from([prefix_with_ports("10.0.1.0/24", 8080, 8090)]),
-            }
-        );
+    fn duplicate_public_claims_collapse() {
+        let claims = claims_of(&[
+            port_forwarding("10.0.1.0/24", "192.168.1.0/24", None),
+            port_forwarding("10.0.2.0/24", "192.168.1.0/24", None),
+        ]);
+        assert_eq!(claims.tcp.len(), 1);
+        assert_eq!(claims.udp.len(), 1);
     }
 }

--- a/nat/src/masquerade/apalloc/setup.rs
+++ b/nat/src/masquerade/apalloc/setup.rs
@@ -11,13 +11,12 @@
 
 use super::alloc::{IpAllocator, NatPool, PoolSet};
 use super::region::{AddrInterval, Region, decompose, regions_by_owner};
+use super::reserved::ReservedPorts;
 use super::{NatAllocator, NatIpWithBitmap, PoolTable, PoolTableKey};
 use crate::masquerade::allocator_writer::MasqueradeConfig;
 use crate::masquerade::natip::NatIp;
-use crate::ranges::IpRange;
 use config::external::overlay::vpcpeering::{ValidatedExpose, ValidatedManifest};
-use lpm::prefix::range_map::DisjointRangesBTreeMap;
-use lpm::prefix::{L4Protocol, PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
+use lpm::prefix::{L4Protocol, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use net::packet::VpcDiscriminant;
 use std::collections::BTreeMap;
@@ -274,7 +273,7 @@ fn build_region_allocators<J: NatIpWithBitmap>(
 
             let pool = NatPool::for_range(
                 region.range,
-                build_reserved_prefixes_ports(&reserved),
+                build_reserved_ports(&reserved),
                 exclude_wellknown_ports,
             );
             IpAllocator::new(pool, randomize)
@@ -310,22 +309,21 @@ fn find_masquerade_portfw_overlap<'a>(
     reserve_sets
 }
 
-fn build_reserved_prefixes_ports(
+// Every claim is kept, including several on one address: a set of claims is not a map from
+// address to port range, and recording it as one silently honoured whichever came last.
+fn build_reserved_ports(
     prefixes_and_ports_to_exclude_from_pools: &PrefixPortsSet,
-) -> Option<DisjointRangesBTreeMap<IpRange, PortRange>> {
-    if prefixes_and_ports_to_exclude_from_pools.is_empty() {
-        return None;
-    }
-    let mut reserved_prefixes_ports = DisjointRangesBTreeMap::new();
+) -> ReservedPorts {
+    let mut reserved = ReservedPorts::default();
     for prefix in prefixes_and_ports_to_exclude_from_pools {
         debug_assert!(prefix.ports().is_some());
         let Some(ports) = prefix.ports() else {
             error!("Stepped on a port-forwarding prefix without ports. This is a bug");
             continue;
         };
-        reserved_prefixes_ports.insert(prefix.prefix().into(), ports);
+        reserved.claim(prefix.prefix().into(), ports);
     }
-    Some(reserved_prefixes_ports)
+    reserved
 }
 
 fn pool_table_key_for_expose<I: NatIp>(

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -13,6 +13,7 @@ mod context {
     use crate::masquerade::apalloc::{NatAllocator, PoolTable, PoolTableKey};
     use config::external::overlay::vpc::{Peering, ValidatedVpcTable, Vpc, VpcTable};
     use config::external::overlay::vpcpeering::{VpcExpose, VpcManifest};
+    use lpm::prefix::{PortRange, PrefixWithOptionalPorts};
     use net::ip::NextHeader;
     use net::packet::VpcDiscriminant;
     use net::udp::UdpPort;
@@ -334,6 +335,68 @@ mod context {
     #[allow(dead_code)]
     pub fn build_allocator_partial_overlap() -> NatAllocator {
         let vpc_table = build_context_partial_overlap();
+        let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
+        NatAllocator::new(config)
+    }
+
+    // VPC-1 masquerades onto a single public address towards VPC-3, and forwards a range of
+    // ports on that same address towards the same peer, both declared by the one manifest. The
+    // public space towards a peer is shared between every expose that reaches it, so those ports
+    // are spoken for and masquerade may not hand them out: return traffic to one of them carries
+    // nothing that says which expose it belongs to.
+    #[allow(dead_code)]
+    fn build_context_masquerade_over_forwarded_ports() -> ValidatedVpcTable {
+        let masquerade = VpcExpose::empty()
+            .make_masquerade(None)
+            .unwrap()
+            .ip("1.1.0.0/16".into())
+            .as_range("10.1.0.0/32".into())
+            .unwrap();
+        // The forwarded ports sit on the very address VPC-1 masquerades onto, declared by the
+        // same manifest. That is the shape validation accepts: masquerade and port forwarding may
+        // overlap within one manifest, each implying a direction, while the same overlap across
+        // two VPCs' peerings is rejected by the peer's route table, which could not route the
+        // shared address to one peering. An earlier version of this fixture used the cross-VPC
+        // shape and passed only because building a VpcTable by hand skips collecting peerings
+        // into the peer, so the route check never saw it.
+        let forwarded = VpcExpose::empty()
+            .make_port_forwarding(None, None)
+            .unwrap()
+            .ip(PrefixWithOptionalPorts::new(
+                "2.1.0.0/32".into(),
+                Some(PortRange::new(1024, 1030).unwrap()),
+            ))
+            .as_range(PrefixWithOptionalPorts::new(
+                "10.1.0.0/32".into(),
+                Some(PortRange::new(1024, 1030).unwrap()),
+            ))
+            .unwrap();
+        let remote =
+            VpcManifest::with_exposes("VPC-3", vec![VpcExpose::empty().ip("3.0.0.0/24".into())]);
+
+        let mut vpc1 = Vpc::new("VPC-1", "67890", vni1().as_u32()).unwrap();
+        let vpc3 = Vpc::new("VPC-3", "11111", vni3().as_u32()).unwrap();
+
+        vpc1.peerings.push(Peering {
+            name: "masquerading_peering".into(),
+            local: VpcManifest::with_exposes("VPC-1", vec![masquerade, forwarded]),
+            remote,
+            remote_id: "11111".try_into().unwrap(),
+            remote_vni: vpc3.vni,
+            gwgroup: "default".into(),
+            acl: None,
+        });
+
+        let mut vpctable = VpcTable::new();
+        vpctable.add(vpc1).unwrap();
+        vpctable.add(vpc3).unwrap();
+
+        vpctable.validate().unwrap()
+    }
+
+    #[allow(dead_code)]
+    pub fn build_allocator_masquerade_over_forwarded_ports() -> NatAllocator {
+        let vpc_table = build_context_masquerade_over_forwarded_ports();
         let config = MasqueradeConfig::new(&vpc_table, 1).set_randomize(false);
         NatAllocator::new(config)
     }
@@ -814,6 +877,38 @@ mod std_tests {
             );
             held.push(allocation);
         }
+    }
+
+    // Ports that port forwarding has claimed on a public address are not handed out by
+    // masquerade, even though the two were declared by separate exposes. The claim binds the
+    // public space towards the peer, not the expose that declared it.
+    //
+    // The claim is on the public side. It used to be computed from the private prefixes instead,
+    // which described a space the pools are never asked about, so nothing was reserved at all.
+    #[test]
+    fn test_forwarded_ports_are_not_masqueraded_onto() {
+        let allocator = build_allocator_masquerade_over_forwarded_ports();
+
+        let mut held = Vec::new();
+        let mut ports = Vec::new();
+        for _ in 0..32 {
+            let allocation = allocator
+                .allocate_v4(vpcd1(), vpcd3(), addr_v4("1.1.0.1"), NextHeader::TCP)
+                .unwrap();
+            let ip = allocation.allocation.ip();
+            let port = allocation.allocation.port().as_u16();
+            assert_eq!(ip, addr_v4("10.1.0.0"));
+            assert!(
+                !(1024..=1030).contains(&port),
+                "masquerade handed out {ip}:{port}, which port forwarding has claimed"
+            );
+            ports.push(port);
+            held.push(allocation);
+        }
+
+        // Allocation starts at the lowest port it may use, so the first one lands just past the
+        // claim. Without the reservation it would be 1024, which is what makes this test bite.
+        assert_eq!(ports[0], 1031);
     }
 
     // Both VPCs keep their own entry, rather than the second overwriting the first.

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -69,10 +69,26 @@ pub struct Masquerade {
 }
 
 impl Masquerade {
+    // How far the flow timeouts below are stretched when the tests are run under an emulator.
+    //
+    // A flow expires against the wall clock, while a test refreshes it by doing work: sending a
+    // packet. Under miri or qemu-user that work takes something like two orders of magnitude
+    // longer, so the gap between one packet and the next stops being a fraction of a flow's life
+    // and becomes several times it. A flow a native run keeps comfortably alive is one an emulated
+    // run finds long dead, and the test fails on a clock rather than on anything it meant to
+    // check. Stretching the timeouts keeps them measuring the same amount of work either way.
+    //
+    // `emulated` is set only by the miri and qemu-user paths, so a real data plane always gets the
+    // native values.
+    const TIMEOUT_SCALE: u64 = cfg_select! {
+        emulated => 100,
+        _ => 1,
+    };
+
     // Internal flow timeouts for masquerading
-    pub const MASQUERADE_ONEWAY_TIMEOUT: Duration = Duration::from_secs(5);
-    pub const MASQUERADE_TWOWAY_TIMEOUT: Duration = Duration::from_secs(3);
-    pub const MASQUERADE_CLOSING_TIMEOUT: Duration = Duration::from_secs(2);
+    pub const MASQUERADE_ONEWAY_TIMEOUT: Duration = Duration::from_secs(5 * Self::TIMEOUT_SCALE);
+    pub const MASQUERADE_TWOWAY_TIMEOUT: Duration = Duration::from_secs(3 * Self::TIMEOUT_SCALE);
+    pub const MASQUERADE_CLOSING_TIMEOUT: Duration = Duration::from_secs(2 * Self::TIMEOUT_SCALE);
 
     /// Creates a new [`Masquerade`] processor from provided parameters.
     #[must_use]

--- a/nat/src/masquerade/test.rs
+++ b/nat/src/masquerade/test.rs
@@ -329,6 +329,69 @@ fn build_overlay_2vpcs_modified() -> Overlay {
     Overlay::new(vpc_table, peering_table)
 }
 
+// Two source VPCs using the *same* private prefix, both masquerading towards VPC-3 and each onto
+// a public range of its own. Tenants reusing private address space is ordinary, and is much of
+// what NAT is for, so a private address only identifies a pool together with the VPC it belongs
+// to.
+fn build_overlay_shared_private_prefix() -> Overlay {
+    let mut vpc_table = VpcTable::new();
+    let _ = vpc_table.add(Vpc::new("VPC-1", "AAAAA", 100).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-2", "BBBBB", 200).expect("Failed to add VPC"));
+    let _ = vpc_table.add(Vpc::new("VPC-3", "CCCCC", 300).expect("Failed to add VPC"));
+
+    let expose13 = VpcExpose::empty()
+        .make_masquerade(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("2.2.0.0/16".into())
+        .unwrap();
+    // The same private space as VPC-1, onto a different public range.
+    let expose23 = VpcExpose::empty()
+        .make_masquerade(None)
+        .unwrap()
+        .ip("1.1.0.0/16".into())
+        .as_range("4.4.0.0/16".into())
+        .unwrap();
+
+    let peering13 = VpcPeering::with_default_group(
+        "VPC-1--VPC-3",
+        VpcManifest::new("VPC-1").exposing(expose13),
+        VpcManifest::new("VPC-3").exposing(VpcExpose::empty().ip("3.3.3.0/24".into())),
+    );
+    let peering23 = VpcPeering::with_default_group(
+        "VPC-2--VPC-3",
+        VpcManifest::new("VPC-2").exposing(expose23),
+        VpcManifest::new("VPC-3").exposing(VpcExpose::empty().ip("3.3.3.0/24".into())),
+    );
+
+    let mut peering_table = VpcPeeringTable::new();
+    peering_table.add(peering13).expect("Failed to add peering");
+    peering_table.add(peering23).expect("Failed to add peering");
+
+    Overlay::new(vpc_table, peering_table)
+}
+
+// A TCP packet towards VPC-3, from a given source VPC and private address. A SYN opens a flow;
+// anything else is only translated if one already exists.
+fn tcp_from(src_vni_id: u32, src_ip: &str, syn: bool) -> Packet<TestBuffer> {
+    let mut packet = build_test_tcp_ipv4_packet(src_ip, "3.3.3.1", 4321, 80);
+    {
+        let tcp = packet.try_tcp_mut().unwrap();
+        tcp.set_syn(syn);
+        tcp.set_ack(false);
+        tcp.set_fin(false);
+        tcp.set_rst(false);
+    }
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().src_vpcd = Some(vpcd(src_vni_id));
+    packet.meta_mut().set_masquerade(true);
+    packet
+}
+
+fn translated_source(packet: &Packet<TestBuffer>) -> Ipv4Addr {
+    packet.try_ipv4().unwrap().source().inner()
+}
+
 fn check_packet(
     nat: &mut Masquerade,
     src_vni: Vni,
@@ -1638,6 +1701,70 @@ async fn test_masquerade_reconfig_keep_flow() {
 
     tokio::time::sleep(Duration::from_secs(1)).await;
     assert_eq!(flow_table.active_len(), Some(2));
+}
+
+// Two VPCs using the same private address, masquerading towards the same peer. Each has to be
+// given its own public range, and has to keep it across a config change: re-reservation looks the
+// pool up by source VPC as well, so a flow carried over must land back in the pool its own expose
+// describes rather than in the other VPC's.
+#[tokio::test]
+#[cfg_attr(not(emulated), traced_test)]
+async fn test_masquerade_reconfig_two_vpcs_sharing_a_private_prefix() {
+    let genid = 1;
+    let (flow_table, mut pipeline, mut allocw) =
+        test_setup(genid, &build_overlay_shared_private_prefix());
+
+    // The same private source address, in two different VPCs. The SYN opens the flow; the packet
+    // that creates a flow does not carry it, so a follow-up packet is what shows the flow state.
+    process_packet(&mut pipeline, tcp_from(100, "1.1.0.1", true));
+    process_packet(&mut pipeline, tcp_from(200, "1.1.0.1", true));
+
+    let from_vpc1 = process_packet(&mut pipeline, tcp_from(100, "1.1.0.1", false));
+    let from_vpc2 = process_packet(&mut pipeline, tcp_from(200, "1.1.0.1", false));
+
+    let public1 = translated_source(&from_vpc1);
+    let public2 = translated_source(&from_vpc2);
+    assert_eq!(
+        public1.octets()[0..2],
+        [2, 2],
+        "VPC-1 was not masqueraded onto the range its own expose declares, got {public1}"
+    );
+    assert_eq!(
+        public2.octets()[0..2],
+        [4, 4],
+        "VPC-2 was not masqueraded onto the range its own expose declares, got {public2}"
+    );
+    assert_eq!(flow_genid(&from_vpc1).unwrap(), genid);
+    assert_eq!(flow_genid(&from_vpc2).unwrap(), genid);
+
+    // Apply an identical config. Nothing is re-reserved: `MasqueradeConfig`'s equality leaves
+    // genid out, so the writer keeps the allocator it has and only upgrades the flows onto the new
+    // genid. What this pins is that the two flows come through that untouched, still told apart by
+    // source VPC. Carrying flows into a *new* allocator is a different path, and reaching it takes
+    // a config that actually differs.
+    let overlay = build_overlay_shared_private_prefix().validate().unwrap();
+    let nat_config = MasqueradeConfig::new(overlay.vpc_table(), genid + 1);
+    allocw.update_nat_allocator(nat_config, &flow_table);
+
+    // Both survive, each still translated exactly as before.
+    let from_vpc1 = process_packet(&mut pipeline, tcp_from(100, "1.1.0.1", false));
+    let from_vpc2 = process_packet(&mut pipeline, tcp_from(200, "1.1.0.1", false));
+
+    assert_eq!(
+        translated_source(&from_vpc1),
+        public1,
+        "VPC-1's flow did not keep its public address across the config change"
+    );
+    assert_eq!(
+        translated_source(&from_vpc2),
+        public2,
+        "VPC-2's flow did not keep its public address across the config change"
+    );
+    assert_eq!(flow_genid(&from_vpc1).unwrap(), genid + 1);
+    assert_eq!(flow_genid(&from_vpc2).unwrap(), genid + 1);
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(flow_table.active_len(), Some(4));
 }
 
 #[tokio::test]

--- a/nat/src/ranges.rs
+++ b/nat/src/ranges.rs
@@ -138,7 +138,6 @@ impl IpRange {
         self.end
     }
 
-    #[cfg(test)]
     #[must_use]
     pub fn contains(&self, addr: &IpAddr) -> bool {
         self.start <= *addr && *addr <= self.end


### PR DESCRIPTION
Two defects in the ports masquerade must keep off because port forwarding has claimed them.
Both were reachable. The first was found by the property tests added in the previous PR, which
is why that PR carries two tests committed `#[ignore]`d. The second was found while writing
them rather than by them: the pools are handed claims already expressed in public space, so no
pool-level property can see a mistake in translating the configuration into those claims. It
took the config-level test added here.

- **Only one claim per address was honoured.** The limit was baked in three times over: a map
  keyed by address range where inserting twice overwrote, a pool resolving one range per
  address out of it, and a port allocator storing one range. Each had to change together.
- **Claims were computed in the wrong address space.** They came from intersecting *private*
  prefixes, while the pools are asked about *public* addresses, so effectively nothing was
  ever reserved. Claims are now gathered per peer VPC rather than per manifest, since the
  public space towards a peer is shared between every VPC masquerading onto it.

Verified by mutation: restoring the private prefixes makes the new end-to-end test hand out
the first forwarded port. Two test oracles were also strengthened here rather than higher in
the stack: the reserved-ports property now unions every claim as the implementation does,
instead of skipping claims whose own expose did not declare the address (the gated version
survived ten thousand inputs against a pool built from only each expose's own claims), and the
masquerade-over-forwarded-ports fixture is now the same-manifest configuration production
validation actually accepts, rather than a cross-VPC one it rejects.

## The lifecycle of a claimed block

Claiming ports gives the allocator three states it never had before -- a block claimed in full,
an address whose every block is claimed, and a run of such addresses -- and it mishandled all
three. These were found by review of this PR and the fixes have been moved down from #1700 to
sit with the change that creates the states, so this PR does not ship them:

- **A fully claimed first address disabled the whole region.** Allocation draws the lowest free
  address; if port forwarding had claimed every port on it, the attempt failed and the address
  went straight back into the pool for the next packet to find. Masquerade over `10.1.0.0/31`
  with forwarding over `10.1.0.0/32:1024-65535` could allocate nothing at all, though
  `10.1.0.1` had 64k ports free. Such addresses are now kept out of the pool as it is built.
- **A fully claimed block left the free-block count overstated.** The count was taken before
  claims were applied and never decremented when a block was skipped, so an address reported
  room it did not have, reuse failed on it, and every later flow drew a fresh address. With four
  addresses and one claim, the 260th allocation failed with `NoFreeIp` while 193,533 usable
  pairs sat untouched.
- **An ordinary policy conflict was reported as allocator corruption.** A skipped claimed block
  is not free and has no allocated block, so a reservation aimed at it returned `InternalIssue`
  rather than `PortReservationFailed`. The concurrency model treats `InternalIssue` as fatal,
  and a late carry-over can aim at exactly such a block.

Each was reproduced against this PR's previous head and passes now.
