### PR TITLE
build(nix): stop shipping 727MB of rust-docs in every CI job's closure

### DIFF
--- a/nix/overlays/llvm.nix
+++ b/nix/overlays/llvm.nix
@@ -30,13 +30,19 @@ let
   }) final.llvmPackages'.stdenv;
   # note: rust-bin comes from oxa's overlay, not nixpkgs.  This overlay only works if you have a rust overlay as well.
   rust-toolchain = final.pkgsBuildHost.rust-bin.fromRustupToolchain {
+    # `components` are extensions *on top of* a profile, and the profile
+    # defaults to rustup's `default`, which already carries rust-docs.  Deleting
+    # "rust-docs" from the list below therefore removes nothing by itself -- the
+    # profile has to be named too, or the default puts it straight back.  That
+    # is 727MB of prebuilt HTML nothing in CI reads, in the closure every
+    # dev-shell job pulls over the network into a cold /nix.
+    profile = "minimal";
     channel = if nightly == "true" then "nightly" else sources.rust.version;
     components = [
       "cargo"
       "clippy"
       "llvm-tools"
       "rust-analyzer"
-      "rust-docs"
       "rust-src"
       "rust-std"
       "rustc"


### PR DESCRIPTION
Stacked on #1746 — review/merge that first.

`fromRustupToolchain` applies `components` as extensions **on top of a profile**,
and `profile` defaults to rustup's `default`, which already carries `rust-docs`.
So `rust-docs` was arriving twice, and deleting it from the component list alone
would have removed nothing.

Naming `profile = "minimal"` is what actually drops it. Verified by set-diffing
the joined component paths of the toolchain derivation across three variants:

| variant | `rust-docs` in the joined paths |
| --- | --- |
| today (`"rust-docs"` listed, no `profile`) | yes, twice |
| component deleted, `profile` still unset | **yes, still there** |
| this PR (deleted + `profile = "minimal"`) | no |

A full `diff` of the deduplicated path sets between the last two shows exactly
one line: `rust-docs`. Nothing else about the toolchain moves.
`passthru.availableComponents.rust-src` — which `default.nix` uses in three
places — still resolves to the same store path.

### Why bother

727MB of prebuilt HTML, in the closure of all 8 dev-shell jobs. The lab runners
are ephemeral (`directory /nix does not exist; creating it` every job), so it is
pulled over the network each time, not cached on disk. Measured against the
current dev shell: 5.96GB closure, 325 paths, ~22s to realize.

Nothing in the tree reads it — `grep` for `rust-docs`, `share/doc/rust`, and
`rustup doc` finds only this comment.

### Cost

Every rust-built store path in the shell changes hash, so the first CI run after
this merges repopulates that half of Cachix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
