### PR TITLE
CLI: add output filtering and highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,7 @@ dependencies = [
  "nix 0.31.3",
  "rand 0.10.2",
  "reedline",
+ "regex",
  "rkyv",
  "strum 0.28.0",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ quote = { version = "1.0.47", default-features = false, features = [] }
 rand = { version = "0.10.2", default-features = false, features = [] }
 rapidhash = { version = "4.5.1", default-features = false, features = [] }
 reedline = { version = "0.49.0", default-features = false, features = [] }
+regex = { version = "1.13.1", default-features = false, features = [] }
 rkyv = { version = "0.8.18", default-features = false, features = [] }
 roaring = { version = "0.11.4", default-features = false, features = [] }
 rtnetlink = { git = "https://github.com/githedgehog/rtnetlink.git", branch = "hh/tc-actions4", default-features = false, features = [] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ colored = { workspace = true, features = [] }
 nix = { workspace = true, features = ["socket"] }
 rkyv = { workspace = true, features = ["alloc", "bytecheck", "std"] }
 reedline = { workspace = true }
+regex = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 

--- a/cli/bin/filters.rs
+++ b/cli/bin/filters.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Filter setup for filtering outputs
+
+use colored::Colorize;
+use regex::Regex;
+use std::str::SplitWhitespace;
+
+#[derive(Debug, PartialEq)]
+pub enum FilterCode {
+    Only,
+    Not,
+    HighLight,
+}
+impl TryFrom<&str> for FilterCode {
+    type Error = &'static str;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "only" => Ok(FilterCode::Only),
+            "not" => Ok(FilterCode::Not),
+            "high" => Ok(FilterCode::HighLight),
+            _ => Err("Unknown filter"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Filter {
+    code: FilterCode,
+    tokens: Vec<String>,
+}
+impl Filter {
+    fn from_code(code: FilterCode) -> Self {
+        Self {
+            code,
+            tokens: Vec::new(),
+        }
+    }
+    fn add_token(&mut self, token: &str) {
+        self.tokens.push(token.to_owned());
+    }
+}
+
+pub const PIPE: &str = "|";
+pub const HEADING_CHAR: char = '━';
+
+fn highlight(line: &str, re: &Regex) -> String {
+    let mut result = String::new();
+    let mut last = 0;
+
+    for m in re.find_iter(line) {
+        result.push_str(&line[last..m.start()]);
+        result.push_str(&m.as_str().red().bold().to_string());
+        last = m.end();
+    }
+
+    result.push_str(&line[last..]);
+    result
+}
+
+pub fn parse_filters(
+    mut split: SplitWhitespace<'_>,
+    filters: &mut Vec<Filter>,
+) -> Result<(), &'static str> {
+    loop {
+        let Some(keyword) = split.next() else {
+            return Err("Missing filter");
+        };
+        // build filter from code
+        let mut filter = Filter::from_code(FilterCode::try_from(keyword)?);
+        let mut more_filters = false;
+        for word in split.by_ref() {
+            if word == PIPE {
+                // new filter begins. Store the current one and parse the next
+                more_filters = true;
+                break;
+            }
+            filter.add_token(word);
+        }
+        if filter.tokens.is_empty() {
+            return Err("Missing filter token");
+        }
+        filters.push(filter);
+        if !more_filters {
+            return Ok(());
+        }
+    }
+}
+
+// Filter some output based on the given filters
+pub fn filter_output(output: &str, filters: &Vec<Filter>) -> String {
+    if filters.is_empty() {
+        return output.to_string();
+    }
+
+    // Highlighting does not affect what is output and can be executed last,
+    // collecting all of the patterns to highlight into a single regex.
+    let patterns: Vec<String> = filters
+        .iter()
+        .filter(|filter| matches!(filter.code, FilterCode::HighLight))
+        .flat_map(|filter| filter.tokens.iter().map(String::as_str).map(regex::escape))
+        .collect();
+
+    let high_regex = if patterns.is_empty() {
+        None
+    } else {
+        Regex::new(&patterns.join("|")).ok()
+    };
+
+    let lines: Vec<String> = output
+        .lines()
+        .filter_map(|line| {
+            // line is each of the lines we are about to process. For each line, we
+            // need to tell if it must be output or not and how. `Include` below is
+            // per line and must be true in the last filter for the line to be shown.
+            let mut include = true;
+            if line.contains(HEADING_CHAR) {
+                return Some(line.to_string());
+            }
+
+            // apply the filters in order for each of the lines
+            for filter in filters {
+                match filter.code {
+                    FilterCode::Only => {
+                        if include {
+                            include = filter.tokens.iter().any(|w| line.contains(w));
+                        }
+                    }
+                    FilterCode::Not => {
+                        if include {
+                            include = !filter.tokens.iter().any(|w| line.contains(w));
+                        }
+                    }
+                    FilterCode::HighLight => {
+                        // handled last after applying all filters so that it is
+                        // applied once and only for the lines that should be output, with a single
+                        // regex that includes all patterns
+                    }
+                }
+            }
+            if !include {
+                return None;
+            }
+            match &high_regex {
+                Some(re) => Some(highlight(line, re)),
+                None => Some(line.to_string()),
+            }
+        })
+        .collect();
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod test {
+    use super::FilterCode;
+    use super::filter_output;
+    use crate::terminal::Terminal;
+
+    #[test]
+    fn test_setup_filter() {
+        // test that filters are setup from user input
+        let user_input = "show ip route | only foo bar baz | not bad ugly | high AAAA";
+        let terminput = Terminal::proc_line(user_input).unwrap();
+        let filters = terminput.get_filters();
+        assert_eq!(filters.len(), 3);
+
+        // only foo bar baz
+        let filter_0 = &filters[0];
+        assert_eq!(filter_0.code, FilterCode::Only);
+        assert_eq!(filter_0.tokens.len(), 3);
+        assert!(filter_0.tokens.contains(&"foo".to_string()));
+        assert!(filter_0.tokens.contains(&"bar".to_string()));
+        assert!(filter_0.tokens.contains(&"baz".to_string()));
+
+        // not bad ugly
+        let filter_1 = &filters[1];
+        assert_eq!(filter_1.code, FilterCode::Not);
+        assert_eq!(filter_1.tokens.len(), 2);
+        assert!(filter_1.tokens.contains(&"bad".to_string()));
+        assert!(filter_1.tokens.contains(&"ugly".to_string()));
+
+        // high AAAA
+        let filter_2 = &filters[2];
+        assert_eq!(filter_2.code, FilterCode::HighLight);
+        assert_eq!(filter_2.tokens.len(), 1);
+        assert!(filter_2.tokens.contains(&"AAAA".to_string()));
+    }
+
+    #[test]
+    fn test_output_filter() {
+        let user_input =
+            "somecommand | only 192.168.1.1/32 192.168.2.0 | high Hedgehog | not porcupine lion";
+        let terminput = Terminal::proc_line(user_input).unwrap();
+
+        let output = "
+1 SHOWN 192.168.1.1/32 Hedgehog
+2 NO-SHOW porcupine
+3 NO-SHOW 192.168.3.0
+4 NO-SHOW 192.168.1.1/32 lion
+5 SHOWN My address is 192.168.2.0
+";
+        let output = filter_output(output, terminput.get_filters());
+        println!("{output}");
+        assert!(output.contains("SHOWN"));
+        assert!(!output.contains("NO-SHOW"));
+    }
+}

--- a/cli/bin/main.rs
+++ b/cli/bin/main.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(clippy::collapsible_if)]
 
+use crate::filters::filter_output;
 use argsparse::{ArgsError, CliArgs};
 use clap::Parser;
 use cmdline::Cmdline;
@@ -24,6 +25,7 @@ mod cmdline;
 mod cmdtree;
 mod cmdtree_dp;
 mod completions;
+mod filters;
 mod terminal;
 
 #[rustfmt::skip]
@@ -66,6 +68,7 @@ fn execute_remote_action(
     action: CliAction,       // action to perform
     args: &CliArgs,          // action arguments
     terminal: &mut Terminal, // this terminal
+    input: &TermInput,       // user input
 ) {
     if !terminal.is_connected() {
         print_err!("Not connnected to dataplane.");
@@ -85,7 +88,10 @@ fn execute_remote_action(
 
     // receive and deserialize response, synchronously
     match process_cli_response(&terminal.sock) {
-        Ok(data) => println!("{data}"),
+        Ok(data) => {
+            let out = filter_output(&data, input.get_filters());
+            println!("{out}");
+        }
         Err(e) => print_err!("{e}"),
     }
 }
@@ -95,6 +101,7 @@ fn execute_action(
     args: &CliArgs,    // action arguments
     cmdline: &Cmdline,
     terminal: &mut Terminal, // this terminal
+    input: &TermInput,       // user input
 ) {
     match action {
         CliAction::Clear => terminal.clear(),
@@ -114,7 +121,7 @@ fn execute_action(
             terminal.connect(&bind_addr, &path);
         }
         // all others are remote
-        _ => execute_remote_action(action, args, terminal),
+        _ => execute_remote_action(action, args, terminal, input),
     }
 }
 
@@ -152,7 +159,7 @@ fn process_command(
     if let Some(node) = cmds.find_best(input.get_tokens()) {
         if let Some(action) = &node.action {
             if let Ok(args) = process_args(input) {
-                execute_action(*action, &args, cmdline, terminal);
+                execute_action(*action, &args, cmdline, terminal, input);
             }
         } else if node.depth > 0 {
             print_err!("No action associated to command");
@@ -180,7 +187,7 @@ fn proc_cmdline_commands(
         return;
     }
     for cmd in input_cmds {
-        if let Some(mut input) = terminal.proc_line(cmd) {
+        if let Some(mut input) = Terminal::proc_line(cmd) {
             println!("{}{}", terminal.read_prompt(), input.get_line());
             process_command(terminal, cmds, cmdline, &mut input);
         }

--- a/cli/bin/terminal.rs
+++ b/cli/bin/terminal.rs
@@ -27,6 +27,9 @@ use std::path::Path;
 // our completer
 use crate::completions::CmdCompleter;
 
+// filters
+use crate::filters::{Filter, PIPE, parse_filters};
+
 #[macro_export]
 // macro to print errors in cli binary
 macro_rules! print_err {
@@ -79,6 +82,7 @@ pub struct TermInput {
     line: String,
     tokens: VecDeque<String>,
     args: HashMap<String, String>,
+    filters: Vec<Filter>,
 }
 #[allow(unused)]
 impl TermInput {
@@ -90,6 +94,9 @@ impl TermInput {
     }
     pub fn get_args(&self) -> &HashMap<String, String> {
         &self.args
+    }
+    pub fn get_filters(&self) -> &Vec<Filter> {
+        &self.filters
     }
     fn empty() -> Self {
         Self::default()
@@ -146,16 +153,23 @@ impl Terminal {
         print!("\x1b[H\x1b[2J");
         let _ = stdout().flush();
     }
-    #[allow(clippy::unused_self)]
-    pub fn proc_line(&self, line: &str) -> Option<TermInput> {
+
+    pub fn proc_line(line: &str) -> Option<TermInput> {
         let mut split = line.split_whitespace();
         let mut tokens: VecDeque<String> = VecDeque::new();
         let mut args = HashMap::new();
-        for word in split {
+        let mut filters = Vec::new();
+        while let Some(word) = split.next() {
             if word.contains('=') {
                 if let Some((arg, arg_value)) = word.split_once('=') {
                     args.insert(arg.to_owned(), arg_value.to_owned());
                 }
+            } else if word == PIPE {
+                if let Err(e) = parse_filters(split, &mut filters) {
+                    print_err!("{e}");
+                    return None;
+                }
+                break;
             } else {
                 tokens.push_back(word.to_owned());
             }
@@ -167,6 +181,7 @@ impl Terminal {
                 line: line.to_owned(),
                 tokens,
                 args,
+                filters,
             })
         }
     }
@@ -188,7 +203,7 @@ impl Terminal {
                     if line.is_empty() {
                         continue;
                     }
-                    if let Some(c) = self.proc_line(line) {
+                    if let Some(c) = Self::proc_line(line) {
                         return c;
                     }
                 }


### PR DESCRIPTION
Adds a simple syntax to filter and/or highlight the output of the cli. Filtering/highlighting must come at the end of the line and start with a pipe | symbol. The syntax is:
  - CMD | only FOO: include only lines containing FOO
  - CMD | not BAR:  exclude lines containing BAR
  - CMD | high BAZ: highlight BAZ

All of the single filters can include multiple words or tokens (space separated). E.g.:

 CMD | high BAZ BAR FOO would highlight all of the tokens present
 CMD | not  BAZ BAR would not show the line if it contains any
 CMD | only BAZ BAR FOO would show lines containing any of the
 tokens.

  
 And an arbitrary number of filters can be specified in a command.
 E.g. CMD | not FOO BAR | Only BAZ Other | high BAZ
 would:
    - not show lines including either FOO or BAR
    - only show lines that included BAZ or Other
    - of the remaining lines, highlight BAZ word
