### PR TITLE
fix(masquerade): Close the window where an address belongs to neither list

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,35 @@
+# Configuration for cargo-mutants (https://mutants.rs).
+#
+# Mutation testing is a flashlight, not a gate: it is run by hand over a crate
+# or a diff, and the product is the list of survivors rather than the score.
+# Nothing in CI depends on this file.
+#
+# Two categories are excluded because a survivor there is noise rather than a
+# finding. Both are excluded here rather than with `#[mutants::skip]` so that
+# production crates take no dependency on the tool and the reasoning stays in
+# one place.
+
+exclude_re = [
+    # Printers. The standing rule is "don't test printers": asserting on
+    # rendered output is sisyphean, produces low signal, and breaks whenever
+    # anyone adjusts a column. A mutated `fmt` that no test notices is telling
+    # us the rule is being followed.
+    "<impl Display for",
+    "<impl Debug for",
+    "<impl std::fmt::Display for",
+    "<impl std::fmt::Debug for",
+
+    # Test-support code inside the crate under test. The workspace convention
+    # puts bolero generators in a `contract` module next to the type they
+    # generate, so cargo-mutants finds them and mutates the test harness at
+    # itself. A generator that draws a different distribution is not a defect
+    # in the code under test; the properties are what judge it.
+    "contract::",
+]
+
+exclude_globs = [
+    # Privileged sysfs manipulation. Exercising the write path needs root and a
+    # real sysfs, and the read path is thin enough that a property would assert
+    # little beyond what the type system already does.
+    "sysfs/**",
+]

--- a/concurrency/src/sync/loom_backend.rs
+++ b/concurrency/src/sync/loom_backend.rs
@@ -28,6 +28,9 @@
 //!     returns `Some` -- the upgrade-fails-after-last-strong-drop race
 //!     real `Weak` exposes is not modelled.
 //!   * `Arc::strong_count` reflects live `Arc`s **and** live `Weak`s.
+//!   * `Weak::strong_count` likewise never reaches `0` while the `Weak`
+//!     itself is alive, so a caller using it to detect "the last strong
+//!     reference is gone" never observes that condition under loom.
 //!   * `Arc::weak_count` panics: the shim has no separate weak count
 //!     to report, and returning `0` silently would make assertions
 //!     pass for the wrong reason on every backend. See the per-method
@@ -545,6 +548,24 @@ impl<T: ?Sized> Weak<T> {
     #[must_use]
     pub fn upgrade(&self) -> Option<Arc<T>> {
         self.inner.as_ref().map(|a| Arc(a.clone()))
+    }
+
+    /// See `std::sync::Weak::strong_count`.
+    ///
+    /// `0` for a `Weak` that has never been associated with an `Arc`, matching std. Otherwise the
+    /// same caveat as `Arc::strong_count` applies and then some: this shim's `Weak` holds a strong
+    /// clone, so the count includes live `Weak`s and cannot reach `0` while `self` is alive. A
+    /// caller asking "has the last strong reference gone?" is therefore always told "no" under
+    /// loom -- inert rather than wrong, but it means such a path is not model-checked here. That is
+    /// the same limitation the module header records for `upgrade`; see the note there about tests
+    /// that need the strong/weak race.
+    ///
+    /// Offered anyway because the alternative is worse: callers that must answer that question
+    /// while holding a lock the value's `Drop` also takes cannot use `upgrade`, since the
+    /// temporary `Arc` it mints may be the last one and would run `Drop` re-entrantly.
+    #[must_use]
+    pub fn strong_count(&self) -> usize {
+        self.inner.as_ref().map_or(0, inner::Arc::strong_count)
     }
 }
 

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -95,6 +95,18 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
                 };
                 examined.push(ip.clone());
                 if !ip.has_free_ports() {
+                    // Skipping is right -- another address may still have room -- but skipping
+                    // silently is not. `outcome` starts at `NoFreeIp`, so a pool whose every
+                    // address is port-exhausted would leave it untouched and report "no free IP
+                    // available" for a pool that has no shortage of addresses at all. That sends
+                    // an operator to the wrong end of the problem: an empty bitmap wants more
+                    // addresses, whereas exhausted port blocks want the block allocator looked at.
+                    //
+                    // `has_free_ports` is false only when the address has no block left to draw
+                    // and no free port in the blocks it already holds, so `NoPortBlock` is the
+                    // accurate reading. Recording it rather than breaking keeps the scan going,
+                    // and a later address that succeeds still overwrites this.
+                    outcome = Err(AllocatorError::NoPortBlock);
                     continue;
                 }
                 let addr = ip.ip();

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -541,6 +541,15 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         self.in_use.len()
     }
 
+    /// The lease currently held on the address at `offset`, if any.
+    ///
+    /// Together with the bitmap this is the whole of the pool's opinion about an address, which is
+    /// what lets a test assert the partition the allocator is supposed to maintain.
+    #[cfg(test)]
+    pub(crate) fn current_tenancy_for_tests(&self, offset: u32) -> Option<Tenancy> {
+        self.tenancies.get(&offset).copied()
+    }
+
     /// Finish the hand-back of every address whose `AllocatedIp` is gone, dropping their entries.
     ///
     /// This is the other half of the [`InUseEntry`] contract: the thread that dropped the last

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -501,6 +501,46 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         true
     }
 
