### PR TITLE
(3)-masquerade: the block-handover races, and honest concurrent oracles

### DIFF
--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -34,13 +34,15 @@
 //! * Neither allocation nor reservation ever reports [`AllocatorError::InternalIssue`]. That is
 //!   the allocator saying its own bookkeeping is inconsistent.
 //!
-//!   A limit worth being honest about: `find_block_for_port` carries a standing `FIXME` wondering
-//!   whether the block it just found non-free can be released before it is looked up, and this
-//!   suite does not reach that interleaving. Reservations here target survivors, and a survivor's
-//!   block is pinned for the whole generation by the reservation [`Published`] holds, so it cannot
-//!   disappear mid-lookup. Reaching it would take generations whose specs differ, so that a pair
-//!   stops being carried and its block can empty while another thread reserves it; that is the
-//!   suite's next extension, not something it does today.
+//!   A limit worth being honest about: this suite does not reach the interleaving where the block
+//!   a reservation just found non-free is released before it is looked up. Reservations here
+//!   target survivors, and a survivor's block is pinned for the whole generation by the
+//!   reservation [`Published`] holds, so it cannot empty mid-lookup. That is a property of how
+//!   this suite reserves, not of what it takes to get there: neither a config change nor
+//!   generations whose specs differ is required, and
+//!   [`a_reservation_racing_the_release_of_its_block_is_not_called_a_bug`] reaches it with one
+//!   pool and one generation. Widening `ReserveExisting` to unpinned pairs would let this suite
+//!   reach it too, and is the extension worth making.
 //!
 //! # No loom
 //!
@@ -74,7 +76,7 @@ use concurrency::thread;
 // `spawn_scoped` is inherent on std's `Builder`, but supplied by `BuilderExt` under shuttle
 #[cfg_attr(not(feature = "shuttle"), allow(unused_imports))]
 use concurrency::thread::BuilderExt;
