### PR TITLE
flow-filter: Clean-up 2-pass context lookups based on flow info initiator flag

### DIFF
--- a/flow-filter/src/context/fuzz.rs
+++ b/flow-filter/src/context/fuzz.rs
@@ -157,10 +157,10 @@ fn oracle_stage2(
 /// Answer a route lookup directly from the validated overlay.
 /// Shared by the context and NF metadata property tests.
 ///
-/// Both stages ask what the flow vouches for first, and only then the plain question. A packet on
-/// an established flow keeps the peering and the NAT mode that flow was built on, even where an
-/// expose covers the same address ungated; the plain question is the fallback, for the forward
-/// traffic that carries no flow information of its own.
+/// Each stage asks exactly one question, chosen from the flow information the caller resolved up
+/// front (see `is_initiator`): a revalidating reply either names the peering it was built on
+/// (stage 1, via `dst_vpcd`) or opens the port-forwarding gate (stage 2, via `gate`); forward
+/// traffic, which carries no flow information, asks the plain question with neither set.
 pub(crate) fn oracle_lookup(overlay: &ValidatedOverlay, probe: &Probe) -> LookupResult {
     let Some(src_vpc) = overlay
         .vpc_table()
@@ -174,10 +174,7 @@ pub(crate) fn oracle_lookup(overlay: &ValidatedOverlay, probe: &Probe) -> Lookup
     }
     let (sport, dport) = probe.ports.unwrap_or((0, 0));
 
-    let verdict = probe
-        .dst_vpcd
-        .and_then(|vpcd| oracle_stage1(src_vpc, probe, dport, Some(vpcd)))
-        .or_else(|| oracle_stage1(src_vpc, probe, dport, None));
+    let verdict = oracle_stage1(src_vpc, probe, dport, probe.dst_vpcd);
     let Some((dst_vpcd, dst_nat)) = verdict else {
         return LookupResult::DestinationMiss;
     };
@@ -187,8 +184,7 @@ pub(crate) fn oracle_lookup(overlay: &ValidatedOverlay, probe: &Probe) -> Lookup
         .iter()
         .find(|p| VpcDiscriminant::from_vni(p.remote_vni()) == dst_vpcd)
         .unwrap_or_else(|| unreachable!("stage 1 hit implies a peering to the verdict VPC"));
-    let src_nat = oracle_stage2(peering, probe, sport, probe.gate)
-        .or_else(|| oracle_stage2(peering, probe, sport, SourceGate::Ungated));
+    let src_nat = oracle_stage2(peering, probe, sport, probe.gate);
     match src_nat {
         Some(src_nat) => LookupResult::Route((dst_vpcd, dst_nat, src_nat)),
         None => LookupResult::SourceMiss(dst_vpcd),

--- a/flow-filter/src/context/tables.rs
+++ b/flow-filter/src/context/tables.rs
@@ -135,10 +135,6 @@ pub(super) struct GateVni(pub(crate) Option<Vni>);
 
 impl GateVni {
     const UNGATED: Self = Self(None);
-
-    fn is_gated(self) -> bool {
-        self.0.is_some()
-    }
 }
 
 impl From<Option<Vni>> for GateVni {
@@ -166,6 +162,7 @@ pub(crate) enum SourceGate {
 }
 
 impl SourceGate {
+    #[cfg(test)] // Currently only used in tests
     pub(crate) fn is_gated(self) -> bool {
         self != Self::Ungated
     }
@@ -739,34 +736,19 @@ impl FlowFilterContext {
 
         match (src_ip, dst_ip) {
             (IpAddr::V4(src_ip), IpAddr::V4(dst_ip)) => {
-                let verdict = if let Some(v) = self.remote_v4.lookup(&RemoteKey {
+                let Some(verdict) = self.remote_v4.lookup(&RemoteKey {
                     proto,
                     src_vni,
                     dst_vni,
                     dst_ip,
                     dst_port,
-                }) {
-                    v
-                } else {
-                    if dst_vni.is_gated()
-                        && let Some(v) = self.remote_v4.lookup(&RemoteKey {
-                            proto,
-                            src_vni,
-                            dst_vni: GateVni::UNGATED,
-                            dst_ip,
-                            dst_port,
-                        })
-                    {
-                        v
-                    } else {
-                        return LookupResult::DestinationMiss;
-                    }
+                }) else {
+                    return LookupResult::DestinationMiss;
                 };
-                let dst_vni = key_vni(verdict.dst_vpcd);
                 match self.local_v4.lookup(&LocalKey {
                     proto,
                     src_vni,
-                    dst_vni,
+                    dst_vni: key_vni(verdict.dst_vpcd),
                     src_ip,
                     src_port,
                     gate,
@@ -774,53 +756,23 @@ impl FlowFilterContext {
                     Some(src_nat_mode) => {
                         LookupResult::Route((verdict.dst_vpcd, verdict.nat_mode, *src_nat_mode))
                     }
-                    None => {
-                        if gate.is_gated()
-                            && let Some(src_nat_mode) = self.local_v4.lookup(&LocalKey {
-                                proto,
-                                src_vni,
-                                dst_vni,
-                                src_ip,
-                                src_port,
-                                gate: SourceGate::Ungated,
-                            })
-                        {
-                            LookupResult::Route((verdict.dst_vpcd, verdict.nat_mode, *src_nat_mode))
-                        } else {
-                            LookupResult::SourceMiss(verdict.dst_vpcd)
-                        }
-                    }
+                    None => LookupResult::SourceMiss(verdict.dst_vpcd),
                 }
             }
             (IpAddr::V6(src_ip), IpAddr::V6(dst_ip)) => {
-                let verdict = if let Some(v) = self.remote_v6.lookup(&RemoteKey {
+                let Some(verdict) = self.remote_v6.lookup(&RemoteKey {
                     proto,
                     src_vni,
                     dst_vni,
                     dst_ip,
                     dst_port,
-                }) {
-                    v
-                } else {
-                    if dst_vni.is_gated()
-                        && let Some(v) = self.remote_v6.lookup(&RemoteKey {
-                            proto,
-                            src_vni,
-                            dst_vni: GateVni::UNGATED,
-                            dst_ip,
-                            dst_port,
-                        })
-                    {
-                        v
-                    } else {
-                        return LookupResult::DestinationMiss;
-                    }
+                }) else {
+                    return LookupResult::DestinationMiss;
                 };
-                let dst_vni = key_vni(verdict.dst_vpcd);
                 match self.local_v6.lookup(&LocalKey {
                     proto,
                     src_vni,
-                    dst_vni,
+                    dst_vni: key_vni(verdict.dst_vpcd),
                     src_ip,
                     src_port,
                     gate,
@@ -828,22 +780,7 @@ impl FlowFilterContext {
                     Some(src_nat_mode) => {
                         LookupResult::Route((verdict.dst_vpcd, verdict.nat_mode, *src_nat_mode))
                     }
-                    None => {
-                        if gate.is_gated()
-                            && let Some(src_nat_mode) = self.local_v6.lookup(&LocalKey {
-                                proto,
-                                src_vni,
-                                dst_vni,
-                                src_ip,
-                                src_port,
-                                gate: SourceGate::Ungated,
-                            })
-                        {
-                            LookupResult::Route((verdict.dst_vpcd, verdict.nat_mode, *src_nat_mode))
-                        } else {
-                            LookupResult::SourceMiss(verdict.dst_vpcd)
-                        }
-                    }
+                    None => LookupResult::SourceMiss(verdict.dst_vpcd),
                 }
             }
             _ => {
@@ -939,31 +876,6 @@ fn lookup_versioned<I: FixedSize + Copy>(
         let mut verdicts: Vec<Option<&Verdict>> = vec![None; q_chunk.len()];
         remote.lookup_batch(&remote_keys, &mut verdicts);
 
-        // Reply traffic for masqueraded flows use the destination VNI as part of the key; this is
-        // to avoid conflicting entries if there are several VPCs exposing overlapping, masqueraded
-        // prefixes to a given VPC. If we have a destination VNI set here, we may be trying to
-        // re-validate a reply packet for a masqueraded flow (we're not sure of the direction, hence
-        // the first attempt with the destination VNI). Try again, without the destination VNI.
-        let mut reval_positions = Vec::new();
-        let mut reval_keys = Vec::new();
-        for (pos, (query, verdict)) in q_chunk.iter().zip(verdicts.iter_mut()).enumerate() {
-            if verdict.is_none() && query.dst_vni.is_gated() {
-                reval_positions.push(pos);
-                reval_keys.push(RemoteKey {
-                    proto: query.proto,
-                    src_vni: query.src_vni,
-                    dst_vni: GateVni::UNGATED,
-                    dst_ip: query.dst_ip,
-                    dst_port: query.dst_port,
-                });
-            }
-        }
-        let mut reval_verdicts = vec![None; reval_keys.len()];
-        remote.lookup_batch(&reval_keys, &mut reval_verdicts);
-        for (pos, verdict) in reval_positions.into_iter().zip(reval_verdicts) {
-            verdicts[pos] = verdict;
-        }
-
         // Stage 2: for the hits only, source -> source NAT.
         // Port-forwarding rules use the NAT mode as part of the key, to dissociate keys from any
         // keys associated to overlapping forward masquerade prefixes.
@@ -985,27 +897,6 @@ fn lookup_versioned<I: FixedSize + Copy>(
         }
         let mut nat_modes: Vec<Option<&NatMode>> = vec![None; local_keys.len()];
         local.lookup_batch(&local_keys, &mut nat_modes);
-
-        // Second pass: if nat_mode was set and we didn't find an entry for reply traffic associated
-        // with a port-forwarding flow, drop the gate to see if we have an entry for forward traffic
-        // for port-forwarding (forward traffic entries do not have flow-info nat mode attached, or
-        // we couldn't use it to initiate new flows).
-        let mut reval_positions = Vec::new();
-        let mut reval_keys = Vec::new();
-        for (pos, (nat_mode, &q_pos)) in nat_modes.iter().zip(hit_pos.iter()).enumerate() {
-            if nat_mode.is_none() && q_chunk[q_pos].gate.is_gated() {
-                reval_positions.push(pos);
-                reval_keys.push(LocalKey {
-                    gate: SourceGate::Ungated,
-                    ..local_keys[pos].clone()
-                });
-            }
-        }
-        let mut reval_nat_modes = vec![None; reval_keys.len()];
-        local.lookup_batch(&reval_keys, &mut reval_nat_modes);
-        for (pos, nat_mode) in reval_positions.into_iter().zip(reval_nat_modes) {
-            nat_modes[pos] = nat_mode;
-        }
 
         // Scatter results back to the caller's output positions. A stage-1 miss stays
         // DestinationMiss; a stage-1 hit whose source matched nothing becomes SourceMiss.

--- a/flow-filter/src/lib.rs
+++ b/flow-filter/src/lib.rs
@@ -305,15 +305,19 @@ impl FlowFilter {
         {
             return (None, SourceGate::Ungated);
         }
+        // We only need to pass this information when re-validating a flow in the return direction.
+        // For the forward direction, we use the regular entries in the flow-filter tables, just as
+        // if we were checking for a new flow.
+        if flow_summary.is_initiator {
+            return (None, SourceGate::Ungated);
+        }
         if flow_summary.needs_masquerade {
-            // If we need revalidation and the flow is masqueraded, we may need the destination VPC
-            // id from the flow to look up for reverse traffic's entry in the "remote" table.
+            // We need return traffic revalidation and the flow is masqueraded. Pass the destination
+            // VPC id from the flow to look up for the related entry in the "remote"-side table.
             (Some(flow_summary.dst_vpcd), SourceGate::Ungated)
         } else if flow_summary.needs_port_forwarding {
-            // We need revalidation and the flow is with port-forwarding, although we don't know if
-            // it's on the source (reply traffic) or destination side (forward traffic). In doubt,
-            // turn on the gate to enable looking up for entries for reply port-forwarding traffic
-            // in the "local"-side context table.
+            // We need return traffic revalidation and the flow is with port-forwarding. Turn on the
+            // gate to enable looking up for entries for related traffic in the "local"-side table.
             (None, SourceGate::PortFwdReply)
         } else {
             (None, SourceGate::Ungated)
@@ -369,6 +373,7 @@ struct FlowSummary {
     dst_vpcd: VpcDiscriminant,
     needs_masquerade: bool,
     needs_port_forwarding: bool,
+    is_initiator: bool,
     flow_info: Arc<FlowInfo>,
 }
 
@@ -386,6 +391,7 @@ impl FlowSummary {
             dst_vpcd,
             needs_masquerade: locked_info.nat_state.is_some(),
             needs_port_forwarding: locked_info.port_fw_state.is_some(),
+            is_initiator: flow_info.get_flags().is_initiator(),
             flow_info: flow_info.clone(),
         })
     }

--- a/flow-filter/src/tests.rs
+++ b/flow-filter/src/tests.rs
@@ -18,7 +18,7 @@ use concurrency::sync::Arc;
 use lpm::prefix::L4Protocol;
 use net::FlowKey;
 use net::buffer::TestBuffer;
-use net::flows::{FlowInfo, FlowStatus};
+use net::flows::{FlowInfo, FlowInfoFlags, FlowStatus};
 use net::headers::Headers;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use net::parse::DeParse;
@@ -39,6 +39,45 @@ fn packet(src_vpcd: Option<VpcDiscriminant>, headers: Headers) -> Packet<TestBuf
     packet
 }
 
+#[allow(clippy::too_many_arguments)]
+fn create_flow_pair(
+    src_vpcd: Option<VpcDiscriminant>,
+    dst_vpcd: Option<VpcDiscriminant>,
+    flow_key: FlowKey,
+    flags: FlowInfoFlags,
+    reply_flow_key: FlowKey,
+    reply_flags: FlowInfoFlags,
+    active: bool,
+    nat_state: bool,
+    port_fw_state: bool,
+) -> (Arc<FlowInfo>, Arc<FlowInfo>) {
+    let expires_at = Instant::now() + Duration::from_secs(60);
+    let (flow_info_fwd, flow_info_reply) =
+        FlowInfo::related_pair(expires_at, flow_key, flags, reply_flow_key, reply_flags).unwrap();
+
+    if active {
+        flow_info_fwd.update_status(FlowStatus::Active);
+        flow_info_reply.update_status(FlowStatus::Active);
+    }
+    {
+        let mut locked_fwd = flow_info_fwd.locked.write();
+        let mut locked_reply = flow_info_reply.locked.write();
+        locked_fwd.dst_vpcd = dst_vpcd;
+        locked_reply.dst_vpcd = src_vpcd;
+        if nat_state {
+            // The concrete type would be a NatState; a bool is enough here since the flow filter
+            // only checks for presence, never downcasts it.
+            locked_fwd.nat_state = Some(Box::new(true));
+            locked_reply.nat_state = Some(Box::new(true));
+        }
+        if port_fw_state {
+            locked_fwd.port_fw_state = Some(Box::new(true));
+            locked_reply.port_fw_state = Some(Box::new(true));
+        }
+    }
+    (flow_info_fwd, flow_info_reply)
+}
+
 // Attach a flow session, the way a downstream stateful NF would. `active` controls the flow status
 // (only active flows can be used to bypass the filter); `dst_vpcd` is the flow's recorded
 // destination (`None` models a buggy flow with no destination); `nat_state` / `port_fw_state` model
@@ -51,33 +90,59 @@ fn attach_flow(
     nat_state: bool,
     port_fw_state: bool,
 ) -> Arc<FlowInfo> {
+    let src_vpcd = packet.meta().src_vpcd;
     let flow_key = FlowKey::try_from(&*packet).unwrap();
+    let flags = packet.meta().compute_flow_flags_forward();
+    let reply_flow_key = flow_key.reverse(dst_vpcd);
+    let reply_flags = packet.meta().compute_flow_flags_reverse();
 
-    let expires_at = Instant::now() + Duration::from_secs(60);
-    let (flow_info, _) = FlowInfo::related_pair(
-        expires_at,
+    let (flow_info, _) = create_flow_pair(
+        src_vpcd,
+        dst_vpcd,
         flow_key,
-        packet.meta().compute_flow_flags_forward(),
-        flow_key.reverse(dst_vpcd),
-        packet.meta().compute_flow_flags_reverse(),
-    )
-    .unwrap();
+        flags,
+        reply_flow_key,
+        reply_flags,
+        active,
+        nat_state,
+        port_fw_state,
+    );
+    packet.meta_mut().flow_info = Some(flow_info.clone());
+    flow_info
+}
 
-    if active {
-        flow_info.update_status(FlowStatus::Active);
-    }
-    {
-        let mut locked = flow_info.locked.write();
-        locked.dst_vpcd = dst_vpcd;
-        if nat_state {
-            // The concrete type would be a NatState; a bool is enough here since the flow filter
-            // only checks for presence, never downcasts it.
-            locked.nat_state = Some(Box::new(true));
-        }
-        if port_fw_state {
-            locked.port_fw_state = Some(Box::new(true));
-        }
-    }
+// Same as `attach_flow`, but do not mark the provided flow as the initiator flow (mark the reverse
+// flow instead).
+fn attach_flow_reply(
+    packet: &mut Packet<TestBuffer>,
+    reply_dst_vpcd: Option<VpcDiscriminant>,
+    active: bool,
+    nat_state: bool,
+    port_fw_state: bool,
+) -> Arc<FlowInfo> {
+    let reply_src_vpcd = packet.meta().src_vpcd;
+    let reply_flow_key = FlowKey::try_from(&*packet).unwrap();
+    let initiator_flow_key = reply_flow_key.reverse(reply_dst_vpcd);
+
+    // We need .compute_flow_flags_forward() here to get the correct NAT flags from the metadata,
+    // but we need to remove the INITIATOR flag
+    let mut reply_flags = packet.meta().compute_flow_flags_forward();
+    reply_flags.remove(FlowInfoFlags::INITIATOR);
+    // Conversely, we need to manually set the INITIATOR flag
+    let mut initiator_flags = packet.meta().compute_flow_flags_reverse();
+    initiator_flags.insert(FlowInfoFlags::INITIATOR);
+
+    let (_, flow_info) = create_flow_pair(
+        reply_dst_vpcd,
+        reply_src_vpcd,
+        initiator_flow_key,
+        initiator_flags,
+        reply_flow_key,
+        reply_flags,
+        active,
+        nat_state,
+        port_fw_state,
+    );
     packet.meta_mut().flow_info = Some(flow_info.clone());
     flow_info
 }
@@ -581,7 +646,7 @@ fn masquerade_reply_on_established_flow_survives_config_change() {
         Some(vpcd(200)),
         build_tcp_packet(v4("5.0.0.10"), v4("30.0.0.5"), 5678, 1234),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(100)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(100)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(100)));
@@ -611,7 +676,7 @@ fn masquerade_reply_with_inactive_flow_is_filtered() {
         Some(vpcd(200)),
         build_tcp_packet(v4("5.0.0.10"), v4("30.0.0.5"), 5678, 1234),
     );
-    attach_flow(&mut p, Some(vpcd(100)), false, true, false);
+    attach_flow_reply(&mut p, Some(vpcd(100)), false, true, false);
     let out = run(&mut flow_filter, p);
     assert_eq!(out.get_done(), Some(DoneReason::Filtered));
 }
@@ -624,7 +689,7 @@ fn masquerade_reply_with_mismatched_flow_destination_is_filtered() {
         Some(vpcd(200)),
         build_tcp_packet(v4("5.0.0.10"), v4("30.0.0.5"), 5678, 1234),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(300)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(300)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert_eq!(out.get_done(), Some(DoneReason::Filtered));
     assert_eq!(flow.status(), FlowStatus::Cancelled);
@@ -639,7 +704,7 @@ fn port_forwarding_reply_on_established_flow_survives_config_change() {
         Some(vpcd(200)),
         build_tcp_packet(v4("192.168.80.5"), v4("10.0.0.5"), 22, 1234),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(100)), true, false, true);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(100)), true, false, true);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(100)));
@@ -715,7 +780,7 @@ fn revalidation_works_in_case_of_remote_masquerade_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("10.0.0.1"), 1111, 2222),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(200)));
@@ -742,7 +807,7 @@ fn revalidation_works_in_case_of_remote_masquerade_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("10.0.0.1"), 1111, 2222),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(200)));
@@ -770,7 +835,7 @@ fn revalidation_works_in_case_of_remote_masquerade_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("10.0.0.1"), 1111, 2222),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert_eq!(out.get_done(), Some(DoneReason::Filtered));
     assert_eq!(flow.status(), FlowStatus::Cancelled);