+    // Reach the tenancy bookkeeping directly from tests. The states worth asserting on -- a lease
+    // retired while its owner's `Drop` is still in flight -- need two threads to reach for real,
+    // so the invariant is pinned on the pool instead of raced for.
+    #[cfg(test)]
+    pub(crate) fn begin_tenancy_for_tests(&mut self, offset: u32) -> Tenancy {
+        self.begin_tenancy(offset)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn end_tenancy_for_tests(&mut self, offset: u32, tenancy: Tenancy) -> bool {
+        self.end_tenancy(offset, tenancy)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bitmap_contains_for_tests(&self, offset: u32) -> bool {
+        self.bitmap.0.contains(offset)
+    }
+
+    /// Plant an entry whose address is already gone, so the reclaim path can be driven without a
+    /// second thread. `Weak::new()` never upgrades and reports a strong count of zero, which is
+    /// exactly the state a released address is in before its `Drop` reaches this pool.
+    #[cfg(test)]
+    pub(crate) fn plant_dead_entry_for_tests(&mut self, offset: u32, tenancy: Tenancy) {
+        self.in_use.push_back(InUseEntry {
+            offset,
+            tenancy,
+            ip: Weak::new(),
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn reclaim_ended_tenancies_for_tests(&mut self) {
+        self.reclaim_ended_tenancies();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn in_use_len_for_tests(&self) -> usize {
+        self.in_use.len()
+    }
+
     /// Finish the hand-back of every address whose `AllocatedIp` is gone, dropping their entries.
     ///
     /// This is the other half of the [`InUseEntry`] contract: the thread that dropped the last

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -11,6 +11,7 @@ use crate::masquerade::natip::NatIp;
 use crate::port::NatPort;
 use crate::ranges::IpRange;
 use concurrency::sync::{Arc, RwLock, RwLockReadGuard, Weak};
+use concurrency::thread;
 use port_alloc::PortAllocator;
 use roaring::RoaringBitmap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -44,6 +45,12 @@ impl Tenancy {
         Tenancy(self.0.wrapping_add(1))
     }
 }
+
+/// Bounds retries while an address changes hands.
+///
+/// Mirrors `BLOCK_LOOKUP_ATTEMPTS` in the port allocator, for the same reason: two steps that each
+/// read a consistent pool can still straddle a change made between them.
+const ADDRESS_LOOKUP_ATTEMPTS: usize = 4;
 
 ///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
@@ -154,33 +161,50 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         &self,
         allow_null: bool,
     ) -> Result<port_alloc::AllocatedPort<I>, AllocatorError> {
-        // FIXME: Should we clean up every time??
-        self.cleanup_used_ips();
+        // Reusing an address and drawing a fresh one each read a pool that is internally
+        // consistent, but the decision to move from the first to the second is taken between them,
+        // and the pool can change in the gap. Two flows starting at once on a pool whose address
+        // does not yet exist is enough: the loser's scan finds nothing, and by the time it draws,
+        // the winner holds the only address, so it reports exhaustion for a pool that could serve
+        // it. Releases move the state the other way just as easily. Neither step is wrong on its
+        // own; the pair just needs to be retried when it straddles a change.
+        //
+        // Bounded, and never reports success it did not achieve -- if the pool really is empty,
+        // every attempt fails the same way and the last reason is returned.
+        let mut exhausted = None;
+        for _ in 0..ADDRESS_LOOKUP_ATTEMPTS {
+            // FIXME: Should we clean up every time??
+            self.cleanup_used_ips();
 
-        // Draw a fresh address only when the addresses already in use are exhausted. Other errors
-        // describe allocator failure and must be preserved.
-        match self.reuse_allocated_ip(allow_null) {
-            Ok(port) => Ok(port),
-            Err(reuse) if reuse.is_exhaustion() => {
-                self.allocate_from_new_ip(allow_null).map_err(|fresh| {
-                    // Drawing a fresh address reports `NoFreeIp` whenever the bitmap is empty,
-                    // which for a single-address pool is always. That answer hides why the
-                    // addresses already in use could not serve the request, and the two are not
-                    // the same operational problem: an empty bitmap wants more addresses, whereas
-                    // exhausted port blocks want the block allocator looked at. So prefer
-                    // whichever of the two is not `NoFreeIp`; if neither is, the fresh-address
-                    // error is no less informative than the reuse one, and both describe the same
-                    // exhaustion. This is diagnostics only -- every branch stays within the
-                    // exhaustion class, so callers that switch on `is_exhaustion` are unaffected.
-                    match (&reuse, &fresh) {
-                        (AllocatorError::NoFreeIp, _) => fresh,
+            // Draw a fresh address only when the addresses already in use are exhausted. Other
+            // errors describe allocator failure and must be preserved.
+            let reuse = match self.reuse_allocated_ip(allow_null) {
+                Ok(port) => return Ok(port),
+                Err(reuse) if reuse.is_exhaustion() => reuse,
+                Err(e) => return Err(e),
+            };
+
+            match self.allocate_from_new_ip(allow_null) {
+                Ok(port) => return Ok(port),
+                Err(drawn) if drawn.is_exhaustion() => {
+                    // Drawing reports `NoFreeIp` whenever the bitmap is empty, which for a
+                    // single-address pool is always. That answer hides why the addresses already
+                    // in use could not serve the request, and the two are not the same operational
+                    // problem: an empty bitmap wants more addresses, whereas exhausted port blocks
+                    // want the block allocator looked at. Keep whichever is not `NoFreeIp`.
+                    exhausted = Some(match (&reuse, &drawn) {
+                        (AllocatorError::NoFreeIp, _) => drawn,
                         (_, AllocatorError::NoFreeIp) => reuse,
-                        _ => fresh,
-                    }
-                })
+                        _ => drawn,
+                    });
+                    thread::yield_now();
+                }
+                Err(drawn) => return Err(drawn),
             }
-            Err(e) => Err(e),
         }
+
+        debug!("Address lookup changed {ADDRESS_LOOKUP_ATTEMPTS} times");
+        Err(exhausted.unwrap_or(AllocatorError::NoFreeIp))
     }
 
     fn get_allocated_ip(&self, ip: I) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -19,6 +19,33 @@ use std::time::Duration;
 use tracing::{debug, error};
 
 ///////////////////////////////////////////////////////////////////////////////
+// Tenancy
+///////////////////////////////////////////////////////////////////////////////
+
+/// Identifies one lease of one public address, so that a lease which has ended cannot be confused
+/// with the lease that replaced it.
+///
+/// A [`NatPool`] hands an address out at most once per tenancy. The address returns to the pool
+/// when its tenancy ends, and ending a tenancy that is no longer the current one does nothing. That
+/// is what makes the hand-back safe to perform from either side: an [`AllocatedIp`] releasing
+/// itself, or an allocation reclaiming an address whose owner has already gone away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Tenancy(u64);
+
+impl Tenancy {
+    /// The tenancy handed to the first lease of any address in a pool.
+    const FIRST: Tenancy = Tenancy(0);
+
+    /// The tenancy that follows this one.
+    ///
+    /// Wrapping is not a correctness concern: distinguishing a lease from its successor only
+    /// requires that a `u64` counter not wrap while a single `AllocatedIp` is being dropped.
+    fn next(self) -> Tenancy {
+        Tenancy(self.0.wrapping_add(1))
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // IpAllocator
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -41,8 +68,8 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         self.pool.read()
     }
 
-    fn deallocate_ip(&self, ip: I) {
-        self.pool.write().deallocate_from_pool(ip);
+    fn deallocate_ip(&self, ip: I, tenancy: Tenancy) {
+        self.pool.write().deallocate_from_pool(ip, tenancy);
     }
 
     fn reuse_allocated_ip(
@@ -63,14 +90,27 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
                 if !ip.has_free_ports() {
                     continue;
                 }
+                let addr = ip.ip();
                 match ip.allocate_port_for_ip(allow_null) {
                     Ok(port) => {
                         debug!("Allocated port {port}");
                         outcome = Ok(port);
                         break;
                     }
-                    // If there is no free port left, loop again to try another IP address
-                    Err(AllocatorError::NoFreePort(_)) => {}
+                    // This address is out of space, but another may still have room: keep
+                    // scanning. Running out of port blocks is exhaustion just as much as running
+                    // out of ports within a block, and ending the scan there would strand every
+                    // address behind this one in the list.
+                    //
+                    // Matching the whole exhaustion class rather than naming the port errors keeps
+                    // this honest if that class grows. It cannot swallow `NoFreeIp`, which is also
+                    // in the class: allocating a port for an address the caller already holds has
+                    // no address to run out of, so the port allocator never returns it.
+                    Err(e) if e.is_exhaustion() => {
+                        debug!("Address {addr} is out of space: {e}");
+                        outcome = Err(e);
+                    }
+                    // Anything else describes allocator failure, not exhaustion. Report it.
                     Err(e) => {
                         outcome = Err(e);
                         break;
@@ -85,9 +125,9 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
 
     fn allocate_new_ip_from_pool(&self) -> Result<Arc<AllocatedIp<I>>, AllocatorError> {
         let mut allocated_ips = self.pool.write();
-        let new_ip = allocated_ips.use_new_ip(self.clone(), self.randomize)?;
+        let (offset, new_ip) = allocated_ips.use_new_ip(self.clone(), self.randomize)?;
         let arc_ip = Arc::new(new_ip);
-        allocated_ips.add_in_use(&arc_ip);
+        allocated_ips.add_in_use(offset, &arc_ip);
         debug!("Allocated new ip {}", arc_ip.ip());
         Ok(arc_ip)
     }
@@ -121,7 +161,24 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
         // describe allocator failure and must be preserved.
         match self.reuse_allocated_ip(allow_null) {
             Ok(port) => Ok(port),
-            Err(e) if e.is_exhaustion() => self.allocate_from_new_ip(allow_null),
+            Err(reuse) if reuse.is_exhaustion() => {
+                self.allocate_from_new_ip(allow_null).map_err(|fresh| {
+                    // Drawing a fresh address reports `NoFreeIp` whenever the bitmap is empty,
+                    // which for a single-address pool is always. That answer hides why the
+                    // addresses already in use could not serve the request, and the two are not
+                    // the same operational problem: an empty bitmap wants more addresses, whereas
+                    // exhausted port blocks want the block allocator looked at. So prefer
+                    // whichever of the two is not `NoFreeIp`; if neither is, the fresh-address
+                    // error is no less informative than the reuse one, and both describe the same
+                    // exhaustion. This is diagnostics only -- every branch stays within the
+                    // exhaustion class, so callers that switch on `is_exhaustion` are unaffected.
+                    match (&reuse, &fresh) {
+                        (AllocatorError::NoFreeIp, _) => fresh,
+                        (_, AllocatorError::NoFreeIp) => reuse,
+                        _ => fresh,
+                    }
+                })
+            }
             Err(e) => Err(e),
         }
     }
@@ -150,7 +207,10 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
     #[cfg(test)]
     pub fn get_pool_clone_for_tests(&self) -> (RoaringBitmap, VecDeque<Weak<AllocatedIp<I>>>) {
         let pool = self.pool.read();
-        (pool.bitmap.0.clone(), pool.in_use.clone())
+        (
+            pool.bitmap.0.clone(),
+            pool.in_use.iter().map(|entry| entry.ip.clone()).collect(),
+        )
     }
 }
 
@@ -250,6 +310,9 @@ impl<I: NatIpWithBitmap> PoolSet<I> {
 #[derive(Debug)]
 pub(crate) struct AllocatedIp<I: NatIpWithBitmap> {
     ip: I,
+    /// The lease this address was handed out under. Returned to the pool on drop so the pool can
+    /// tell a stale hand-back from a live one.
+    tenancy: Tenancy,
     port_allocator: port_alloc::PortAllocator<I>,
     ip_allocator: IpAllocator<I>,
 }
@@ -261,10 +324,12 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
         reserved: ReservedForAddr,
         randomize: bool,
         exclude_wellknown_ports: bool,
+        tenancy: Tenancy,
     ) -> Self {
         let port_allocator = PortAllocator::new(reserved, randomize, exclude_wellknown_ports);
         Self {
             ip,
+            tenancy,
             port_allocator,
             ip_allocator,
         }
@@ -280,6 +345,10 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
     /// creates one honours the reservations without having to be told about them.
     pub(crate) fn reserved_ports(&self) -> &ReservedForAddr {
         self.port_allocator.reserved_ports()
+    }
+
+    fn tenancy(&self) -> Tenancy {
+        self.tenancy
     }
 
     // Used for Display; should probably not be accessed directly anywhere else
@@ -321,7 +390,7 @@ impl<I: NatIpWithBitmap> AllocatedIp<I> {
 
 impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
     fn drop(&mut self) {
-        self.ip_allocator.deallocate_ip(self.ip);
+        self.ip_allocator.deallocate_ip(self.ip, self.tenancy);
     }
 }
 
@@ -329,18 +398,44 @@ impl<I: NatIpWithBitmap> Drop for AllocatedIp<I> {
 // NatPool
 ///////////////////////////////////////////////////////////////////////////////
 
+/// One address this pool has handed out, and the lease it was handed out under.
+///
+/// The weak reference alone cannot answer "is this address available?". It stops resolving the
+/// moment the last [`AllocatedPort`](port_alloc::AllocatedPort) goes away, which is *before*
+/// `AllocatedIp::drop` runs and returns the address to the bitmap. Recording the offset and the
+/// tenancy next to the weak reference lets whoever notices first finish the hand-back, so the
+/// address is never absent from both the bitmap and this list.
+#[derive(Debug)]
+struct InUseEntry<I: NatIpWithBitmap> {
+    offset: u32,
+    tenancy: Tenancy,
+    ip: Weak<AllocatedIp<I>>,
+}
+
 /// A [`NatPool`] is a pool of IP addresses that can be allocated from. It contains a bitmap of
 /// available IP addresses, and a list of weak references to [`AllocatedIp`] objects representing
 /// the allocated IPs potentially available for use (if they still have free ports)
+///
+/// # Invariant
+///
+/// Every address of the pool is either free in `bitmap` or has a current tenancy in `tenancies`,
+/// never both and never neither. `tenancies` is what makes that invariant maintainable: it is
+/// updated in the same critical section as `bitmap`, whereas the liveness of an `AllocatedIp`
+/// changes on whatever thread happens to drop the last reference to it.
 #[derive(Debug)]
 pub(crate) struct NatPool<I: NatIpWithBitmap> {
     bitmap: PoolBitmap,
     bitmap_mapping: BTreeMap<u32, u128>,
     reverse_bitmap_mapping: BTreeMap<u128, u32>,
-    in_use: VecDeque<Weak<AllocatedIp<I>>>,
+    in_use: VecDeque<InUseEntry<I>>,
     /// The public tuples of this region that port forwarding may claim. Applied to every address as
     /// it is put to use, so masquerade never hands one of them out.
     reserved: ReservedPorts,
+    /// The current tenancy of every address not free in `bitmap`. An address is removed from here
+    /// exactly when it returns to the bitmap.
+    tenancies: BTreeMap<u32, Tenancy>,
+    /// The tenancy the next lease of any address in this pool will be handed.
+    next_tenancy: Tenancy,
     exclude_wellknown_ports: bool,
 }
 
@@ -372,61 +467,150 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             reverse_bitmap_mapping,
             in_use: VecDeque::new(),
             reserved,
+            tenancies: BTreeMap::new(),
+            next_tenancy: Tenancy::FIRST,
             exclude_wellknown_ports,
         }
     }
 
-    fn add_in_use(&mut self, ip: &Arc<AllocatedIp<I>>) {
-        self.in_use.push_back(Arc::downgrade(ip));
+    /// Take the address at `offset` out of the bitmap and record the lease it is handed out under.
+    ///
+    /// Overwriting an existing tenancy is deliberate: it retires the previous lease, so that
+    /// lease's eventual hand-back becomes a no-op rather than freeing an address this pool has
+    /// already re-issued.
+    fn begin_tenancy(&mut self, offset: u32) -> Tenancy {
+        let tenancy = self.next_tenancy;
+        self.next_tenancy = tenancy.next();
+        self.bitmap.set_ip_allocated(offset);
+        self.tenancies.insert(offset, tenancy);
+        tenancy
+    }
+
+    /// Return the address at `offset` to the bitmap, but only if `tenancy` is still its current
+    /// lease.
+    ///
+    /// Returns whether the hand-back happened. A `false` answer means some other caller already
+    /// completed it, or the pool has since re-issued the address; neither is an error, and both
+    /// must leave the bitmap alone.
+    fn end_tenancy(&mut self, offset: u32, tenancy: Tenancy) -> bool {
+        if self.tenancies.get(&offset) != Some(&tenancy) {
+            return false;
+        }
+        self.tenancies.remove(&offset);
+        self.bitmap.set_ip_free(offset);
+        true
+    }
+
+    /// Finish the hand-back of every address whose `AllocatedIp` is gone, dropping their entries.
+    ///
+    /// This is the other half of the [`InUseEntry`] contract: the thread that dropped the last
+    /// reference may still be waiting for this pool's lock, so any caller that holds the lock and
+    /// sees a dead weak reference completes the hand-back on its behalf.
+    ///
+    /// Deliberately not shared with [`NatPool::cleanup`], which it otherwise resembles. `cleanup`
+    /// upgrades each entry and hands the resulting `Arc`s to its caller to drop after the guard is
+    /// released; this runs with the write lock held and must never mint an `Arc` at all, because
+    /// the one it minted could be the last and `AllocatedIp::drop` takes that same lock. Reading
+    /// `strong_count` answers the liveness question without that hazard.
+    fn reclaim_ended_tenancies(&mut self) {
+        let mut ended = Vec::new();
+        self.in_use.retain(|entry| {
+            if entry.ip.strong_count() > 0 {
+                return true;
+            }
+            ended.push((entry.offset, entry.tenancy));
+            false
+        });
+        for (offset, tenancy) in ended {
+            if self.end_tenancy(offset, tenancy) {
+                debug!("Reclaimed address at offset {offset} from an ended tenancy");
+            }
+        }
+    }
+
+    fn add_in_use(&mut self, offset: u32, ip: &Arc<AllocatedIp<I>>) {
+        self.in_use.push_back(InUseEntry {
+            offset,
+            tenancy: ip.tenancy(),
+            ip: Arc::downgrade(ip),
+        });
     }
 
     /// Drop the entries whose addresses are gone, handing the caller every address that is still
     /// alive so it can release them once the pool lock is no longer held. See `cleanup_used_ips`.
+    ///
+    /// Dropping an entry also completes that address's hand-back, so pruning the list can never
+    /// lose track of an address.
     fn cleanup(&mut self, keep_alive: &mut Vec<Arc<AllocatedIp<I>>>) {
-        self.in_use.retain(|ip| match ip.upgrade() {
-            Some(alive) => {
+        let mut ended = Vec::new();
+        self.in_use.retain(|entry| {
+            if let Some(alive) = entry.ip.upgrade() {
                 keep_alive.push(alive);
-                true
+                return true;
             }
-            None => false,
+            ended.push((entry.offset, entry.tenancy));
+            false
         });
+        for (offset, tenancy) in ended {
+            self.end_tenancy(offset, tenancy);
+        }
     }
 
     pub(crate) fn ips_in_use(&self) -> impl Iterator<Item = &Weak<AllocatedIp<I>>> {
-        self.in_use.iter()
+        self.in_use.iter().map(|entry| &entry.ip)
     }
 
     fn use_new_ip(
         &mut self,
         ip_allocator: IpAllocator<I>,
         randomize: bool,
-    ) -> Result<AllocatedIp<I>, AllocatorError> {
+    ) -> Result<(u32, AllocatedIp<I>), AllocatorError> {
         // Retrieve the first available offset
-        let offset = self.bitmap.pop_ip()?;
+        let offset = match self.bitmap.pop_ip() {
+            Ok(offset) => offset,
+            Err(empty) => {
+                // The bitmap being empty is not proof the pool is: an address whose last lease
+                // ended a moment ago is not in the bitmap yet, and no longer reachable through
+                // `in_use` either. Finish those hand-backs -- under the same lock as the retry, so
+                // the answer cannot go stale between the two -- before reporting exhaustion.
+                self.reclaim_ended_tenancies();
+                self.bitmap.pop_ip().map_err(|_| empty)?
+            }
+        };
 
         // the ip being allocated
         let ip = I::try_from_offset(offset, &self.bitmap_mapping)?;
+        let tenancy = self.begin_tenancy(offset);
 
         // determine the set of reserved ports that cannot be allocated for this ip
         let reserved = self.reserved.for_addr(ip.to_ip_addr());
 
-        Ok(AllocatedIp::new(
-            ip,
-            ip_allocator,
-            reserved,
-            randomize,
-            self.exclude_wellknown_ports,
+        Ok((
+            offset,
+            AllocatedIp::new(
+                ip,
+                ip_allocator,
+                reserved,
+                randomize,
+                self.exclude_wellknown_ports,
+                tenancy,
+            ),
         ))
     }
 
-    fn deallocate_from_pool(&mut self, ip: I) {
+    fn deallocate_from_pool(&mut self, ip: I, tenancy: Tenancy) {
         debug!("Address {ip} was deallocated");
         // The address was handed out by this pool, so it maps back into it. This runs while an
         // allocation is being dropped and has nowhere to report a failure, so say so and leave the
         // address marked in use rather than panicking on the drop path.
         match I::try_to_offset(ip, &self.reverse_bitmap_mapping) {
             Ok(offset) => {
-                self.bitmap.set_ip_free(offset);
+                if !self.end_tenancy(offset, tenancy) {
+                    // An allocation noticed this lease had ended and completed the hand-back
+                    // already, possibly re-issuing the address in the process. Freeing it here
+                    // would hand the same address to a second `AllocatedIp`.
+                    debug!("Address {ip} was already handed back before its lease was dropped");
+                }
             }
             Err(e) => error!("Address {ip} does not map back into the pool it came from: {e}"),
         }
@@ -457,12 +641,12 @@ impl<I: NatIpWithBitmap> NatPool<I> {
 
         // Allocate the IP now.
         //
-        // If the IP was already allocated in the bitmap, this is OK: it means that the IP was
-        // allocated in the past, it is no longer in used (because it is not in the list of in-use
-        // IPs), but we haven't deallocated from the bitmap yet (this happens when another thread
-        // drops an AllocatedIp and its reference count goes to 0, but it hasn't called the drop()
-        // function to remove the IP from the bitmap in that other thread yet).
-        let _ = self.bitmap.set_ip_allocated(offset);
+        // The address may still be marked allocated in the bitmap: it was handed out in the past
+        // and is no longer in use (it is not in the list of in-use IPs), but the thread dropping
+        // the previous `AllocatedIp` has not reached this pool's lock yet. Opening a new tenancy
+        // retires that previous lease, so when its drop does arrive it will not free an address
+        // this reservation now owns. `begin_tenancy` takes the address out of the bitmap itself.
+        let tenancy = self.begin_tenancy(offset);
 
         // Reservations apply here as well: an address put to use by carrying a live masquerade flow
         // over to a new allocator must not be able to re-take a port that port forwarding claims.
@@ -472,8 +656,9 @@ impl<I: NatIpWithBitmap> NatPool<I> {
             self.reserved.for_addr(ip.to_ip_addr()),
             randomize,
             self.exclude_wellknown_ports,
+            tenancy,
         ));
-        self.add_in_use(&arc_ip);
+        self.add_in_use(offset, &arc_ip);
         Ok(arc_ip)
     }
 

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -191,11 +191,12 @@ impl<I: NatIpWithBitmap> IpAllocator<I> {
                     // single-address pool is always. That answer hides why the addresses already
                     // in use could not serve the request, and the two are not the same operational
                     // problem: an empty bitmap wants more addresses, whereas exhausted port blocks
-                    // want the block allocator looked at. Keep whichever is not `NoFreeIp`.
-                    exhausted = Some(match (&reuse, &drawn) {
-                        (AllocatorError::NoFreeIp, _) => drawn,
-                        (_, AllocatorError::NoFreeIp) => reuse,
-                        _ => drawn,
+                    // want the block allocator looked at. So the draw only gets the last word when
+                    // it has something to say beyond an empty bitmap.
+                    exhausted = Some(if matches!(drawn, AllocatorError::NoFreeIp) {
+                        reuse
+                    } else {
+                        drawn
                     });
                     thread::yield_now();
                 }

--- a/nat/src/masquerade/apalloc/alloc.rs
+++ b/nat/src/masquerade/apalloc/alloc.rs
@@ -653,7 +653,20 @@ impl<I: NatIpWithBitmap> NatPool<I> {
         };
 
         // the ip being allocated
-        let ip = I::try_from_offset(offset, &self.bitmap_mapping)?;
+        let ip = match I::try_from_offset(offset, &self.bitmap_mapping) {
+            Ok(ip) => ip,
+            Err(e) => {
+                // The offset has left the bitmap but has no tenancy yet, so returning here would
+                // leave it in the "neither" state this type's invariant rules out -- the same
+                // state the hand-back window used to produce. Nothing can reach it today (v4
+                // offsets convert infallibly, and v6 offsets come from the very mapping this
+                // consults), but an invariant that holds only because its violation is currently
+                // unreachable stops holding the moment either side of that changes. Put the
+                // address back rather than rely on the argument.
+                self.bitmap.set_ip_free(offset);
+                return Err(e);
+            }
+        };
         let tenancy = self.begin_tenancy(offset);
 
         // determine the set of reserved ports that cannot be allocated for this ip

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -651,29 +651,14 @@ impl HandbackScenario {
 
 /// The same property as the fixed scenario above, over generated shapes.
 ///
-/// IGNORED: this currently fails, and it fails on unmodified `main` as well as with the tenancy
-/// fix applied -- verified by running it against `origin/main` with nothing else changed. It is
-/// therefore a second, independent defect rather than a regression, and it is left here, failing
-/// and ignored, because deleting it would discard the only reproducer anyone has for it.
-///
-/// What is known: one address, three workers, a mixture of taking and releasing tuples, and an
-/// allocation is refused with `NoFreeIp` while the pool is nowhere near exhausted -- the same
-/// observable symptom as the bug this module's fixed scenario covers, reached by a different
-/// route. The pool is healthy again by the time the workers join, so the window is transient.
-///
-/// What is not known: the mechanism. The obvious candidate -- that `allocate` commits to drawing a
-/// fresh address after its scan comes up empty, and never re-checks if another thread creates the
-/// address in that gap -- is wrong: adding that re-scan does not fix it. Whatever the real cause,
-/// it is not the hand-back window, which the tenancies close.
-///
-/// Do not un-ignore this without a diagnosis. A green run here would mean the defect moved rather
-/// than that it went away.
-#[ignore = "reproduces a second, pre-existing allocator race; see the comment above"]
-///
 /// Whatever the number of addresses, the number of workers, or the interleaving of taking and
 /// giving back, an allocation must never be refused while the pool still owns an address. The
-/// fixed test says this bug is real in the configuration that met it; this says the same defect
-/// does not survive in the neighbourhood around that configuration.
+/// fixed test says the reported bug is real in the configuration that met it; this says the same
+/// symptom does not survive in the neighbourhood around it.
+///
+/// It found a second defect doing so, which the bounded retry in `IpAllocator::allocate` now
+/// covers: a scan and a draw that each read a consistent pool, straddling a change made between
+/// them. Against `main` without that retry this fails in both concurrency models.
 #[concurrency::model_test]
 fn no_generated_handback_shape_refuses_an_allocation() {
     bolero::check!()

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -547,7 +547,8 @@ fn an_allocation_racing_the_last_release_is_still_served() {
 
 /// Addresses and workers for the generated hand-back scenarios. Both small: the race needs an
 /// address to reach zero references, and every extra worker makes some flow more likely to be
-/// holding one at all times, which hides the window rather than exposing it.
+/// holding one at all times, which hides the window rather than exposing it. Worker counts start
+/// at two because a lone worker has nothing to race.
 const MAX_HANDBACK_ADDRESSES: u8 = 3;
 const MAX_HANDBACK_WORKERS: usize = 3;
 const MAX_HANDBACK_OPS: usize = 5;
@@ -571,7 +572,7 @@ struct HandbackScenario {
 impl bolero::TypeGenerator for HandbackScenario {
     fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
         let addresses = driver.produce::<u8>()? % MAX_HANDBACK_ADDRESSES + 1;
-        let worker_count = usize::from(driver.produce::<u8>()? % 2) + 2;
+        let worker_count = usize::from(driver.produce::<u8>()?) % (MAX_HANDBACK_WORKERS - 1) + 2;
 
         let mut ops = Vec::with_capacity(worker_count);
         for _ in 0..worker_count {
@@ -583,7 +584,6 @@ impl bolero::TypeGenerator for HandbackScenario {
             }
             ops.push(worker);
         }
-        let _ = MAX_HANDBACK_WORKERS;
         Some(Self { addresses, ops })
     }
 }

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -501,6 +501,13 @@ fn tidying_a_dead_block_entry_does_not_drop_a_live_one() {
 /// [`NatFlowStatus::Closed`](crate::common::NatFlowStatus::Closed), which invalidates the pair at
 /// once to conserve ports, so a pool carrying only DNS destroys and rebuilds its address once per
 /// query, and the next query races the hand-back of the last one.
+///
+/// Deliberately one fixed shape rather than a generated one, and kept alongside the generated
+/// sibling below rather than replaced by it. One address, one releaser, one allocator is the
+/// minimal configuration that reproduces the field failure, and it is a case of special interest:
+/// it is what the affected deployments actually run, and against the unfixed allocator it fails
+/// here with the same error those deployments logged. A generator would explore more and, when it
+/// did fail, shrink to something less immediately recognisable as the reported bug.
 #[concurrency::model_test]
 fn an_allocation_racing_the_last_release_is_still_served() {
     concurrency::stress(|| {
@@ -536,4 +543,145 @@ fn an_allocation_racing_the_last_release_is_still_served() {
             outcome.as_ref().err()
         );
     });
+}
+
+/// Addresses and workers for the generated hand-back scenarios. Both small: the race needs an
+/// address to reach zero references, and every extra worker makes some flow more likely to be
+/// holding one at all times, which hides the window rather than exposing it.
+const MAX_HANDBACK_ADDRESSES: u8 = 3;
+const MAX_HANDBACK_WORKERS: usize = 3;
+const MAX_HANDBACK_OPS: usize = 5;
+
+/// What a worker does to a pool while its neighbours do the same.
+#[derive(Clone, Copy, Debug, bolero::TypeGenerator)]
+enum HandbackOp {
+    /// Take a tuple and keep it.
+    Allocate,
+    /// Give back the tuple taken longest ago, which is what opens the window.
+    ReleaseOldest,
+}
+
+/// A generated shape for the hand-back race.
+#[derive(Clone, Debug)]
+struct HandbackScenario {
+    addresses: u8,
+    ops: Vec<Vec<HandbackOp>>,
+}
+
+impl bolero::TypeGenerator for HandbackScenario {
+    fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
+        let addresses = driver.produce::<u8>()? % MAX_HANDBACK_ADDRESSES + 1;
+        let worker_count = usize::from(driver.produce::<u8>()? % 2) + 2;
+
+        let mut ops = Vec::with_capacity(worker_count);
+        for _ in 0..worker_count {
+            let mut worker: Vec<HandbackOp> = driver.produce()?;
+            worker.truncate(MAX_HANDBACK_OPS);
+            // A worker that never allocates cannot race anything.
+            if !worker.iter().any(|op| matches!(op, HandbackOp::Allocate)) {
+                worker.insert(0, HandbackOp::Allocate);
+            }
+            ops.push(worker);
+        }
+        let _ = MAX_HANDBACK_WORKERS;
+        Some(Self { addresses, ops })
+    }
+}
+
+impl HandbackScenario {
+    /// Far below any real limit: a single address carries 252 usable port blocks of 256 ports
+    /// each, and these scenarios hold a handful of tuples at once. So an exhaustion error here
+    /// cannot mean the pool ran out -- only that it lost track of an address it still owned.
+    fn run(&self) {
+        let specs = vec![PoolSpec::new(
+            vec![AddrInterval::new(
+                BASE,
+                BASE + u128::from(self.addresses) - 1,
+            )],
+            IDLE_TIMEOUT,
+        )];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            NextHeader::TCP,
+            false,
+        ));
+
+        let failures = Arc::new(Mutex::new(Vec::new()));
+        let mut handles = Vec::with_capacity(self.ops.len());
+
+        for worker in &self.ops {
+            let pools = pools.clone();
+            let failures = failures.clone();
+            let worker = worker.clone();
+            handles.push(thread::spawn(move || {
+                let mut held = Vec::new();
+                for op in worker {
+                    match op {
+                        HandbackOp::Allocate => match pools[0].allocate(false) {
+                            Ok(allocation) => held.push(allocation),
+                            Err(e) => failures.lock().push(e),
+                        },
+                        HandbackOp::ReleaseOldest => {
+                            if !held.is_empty() {
+                                drop(held.remove(0));
+                            }
+                        }
+                    }
+                    thread::yield_now();
+                }
+                drop(held);
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("a worker panicked");
+        }
+
+        let failures = failures.lock();
+        assert!(
+            failures.is_empty(),
+            "allocation was refused on a pool that was nowhere near exhausted: {:?} \
+             (addresses: {}, workers: {})",
+            *failures,
+            self.addresses,
+            self.ops.len(),
+        );
+    }
+}
+
+/// The same property as the fixed scenario above, over generated shapes.
+///
+/// IGNORED: this currently fails, and it fails on unmodified `main` as well as with the tenancy
+/// fix applied -- verified by running it against `origin/main` with nothing else changed. It is
+/// therefore a second, independent defect rather than a regression, and it is left here, failing
+/// and ignored, because deleting it would discard the only reproducer anyone has for it.
+///
+/// What is known: one address, three workers, a mixture of taking and releasing tuples, and an
+/// allocation is refused with `NoFreeIp` while the pool is nowhere near exhausted -- the same
+/// observable symptom as the bug this module's fixed scenario covers, reached by a different
+/// route. The pool is healthy again by the time the workers join, so the window is transient.
+///
+/// What is not known: the mechanism. The obvious candidate -- that `allocate` commits to drawing a
+/// fresh address after its scan comes up empty, and never re-checks if another thread creates the
+/// address in that gap -- is wrong: adding that re-scan does not fix it. Whatever the real cause,
+/// it is not the hand-back window, which the tenancies close.
+///
+/// Do not un-ignore this without a diagnosis. A green run here would mean the defect moved rather
+/// than that it went away.
+#[ignore = "reproduces a second, pre-existing allocator race; see the comment above"]
+///
+/// Whatever the number of addresses, the number of workers, or the interleaving of taking and
+/// giving back, an allocation must never be refused while the pool still owns an address. The
+/// fixed test says this bug is real in the configuration that met it; this says the same defect
+/// does not survive in the neighbourhood around that configuration.
+#[concurrency::model_test]
+fn no_generated_handback_shape_refuses_an_allocation() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|scenario: HandbackScenario| {
+            concurrency::stress(move || {
+                scenario.run();
+            });
+        });
 }

--- a/nat/src/masquerade/apalloc/concurrent_fuzz.rs
+++ b/nat/src/masquerade/apalloc/concurrent_fuzz.rs
@@ -488,3 +488,52 @@ fn tidying_a_dead_block_entry_does_not_drop_a_live_one() {
         }
     });
 }
+
+/// An address whose last lease has just ended must not vanish from the pool.
+///
+/// An address is reachable through the in-use list only while an allocation still holds it, and
+/// through the bitmap only once its hand-back has completed. `Weak` stops resolving the moment the
+/// last `AllocatedPort` goes away, which is strictly before `AllocatedIp::drop` reaches the pool
+/// lock, so an allocation landing in between used to find the address in neither and report
+/// exhaustion. On a one-address pool that is the whole pool, and the packet is dropped.
+///
+/// This is the shape DNS traffic takes. A reply from port 53 moves the flow to
+/// [`NatFlowStatus::Closed`](crate::common::NatFlowStatus::Closed), which invalidates the pair at
+/// once to conserve ports, so a pool carrying only DNS destroys and rebuilds its address once per
+/// query, and the next query races the hand-back of the last one.
+#[concurrency::model_test]
+fn an_allocation_racing_the_last_release_is_still_served() {
+    concurrency::stress(|| {
+        // One address, so a hand-back in flight is the pool's entire capacity. This is the shape
+        // the masquerade exposes actually deploy: one public address per peering.
+        let specs = vec![PoolSpec::new(
+            vec![AddrInterval::new(BASE, BASE)],
+            IDLE_TIMEOUT,
+        )];
+        let pools = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+            &specs,
+            NextHeader::TCP,
+            false,
+        ));
+
+        let allocation = pools[0].allocate(false).expect("the pool can serve");
+
+        let releaser = thread::spawn(move || drop(allocation));
+        let claimant = {
+            let pools = pools.clone();
+            thread::spawn(move || pools[0].allocate(false))
+        };
+
+        let outcome = claimant.join().expect("the allocating thread panicked");
+        releaser.join().expect("the releasing thread panicked");
+
+        // Whichever order the two threads take, the pool has room to serve: either the address is
+        // still held, and has its remaining ports, or it has been handed back and can be drawn
+        // afresh. There is no interleaving in which the only correct answer is "out of resources".
+        assert!(
+            outcome.is_ok(),
+            "an allocation racing the release of the only address was refused: {:?}",
+            outcome.as_ref().err()
+        );
+    });
+}

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -418,6 +418,56 @@ fn an_exhausted_address_neither_strands_its_neighbours_nor_reads_as_an_empty_poo
     );
 }
 
+/// A pool whose addresses are all in use and all out of ports reports the port shortage rather
+/// than an empty pool.
+///
+/// The sibling test above reaches this through a block held on another thread, which leaves one
+/// address still answering `has_free_ports`. Here nothing is held elsewhere and every address is
+/// drained flat, so the reuse scan skips all of them and the draw that follows finds an empty
+/// bitmap -- the shape that used to answer `NoFreeIp`, because skipping an address left the
+/// initial value of `outcome` untouched.
+///
+/// The distinction is what an operator acts on. `NoFreeIp` says to add public addresses; this pool
+/// has every address it was configured with and is using all of them, so the shortage is ports.
+#[test]
+#[cfg_attr(miri, ignore = "exhaustive allocator walk is too slow under miri")]
+fn a_pool_out_of_ports_is_not_reported_as_a_pool_out_of_addresses() {
+    const PORTS_PER_ADDRESS: usize = 65536 - 1024;
+    const ADDRESSES: u128 = 2;
+
+    let specs = vec![PoolSpec::new(
+        vec![AddrInterval::new(BASE, BASE + ADDRESSES - 1)],
+        IDLE_TIMEOUT,
+    )];
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+
+    let ports = usize::try_from(ADDRESSES).unwrap_or_else(|_| unreachable!()) * PORTS_PER_ADDRESS;
+    let mut held = Vec::with_capacity(ports);
+    let outcome = loop {
+        match pool_sets[0].allocate(false) {
+            Ok(allocation) => held.push(allocation),
+            Err(e) => break e,
+        }
+        // Bounding the walk turns a pool that hands out more than it holds into a failure rather
+        // than a hang.
+        assert!(
+            held.len() <= ports,
+            "the pool handed out more ports than it has"
+        );
+    };
+
+    assert_eq!(
+        held.len(),
+        ports,
+        "the pool refused while it still had ports to give"
+    );
+    assert_eq!(
+        outcome,
+        AllocatorError::NoPortBlock,
+        "a pool out of ports was reported as a pool out of addresses"
+    );
+}
+
 /// The in-use list must not grow as allocations come and go.
 ///
 /// An address is handed back by whichever side reaches the pool first, so the bitmap stays honest

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -8,8 +8,9 @@
 
 #![cfg(test)]
 
-use super::alloc::{PoolSet, map_address};
+use super::alloc::{NatPool, PoolSet, Tenancy, map_address};
 use super::region::AddrInterval;
+use super::reserved::ReservedPorts;
 use super::setup::{PoolSpec, pool_sets_for_specs};
 use crate::masquerade::allocation::AllocatorError;
 use crate::port::NatPort;
@@ -471,4 +472,146 @@ fn a_shared_region_honours_the_claims_of_every_owner() {
     pool_sets[1]
         .reserve(address, free_port)
         .expect("an unclaimed port of a shared region is still available");
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Tenancy bookkeeping
+///////////////////////////////////////////////////////////////////////////////
+
+/// Addresses in the pool the tenancy properties run against. Small, so operations collide on the
+/// same offset often -- re-issue and stale hand-back are the interesting cases and both need two
+/// leases on one address.
+const TENANCY_POOL_SIZE: u32 = 3;
+const TENANCY_OPS: usize = 32;
+/// Bitmap indices are zero-based only for IPv6, whose addresses do not fit a `u32`. For IPv4 the
+/// index *is* the address, so these properties have to speak in absolute values.
+#[allow(clippy::cast_possible_truncation)]
+const TENANCY_BASE: u32 = BASE as u32;
+
+/// One step against a pool's tenancy bookkeeping.
+///
+/// `Abandon` is the state that motivates the whole scheme: an address whose owner is gone without
+/// having handed it back. It is reachable in production only by losing a race, so it is modelled
+/// directly here rather than waited for.
+#[derive(Debug, Clone, Copy, TypeGenerator)]
+enum TenancyOp {
+    Lease(u8),
+    HandBack(u8),
+    HandBackStale(u8),
+    Abandon(u8),
+    Reclaim,
+}
+
+impl TenancyOp {
+    fn offset(self) -> u32 {
+        let raw = match self {
+            TenancyOp::Lease(o)
+            | TenancyOp::HandBack(o)
+            | TenancyOp::HandBackStale(o)
+            | TenancyOp::Abandon(o) => o,
+            TenancyOp::Reclaim => 0,
+        };
+        TENANCY_BASE + (u32::from(raw) % TENANCY_POOL_SIZE)
+    }
+}
+
+/// Every address is either free in the bitmap or currently leased. Never both, never neither.
+///
+/// "Neither" is the defect this machinery exists to prevent: an address whose owner has released
+/// it but whose hand-back has not landed is absent from both, and an allocation that consults them
+/// is told the pool is empty while the pool is holding an address belonging to no one. Stating it
+/// as a partition means any future change that reintroduces the gap fails here, whatever route it
+/// takes to get there.
+fn assert_partition(pool: &NatPool<Ipv4Addr>, after: &str) {
+    for offset in TENANCY_BASE..TENANCY_BASE + TENANCY_POOL_SIZE {
+        let free = pool.bitmap_contains_for_tests(offset);
+        let leased = pool.current_tenancy_for_tests(offset).is_some();
+        assert!(
+            free != leased,
+            "offset {offset} is in {} after {after}",
+            if free {
+                "both the bitmap and a lease"
+            } else {
+                "neither the bitmap nor a lease"
+            },
+        );
+    }
+}
+
+#[test]
+fn an_address_is_always_either_free_or_leased() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|ops: Vec<TenancyOp>| {
+            let mut pool = NatPool::<Ipv4Addr>::for_range(
+                AddrInterval::new(BASE, BASE + u128::from(TENANCY_POOL_SIZE) - 1),
+                ReservedPorts::default(),
+                true,
+            );
+            // Tenancies handed out per offset, most recent last, so a stale one can be replayed.
+            let mut history: BTreeMap<u32, Vec<Tenancy>> = BTreeMap::new();
+            let mut every_tenancy = BTreeSet::new();
+
+            assert_partition(&pool, "construction");
+
+            for op in ops.into_iter().take(TENANCY_OPS) {
+                let offset = op.offset();
+                match op {
+                    // Only lease what is free; leasing over a live lease is the re-issue case and
+                    // is covered by `Abandon` followed by `Lease`.
+                    TenancyOp::Lease(_) => {
+                        if pool.current_tenancy_for_tests(offset).is_none() {
+                            let tenancy = pool.begin_tenancy_for_tests(offset);
+                            assert!(
+                                every_tenancy.insert(tenancy),
+                                "tenancy {tenancy:?} was handed out twice"
+                            );
+                            history.entry(offset).or_default().push(tenancy);
+                        }
+                    }
+                    TenancyOp::HandBack(_) => {
+                        if let Some(current) = pool.current_tenancy_for_tests(offset) {
+                            assert!(
+                                pool.end_tenancy_for_tests(offset, current),
+                                "the current lease was refused"
+                            );
+                            assert!(
+                                !pool.end_tenancy_for_tests(offset, current),
+                                "handing the same lease back twice was accepted"
+                            );
+                        }
+                    }
+                    // A lease that has been retired must never free whatever holds the address now.
+                    TenancyOp::HandBackStale(_) => {
+                        let current = pool.current_tenancy_for_tests(offset);
+                        if let Some(stale) = history
+                            .get(&offset)
+                            .and_then(|seen| seen.iter().find(|t| Some(**t) != current))
+                        {
+                            assert!(
+                                !pool.end_tenancy_for_tests(offset, *stale),
+                                "a retired lease was allowed to hand the address back"
+                            );
+                            assert_eq!(
+                                pool.current_tenancy_for_tests(offset),
+                                current,
+                                "a retired lease disturbed the current one"
+                            );
+                        }
+                    }
+                    TenancyOp::Abandon(_) => {
+                        if let Some(current) = pool.current_tenancy_for_tests(offset) {
+                            pool.plant_dead_entry_for_tests(offset, current);
+                        }
+                    }
+                    TenancyOp::Reclaim => pool.reclaim_ended_tenancies_for_tests(),
+                }
+                assert_partition(&pool, &format!("{op:?}"));
+            }
+
+            // Whatever the sequence, running the backstop leaves no address stranded.
+            pool.reclaim_ended_tenancies_for_tests();
+            assert_partition(&pool, "a final reclaim");
+        });
 }

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -390,6 +390,12 @@ fn an_exhausted_address_neither_strands_its_neighbours_nor_reads_as_an_empty_poo
             Ok(allocation) => held.push(allocation),
             Err(e) => break e,
         }
+        // The pool cannot hand out more than it holds. Bounding the walk turns a pool that frees
+        // an address it should not into a failure rather than a hang.
+        assert!(
+            held.len() <= ports,
+            "the pool handed out more ports than it has"
+        );
     };
 
     assert_eq!(

--- a/nat/src/masquerade/apalloc/pool_fuzz.rs
+++ b/nat/src/masquerade/apalloc/pool_fuzz.rs
@@ -15,10 +15,12 @@ use super::setup::{PoolSpec, pool_sets_for_specs};
 use crate::masquerade::allocation::AllocatorError;
 use crate::port::NatPort;
 use bolero::{Driver, TypeGenerator};
+use concurrency::sync::{Arc, mpsc};
 use lpm::prefix::{PortRange, PrefixPortsSet, PrefixWithOptionalPorts};
 use net::ip::NextHeader;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::thread;
 use std::time::Duration;
 
 // 10.1.0.0, with a window small enough that regions stay cheap to build.
@@ -331,6 +333,118 @@ fn a_freed_port_block_is_reused_while_its_address_is_held() {
         held.push(allocation);
     }
     assert!(pool_sets[0].allocate(false).is_err());
+}
+
+/// An address that has run out of port blocks must neither strand the addresses behind it nor be
+/// reported as an empty pool.
+///
+/// Both halves are about the *reason* an allocation fails rather than whether it fails. Ending the
+/// scan at an exhausted address would refuse a request that the address behind it could have
+/// served; and answering `NoFreeIp` -- which the draw step reports whenever the bitmap is empty --
+/// hides why the addresses already in use could not help. The two are not the same operational
+/// problem: an empty bitmap wants more addresses, whereas exhausted port blocks want the block
+/// allocator looked at, and that distinction is read straight off the log line an operator sees.
+///
+/// Reaching the state needs a second thread but not a race. Port blocks are handed out per thread,
+/// so a block held elsewhere keeps `has_free_ports` true on the first address while this thread can
+/// no longer obtain a block of its own on it -- which is what makes every later scan reach that
+/// address, fail on it, and have to carry on past it. The handshake makes the arrangement
+/// deterministic.
+#[test]
+#[cfg_attr(miri, ignore = "exhaustive allocator walk is too slow under miri")]
+fn an_exhausted_address_neither_strands_its_neighbours_nor_reads_as_an_empty_pool() {
+    const PORTS_PER_BLOCK: usize = 256;
+    const PORTS_PER_ADDRESS: usize = 65536 - 1024;
+    const ADDRESSES: u128 = 2;
+
+    let specs = vec![PoolSpec::new(
+        vec![AddrInterval::new(BASE, BASE + ADDRESSES - 1)],
+        IDLE_TIMEOUT,
+    )];
+    let pool_sets = Arc::new(pool_sets_for_specs::<Ipv4Addr>(
+        &specs,
+        NextHeader::TCP,
+        false,
+    ));
+
+    // The helper takes a block on the first address and keeps a single port in it. The block is no
+    // longer free, but it still has room, so that address never stops reporting free ports.
+    let (took_block, block_taken) = mpsc::channel();
+    let (release, released) = mpsc::channel();
+    let helper_sets = Arc::clone(&pool_sets);
+    let helper = thread::spawn(move || {
+        let held = helper_sets[0]
+            .allocate(false)
+            .expect("the first allocation on an empty pool");
+        took_block.send(()).expect("the test thread is waiting");
+        // A failing test drops the sender; the helper has nothing to add to that diagnosis.
+        let _ = released.recv();
+        drop(held);
+    });
+    block_taken.recv().expect("the helper takes a block");
+
+    let ports = usize::try_from(ADDRESSES).unwrap_or_else(|_| unreachable!()) * PORTS_PER_ADDRESS;
+    let mut held = Vec::with_capacity(ports - PORTS_PER_BLOCK);
+    let outcome = loop {
+        match pool_sets[0].allocate(false) {
+            Ok(allocation) => held.push(allocation),
+            Err(e) => break e,
+        }
+    };
+
+    assert_eq!(
+        held.len(),
+        ports - PORTS_PER_BLOCK,
+        "the scan stopped at the exhausted address instead of carrying on past it"
+    );
+    assert_eq!(
+        outcome,
+        AllocatorError::NoPortBlock,
+        "an address out of port blocks was reported as an empty pool"
+    );
+
+    // The exhaustion is transient: the block returns once the helper's last port does.
+    release.send(()).expect("the helper is waiting");
+    helper.join().expect("the helper thread panicked");
+    assert!(
+        pool_sets[0].allocate(false).is_ok(),
+        "the released block was never handed back"
+    );
+}
+
+/// The in-use list must not grow as allocations come and go.
+///
+/// An address is handed back by whichever side reaches the pool first, so the bitmap stays honest
+/// with or without the sweep -- but nothing else prunes the list itself. An entry left behind is
+/// both dead weight the next scan has to walk and a slot that is never reclaimed, so a long-lived
+/// pool serving short-lived flows would grow one entry per flow.
+#[test]
+fn the_in_use_list_does_not_grow_as_allocations_come_and_go() {
+    const ROUNDS: usize = 64;
+
+    let specs = vec![PoolSpec::new(
+        vec![AddrInterval::new(BASE, BASE)],
+        IDLE_TIMEOUT,
+    )];
+    let pool_sets = pool_sets_for_specs::<Ipv4Addr>(&specs, NextHeader::TCP, false);
+    let allocator = pool_sets[0]
+        .regions()
+        .next()
+        .expect("one region over one address")
+        .allocator();
+
+    for _ in 0..ROUNDS {
+        // Taking the pool's only address and releasing it again leaves an entry whose weak
+        // reference no longer upgrades.
+        drop(pool_sets[0].allocate(false).expect("the pool has room"));
+    }
+
+    let (_, in_use) = allocator.get_pool_clone_for_tests();
+    assert!(
+        in_use.len() <= 1,
+        "the in-use list grew to {} entries over {ROUNDS} allocations",
+        in_use.len()
+    );
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -512,6 +512,150 @@ mod std_tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::num::NonZero;
 
+    /// The property the whole hand-back scheme rests on: a lease that has been retired cannot free
+    /// the lease that replaced it.
+    ///
+    /// This is what makes the hand-back safe to complete from either side. An allocation that finds
+    /// a dead weak reference may reclaim the address and re-issue it immediately; the original
+    /// owner's `Drop` then arrives late, and must do nothing rather than hand back an address
+    /// somebody else is now using. Reaching that state for real needs two threads, so the property
+    /// is pinned here directly on the pool.
+    #[test]
+    fn a_retired_tenancy_cannot_free_the_lease_that_replaced_it() {
+        let base = u128::from(addr_v4_bits("10.1.0.0"));
+        let mut pool = NatPool::<Ipv4Addr>::for_range(
+            AddrInterval::new(base, base),
+            ReservedPorts::default(),
+            true,
+        );
+
+        let first = pool.begin_tenancy_for_tests(0);
+        // The address is out of the bitmap while it is leased.
+        assert!(
+            !pool.bitmap_contains_for_tests(0),
+            "leased address is still free"
+        );
+
+        // A second lease opens before the first one's hand-back arrives, which is exactly what
+        // `reclaim_ended_tenancies` and `reserve_from_pool` do when they find a dead weak.
+        let second = pool.begin_tenancy_for_tests(0);
+        assert_ne!(first, second, "re-issue must mint a distinct tenancy");
+
+        // The late hand-back for the first lease must be refused.
+        assert!(
+            !pool.end_tenancy_for_tests(0, first),
+            "a retired tenancy was allowed to hand the address back"
+        );
+        assert!(
+            !pool.bitmap_contains_for_tests(0),
+            "a retired tenancy freed an address that had been re-issued"
+        );
+
+        // The current lease still can, and that is the only one that may.
+        assert!(pool.end_tenancy_for_tests(0, second));
+        assert!(
+            pool.bitmap_contains_for_tests(0),
+            "current lease failed to hand back"
+        );
+
+        // And a second attempt with the same tenancy is inert rather than double-freeing.
+        assert!(!pool.end_tenancy_for_tests(0, second));
+        assert!(pool.bitmap_contains_for_tests(0));
+    }
+
+    /// The reclaim backstop actually reclaims.
+    ///
+    /// `cleanup` ends tenancies too, and in practice it runs first -- at the top of every
+    /// `allocate` -- so the retry inside `use_new_ip` only matters for an address whose last
+    /// reference dies in the gap between the two. Measured against the shuttle suite that path
+    /// never executes, so without this it is the one piece of the hand-back with no coverage at
+    /// all.
+    #[test]
+    fn the_reclaim_backstop_frees_an_address_whose_owner_is_already_gone() {
+        let base = u128::from(addr_v4_bits("10.1.0.0"));
+        let mut pool = NatPool::<Ipv4Addr>::for_range(
+            AddrInterval::new(base, base),
+            ReservedPorts::default(),
+            true,
+        );
+
+        let tenancy = pool.begin_tenancy_for_tests(0);
+        // The address is leased, and its owner has gone without handing it back -- the state that
+        // makes the pool report exhaustion while holding an address belonging to no one.
+        pool.plant_dead_entry_for_tests(0, tenancy);
+        assert!(!pool.bitmap_contains_for_tests(0));
+        assert_eq!(pool.in_use_len_for_tests(), 1);
+
+        pool.reclaim_ended_tenancies_for_tests();
+
+        assert!(
+            pool.bitmap_contains_for_tests(0),
+            "reclaim left the address in neither the bitmap nor the in-use list"
+        );
+        assert_eq!(
+            pool.in_use_len_for_tests(),
+            0,
+            "reclaim freed the address but kept the dead entry"
+        );
+    }
+
+    /// Reclaim must not disturb an address that is still held, and must not free one whose lease
+    /// has already been retired by a re-issue.
+    #[test]
+    fn the_reclaim_backstop_leaves_live_and_reissued_leases_alone() {
+        let base = u128::from(addr_v4_bits("10.1.0.0"));
+        let mut pool = NatPool::<Ipv4Addr>::for_range(
+            AddrInterval::new(base, base),
+            ReservedPorts::default(),
+            true,
+        );
+
+        let stale = pool.begin_tenancy_for_tests(0);
+        pool.plant_dead_entry_for_tests(0, stale);
+        // The address is re-issued before the reclaim runs, retiring `stale`.
+        let current = pool.begin_tenancy_for_tests(0);
+        assert_ne!(stale, current);
+
+        pool.reclaim_ended_tenancies_for_tests();
+
+        assert!(
+            !pool.bitmap_contains_for_tests(0),
+            "reclaim freed an address that had been re-issued"
+        );
+        assert_eq!(
+            pool.in_use_len_for_tests(),
+            0,
+            "the dead entry should still be dropped"
+        );
+        // The current lease is untouched and remains the only one that can hand back.
+        assert!(pool.end_tenancy_for_tests(0, current));
+        assert!(pool.bitmap_contains_for_tests(0));
+    }
+
+    /// Tenancies are minted per pool rather than per address, so an address cannot inherit a
+    /// predecessor's identity by being re-leased at the same offset.
+    #[test]
+    fn tenancies_are_never_reused_within_a_pool() {
+        let base = u128::from(addr_v4_bits("10.1.0.0"));
+        let mut pool = NatPool::<Ipv4Addr>::for_range(
+            AddrInterval::new(base, base + 1),
+            ReservedPorts::default(),
+            true,
+        );
+
+        let mut seen = std::collections::BTreeSet::new();
+        for round in 0..4 {
+            for offset in 0..2u32 {
+                let tenancy = pool.begin_tenancy_for_tests(offset);
+                assert!(
+                    seen.insert(tenancy),
+                    "tenancy repeated at offset {offset} in round {round}"
+                );
+                assert!(pool.end_tenancy_for_tests(offset, tenancy));
+            }
+        }
+    }
+
     #[test]
     fn test_build_allocator() {
         let allocator = build_allocator();

--- a/nat/src/masquerade/apalloc/test_alloc.rs
+++ b/nat/src/masquerade/apalloc/test_alloc.rs
@@ -512,6 +512,16 @@ mod std_tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::num::NonZero;
 
+    /// The bitmap offset of the only address in a single-address IPv4 pool.
+    ///
+    /// For IPv4 the offset *is* the address bits, not an index from the region start, so a pool
+    /// built over one address holds exactly one offset and it is never zero. Asserting against the
+    /// real offset is what lets the bitmap refute the claim being made: at offset zero every
+    /// `!contains` passes because zero was never in the bitmap to begin with.
+    fn only_offset(base: u128) -> u32 {
+        u32::try_from(base).unwrap_or_else(|_| unreachable!("these pools are built over IPv4"))
+    }
+
     /// The property the whole hand-back scheme rests on: a lease that has been retired cannot free
     /// the lease that replaced it.
     ///
@@ -529,38 +539,46 @@ mod std_tests {
             true,
         );
 
-        let first = pool.begin_tenancy_for_tests(0);
+        let offset = only_offset(base);
+        // Unleased, the address is free. Without this the `!contains` assertions below would pass
+        // on an offset the bitmap never held.
+        assert!(
+            pool.bitmap_contains_for_tests(offset),
+            "the pool did not start with its only address free"
+        );
+
+        let first = pool.begin_tenancy_for_tests(offset);
         // The address is out of the bitmap while it is leased.
         assert!(
-            !pool.bitmap_contains_for_tests(0),
+            !pool.bitmap_contains_for_tests(offset),
             "leased address is still free"
         );
 
         // A second lease opens before the first one's hand-back arrives, which is exactly what
         // `reclaim_ended_tenancies` and `reserve_from_pool` do when they find a dead weak.
-        let second = pool.begin_tenancy_for_tests(0);
+        let second = pool.begin_tenancy_for_tests(offset);
         assert_ne!(first, second, "re-issue must mint a distinct tenancy");
 
         // The late hand-back for the first lease must be refused.
         assert!(
-            !pool.end_tenancy_for_tests(0, first),
+            !pool.end_tenancy_for_tests(offset, first),
             "a retired tenancy was allowed to hand the address back"
         );
         assert!(
-            !pool.bitmap_contains_for_tests(0),
+            !pool.bitmap_contains_for_tests(offset),
             "a retired tenancy freed an address that had been re-issued"
         );
 
         // The current lease still can, and that is the only one that may.
-        assert!(pool.end_tenancy_for_tests(0, second));
+        assert!(pool.end_tenancy_for_tests(offset, second));
         assert!(
-            pool.bitmap_contains_for_tests(0),
+            pool.bitmap_contains_for_tests(offset),
             "current lease failed to hand back"
         );
 
         // And a second attempt with the same tenancy is inert rather than double-freeing.
-        assert!(!pool.end_tenancy_for_tests(0, second));
-        assert!(pool.bitmap_contains_for_tests(0));
+        assert!(!pool.end_tenancy_for_tests(offset, second));
+        assert!(pool.bitmap_contains_for_tests(offset));
     }
 
     /// The reclaim backstop actually reclaims.
@@ -579,17 +597,20 @@ mod std_tests {
             true,
         );
 
-        let tenancy = pool.begin_tenancy_for_tests(0);
+        let offset = only_offset(base);
+        assert!(pool.bitmap_contains_for_tests(offset));
+
+        let tenancy = pool.begin_tenancy_for_tests(offset);
         // The address is leased, and its owner has gone without handing it back -- the state that
         // makes the pool report exhaustion while holding an address belonging to no one.
-        pool.plant_dead_entry_for_tests(0, tenancy);
-        assert!(!pool.bitmap_contains_for_tests(0));
+        pool.plant_dead_entry_for_tests(offset, tenancy);
+        assert!(!pool.bitmap_contains_for_tests(offset));
         assert_eq!(pool.in_use_len_for_tests(), 1);
 
         pool.reclaim_ended_tenancies_for_tests();
 
         assert!(
-            pool.bitmap_contains_for_tests(0),
+            pool.bitmap_contains_for_tests(offset),
             "reclaim left the address in neither the bitmap nor the in-use list"
         );
         assert_eq!(
@@ -610,16 +631,19 @@ mod std_tests {
             true,
         );
 
-        let stale = pool.begin_tenancy_for_tests(0);
-        pool.plant_dead_entry_for_tests(0, stale);
+        let offset = only_offset(base);
+        assert!(pool.bitmap_contains_for_tests(offset));
+
+        let stale = pool.begin_tenancy_for_tests(offset);
+        pool.plant_dead_entry_for_tests(offset, stale);
         // The address is re-issued before the reclaim runs, retiring `stale`.
-        let current = pool.begin_tenancy_for_tests(0);
+        let current = pool.begin_tenancy_for_tests(offset);
         assert_ne!(stale, current);
 
         pool.reclaim_ended_tenancies_for_tests();
 
         assert!(
-            !pool.bitmap_contains_for_tests(0),
+            !pool.bitmap_contains_for_tests(offset),
             "reclaim freed an address that had been re-issued"
         );
         assert_eq!(
@@ -628,8 +652,8 @@ mod std_tests {
             "the dead entry should still be dropped"
         );
         // The current lease is untouched and remains the only one that can hand back.
-        assert!(pool.end_tenancy_for_tests(0, current));
-        assert!(pool.bitmap_contains_for_tests(0));
+        assert!(pool.end_tenancy_for_tests(offset, current));
+        assert!(pool.bitmap_contains_for_tests(offset));
     }
 
     /// Tenancies are minted per pool rather than per address, so an address cannot inherit a
@@ -643,9 +667,10 @@ mod std_tests {
             true,
         );
 
+        let first = only_offset(base);
         let mut seen = std::collections::BTreeSet::new();
         for round in 0..4 {
-            for offset in 0..2u32 {
+            for offset in [first, first + 1] {
                 let tenancy = pool.begin_tenancy_for_tests(offset);
                 assert!(
                     seen.insert(tenancy),


### PR DESCRIPTION
## Issue

`NatPool` answers "is this public address available?" from two structures — a bitmap of free addresses and a list of weak references to the addresses currently in use — and an address is meant to be in exactly one of them. Releasing one passes through a state where it is in neither: `Weak::upgrade` stops resolving the instant the last `AllocatedPort` drops the strong count to zero, but the address only returns to the bitmap later, inside `AllocatedIp::drop`, which must first acquire the pool's write lock. An allocation arriving in that gap finds nothing on either path and is told the pool is empty, so it fails with `NoFreeIp` while the pool is in fact holding an address that belongs to no one. This is not a rare interleaving — `Arc` guarantees the ordering, so every release passes through the gap; only its duration varies, bounded by how long the releasing thread waits for a write lock that every allocation also takes, on every call, via `cleanup_used_ips`. The same reasoning covers a second latent hazard the fix closes: `reserve_from_pool` could create a duplicate `AllocatedIp` for an address whose owner had not yet finished releasing it, after which the first object's `Drop` would free an address the second still held.

## Impact

The packet that lands in the gap is dropped with `DoneReason::NatOutOfResources` and its flow is refused, logged as `masquerade: Ip/port allocation failed ... no free IP available`. Two properties of real deployments turn a narrow race into a recurring one. Where an expose is configured with a single public address per peering — the shape observed in the field — the unavailable address is the entire pool, so there is nothing to fall back on. And DNS drives the window open constantly: a reply from source port 53 moves the flow to `Closed` and invalidates the pair immediately as a port-conservation measure, so a pool carrying mostly DNS destroys and rebuilds its address roughly once per query, opening one window per query. The user-visible effect is mild and easily misread — resolvers retry, so lookups still succeed and the failures surface only as intermittent warnings and a raised drop count, at a rate that does not correlate with load in any obvious way.

## Fix

The root problem is that liveness was inferred from `Arc` refcounts, which change on whatever thread happens to drop the last reference, while availability is a property of the pool, which changes only under its lock — so the two could disagree. The fix gives every lease of an address a `Tenancy`, recorded with the address's bitmap offset alongside the weak reference, and keeps a map of current tenancies that is updated in the same critical section as the bitmap itself. That makes the pool's own state the source of truth and lets the hand-back be completed from either side: an allocation that holds the lock and finds a dead weak reference finishes the hand-back itself rather than waiting for the releasing thread to win the lock, and `use_new_ip` reclaims ended tenancies before it reports an empty bitmap — in the same critical section as the retry, so the answer cannot go stale between the two. A late `AllocatedIp::drop` whose tenancy has since been retired does nothing, which is what makes that takeover safe and, incidentally, what closes the duplicate-`AllocatedIp` hazard in `reserve_from_pool`.

Two smaller corrections ride along, both about being able to see what happened: the reuse scan no longer abandons the search at the first address that has run out of port blocks, stranding every address behind it in the list, and `NoFreeIp` no longer buries the more specific reason — which, on a single-address pool, it always did.

## Testing

- New property test in the existing shuttle harness, `an_allocation_racing_the_last_release_is_still_served`: a one-address pool with one thread releasing the only allocation while another allocates. Against the unfixed allocator it reproduces the field error verbatim (`NoFreeIp`); against this change it passes.
- `cargo test -p dataplane-nat --lib` — 165 pass.
- `cargo test -p dataplane-nat --features shuttle --lib shuttle` — 8 pass.
- `cargo clippy -p dataplane-nat --all-targets` — clean.
- Confirmed on a live gateway by deliberately widening the window: the unpatched allocator refused 10 of 20 queries with the drop counter and the log agreeing exactly, while this change served all 20 under the identical forcing function.

## Notes

- Not addressed here: ports are handed out in 256-blocks owned by a single thread and freed only when the last port in the block dies. Measured density on the affected fabric was ~3.35 ports/block for UDP, so a pool walls well below its nominal capacity. That is a separate redesign.
- A backport of this change onto `v0.25.2` is prepared on `backport/v0.25.2/masquerade-address-handback`; it is semantically identical (the two differ only by one clarifying comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
