### PR TITLE
fix(masquerade): Close the window where an address belongs to neither list

### DIFF
--- a/concurrency/src/sync/loom_backend.rs
+++ b/concurrency/src/sync/loom_backend.rs
@@ -28,6 +28,9 @@
 //!     returns `Some` -- the upgrade-fails-after-last-strong-drop race
 //!     real `Weak` exposes is not modelled.
 //!   * `Arc::strong_count` reflects live `Arc`s **and** live `Weak`s.
+//!   * `Weak::strong_count` likewise never reaches `0` while the `Weak`
+//!     itself is alive, so a caller using it to detect "the last strong
+//!     reference is gone" never observes that condition under loom.
 //!   * `Arc::weak_count` panics: the shim has no separate weak count
 //!     to report, and returning `0` silently would make assertions
 //!     pass for the wrong reason on every backend. See the per-method
@@ -545,6 +548,24 @@ impl<T: ?Sized> Weak<T> {
     #[must_use]
     pub fn upgrade(&self) -> Option<Arc<T>> {
         self.inner.as_ref().map(|a| Arc(a.clone()))
+    }
+
+    /// See `std::sync::Weak::strong_count`.
+    ///
+    /// `0` for a `Weak` that has never been associated with an `Arc`, matching std. Otherwise the
+    /// same caveat as `Arc::strong_count` applies and then some: this shim's `Weak` holds a strong
+    /// clone, so the count includes live `Weak`s and cannot reach `0` while `self` is alive. A
+    /// caller asking "has the last strong reference gone?" is therefore always told "no" under
+    /// loom -- inert rather than wrong, but it means such a path is not model-checked here. That is
+    /// the same limitation the module header records for `upgrade`; see the note there about tests
+    /// that need the strong/weak race.
+    ///
+    /// Offered anyway because the alternative is worse: callers that must answer that question
+    /// while holding a lock the value's `Drop` also takes cannot use `upgrade`, since the
+    /// temporary `Arc` it mints may be the last one and would run `Drop` re-entrantly.
+    #[must_use]
+    pub fn strong_count(&self) -> usize {
+        self.inner.as_ref().map_or(0, inner::Arc::strong_count)
     }
 }
 

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -19,6 +19,33 @@ use std::time::Duration;
 use tracing::{debug, error};
 
 ///////////////////////////////////////////////////////////////////////////////