-use lpm::prefix::PrefixPortsSet;
+use lpm::prefix::{PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use std::collections::BTreeSet;
 use std::net::Ipv4Addr;
@@ -511,5 +513,132 @@ fn printing_the_pool_does_not_wedge_it_against_a_flow_ending() {
 
         printer.join().expect("the printing thread panicked");
         releaser.join().expect("the releasing thread panicked");
+    });
+}
+
+/// Reserving a port races the release of the block that holds it.
+///
+/// A block is given back in two steps: its free flag is stored `true`, and the weak entry in the
+/// list of allocated blocks expires when the last `Arc` to it goes. A reservation reads the flag
+/// and then searches that list, so it can fall between the two and find the block neither free nor
+/// allocated. The allocator used to call that broken bookkeeping and return `InternalIssue`, which
+/// the caller reads as the allocator being unfit rather than as one flow failing.
+///
+/// [`stress_test_config_change`] cannot reach this. Its reservations target survivors, and a
+/// survivor's block is pinned for the whole generation by the reservation [`Published`] holds, so
+/// it never empties mid-lookup. Neither a config change nor differing specs is needed to get
+/// there, though -- one pool and one generation will do, which is what this pins.
+///
+/// Production reaches it through the late flow `nf.rs` handles: a packet that allocated from the
+/// previous allocator and installs its flow after a new one was published re-reserves its pair
+/// against the current allocator, and that pair is not among the writer's pinned survivors. The
+/// block behind it can be emptying at that moment.
+///
+/// Either answer is legitimate -- refused while the pair is held, granted once it is released --
+/// and the test takes both. What it refuses is the allocator disclaiming its own state.
+#[concurrency::model_test]
+fn a_reservation_racing_the_release_of_its_block_is_not_called_a_bug() {
+    concurrency::stress(|| {
+        let specs = vec![PoolSpec {
+            // One address, so both threads are working on the same port allocator.
+            public_ranges: vec![AddrInterval::new(BASE, BASE)],
+            idle_timeout: IDLE_TIMEOUT,
+        }];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            &PrefixPortsSet::new(),
+            NextHeader::TCP,
+            false,
+        ));
+
+        let allocation = pools[0].allocate(false).expect("the pool can serve");
+        let (ip, port) = (allocation.ip(), allocation.port());
+
+        // The only holder of the pair, and so of its block: dropping it empties the block.
+        let releaser = thread::spawn(move || drop(allocation));
+        let reserver = {
+            let pools = pools.clone();
+            thread::spawn(move || pools[0].reserve(ip, port))
+        };
+
+        let outcome = reserver.join().expect("the reserving thread panicked");
+        releaser.join().expect("the releasing thread panicked");
+
+        if let Err(AllocatorError::InternalIssue(message)) = &outcome {
+            panic!("a reservation racing the release of its block was called a bug: {message}");
+        }
+    });
+}
+
+/// Tidying a dead entry out of the list of allocated blocks races another task listing a live one.
+///
+/// A task allocating from the block it used last finds its entry through a weak reference. When
+/// that reference has expired the entry is dropped as it is found -- but the lookup and the drop
+/// take the lock separately, so between them another task can claim the freed block and list it at
+/// the same index. The drop then deletes an entry for a block that is in use.
+///
+/// Nothing is handed out twice, so this is availability rather than isolation: the orphaned block
+/// stays claimed by its holder while the allocator no longer knows of it, so reservations into it
+/// find it neither free nor listed and are refused, and its free ports stop counting towards the
+/// address having room.
+///
+/// The third place the allocator sets a block's flag and its entry in the list apart from one
+/// another, after the two in `find_block_for_port`. Here the answer is to re-check under the write
+/// lock rather than to retry, since the caller has a lock to take anyway.
+///
+/// Worth knowing before trusting this one: the interleaving is narrow, and `stress` gives each
+/// body sixteen iterations over three schedulers. Reverting the fix is caught in roughly two runs
+/// in three, not every run. It never fails with the fix, so it costs nothing in CI, but a
+/// regression may take a couple of runs to show. Making the contending task poised before the
+/// block is freed was tried and made it worse -- four runs in twelve rather than eight.
+#[concurrency::model_test]
+fn tidying_a_dead_block_entry_does_not_drop_a_live_one() {
+    concurrency::stress(|| {
+        let address = Ipv4Addr::from(u32::try_from(BASE).unwrap_or_else(|_| unreachable!()));
+        let claim = |lo: u16, hi: u16| {
+            PrefixWithOptionalPorts::new(
+                format!("{address}/32").as_str().into(),
+                Some(PortRange::new(lo, hi).unwrap_or_else(|_| unreachable!())),
+            )
+        };
+        // Two usable blocks, the first with exactly one usable port. One allocation then fills the
+        // first block and pins the address, which is what lets the second block die on its own --
+        // dropping the last port of the only block would take the whole address with it, and the
+        // next allocation would build a fresh allocator with no stale entry to find.
+        let specs = vec![PoolSpec {
+            public_ranges: vec![AddrInterval::new(BASE, BASE)],
+            idle_timeout: IDLE_TIMEOUT,
+        }];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            &PrefixPortsSet::from([claim(1025, 1279), claim(1536, u16::MAX)]),
+            NextHeader::TCP,
+            false,
+        ));
+
+        let _keeper = pools[0].allocate(false).expect("the keeper allocation");
+        // Opens the second block, leaving this task's hint on it, and then dies: the hint now
+        // names an index whose entry in the list cannot be upgraded.
+        drop(pools[0].allocate(false).expect("the second block"));
+
+        // One task claims the freed block and lists it...
+        let holder = {
+            let pools = pools.clone();
+            thread::spawn(move || pools[0].allocate(false).ok())
+        };
+        // ...while this one follows its stale hint and tidies the list.
+        let mine = pools[0].allocate(false).ok();
+        let theirs = holder.join().expect("the other task panicked");
+
+        // Whichever of them got it, the block is held and has free ports left, so the allocator
+        // has to be able to find it.
+        if mine.is_some() || theirs.is_some() {
+            let port = NatPort::new_port_checked(1400).unwrap_or_else(|_| unreachable!());
+            let outcome = pools[0].reserve(address, port);
+            assert!(
+                outcome.is_ok(),
+                "a block in use was dropped from the list: reserving into it gave {outcome:?}"
+            );
+        }
     });
 }

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -31,10 +31,16 @@
 //! * An address and port is never handed to two live flows drawn from the same allocator. Shapes
 //!   that hold every allocation for the length of the run check this exactly; those that free as
 //!   they go trade that for exercising deallocation. See [`Live`] for why the two differ.
