### PR TITLE
build(deps): take bolero from a fork that tolerates an unresolvable corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,8 +471,7 @@ checksum = "b1b08cb4ecbb540b940016b0a0f35b7e48ab0cc372ab88150c351de4cc469959"
 [[package]]
 name = "bolero"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff44d278fc0062c95327087ed96b3d256906d1d8f579e534a3de8d6b386913a"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -487,8 +486,7 @@ dependencies = [
 [[package]]
 name = "bolero-afl"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bf4cbd0bacf9356d3c7e5d9d088480f2076ba3c595c15ee9a6a378cdd7b297"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -497,8 +495,7 @@ dependencies = [
 [[package]]
 name = "bolero-engine"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca199170a7c92c669c1019f9219a316b66bcdcfa4b36cac5a460a4c1a851aba"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "anyhow",
  "bolero-generator",
@@ -511,8 +508,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator"
 version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a5782f2650f80d533f58ec339c6dce4cc5428f9c2755894f98156f52af81f2"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-generator-derive",
  "either",
@@ -524,8 +520,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator-derive"
 version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a21a3b022507b9edd2050caf370d945e398c1a7c8455531220fa3968c45d29e"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
@@ -536,8 +531,7 @@ dependencies = [
 [[package]]
 name = "bolero-honggfuzz"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a118ef27295eddefadc6a99728ee698d1b18d2e80dc4777d21bee3385096ffd"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-engine",
 ]
@@ -545,8 +539,7 @@ dependencies = [
 [[package]]
 name = "bolero-kani"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852ea5784a9f3e68bfd302ca80b8b863bce140593eb5770fee6ab110899c28fc"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-engine",
 ]
@@ -554,8 +547,7 @@ dependencies = [
 [[package]]
 name = "bolero-libfuzzer"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
+source = "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -5621,7 +5613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,9 @@ axum-server = { version = "0.8.0", default-features = false, features = [] }
 bindgen = { version = "0.72.1", default-features = false, features = [] }
 bitflags = { version = "2.13.1", default-features = false, features = [] }
 bnum = { version = "0.14.4", default-features = false, features = [] }
-bolero = { version = "0.13.4", default-features = false, features = [] }
+# The fork treats an unresolvable optional corpus as absent, allowing remapped
+# and archived tests to run. Pin the revision so branch changes cannot alter it.
+bolero = { git = "https://github.com/githedgehog/bolero.git", rev = "2fa595633a72e9b30721f9d37f0014a6ae8f77d4", default-features = false, features = [] }
 bytecheck = { version = "0.8.3", default-features = false, features = [] }
 bytes = { version = "1.12.1", default-features = false, features = [] }
 caps = { version = "0.5.6", default-features = false, features = [] }

--- a/default.nix
+++ b/default.nix
@@ -231,11 +231,33 @@ let
     src = lib.cleanSource ./.;
     name = "source";
   };
+  # Hash every git dependency so crane uses cacheable fixed-output derivations
+  # instead of cloning whole repositories during evaluation. Keys must match
+  # Cargo.lock sources after percent-decoding branch names: a wrong hash fails
+  # when `vendor-cargo-deps` is realised, but a key that stops matching -- which
+  # a branch rename does -- only warns and silently falls back to the
+  # evaluation-time clone this is meant to avoid.
   cargoVendorDir = craneLib.vendorMultipleCargoDeps {
     cargoLockList = [
       ./Cargo.lock
       "${pkgs.rust-toolchain.passthru.availableComponents.rust-src}/lib/rustlib/src/rust/library/Cargo.lock"
     ];
+    outputHashes = {
+      "git+https://github.com/githedgehog/bolero.git?rev=2fa595633a72e9b30721f9d37f0014a6ae8f77d4#2fa595633a72e9b30721f9d37f0014a6ae8f77d4" =
+        "sha256-ipue/XsDxOeO4lThRcIdpQsztC5AbAkgwUHDYWTH9qY=";
+      "git+https://github.com/githedgehog/dplane-rpc.git?branch=pr/daniel-noland/bumps#6c84b7aff35abb4e94fbb0d09870a0b4a2322913" =
+        "sha256-YOCcWOynWN49KKY17KfP31QBK1ZM6x6Xl4/tdfNwgIs=";
+      "git+https://github.com/githedgehog/fixin?branch=main#5e0de31606466b17372f8a2cff090cc0461d572c" =
+        "sha256-GfBnaL6ke3ekm+HbV34yXdF4ArYHismxbPHF5/M94yk=";
+      "git+https://github.com/githedgehog/left-right.git?branch=fredi/fix-writehandle-drop#765813aa25c8328746e93a7a5ccc75deb57b1d80" =
+        "sha256-GVP11hLRmHip5+MH9U1bD4bANxDpdnkN9cvMo6RDFfY=";
+      "git+https://github.com/githedgehog/netlink-packet-route.git?branch=pr/daniel-noland/swing6#9a257c60e25bc5db50a1cd14aa493d6ec294c23d" =
+        "sha256-w5dK1IfqR1kJDa4ugbvEC4VIASwGlKU6oxEd9USUwMw=";
+      "git+https://github.com/githedgehog/rtnetlink.git?branch=hh/tc-actions4#c6b8d9865858c458e7f27fa67469f2171e1644a4" =
+        "sha256-u14ugCKWU4nwXkQdlleThJLYU4Ft/LJNTKywMUlwxPM=";
+      "git+https://github.com/githedgehog/testn.git?tag=v0.0.10#e49aba8400beb2cb117a3f542b114080cf572283" =
+        "sha256-XwEKLdc2Y7fteSKKOERgjKTdxELy7K/wOVuB/SSj3ng=";
+    };
   };
   # For wasm32, pkgs is the host nixpkgs (no pkgsCross), so ctarget resolves to the
   # host platform (e.g. x86_64-unknown-linux-gnu).  That means is-cross-compile is
@@ -519,12 +541,7 @@ let
             ++ cargo-cmd-prefix-tests
           ))
           # Record the remapped source root without changing normal archives.
-          + (
-            if instrumentation == "coverage" then
-              "; echo -n '${src}' > $out/source-prefix"
-            else
-              ""
-          );
+          + (if instrumentation == "coverage" then "; echo -n '${src}' > $out/source-prefix" else "");
       };
     };
 


### PR DESCRIPTION
Third of five; stacked on #1714. #1728 is stacked on this.

## Summary

- Use a revision-pinned Bolero fork based exactly on the published 0.13.4
  release. Its only behavior change treats an unresolvable optional corpus as
  absent instead of aborting archived or remapped property tests.
- Supply hashes for every git dependency so crane fetches them as cacheable
  fixed-output derivations instead of cloning at Nix evaluation time.

The Bolero change allows #1728 to use a stable relative source remap without a
machine-global symlink. It does not hide a committed corpus: `__fuzz__` is
gitignored. Cargo lockfile URLs with encoded branch names are normalized before
hash lookup.

The fork delta has not yet been proposed upstream.