+// Tenancy
+///////////////////////////////////////////////////////////////////////////////
+
+/// Identifies one lease of one public address, so that a lease which has ended cannot be confused
+/// with the lease that replaced it.
+///
+/// A [`NatPool`] hands an address out at most once per tenancy. The address returns to the pool
+/// when its tenancy ends, and ending a tenancy that is no longer the current one does nothing. That
+/// is what makes the hand-back safe to perform from either side: an [`AllocatedIp`] releasing
+/// itself, or an allocation reclaiming an address whose owner has already gone away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Tenancy(u64);
+
+impl Tenancy {
+    /// The tenancy handed to the first lease of any address in a pool.
+    const FIRST: Tenancy = Tenancy(0);
+
+    /// The tenancy that follows this one.
+    ///
+    /// Wrapping is not a correctness concern: distinguishing a lease from its successor only
+    /// requires that a `u64` counter not wrap while a single `AllocatedIp` is being dropped.
+    fn next(self) -> Tenancy {
+        Tenancy(self.0.wrapping_add(1))
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -41,8 +68,8 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         self.pool.read()
     }
 
-    fn deallocate_ip(&self, ip: I) {
-        self.pool.write().deallocate_from_pool(ip);
+    fn deallocate_ip(&self, ip: I, tenancy: Tenancy) {
+        self.pool.write().deallocate_from_pool(ip, tenancy);
     }
 
     fn reuse_allocated_ip(
@@ -63,14 +90,27 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
                 if !ip.has_free_ports() {
                     continue;
                 }
+                let addr = ip.ip();
                 match ip.allocate_port_for_ip(allow_null) {
                     Ok(port) => {
                         debug!("Allocated port {port}");
                         outcome = Ok(port);
                         break;
                     }
-                    // If there is no free port left, loop again to try another IP address
-                    Err(AllocatorError::NoFreePort(_)) => {}
+                    // This address is out of space, but another may still have room: keep
+                    // scanning. Running out of port blocks is exhaustion just as much as running
+                    // out of ports within a block, and ending the scan there would strand every
+                    // address behind this one in the list.
+                    //
+                    // Matching the whole exhaustion class rather than naming the port errors keeps
+                    // this honest if that class grows. It cannot swallow `NoFreeIp`, which is also
+                    // in the class: allocating a port for an address the caller already holds has
+                    // no address to run out of, so the port allocator never returns it.
+                    Err(e) if e.is_exhaustion() => {
+                        debug!("Address {addr} is out of space: {e}");
+                        outcome = Err(e);
+                    }
+                    // Anything else describes allocator failure, not exhaustion. Report it.
                     Err(e) => {
                         outcome = Err(e);
                         break;
@@ -85,9 +125,9 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
 
     fn allocate_new_ip_from_pool(&self) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
         let mut allocated_ips = self.pool.write();
-        let new_ip = allocated_ips.use_new_ip(self.clone(), self.randomize)?;
+        let (offset, new_ip) = allocated_ips.use_new_ip(self.clone(), self.randomize)?;
         let arc_ip = Arc::new(new_ip);
-        allocated_ips.add_in_use(&arc_ip);
+        allocated_ips.add_in_use(offset, &arc_ip);
         debug!("Allocated new ip {}", arc_ip.ip());
         Ok(arc_ip)
     }
@@ -121,7 +161,24 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         // describe allocator failure and must be preserved.
         match self.reuse_allocated_ip(allow_null) {
             Ok(port) => Ok(port),
-            Err(e) if e.is_exhaustion() => self.allocate_from_new_ip(allow_null),
+            Err(reuse) if reuse.is_exhaustion() => {
+                self.allocate_from_new_ip(allow_null).map_err(|fresh| {
+                    // Drawing a fresh address reports `NoFreeIp` whenever the bitmap is empty,
+                    // which for a single-address pool is always. That answer hides why the
+                    // addresses already in use could not serve the request, and the two are not
+                    // the same operational problem: an empty bitmap wants more addresses, whereas
+                    // exhausted port blocks want the block allocator looked at. So prefer
+                    // whichever of the two is not `NoFreeIp`; if neither is, the fresh-address
+                    // error is no less informative than the reuse one, and both describe the same
+                    // exhaustion. This is diagnostics only -- every branch stays within the
+                    // exhaustion class, so callers that switch on `is_exhaustion` are unaffected.
+                    match (&reuse, &fresh) {
+                        (AllocatorError::NoFreeIp, _) => fresh,
+                        (_, AllocatorError::NoFreeIp) => reuse,
+                        _ => fresh,
+                    }
+                })
+            }
             Err(e) => Err(e),
         }
     }
@@ -150,7 +207,10 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
     #[cfg(test)]
     pub fn get_pool_clone_for_tests(&self) -> (RoaringBitmap, VecDeque<Weak<AllocatedIp<I>>>) {
         let pool = self.pool.read();
-        (pool.bitmap.0.clone(), pool.in_use.clone())
+        (
+            pool.bitmap.0.clone(),
+            pool.in_use.iter().map(|entry| entry.ip.clone()).collect(),
+        )
     }
 }
 
@@ -250,6 +310,9 @@ impl<I: NatIpWithBitmap> PoolSet<I> {
 #[derive(Debug)]
 pub(crate) struct AllocatedIp<I: NatIpWithBitmap> {
     ip: I,
+    /// The lease this address was handed out under. Returned to the pool on drop so the pool can
+    /// tell a stale hand-back from a live one.
+    tenancy: Tenancy,
     port_allocator: port_alloc::PortAllocator<I>,
     ip_allocator: IpAllocator<I>,
 }
@@ -261,10 +324,12 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
         reserved: ReservedForAddr,
         randomize: bool,
         exclude_wellknown_ports: bool,
+        tenancy: Tenancy,
     ) -> Self {
         let port_allocator = PortAllocator::new(reserved, randomize, exclude_wellknown_ports);
         Self {
             ip,
+            tenancy,
             port_allocator,
             ip_allocator,
         }
@@ -280,6 +345,10 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
     /// creates one honours the reservations without having to be told about them.
     pub(crate) fn reserved_ports(&self) -> &ReservedForAddr {
         self.port_allocator.reserved_ports()
+    }
+
+    fn tenancy(&self) -> Tenancy {
+        self.tenancy
     }
 
     // Used for Display; should probably not be accessed directly anywhere else
@@ -321,7 +390,7 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
 
 impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
     fn drop(&mut self) {
-        self.ip_allocator.deallocate_ip(self.ip);
+        self.ip_allocator.deallocate_ip(self.ip, self.tenancy);
     }
 }
 
@@ -329,18 +398,44 @@ impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
 // NatPool
 ///////////////////////////////////////////////////////////////////////////////
 
+/// One address this pool has handed out, and the lease it was handed out under.
+///
+/// The weak reference alone cannot answer "is this address available?". It stops resolving the
+/// moment the last [`AllocatedPort`](port_alloc::AllocatedPort) goes away, which is *before*
+/// `AllocatedIp::drop` runs and returns the address to the bitmap. Recording the offset and the
+/// tenancy next to the weak reference lets whoever notices first finish the hand-back, so the
+/// address is never absent from both the bitmap and this list.
+#[derive(Debug)]
+struct InUseEntry<I: NatIpWithBitmap> {
+    offset: u32,
+    tenancy: Tenancy,
+    ip: Weak<AllocatedIp<I>>,
+}
+
 /// A [`NatPool`] is a pool of IP addresses that can be allocated from. It contains a bitmap of
 /// available IP addresses, and a list of weak references to [`AllocatedIp`] objects representing
 /// the allocated IPs potentially available for use (if they still have free ports)
+///
+/// # Invariant
+///
+/// Every address of the pool is either free in `bitmap` or has a current tenancy in `tenancies`,
+/// never both and never neither. `tenancies` is what makes that invariant maintainable: it is
+/// updated in the same critical section as `bitmap`, whereas the liveness of an `AllocatedIp`
+/// changes on whatever thread happens to drop the last reference to it.
 #[derive(Debug)]
 pub(crate) struct NatPool<I: NatIpWithBitmap> {
     bitmap: PoolBitmap,
     bitmap_mapping: BTreeMap<u32, u128>,
     reverse_bitmap_mapping: BTreeMap<u128, u32>,
-    in_use: VecDeque<Weak<AllocatedIp<I>>>,
+    in_use: VecDeque<InUseEntry<I>>,
     /// The public tuples of this region that port forwarding may claim. Applied to every address as
     /// it is put to use, so masquerade never hands one of them out.
     reserved: ReservedPorts,
+    /// The current tenancy of every address not free in `bitmap`. An address is removed from here
+    /// exactly when it returns to the bitmap.
+    tenancies: BTreeMap<u32, Tenancy>,
+    /// The tenancy the next lease of any address in this pool will be handed.
+    next_tenancy: Tenancy,
     exclude_wellknown_ports: bool,
 }
 
@@ -372,61 +467,150 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             reverse_bitmap_mapping,
             in_use: VecDeque::new(),
             reserved,
+            tenancies: BTreeMap::new(),
+            next_tenancy: Tenancy::FIRST,
             exclude_wellknown_ports,
         }
     }
 