-//! * Neither allocation nor reservation ever reports [`AllocatorError::InternalIssue`]. That is the
-//!   allocator saying its own bookkeeping is inconsistent, and `find_block_for_port` carries a
-//!   standing `FIXME` wondering whether the block it just found non-free can be released before it
-//!   is looked up. Reserving concurrently with allocating is what would show it.
+//! * Neither allocation nor reservation ever reports [`AllocatorError::InternalIssue`]. That is
+//!   the allocator saying its own bookkeeping is inconsistent.
+//!
+//!   A limit worth being honest about: `find_block_for_port` carries a standing `FIXME` wondering
+//!   whether the block it just found non-free can be released before it is looked up, and this
+//!   suite does not reach that interleaving. Reservations here target survivors, and a survivor's
+//!   block is pinned for the whole generation by the reservation [`Published`] holds, so it cannot
+//!   disappear mid-lookup. Reaching it would take generations whose specs differ, so that a pair
+//!   stops being carried and its block can empty while another thread reserves it; that is the
+//!   suite's next extension, not something it does today.
 //!
 //! # No loom
 //!
@@ -198,11 +204,14 @@ impl Published {
                     carried.insert((ip, port.as_u16()));
                     reservations.push(reservation);
                 }
-                Err(AllocatorError::InternalIssue(message)) => {
-                    panic!("re-reserving {ip}:{port} for generation {generation}: {message}")
+                // Nothing may refuse a survivor. Every generation is built from the same specs, so
+                // the address is still served; the survivors are distinct pairs; and the allocator
+                // is fresh, so nothing else holds them. Accepting failure here would let the model
+                // publish generations that quietly carried nothing, and every property about
+                // carried pairs would pass vacuously.
+                Err(e) => {
+                    panic!("re-reserving {ip}:{port} for generation {generation} failed: {e}")
                 }
-                // The address may no longer be served, or another survivor may already hold it.
-                Err(_) => {}
             }
         }
 
@@ -408,16 +417,37 @@ fn packet_worker(
             }
             PacketOp::ReserveExisting => {
                 // Race a reservation against the other threads' allocations on pools that are
-                // already published and in use. Failing is fine, claiming inconsistent bookkeeping
-                // is not.
+                // already published and in use.
+                //
+                // Every survivor is carried into every generation -- the builder panics otherwise
+                // -- so in a correct allocator this reservation is always refused: the writer's
+                // own reservation holds the pair. The refusal is the same rule as for allocation,
+                // checked on the path a config change actually takes, and the success arm below is
+                // an oracle rather than a covered path: it can only run if a bug lets a held pair
+                // be reserved twice, and then it must not be dropped here, or the port would go
+                // back to the pools mid-run and the other oracles would be reasoning over a lie.
                 if let Some(&(owner, ip, port)) = survivors.get(step % survivors.len().max(1))
                     && let Some(pool) = published.pools.get(owner)
-                    && let Err(AllocatorError::InternalIssue(message)) = pool.reserve(ip, port)
                 {
-                    panic!(
-                        "reserving {ip}:{port} in generation {}: {message}",
-                        published.generation
-                    );
+                    let carried = published.carried.contains(&(ip, port.as_u16()));
+                    match pool.reserve(ip, port) {
+                        Ok(reservation) => {
+                            assert!(
+                                !carried,
+                                "generation {} reserved {ip}:{port} a second time, although a \
+                                 carried-over flow already holds it",
+                                published.generation
+                            );
+                            live.claim(published.generation, ip, port.as_u16());
+                            held.push((published.generation, reservation));
+                        }
+                        Err(AllocatorError::InternalIssue(message)) => panic!(
+                            "reserving {ip}:{port} in generation {}: {message}",
+                            published.generation
+                        ),
+                        // Refused because it is held, which is the ordinary outcome here.
+                        Err(_) => {}
+                    }
                 }
             }
         }

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -301,6 +301,38 @@ fn an_exhausted_region_falls_through_to_the_next() {
     );
 }
 
