### PR TITLE
ci: Cap the check job at 8 concurrent compile jobs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -120,6 +120,16 @@ jobs:
       - check_changes
     permissions: &check-perms
       contents: "read"
+    # The lab runners have 10 cores. `jobs` is nix's --max-jobs (concurrent
+    # derivations) and `cores` is nix's --cores (NIX_BUILD_CORES, which crane
+    # turns into CARGO_BUILD_JOBS and enableParallelBuilding turns into
+    # `make -j`), so the cap on a job is their product. Every job below that
+    # reaches `nix build` sets `jobs=1 cores=8`: one derivation at a time,
+    # eight compile threads inside it, two cores left for everything else.
+    # A single cargo build of the workspace dominates these jobs, so
+    # serializing derivations costs us little and that build gets the 8.
+    # The exception is `cross`, which runs two matrix entries at once and
+    # so halves its `cores` to stay inside the same budget.
     env: &check-env
       USER: "runner"
       JUST_VARS: >-
@@ -362,6 +372,8 @@ jobs:
             platform="x86-64-v3"
           fi
           base_args=(
+            jobs=1
+            cores=8
             docker_sock=/run/docker/docker.sock
             debug_justfile="${DEBUG_JUSTFILE}"
             profile="${PROFILE}"
@@ -474,7 +486,11 @@ jobs:
       - name: "all packages"
         uses: *just
         env:
+          # miri never reaches `nix build`, so the root justfile's `jobs` and
+          # `cores` can't cap it; the module takes its own `cores` and hands
+          # it to cargo and to nextest. See the comment on `check-env`.
           JUST_VARS: >-
+            miri::cores=8
             miri::cpu=${{ matrix.cpu }}
         with:
           recipe: "miri::test"
@@ -490,6 +506,7 @@ jobs:
         uses: *just
         env:
           JUST_VARS: >-
+            miri::cores=8
             miri::seeds=8
             miri::cpu=${{ matrix.cpu }}
             miri::provenance=permissive
@@ -500,6 +517,7 @@ jobs:
         uses: *just
         env:
           JUST_VARS: >-
+            miri::cores=8
             miri::cpu=${{ matrix.cpu }}
             miri::provenance=strict
         with:
@@ -539,6 +557,8 @@ jobs:
         uses: *just
         env:
           JUST_VARS: >-
+            jobs=1
+            cores=8
             platform=${{ matrix.platform }}
             profile=${{ matrix.profile }}
             libc=${{ matrix.libc }}
@@ -597,7 +617,12 @@ jobs:
           }}
         uses: *just
         env:
+          # cores=4, not the 8 the rest of CI uses: this is the one job with
+          # `max-parallel: 2`, so two matrix entries that land on the same
+          # lab runner still fit inside its 10 cores.
           JUST_VARS: >-
+            jobs=1
+            cores=4
             platform=${{ matrix.platform }}
             profile=${{ matrix.profile }}
             libc=${{ matrix.libc }}
@@ -607,6 +632,8 @@ jobs:
         uses: *just
         env:
           JUST_VARS: >-
+            jobs=1
+            cores=4
             platform=${{ matrix.platform }}
             profile=${{ matrix.profile }}
             libc=${{ matrix.libc }}
@@ -631,8 +658,8 @@ jobs:
     # This job doesn't use the `*check-env` anchor: that anchor's
     # `JUST_VARS` references `matrix.build.*`, and this job has no
     # matrix. Each step below sets `JUST_VARS` itself, inlining the
-    # docker_sock / debug_justfile / oci_repo settings that the
-    # anchor would have provided.
+    # jobs / cores / docker_sock / debug_justfile / oci_repo settings
+    # that the anchor would have provided.
     env:
       USER: "runner"
     steps:
@@ -641,6 +668,8 @@ jobs:
       - name: "shuttle"
         env:
           JUST_VARS: >-
+            jobs=1
+            cores=8
             docker_sock=/run/docker/docker.sock
             debug_justfile=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_justfile || false }}
             profile=fuzz
@@ -652,6 +681,8 @@ jobs:
       - name: "loom"
         env:
           JUST_VARS: >-
+            jobs=1
+            cores=8
             docker_sock=/run/docker/docker.sock
             debug_justfile=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_justfile || false }}
             profile=fuzz
@@ -865,6 +896,8 @@ jobs:
         run: |
           set -euo pipefail;
           just \
+            jobs=1 \
+            cores=8 \
             docker_sock=/run/docker/docker.sock \
             oci_repo=ghcr.io \
             version="${ref_name}" \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -123,6 +123,8 @@ jobs:
     env: &check-env
       USER: "runner"
       JUST_VARS: >-
+        jobs=1
+        cores=8
         docker_sock=/run/docker/docker.sock
         debug_justfile=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_justfile || false }}
         profile=${{ matrix.build.profile }}