-    fn add_in_use(&mut self, ip: &Arc<AllocatedIp<I>>) {
-        self.in_use.push_back(Arc::downgrade(ip));
+    /// Take the address at `offset` out of the bitmap and record the lease it is handed out under.
+    ///
+    /// Overwriting an existing tenancy is deliberate: it retires the previous lease, so that
+    /// lease's eventual hand-back becomes a no-op rather than freeing an address this pool has
+    /// already re-issued.
+    fn begin_tenancy(&mut self, offset: u32) -> Tenancy {
+        let tenancy = self.next_tenancy;
+        self.next_tenancy = tenancy.next();
+        self.bitmap.set_ip_allocated(offset);
+        self.tenancies.insert(offset, tenancy);
+        tenancy
+    }
+
+    /// Return the address at `offset` to the bitmap, but only if `tenancy` is still its current
+    /// lease.
+    ///
+    /// Returns whether the hand-back happened. A `false` answer means some other caller already
+    /// completed it, or the pool has since re-issued the address; neither is an error, and both
+    /// must leave the bitmap alone.
+    fn end_tenancy(&mut self, offset: u32, tenancy: Tenancy) -> bool {
+        if self.tenancies.get(&offset) != Some(&tenancy) {
+            return false;
+        }
+        self.tenancies.remove(&offset);
+        self.bitmap.set_ip_free(offset);
+        true
+    }
+
+    /// Finish the hand-back of every address whose `AllocatedIp` is gone, dropping their entries.
+    ///
+    /// This is the other half of the [`InUseEntry`] contract: the thread that dropped the last
+    /// reference may still be waiting for this pool's lock, so any caller that holds the lock and
+    /// sees a dead weak reference completes the hand-back on its behalf.
+    ///
+    /// Deliberately not shared with [`NatPool::cleanup`], which it otherwise resembles. `cleanup`
+    /// upgrades each entry and hands the resulting `Arc`s to its caller to drop after the guard is
+    /// released; this runs with the write lock held and must never mint an `Arc` at all, because
+    /// the one it minted could be the last and `AllocatedIp::drop` takes that same lock. Reading
+    /// `strong_count` answers the liveness question without that hazard.
+    fn reclaim_ended_tenancies(&mut self) {
+        let mut ended = Vec::new();
+        self.in_use.retain(|entry| {
+            if entry.ip.strong_count() > 0 {
+                return true;
+            }
+            ended.push((entry.offset, entry.tenancy));
+            false
+        });
+        for (offset, tenancy) in ended {
+            if self.end_tenancy(offset, tenancy) {
+                debug!("Reclaimed address at offset {offset} from an ended tenancy");
+            }
+        }
+    }
+
+    fn add_in_use(&mut self, offset: u32, ip: &Arc<AllocatedIp<I>>) {
+        self.in_use.push_back(InUseEntry {
+            offset,
+            tenancy: ip.tenancy(),
+            ip: Arc::downgrade(ip),
+        });
     }
 
     /// Drop the entries whose addresses are gone, handing the caller every address that is still
     /// alive so it can release them once the pool lock is no longer held. See `cleanup_used_ips`.
+    ///
+    /// Dropping an entry also completes that address's hand-back, so pruning the list can never
+    /// lose track of an address.
     fn cleanup(&mut self, keep_alive: &mut Vec<Arc<AllocatedIp<I>>>) {
-        self.in_use.retain(|ip| match ip.upgrade() {
-            Some(alive) => {
+        let mut ended = Vec::new();
+        self.in_use.retain(|entry| {
+            if let Some(alive) = entry.ip.upgrade() {
                 keep_alive.push(alive);
-                true
+                return true;
             }
-            None => false,
+            ended.push((entry.offset, entry.tenancy));
+            false
         });
+        for (offset, tenancy) in ended {
+            self.end_tenancy(offset, tenancy);
+        }
     }
 
     pub(crate) fn ips_in_use(&self) -> impl Iterator<Item = &Weak<AllocatedIp<I>>> {
-        self.in_use.iter()
+        self.in_use.iter().map(|entry| &entry.ip)
     }
 
     fn use_new_ip(
         &mut self,
         ip_allocator: IpAllocator<I>,
         randomize: bool,
-    ) -> Result<AllocatedIp<I>, AllocatorError> {
+    ) -> Result<(u32, AllocatedIp<I>), AllocatorError> {
         // Retrieve the first available offset
-        let offset = self.bitmap.pop_ip()?;
+        let offset = match self.bitmap.pop_ip() {
+            Ok(offset) => offset,
+            Err(empty) => {
+                // The bitmap being empty is not proof the pool is: an address whose last lease
+                // ended a moment ago is not in the bitmap yet, and no longer reachable through
+                // `in_use` either. Finish those hand-backs -- under the same lock as the retry, so
+                // the answer cannot go stale between the two -- before reporting exhaustion.
+                self.reclaim_ended_tenancies();
+                self.bitmap.pop_ip().map_err(|_| empty)?
+            }
+        };
 
         // the ip being allocated
         let ip = I::try_from_offset(offset, &self.bitmap_mapping)?;
+        let tenancy = self.begin_tenancy(offset);
 
         // determine the set of reserved ports that cannot be allocated for this ip
         let reserved = self.reserved.for_addr(ip.to_ip_addr());
 
-        Ok(AllocatedIp::new(
-            ip,
-            ip_allocator,
-            reserved,
-            randomize,
-            self.exclude_wellknown_ports,
+        Ok((
+            offset,
+            AllocatedIp::new(
+                ip,
+                ip_allocator,
+                reserved,
+                randomize,
+                self.exclude_wellknown_ports,
+                tenancy,
+            ),
         ))
     }
 
-    fn deallocate_from_pool(&mut self, ip: I) {
+    fn deallocate_from_pool(&mut self, ip: I, tenancy: Tenancy) {
         debug!("Address {ip} was deallocated");
         // The address was handed out by this pool, so it maps back into it. This runs while an
         // allocation is being dropped and has nowhere to report a failure, so say so and leave the
         // address marked in use rather than panicking on the drop path.
         match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
             Ok(offset) => {
-                self.bitmap.set_ip_free(offset);
+                if !self.end_tenancy(offset, tenancy) {
+                    // An allocation noticed this lease had ended and completed the hand-back
+                    // already, possibly re-issuing the address in the process. Freeing it here
+                    // would hand the same address to a second `AllocatedIp`.
+                    debug!("Address {ip} was already handed back before its lease was dropped");
+                }
             }
             Err(e) => error!("Address {ip} does not map back into the pool it came from: {e}"),
         }
@@ -457,12 +641,12 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 
         // Allocate the IP now.
         //
-        // If the IP was already allocated in the bitmap, this is OK: it means that the IP was
-        // allocated in the past, it is no longer in used (because it is not in the list of in-use
-        // IPs), but we haven't deallocated from the bitmap yet (this happens when another thread
-        // drops an AllocatedIp and its reference count goes to 0, but it hasn't called the drop()
-        // function to remove the IP from the bitmap in that other thread yet).
-        let _ = self.bitmap.set_ip_allocated(offset);
+        // The address may still be marked allocated in the bitmap: it was handed out in the past
+        // and is no longer in use (it is not in the list of in-use IPs), but the thread dropping
+        // the previous `AllocatedIp` has not reached this pool's lock yet. Opening a new tenancy
+        // retires that previous lease, so when its drop does arrive it will not free an address
+        // this reservation now owns. `begin_tenancy` takes the address out of the bitmap itself.
+        let tenancy = self.begin_tenancy(offset);
 
         // Reservations apply here as well: an address put to use by carrying a live masquerade flow
         // over to a new allocator must not be able to re-take a port that port forwarding claims.
@@ -472,8 +656,9 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             self.reserved.for_addr(ip.to_ip_addr()),
             randomize,
             self.exclude_wellknown_ports,
+            tenancy,
         ));
-        self.add_in_use(&arc_ip);
+        self.add_in_use(offset, &arc_ip);
         Ok(arc_ip)
     }
 

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -488,3 +488,52 @@ fn tidying_a_dead_block_entry_does_not_drop_a_live_one() {
         }
     });
 }
+
+/// An address whose last lease has just ended must not vanish from the pool.
+///
+/// An address is reachable through the in-use list only while an allocation still holds it, and
+/// through the bitmap only once its hand-back has completed. `Weak` stops resolving the moment the
+/// last `AllocatedPort` goes away, which is strictly before `AllocatedIp::drop` reaches the pool
+/// lock, so an allocation landing in between used to find the address in neither and report
+/// exhaustion. On a one-address pool that is the whole pool, and the packet is dropped.
+///
+/// This is the shape DNS traffic takes. A reply from port 53 moves the flow to
+/// [`NatFlowStatus::Closed`](crate::common::NatFlowStatus::Closed), which invalidates the pair at
+/// once to conserve ports, so a pool carrying only DNS destroys and rebuilds its address once per
+/// query, and the next query races the hand-back of the last one.
+#[concurrency::model_test]
+fn an_allocation_racing_the_last_release_is_still_served() {
+    concurrency::stress(|| {
+        // One address, so a hand-back in flight is the pool's entire capacity. This is the shape
+        // the masquerade exposes actually deploy: one public address per peering.
+        let specs = vec![PoolSpec::new(
+            vec![AddrInterval::new(BASE, BASE)],
+            IDLE_TIMEOUT,
+        )];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            NextHeader::TCP,
+            false,
+        ));
+
+        let allocation = pools[0].allocate(false).expect("the pool can serve");
+
+        let releaser = thread::spawn(move || drop(allocation));
+        let claimant = {
+            let pools = pools.clone();
+            thread::spawn(move || pools[0].allocate(false))
+        };
+
+        let outcome = claimant.join().expect("the allocating thread panicked");
+        releaser.join().expect("the releasing thread panicked");
+
+        // Whichever order the two threads take, the pool has room to serve: either the address is
+        // still held, and has its remaining ports, or it has been handed back and can be drawn
+        // afresh. There is no interleaving in which the only correct answer is "out of resources".
+        assert!(
+            outcome.is_ok(),
+            "an allocation racing the release of the only address was refused: {:?}",
+            outcome.as_ref().err()
+        );
+    });
+}