+/// A port given back while other ports of the same address are still held is available again.
+///
+/// [`freed_allocations_become_available_again`] drops everything at once, which frees whole port
+/// blocks and rebuilds them, so it passes whether or not an individual port is ever returned. A
+/// flow ending while its neighbours carry on is the ordinary case, and the one that leaks: a port
+/// that stays marked used is one the block cannot hand out again for as long as it lives.
+#[test]
+fn a_port_freed_on_its_own_is_handed_out_again() {
+    let specs = vec![PoolSpec {
+        public_ranges: vec![AddrInterval::new(BASE, BASE)],
+        idle_timeout: IDLE_TIMEOUT,
+    }];
+    let pool_sets =
+        pool_sets_for_specs::<Ipv4Addr>(&specs, &PrefixPortsSet::new(), NextHeader::TCP, false);
+
+    let mut held: Vec<_> = (0..5)
+        .map(|_| pool_sets[0].allocate(false).expect("pool has room"))
+        .collect();
+
+    // Give back one from the middle, keeping the rest, so the block stays alive.
+    let returned = held.remove(2);
+    let (ip, port) = (returned.ip(), returned.port().as_u16());
+    drop(returned);
+
+    let next = pool_sets[0].allocate(false).expect("pool has room");
+    assert_eq!(
+        (next.ip(), next.port().as_u16()),
+        (ip, port),
+        "the port given back was not handed out again"
+    );
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Exhaustion
 ///////////////////////////////////////////////////////////////////////////////

--- a/nat/src/masquerade/apalloc/port_alloc.rs
+++ b/nat/src/masquerade/apalloc/port_alloc.rs
@@ -29,6 +29,17 @@ use rand::seq::SliceRandom;
 #[concurrency_mode(shuttle)]
 use shuttle::rand::{Rng, thread_rng};
 
+/// How many times a reservation will look a port's block up before giving up on it.
+///
+/// A block's flag and its entry in the map of allocated blocks are set apart from one another at
+/// both ends of its life, so a lookup landing between them finds it neither free nor allocated and
+/// has to start over. Releasing stores the flag `true` and lets the weak entry expire with the
+/// `Arc`; claiming takes the flag first and inserts the entry after building the block. Either gap
+/// is enough, and the second needs no release at all -- a thread descheduled between the two holds
+/// it open for as long as it is parked. This is a bound on livelock, not a number of expected
+/// attempts.
+const BLOCK_LOOKUP_ATTEMPTS: usize = 4;
+
 ///////////////////////////////////////////////////////////////////////////////
 // AllocatorPortBlock
 ///////////////////////////////////////////////////////////////////////////////
@@ -362,35 +373,43 @@ impl<I: NatIpWithBitmap> PortAllocator<I> {
         ip: Arc<AllocatedIp<I>>,
         port: NatPort,
     ) -> Result<Arc<AllocatedPortBlock<I>>, AllocatorError> {
-        let (block_was_free, index) = self.try_to_reserve_block(port)?;
         let allow_null = matches!(port, NatPort::Identifier(_));
-        if block_was_free {
-            return self.allocate_block_for_reservation(ip, index, port, allow_null);
+        for _ in 0..BLOCK_LOOKUP_ATTEMPTS {
+            let (block_was_free, index) = self.try_to_reserve_block(port)?;
+            if block_was_free {
+                return self.allocate_block_for_reservation(ip, index, port, allow_null);
+            }
+            if let Some(block) = self.allocated_blocks.search_for_block(port) {
+                return Ok(block);
+            }
+            // A block masquerade may never draw from never joins the list of allocated blocks, so
+            // its absence from that list says nothing about the bookkeeping. Port forwarding
+            // claiming a block in full is the way to reach this from a configuration: a flow
+            // carried across a config change may hold a port in a block the new configuration has
+            // claimed.
+            //
+            // Answer as a claim on part of the same block does, where the block is allocatable and
+            // its own bitmap refuses the port. How much of a block an operator happened to claim is
+            // not something the caller should be able to tell apart, and it is certainly not the
+            // difference between a policy conflict and a broken allocator.
+            if self.block_is_excluded(port) {
+                debug!("Port {port} lies in a block that port forwarding has claimed in full");
+                return Err(AllocatorError::PortReservationFailed(port.as_u16()));
+            }
+            // Not free, not allocated, not excluded: the block is mid-handover. Either its last
+            // holder released it between the flag being read and the map being searched, or
+            // another thread has claimed it and not yet published it. Nothing is wrong either
+            // way, and starting over is the answer to both -- the next attempt finds the block
+            // free if it was released, and in the map once the claimant gets there.
+            debug!("Block holding port {port} was released mid-lookup, retrying");
         }
-        if let Some(block) = self.allocated_blocks.search_for_block(port) {
-            return Ok(block);
-        }
-        // A block masquerade may never draw from never joins the list of allocated blocks, so its
-        // absence from that list says nothing about the bookkeeping. Port forwarding claiming a
-        // block in full is the way to reach this from a configuration: a flow carried across a
-        // config change may hold a port in a block the new configuration has claimed.
-        //
-        // Answer as a claim on part of the same block does, where the block is allocatable and its
-        // own bitmap refuses the port. How much of a block an operator happened to claim is not
-        // something the caller should be able to tell apart, and it is certainly not the difference
-        // between a policy conflict and a broken allocator.
-        if self.block_is_excluded(port) {
-            debug!("Port {port} lies in a block that port forwarding has claimed in full");
-            return Err(AllocatorError::PortReservationFailed(port.as_u16()));
-        }
-        // Block was not free but is not in the list of allocated blocks either??
-        //
-        // FIXME: This can legitimately happen if the block was released just after we checked
-        // whether it was free? (Not observed in shuttle tests so far.) Do we need an additional
-        // lock around the PortAllocator?
-        Err(AllocatorError::InternalIssue(
-            "Block not free, although absent from list of allocated blocks".to_string(),
-        ))
+        // Every attempt landed in that window: either this block kept changing hands, or a thread
+        // claiming it stayed parked between taking its flag and publishing it. Say the reservation
+        // failed rather than claim the bookkeeping is broken -- the caller drops one flow, where
+        // `InternalIssue` is read as the allocator being unfit and costs the packet its whole
+        // batch.
+        debug!("Block holding port {port} was released mid-lookup {BLOCK_LOOKUP_ATTEMPTS} times");
+        Err(AllocatorError::PortReservationFailed(port.as_u16()))
     }
 
     pub(crate) fn reserve_port(
@@ -712,13 +731,27 @@ impl<I: NatIpWithBitmap> AllocatedPortBlockMap<I> {
         self.0.read().get(&index).cloned()
     }
 
-    fn remove(&self, index: usize) {
-        self.0.write().remove(&index);
+    // Drop the entry at this index, but only if what is there now is still dead.
+    //
+    // The caller found its own copy of the weak reference expired, under no lock. By the time it
+    // gets here another thread may have claimed the freed block and inserted a live reference at
+    // the same index, and removing that would orphan a block that is in use: reservations into it
+    // would find it neither free nor listed, and its free ports would be invisible to
+    // `has_entries_with_free_ports`. Re-checking under the write lock is what makes the removal
+    // apply to the entry the caller actually saw. A different *dead* entry is fine to drop; that
+    // is the same tidying, one turn later.
+    fn remove_if_still_dead(&self, index: usize) {
+        let mut blocks = self.0.write();
+        if let Some(stored) = blocks.get(&index)
+            && stored.upgrade().is_none()
+        {
+            blocks.remove(&index);
+        }
     }
 
     fn get(&self, index: usize) -> Option<Arc<AllocatedPortBlock<I>>> {
         self.get_weak(index)?.upgrade().or_else(|| {
-            self.remove(index);
+            self.remove_if_still_dead(index);
             None
         })
     }
@@ -735,11 +768,13 @@ impl<I: NatIpWithBitmap> AllocatedPortBlockMap<I> {
     }
 
     fn search_for_block(&self, port: NatPort) -> Option<Arc<AllocatedPortBlock<I>>> {
-        let blocks = self.0.read();
-        blocks
+        // One upgrade, kept. Upgrading to test the block and again to return it let the block die
+        // in between, so a block that was there a moment ago read as absent -- which the caller
+        // cannot tell from a block that was never listed.
+        self.0
+            .read()
             .values()
-            .find(|block| block.upgrade().is_some_and(|block| block.covers(port)))?
-            .upgrade()
+            .find_map(|block| block.upgrade().filter(|block| block.covers(port)))
     }
 
     // Used for Display


### PR DESCRIPTION
The `set_bitmap_value` fix this PR used to carry has moved to the bottom of the stack, into
#1696. It had to: the concurrent model checker cannot assert that a pair already held is refused a
second time until that fix is in, and a suite that accepts such a success certifies the defect
instead of catching it. With it at the bottom, no PR in the stack ever ships a live
duplicate-reservation bug.

What is left here is the testing that fix makes possible.

## The concurrent suite now guards this fix

The model checker's reservation oracle moved here from further up the stack, because here is where
it can hold. It asserts that a second reservation of a pair a carried-over flow still holds is
refused -- which is exactly what the duplicate-reservation guard above makes true, and what was
false before it. Under the previous arrangement the suite accepted such a success and dropped it,
so it passed while certifying the very defect this PR fixes.

Mutation-verified against this PR's own change: revert the `set_bitmap_value` guard and
`stress_test_config_change` fails.

`Published::build` also stopped accepting carry-over failures. Every generation is built from the
same specs with a fresh allocator and distinct survivor pairs, so nothing may refuse one; tolerating
it let the model publish generations that carried nothing, and every property about carried pairs
passed vacuously over them.

## A race the model could not reach, found by review

The suite's own documentation claimed the reservation/release window in `find_block_for_port`
needed generations whose specs differ to reach. That was wrong, and the claim was made by this
PR. One pool and one generation reach it: allocate a pair, then race a reservation of that pair
against dropping its only holder. Shuttle finds the schedule in a single execution.

A block is given back in two steps a reader can fall between -- the free flag is stored `true`,
and the weak entry in the list of allocated blocks expires with the last `Arc`. A reservation
reads the flag and then searches the list, so it could see the block as neither, and returned
`InternalIssue`: the allocator declaring its own bookkeeping broken for a moment in which nothing
is wrong. The lookup now starts over, bounded, and answers a failed reservation if every attempt
lands in the window.

Production reaches this through the late flow `nf.rs` already handles, where a packet that
allocated from the previous allocator installs its flow after a new one is published. That pair
is not among the writer's pinned survivors, so the block behind it can be emptying as it
re-reserves. The cost was a spuriously invalidated flow during a config change.

The defect predates this stack -- the code carried a `FIXME` wondering whether the window was
reachable and noting it had not been seen under shuttle. It is fixed here rather than lower
because this is the PR that makes the concurrent oracle honest, and the claim it corrects is one
this PR made. The regression test fails on the first schedule without the fix.

What the suite still cannot reach on its own is unchanged and now stated correctly: its
reservations target survivors, whose blocks are pinned for the generation. Widening
`ReserveExisting` to unpinned pairs is the extension that would close it.

## A third instance of the same shape

Review of the whole stack found the same two-step handover a third time, and it is fixed here
alongside the other two. Tidying a dead entry out of the list of allocated blocks looks the entry
up and drops it under separate locks, so another thread can claim the freed block and list it at
that index in between; the drop then deletes an entry for a block that is in use.

Nothing is handed out twice, so this is availability rather than isolation — the orphaned block
stays claimed by its holder while the allocator no longer knows of it, so reservations into it are
refused and its free ports stop counting towards the address having room. Shuttle reproduces it and
the symptom is exactly that: `PortReservationFailed` on a block with 255 ports free.

The answer here is to re-check under the write lock rather than to retry, since the caller has a
lock to take anyway. `search_for_block` had the same double-upgrade shape and now keeps its first
one.