### PR TITLE
bump: FRR back to stable/10.5 (just in case)

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -52,11 +52,11 @@
         "owner": "githedgehog",
         "repo": "dplane-plugin"
       },
-      "branch": "hh-master-10.6",
+      "branch": "hh-master-10.5",
       "submodules": false,
-      "revision": "19d17cdba14bfca79fa6797e8459f217232f906c",
-      "url": "https://github.com/githedgehog/dplane-plugin/archive/19d17cdba14bfca79fa6797e8459f217232f906c.tar.gz",
-      "hash": "sha256-WDddiCEB2m0bhVH1pVAbRuVb9Ke3VxsGGLsOXcAx7uQ="
+      "revision": "f3517e68ef53955f107993b45c64222576e2e42d",
+      "url": "https://github.com/githedgehog/dplane-plugin/archive/f3517e68ef53955f107993b45c64222576e2e42d.tar.gz",
+      "hash": "sha256-C5Hn5L7TVwmh4q4EGKHs5fxx6DX9lTqSGHfQTz6lVuM="
     },
     "dplane-rpc": {
       "type": "Git",
@@ -95,11 +95,11 @@
         "owner": "FRRouting",
         "repo": "frr"
       },
-      "branch": "stable/10.6",
+      "branch": "stable/10.5",
       "submodules": false,
-      "revision": "4a2c602d195fcfd060318480a8ea39c093054eee",
-      "url": "https://github.com/FRRouting/frr/archive/4a2c602d195fcfd060318480a8ea39c093054eee.tar.gz",
-      "hash": "sha256-rGTkZNlvNzFL7RIuguaMz2rfvO4J8N+T9ke5YG9MhdQ="
+      "revision": "5ece2d67618a0d1ea9c49342b8fb522960f7facc",
+      "url": "https://github.com/FRRouting/frr/archive/5ece2d67618a0d1ea9c49342b8fb522960f7facc.tar.gz",
+      "hash": "sha256-85/Uss3VWI2q8TUKIo/lgOkrzsGvBgWrjyCJBTqf/nM="
     },
     "frr-agent": {
       "type": "Git",
@@ -121,11 +121,11 @@
         "owner": "githedgehog",
         "repo": "frr"
       },
-      "branch": "hh-master-10.6",
+      "branch": "hh-master-10.5",
       "submodules": false,
-      "revision": "b2ca1eb04c8746d17f11fe49181d1e2287be1470",
-      "url": "https://github.com/githedgehog/frr/archive/b2ca1eb04c8746d17f11fe49181d1e2287be1470.tar.gz",
-      "hash": "sha256-BsFh/T7VlIravMLA5m/mKjUy8bT9rnmLYzI0g/RX6J8="
+      "revision": "d6cbff16e2261a7e1a88c6369de9e5c1d1bdb4f7",
+      "url": "https://github.com/githedgehog/frr/archive/d6cbff16e2261a7e1a88c6369de9e5c1d1bdb4f7.tar.gz",
+      "hash": "sha256-dUjnWQFcP+iUcYl1vetWbawL9HZt8FmMzC0cJdUJrxI="
     },
     "kopium": {
       "type": "GitRelease",

--- a/scripts/gen-pins.sh
+++ b/scripts/gen-pins.sh
@@ -57,12 +57,12 @@ npins add github kube-rs kopium
 npins add github githedgehog fabric # Will pick highest tagged version on pin bump
 npins freeze fabric
 
-npins add github FRRouting frr --branch stable/10.6 # floats with branch on pin bump
-npins add github --name frr-dp githedgehog frr --branch hh-master-10.6 # floats with branch on pin bump
+npins add github FRRouting frr --branch stable/10.5 # floats with branch on pin bump
+npins add github --name frr-dp githedgehog frr --branch hh-master-10.5 # floats with branch on pin bump
 
 npins add github githedgehog frr-agent --branch master # floats with branch on pin bump
 npins add github githedgehog dplane-rpc --branch master # floats with branch on pin bump
-npins add github githedgehog dplane-plugin --branch hh-master-10.6 # floats with branch on pin bump
+npins add github githedgehog dplane-plugin --branch hh-master-10.5 # floats with branch on pin bump
 
 npins add github opengrep opengrep
 npins add github mermaid-js mermaid --release-prefix "mermaid@"


### PR DESCRIPTION
FRR 10.6 regressed on us, so walk the three pins that moved in ddae59e2f ("bump: FRR on stable/10.6") back to their 10.5 branches:

  frr            stable/10.6    -> stable/10.5
  frr-dp         hh-master-10.6 -> hh-master-10.5
  dplane-plugin  hh-master-10.6 -> hh-master-10.5

`frr-dp` and `dplane-plugin` land exactly where they sat before the 10.6 bump -- neither 10.5 branch has moved since. Upstream `frr` picks up the current tip of stable/10.5 (5ece2d67) rather than the older e3681378 we were on, which is the intended behavior for these pins: they float with their branch on pin bump.

`dplane-plugin` goes to `hh-master-10.5` rather than back to `master` as it was named pre-bump; `master` has since advanced onto the 10.6 work, and `hh-master-10.5` is the branch holding the revision we actually ran.

`nix/pkgs/frr` needs no change: `version` is derived from the pin's branch, and both patches apply cleanly to the 10.5 trees.