### PR TITLE
build(deps): take h2 past the empty DATA frame advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2210,7 +2210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4928,7 +4928,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4985,7 +4985,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5624,7 +5624,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6337,7 +6337,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
RUSTSEC-2026-0258, published 2026-08-17: h2 through 0.4.15 accepts and queues empty DATA frames without limit. A stream that is not actively drained can therefore grow its queue unboundedly, or panic when the queued length overflows. Rated low severity; a denial-of-service vector rather than a disclosure one.

`cargo deny check advisories` fails on it, which blocks the merge queue for every branch. This is main's problem rather than the stack's -- `origin/main` carries 0.4.15 too -- so the fix goes at the very bottom where everything above can inherit it.

h2 is not a direct dependency anywhere in the workspace. It arrives under hyper, and hyper under kube-client, tonic, reqwest, axum and bollard, so there is nothing to change but the lockfile.

`cargo update -p h2 --precise 0.4.16`. The six windows-sys lines come with it: resolving the new h2 lets cargo point six existing dependents at the 0.59.0 entry that was already in the lock. No package is added or removed, and the lockfile is otherwise stable under this toolchain -- a bare `cargo metadata` leaves it untouched.