### PR DESCRIPTION
## Issue

`NatPool` answers "is this public address available?" from two structures — a bitmap of free addresses and a list of weak references to the addresses currently in use — and an address is meant to be in exactly one of them. Releasing one passes through a state where it is in neither: `Weak::upgrade` stops resolving the instant the last `AllocatedPort` drops the strong count to zero, but the address only returns to the bitmap later, inside `AllocatedIp::drop`, which must first acquire the pool's write lock. An allocation arriving in that gap finds nothing on either path and is told the pool is empty, so it fails with `NoFreeIp` while the pool is in fact holding an address that belongs to no one. This is not a rare interleaving — `Arc` guarantees the ordering, so every release passes through the gap; only its duration varies, bounded by how long the releasing thread waits for a write lock that every allocation also takes, on every call, via `cleanup_used_ips`. The same reasoning covers a second latent hazard the fix closes: `reserve_from_pool` could create a duplicate `AllocatedIp` for an address whose owner had not yet finished releasing it, after which the first object's `Drop` would free an address the second still held.

## Impact

The packet that lands in the gap is dropped with `DoneReason::NatOutOfResources` and its flow is refused, logged as `masquerade: Ip/port allocation failed ... no free IP available`. Two properties of real deployments turn a narrow race into a recurring one. Where an expose is configured with a single public address per peering — the shape observed in the field — the unavailable address is the entire pool, so there is nothing to fall back on. And DNS drives the window open constantly: a reply from source port 53 moves the flow to `Closed` and invalidates the pair immediately as a port-conservation measure, so a pool carrying mostly DNS destroys and rebuilds its address roughly once per query, opening one window per query. The user-visible effect is mild and easily misread — resolvers retry, so lookups still succeed and the failures surface only as intermittent warnings and a raised drop count, at a rate that does not correlate with load in any obvious way.