--- a/justfile
+++ b/justfile
@@ -338,7 +338,8 @@ push-container target="dataplane" *args: (build-container target args) && versio
             exit 99
     esac
 
-# Note: deliberately ignores all recipe parameters save version, debug_justfile, and oci_repo.
+# Note: deliberately ignores all recipe parameters save version, debug_justfile,
+# oci_repo, and the jobs/cores build-parallelism caps.
 # Pushes all release container images.
 [script]
 push:
@@ -349,7 +350,7 @@ push:
         else
           platform="x86-64-v3"
         fi
-        just debug_justfile="{{debug_justfile}}" oci_repo="{{oci_repo}}" version="{{version}}" profile=release platform="${platform}" sanitize= instrument=none push-container "${container}"
+        just jobs="{{jobs}}" cores="{{cores}}" debug_justfile="{{debug_justfile}}" oci_repo="{{oci_repo}}" version="{{version}}" profile=release platform="${platform}" sanitize= instrument=none push-container "${container}"
     done
 
 # Print names of container images to build or push

--- a/justfile
+++ b/justfile
@@ -13,8 +13,17 @@ debug_justfile := "false"
 [private]
 _just_debuggable_ := if debug_justfile == "true" { "set -x" } else { "" }
 
-# number of nix jobs to run in parallel
+# number of nix derivations to build concurrently
 jobs := "8"
+
+# threads each nix derivation may use ("0" means every core on the machine).
+#
+# nix hands this to the builder as NIX_BUILD_CORES, which crane turns into
+# CARGO_BUILD_JOBS and nixpkgs' enableParallelBuilding turns into make -j, so
+# it is the cap on concurrent compile/link jobs *within* one derivation. The
+# cap on the whole build is therefore `jobs` x `cores`; a runner with fewer
+# cores than that will oversubscribe itself.
+cores := "0"
 
 # libc
 libc := if platform == "wasm32-wasip1" { "none" } else { "gnu" }
@@ -139,6 +148,7 @@ build target="dataplane.tar" *args:
       --show-trace \
       --out-link "results/${target}" \
       --max-jobs "{{jobs}}" \
+      --cores "{{cores}}" \
       --keep-failed \
       {{ args }}
 

--- a/miri.just
+++ b/miri.just
@@ -11,6 +11,14 @@ debug_justfile := "false"
 [private]
 _just_debuggable_ := if debug_justfile == "true" { "set -x" } else { "" }
 
+# threads miri may use ("0" means every core on the machine).
+#
+# This module compiles and runs on the host inside `nix-shell`, so the root
+# justfile's `cores` (which is just `nix build --cores`) never reaches it.
+# We therefore hand the cap to cargo and to nextest ourselves: cargo through
+# CARGO_BUILD_JOBS for the build, nextest through --test-threads for the run.
+export cores := "0"
+
 export cpu := "powerpc64"
 [private]
 export target := cpu + "-unknown-linux-gnu"
@@ -52,7 +60,14 @@ test *args="":
       # Umbrella cfg shared with the qemu-user path in nix/profiles.nix.
       RUSTFLAGS+="--cfg=emulated"
       declare -rx RUSTFLAGS
-      declare -ra cmd=("nice" "-n" "19" "cargo" "miri" "nextest" "run" "--profile=miri" "--target=${target}")
+      declare -a cmd=("nice" "-n" "19" "cargo" "miri" "nextest" "run" "--profile=miri" "--target=${target}")
+      if [ "${cores}" != "0" ]; then
+        # nextest defaults --test-threads to the core count; the miri profile
+        # then spends `threads-required` (== ${seeds}) of those slots per test.
+        declare -rx CARGO_BUILD_JOBS="${cores}"
+        cmd+=("--test-threads=${cores}")
+      fi
+      declare -r cmd
       echo "Running Miri with args: {{ args }}"
       echo "MIRIFLAGS=$MIRIFLAGS"
       echo "RUSTFLAGS=$RUSTFLAGS"


### PR DESCRIPTION
The lab runners give us 10 cores, and nothing was holding the build to them.

`jobs` was already 8, but it feeds `nix build --max-jobs`, which counts derivations, not threads. The per-derivation thread count comes from `--cores`, which we never passed, so nix used its default of 0 and handed every derivation the whole machine: crane's `configureCargoCommonVarsHook` turns `NIX_BUILD_CORES` into `CARGO_BUILD_JOBS`, and the C derivations we build with `enableParallelBuilding` turn it into `make -j`. The ceiling was 8 derivations times 10 threads.

So this adds a `cores` variable to pass through to `--cores`. It defaults to `"0"`, leaving every other caller exactly where it was, and the `check` job sets `jobs=1 cores=8` to bring the product down to 8. Serializing derivations costs little here because one cargo build of the workspace dominates the job, and that build is the one that wants the 8 threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)