@@ -816,7 +881,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("2.0.0.1"), 2000, 8000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, false, true);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, false, true);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(200)));
@@ -852,7 +917,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(200)),
         build_tcp_packet(v4("2.0.0.1"), v4("10.0.0.1"), 8000, 5000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(100)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(100)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(100)));
@@ -883,7 +948,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("2.0.0.1"), 2000, 8000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, false, true);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, false, true);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(200)));
@@ -909,7 +974,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(200)),
         build_tcp_packet(v4("2.0.0.1"), v4("10.0.0.1"), 8000, 5000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(100)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(100)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert!(!out.is_done(), "{:?}", out.get_done());
     assert_eq!(out.meta().dst_vpcd, Some(vpcd(100)));
@@ -937,7 +1002,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(100)),
         build_tcp_packet(v4("1.0.0.1"), v4("2.0.0.1"), 2000, 8000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(200)), true, false, true);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(200)), true, false, true);
     let out = run(&mut flow_filter, p);
     assert_eq!(out.get_done(), Some(DoneReason::Filtered));
     assert_eq!(flow.status(), FlowStatus::Cancelled);
@@ -947,7 +1012,7 @@ fn revalidation_works_in_case_of_local_masquerade_portforwarding_overlap() {
         Some(vpcd(200)),
         build_tcp_packet(v4("2.0.0.1"), v4("10.0.0.1"), 8000, 5000),
     );