## Fix

The root problem is that liveness was inferred from `Arc` refcounts, which change on whatever thread happens to drop the last reference, while availability is a property of the pool, which changes only under its lock — so the two could disagree. The fix gives every lease of an address a `Tenancy`, recorded with the address's bitmap offset alongside the weak reference, and keeps a map of current tenancies that is updated in the same critical section as the bitmap itself. That makes the pool's own state the source of truth and lets the hand-back be completed from either side: an allocation that holds the lock and finds a dead weak reference finishes the hand-back itself rather than waiting for the releasing thread to win the lock, and `use_new_ip` reclaims ended tenancies before it reports an empty bitmap — in the same critical section as the retry, so the answer cannot go stale between the two. A late `AllocatedIp::drop` whose tenancy has since been retired does nothing, which is what makes that takeover safe and, incidentally, what closes the duplicate-`AllocatedIp` hazard in `reserve_from_pool`.

Two smaller corrections ride along, both about being able to see what happened: the reuse scan no longer abandons the search at the first address that has run out of port blocks, stranding every address behind it in the list, and `NoFreeIp` no longer buries the more specific reason — which, on a single-address pool, it always did.

## Testing

- New property test in the existing shuttle harness, `an_allocation_racing_the_last_release_is_still_served`: a one-address pool with one thread releasing the only allocation while another allocates. Against the unfixed allocator it reproduces the field error verbatim (`NoFreeIp`); against this change it passes.
- `cargo test -p dataplane-nat --lib` — 165 pass.
- `cargo test -p dataplane-nat --features shuttle --lib shuttle` — 8 pass.
- `cargo clippy -p dataplane-nat --all-targets` — clean.
- Confirmed on a live gateway by deliberately widening the window: the unpatched allocator refused 10 of 20 queries with the drop counter and the log agreeing exactly, while this change served all 20 under the identical forcing function.

## Notes

- Not addressed here: ports are handed out in 256-blocks owned by a single thread and freed only when the last port in the block dies. Measured density on the affected fabric was ~3.35 ports/block for UDP, so a pool walls well below its nominal capacity. That is a separate redesign.
- A backport of this change onto `v0.25.2` is prepared on `backport/v0.25.2/masquerade-address-handback`; it is semantically identical (the two differ only by one clarifying comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)