-    let flow = attach_flow(&mut p, Some(vpcd(100)), true, true, false);
+    let flow = attach_flow_reply(&mut p, Some(vpcd(100)), true, true, false);
     let out = run(&mut flow_filter, p);
     assert_eq!(out.get_done(), Some(DoneReason::Filtered));
     assert_eq!(flow.status(), FlowStatus::Cancelled);

--- a/flow-filter/src/tests.rs
+++ b/flow-filter/src/tests.rs
@@ -1248,6 +1248,7 @@ fn invalidation_decision_matches_spec() {
                 },
                 needs_masquerade: case.flow_masquerade,
                 needs_port_forwarding: case.flow_port_forwarding,
+                is_initiator: true,
                 flow_info,
             });
 


### PR DESCRIPTION
In the flow-filter stage, in the case of traffic for masquerade or port-forwarding with outdated flow information attached, we try to revalidate the flow based on flow information. To do so, we have specific, gated entries in the flow-filter context tables, and we run each lookup (remote then local side) in possibly two steps: once with the gate activated, in case we're dealing with reply traffic, and once without it, in case of forward traffic.

Now that we added a flag to flow information to tell whether each flow in a pair is the initiating, or reply-direction flow, we don't actually need to do these two-step lookups ever: we can infer the direction (forward or reply) from the packet from the presence or absence of the flag. Let's do this, and remove the unnecessary lookups.