### PR TITLE
Fixes and tests for ICMP quoted packets checksum update

### DIFF
--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -80,15 +80,24 @@ pub(crate) fn nat_translate_icmp_inner_src<Buf: PacketBufferMut>(
         .embedded_headers_mut()
         .ok_or(IcmpErrorMsgError::NoEmbeddedHeaders)?;
 
-    embedded_headers
+    let inner_ip = embedded_headers
         .try_inner_ip_mut()
-        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?
+        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?;
+    let old_addr = inner_ip.src_addr();
+    inner_ip
         .try_set_source(
             target_addr
                 .try_into()
                 .map_err(|_| IcmpErrorMsgError::NotUnicast(target_addr))?,
         )
         .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
+
+    // The inner IP addresses belong to the pseudo-header covered by the checksum of the inner
+    // transport header, for TCP/UDP/ICMPv6 (but not ICMPv4). Update the checksum if relevant.
+    if let Some(transport) = embedded_headers.try_embedded_transport_mut() {
+        // Note: update_checksum_for_address is a no-op for ICMPv4
+        transport.update_checksum_for_address(old_addr, target_addr);
+    }
 
     let Some(target_port) = target_port else {
         // No port to translate, we're done
@@ -122,11 +131,19 @@ pub(crate) fn nat_translate_icmp_inner_dst<Buf: PacketBufferMut>(
         .embedded_headers_mut()
         .ok_or(IcmpErrorMsgError::NoEmbeddedHeaders)?;
 
-    embedded_headers
+    let inner_ip = embedded_headers
         .try_inner_ip_mut()
-        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?
+        .ok_or(IcmpErrorMsgError::NoInnerIpHeader)?;
+    let old_addr = inner_ip.dst_addr();
+    inner_ip
         .try_set_destination(target_addr)
         .map_err(|_| IcmpErrorMsgError::InvalidIpVersion)?;
+
+    // See the comment on the source address translation: update the checksum of the inner
+    // transport header to account for the new address in the pseudo-header.
+    if let Some(transport) = embedded_headers.try_embedded_transport_mut() {
+        transport.update_checksum_for_address(old_addr, target_addr);
+    }
 
     let Some(target_port) = target_port else {
         // No port to translate, we're done

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -246,13 +246,17 @@ mod bolero_tests {
     use net::checksum::ChecksumError;
     use net::headers::TryHeaders;
     use net::headers::{
-        Net, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut, TryIp, TryIpv4,
+        Net, TryEmbeddedHeaders, TryEmbeddedTransport, TryIcmpAnyMut, TryInnerIp, TryInnerIpv4Mut,
+        TryIp, TryIpv4,
     };
     use net::icmp_any::IcmpAnyChecksum;
+    use net::icmp6::Icmp6ChecksumPayload;
     use net::ipv4::{Ipv4Checksum, UnicastIpv4Addr};
     use net::ipv6::UnicastIpv6Addr;
     use net::packet::IcmpErrorMsg;
     use net::packet::icmp_err::{IcmpErrorPacket, IcmpErrorPacketError};
+    use net::tcp::TcpChecksumPayload;
+    use net::udp::UdpChecksumPayload;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[derive(Debug, Clone, Copy)]
@@ -329,6 +333,162 @@ mod bolero_tests {
             .map(|ip| (ip.src_addr(), ip.dst_addr()))
     }
 
+    fn get_inner_transport_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet
+            .try_embedded_transport()
+            .and_then(EmbeddedTransport::checksum)
+    }
+
+    // Compute from scratch the checksum of the embedded transport header, over the inner headers
+    // and the embedded transport payload.
+    //
+    // Returns None when the embedded IP packet fragment is truncated, because we then miss some of
+    // the data covered by the checksum, and can't recompute it.
+    fn compute_inner_transport_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        let embedded_headers = packet.embedded_headers()?;
+        // The bytes left in the packet hold the embedded transport payload, followed with the
+        // optional ICMP padding and Extension Structures which are not covered by the checksum
+        let payload_length = usize::from(embedded_headers.payload_length()?);
+        let payload = packet.payload().as_ref().get(..payload_length)?;
+        let inner_net = embedded_headers.try_inner_ip()?;
+        match embedded_headers.try_embedded_transport()? {
+            EmbeddedTransport::Tcp(tcp) => tcp
+                .compute_checksum(&TcpChecksumPayload::new(inner_net, payload))
+                .map(u16::from)
+                .ok(),
+            EmbeddedTransport::Udp(udp) => udp
+                .compute_checksum(&UdpChecksumPayload::new(inner_net, payload))
+                .map(u16::from)
+                .ok(),
+            EmbeddedTransport::Icmp4(icmp4) => icmp4.compute_checksum(payload).map(u16::from).ok(),
+            EmbeddedTransport::Icmp6(icmp6) => {
+                let Net::Ipv6(inner_ipv6) = inner_net else {
+                    return None;
+                };
+                let checksum_payload = Icmp6ChecksumPayload::new(
+                    inner_ipv6.source().inner(),
+                    inner_ipv6.destination(),
+                    payload,
+                );
+                icmp6
+                    .compute_checksum(&checksum_payload)
+                    .map(u16::from)
+                    .ok()
+            }
+        }
+    }
+
+    fn set_inner_transport_checksum(packet: &mut Packet<TestBuffer>, checksum: u16) {
+        if let Some(transport) = packet.try_embedded_transport_mut() {
+            EmbeddedTransport::set_checksum_if_possible(transport, checksum);
+        }
+    }
+
+    // Reference implementation of the incremental checksum update from RFC 1624, relying on
+    //
+    //     HC' = ~(~HC + ~m + m')    --    [Eqn. 3]
+    //
+    // instead of the [Eqn. 4] variant used by increment_update_checksum(), so that we don't
+    // validate the implementation against itself.
+    fn expected_incremental_checksum(current_checksum: u16, old_value: u16, new_value: u16) -> u16 {
+        fn add_ones_complement(a: u16, b: u16) -> u16 {
+            let mut sum = u32::from(a) + u32::from(b);
+            while sum > 0xffff {
+                sum = (sum & 0xffff) + (sum >> 16);
+            }
+            u16::try_from(sum).unwrap_or_else(|_| unreachable!())
+        }
+        if old_value == new_value {
+            // Like Checksum::incremental_checksum(), skip a value that doesn't change: folding it
+            // in would be neutral, but for a 0xffff checksum, which it would rewrite as 0x0000
+            return current_checksum;
+        }
+        !add_ones_complement(
+            add_ones_complement(!current_checksum, !old_value),
+            new_value,
+        )
+    }
+
+    // Pair up the 16-bit words of an IP address change, in the order in which they are covered by
+    // the pseudo-header. The translation skips the update altogether when the address doesn't
+    // change, so return no pair in that case.
+    fn address_word_changes(old: IpAddr, new: IpAddr) -> Vec<(u16, u16)> {
+        fn words(addr: IpAddr) -> Vec<u16> {
+            match addr {
+                IpAddr::V4(addr) => {
+                    let [a, b, c, d] = addr.octets();
+                    vec![u16::from_be_bytes([a, b]), u16::from_be_bytes([c, d])]
+                }
+                IpAddr::V6(addr) => addr.segments().to_vec(),
+            }
+        }
+        if old == new {
+            return Vec::new();
+        }
+        words(old).into_iter().zip(words(new)).collect()
+    }
+
+    // Check that the checksum of the inner transport header accounts for the new addresses, ports
+    // or ICMP identifier, with incremental updates. This is all we can check when the embedded IP
+    // packet fragment is truncated, as we can't recompute the checksum from scratch in that case.
+    fn check_inner_transport_checksum(
+        packet: &Packet<TestBuffer>,
+        initial_checksum: Option<u16>,
+        initial_addresses: (IpAddr, IpAddr),
+        initial_ports: Option<TransportFields>,
+        new_ports: Option<TransportFields>,
+    ) {
+        // The checksum of ICMPv4 covers no pseudo-header, the inner IP addresses don't affect it
+        let addresses_covered = !matches!(
+            packet.try_embedded_transport(),
+            Some(EmbeddedTransport::Icmp4(_))
+        );
+        let new_addresses = get_inner_addresses(packet).unwrap();
+
+        // Replicate the incremental updates that the translation performs. The order in which we
+        // chain them is indifferent: they are additions in one's complement arithmetic, which is
+        // commutative, down to the representation of the resulting checksum.
+        let mut changes = Vec::new();
+        if addresses_covered {
+            changes.extend(address_word_changes(initial_addresses.0, new_addresses.0));
+        }
+        match (initial_ports, new_ports) {
+            (
+                Some(TransportFields::Ports(initial_src, _)),
+                Some(TransportFields::Ports(new_src, _)),
+            ) if initial_src != new_src => changes.push((initial_src, new_src)),
+            (
+                Some(TransportFields::Identifier(initial)),
+                Some(TransportFields::Identifier(new)),
+            ) if initial != new => changes.push((initial, new)),
+            _ => {}
+        }
+        if addresses_covered {
+            changes.extend(address_word_changes(initial_addresses.1, new_addresses.1));
+        }
+        if let (
+            Some(TransportFields::Ports(_, initial_dst)),
+            Some(TransportFields::Ports(_, new_dst)),
+        ) = (initial_ports, new_ports)
+            && initial_dst != new_dst
+        {
+            changes.push((initial_dst, new_dst));
+        }
+
+        let expected = initial_checksum.map(|checksum| {
+            changes
+                .into_iter()
+                .fold(checksum, |checksum, (old_value, new_value)| {
+                    expected_incremental_checksum(checksum, old_value, new_value)
+                })
+        });
+        assert_eq!(
+            get_inner_transport_checksum(packet),
+            expected,
+            "inner transport checksum not incrementally updated as expected"
+        );
+    }
+
     fn get_inner_ports(packet: &Packet<TestBuffer>) -> Option<TransportFields> {
         match packet.try_embedded_transport() {
             Some(EmbeddedTransport::Tcp(tcp)) => Some(TransportFields::Ports(
@@ -352,6 +512,7 @@ mod bolero_tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_translation() {
         bolero::check!()
             .with_generator((
@@ -365,8 +526,26 @@ mod bolero_tests {
             ))
             .for_each(
                 |(icmp_error_msg, src_v4, dst_v4, src_v6, dst_v6, src_port, dst_port)| {
-                    let initial_outer_addresses = get_outer_addresses(icmp_error_msg).unwrap();
-                    let initial_ports = get_inner_ports(icmp_error_msg);
+                    let mut icmp_error_msg_clone = icmp_error_msg.clone();
+
+                    // The generator doesn't set checksums. When the embedded IP packet fragment is
+                    // not truncated, set a valid checksum on the embedded transport header, so that
+                    // we can recompute it from scratch after the translation and compare.
+                    let inner_payload_is_full =
+                        match compute_inner_transport_checksum(&icmp_error_msg_clone) {
+                            Some(checksum) => {
+                                set_inner_transport_checksum(&mut icmp_error_msg_clone, checksum);
+                                true
+                            }
+                            None => false,
+                        };
+
+                    let initial_outer_addresses =
+                        get_outer_addresses(&icmp_error_msg_clone).unwrap();
+                    let initial_inner_addresses = get_inner_addresses(&icmp_error_msg_clone);
+                    let initial_ports = get_inner_ports(&icmp_error_msg_clone);
+                    let initial_inner_checksum =
+                        get_inner_transport_checksum(&icmp_error_msg_clone);
                     let tr_data = match icmp_error_msg.headers().try_ip() {
                         Some(Net::Ipv4(_)) => NatTranslationData {
                             src_addr: Some(IpAddr::V4(Ipv4Addr::from(*src_v4))),
@@ -384,7 +563,6 @@ mod bolero_tests {
                     };
 
                     // Translate inner IP addresses, and possibly inner ports
-                    let mut icmp_error_msg_clone = icmp_error_msg.clone();
                     let inner_translation_result =
                         nat_translate_icmp_inner(&mut icmp_error_msg_clone, &tr_data);
                     if (*src_port == Some(NatPort::Identifier(0))
@@ -448,6 +626,23 @@ mod bolero_tests {
                         },
                         (None, None) => {}
                         _ => unreachable!(),
+                    }
+
+                    // Check the checksum of the inner transport header has been updated
+                    if inner_payload_is_full {
+                        assert_eq!(
+                            get_inner_transport_checksum(&icmp_error_msg_clone).unwrap(),
+                            compute_inner_transport_checksum(&icmp_error_msg_clone).unwrap(),
+                            "inner transport checksum doesn't match the recomputed value"
+                        );
+                    } else {
+                        check_inner_transport_checksum(
+                            &icmp_error_msg_clone,
+                            initial_inner_checksum,
+                            initial_inner_addresses.unwrap(),
+                            initial_ports,
+                            new_ports,
+                        );
                     }
 
                     if new_ports.is_some() {

--- a/nat/src/icmp_handler/icmp_error_msg.rs
+++ b/nat/src/icmp_handler/icmp_error_msg.rs
@@ -9,7 +9,8 @@ use crate::NatTranslationData;
 use net::buffer::PacketBufferMut;
 use net::checksum::Checksum;
 use net::headers::{
-    EmbeddedTransport, TryEmbeddedHeadersMut, TryEmbeddedTransportMut, TryInnerIpMut,
+    EmbeddedIpVersion, EmbeddedTransport, TryEmbeddedHeadersMut, TryEmbeddedTransportMut,
+    TryInnerIpMut,
 };
 use net::icmp_any::TruncatedIcmpAny;
 use net::packet::{DoneReason, Packet};
@@ -110,7 +111,7 @@ pub(crate) fn nat_translate_icmp_inner_src<Buf: PacketBufferMut>(
 
     match transport {
         EmbeddedTransport::Tcp(_) | EmbeddedTransport::Udp(_) => {
-            translate_inner_tcp_udp_src(transport, target_port)?;
+            translate_inner_tcp_udp_src(transport, quoted_version(old_addr), target_port)?;
         }
         EmbeddedTransport::Icmp4(icmp4) => {
             translate_inner_icmp(icmp4, target_port);
@@ -156,9 +157,17 @@ pub(crate) fn nat_translate_icmp_inner_dst<Buf: PacketBufferMut>(
 
     match transport {
         EmbeddedTransport::Tcp(_) | EmbeddedTransport::Udp(_) => {
-            translate_inner_tcp_udp_dst(transport, target_port)
+            translate_inner_tcp_udp_dst(transport, quoted_version(old_addr), target_port)
         }
         _ => Ok(()), // ICMP is dealt with when dealing with the source port
+    }
+}
+
+fn quoted_version(addr: IpAddr) -> EmbeddedIpVersion {
+    if addr.is_ipv4() {
+        EmbeddedIpVersion::Ipv4
+    } else {
+        EmbeddedIpVersion::Ipv6
     }
 }
 
@@ -192,6 +201,7 @@ where
 
 fn translate_inner_tcp_udp_src(
     transport: &mut EmbeddedTransport,
+    quoted: EmbeddedIpVersion,
     target_port: NatPort,
 ) -> Result<(), IcmpErrorMsgError> {
     // Assume we have TCP or UDP, with source port always present
@@ -209,13 +219,14 @@ fn translate_inner_tcp_udp_src(
     // transport checksum update is to do an unconditional, incremental update here. Note
     // that this checksum will not be updated again when deparsing the packet.
     if let Some(current_checksum) = transport.checksum() {
-        transport.update_checksum(current_checksum, old_port, new_port.get());
+        transport.update_checksum(quoted, current_checksum, old_port, new_port.get());
     }
     Ok(())
 }
 
 fn translate_inner_tcp_udp_dst(
     transport: &mut EmbeddedTransport,
+    quoted: EmbeddedIpVersion,
     target_port: NatPort,
 ) -> Result<(), IcmpErrorMsgError> {
     // Assume we have TCP or UDP, with destination port always present
@@ -233,7 +244,7 @@ fn translate_inner_tcp_udp_dst(
         .set_destination(new_port)
         .unwrap_or_else(|_| unreachable!());
     if let Some(current_checksum) = transport.checksum() {
-        transport.update_checksum(current_checksum, old_port, new_port.get());
+        transport.update_checksum(quoted, current_checksum, old_port, new_port.get());
     }
     Ok(())
 }
@@ -344,6 +355,29 @@ mod bolero_tests {
     //
     // Returns None when the embedded IP packet fragment is truncated, because we then miss some of
     // the data covered by the checksum, and can't recompute it.
+    // Tell whether the embedded transport header is UDP, and if so whether it carries no checksum
+    // at all, which RFC 768 allows over IPv4 only
+    fn inner_udp_state(packet: &Packet<TestBuffer>) -> (bool, bool) {
+        let is_udp = matches!(
+            packet.try_embedded_transport(),
+            Some(EmbeddedTransport::Udp(_))
+        );
+        let disabled = is_udp
+            && matches!(packet.try_inner_ip(), Some(Net::Ipv4(_)))
+            && get_inner_transport_checksum(packet) == Some(0);
+        (is_udp, disabled)
+    }
+
+    // RFC 768: a UDP checksum that computes to zero travels as all ones, so that it is not mistaken
+    // for the marker for "no checksum"
+    fn spell_udp_zero(checksum: u16, is_udp: bool) -> u16 {
+        if is_udp && checksum == 0 {
+            u16::MAX
+        } else {
+            checksum
+        }
+    }
+
     fn compute_inner_transport_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
         let embedded_headers = packet.embedded_headers()?;
         // The bytes left in the packet hold the embedded transport payload, followed with the
@@ -358,7 +392,7 @@ mod bolero_tests {
                 .ok(),
             EmbeddedTransport::Udp(udp) => udp
                 .compute_checksum(&UdpChecksumPayload::new(inner_net, payload))
-                .map(u16::from)
+                .map(|checksum| spell_udp_zero(u16::from(checksum), true))
                 .ok(),
             EmbeddedTransport::Icmp4(icmp4) => icmp4.compute_checksum(payload).map(u16::from).ok(),
             EmbeddedTransport::Icmp6(icmp6) => {
@@ -437,7 +471,9 @@ mod bolero_tests {
         initial_addresses: (IpAddr, IpAddr),
         initial_ports: Option<TransportFields>,
         new_ports: Option<TransportFields>,
+        udp: (bool, bool),
     ) {
+        let (is_udp, udp_checksum_disabled) = udp;
         // The checksum of ICMPv4 covers no pseudo-header, the inner IP addresses don't affect it
         let addresses_covered = !matches!(
             packet.try_embedded_transport(),
@@ -476,10 +512,15 @@ mod bolero_tests {
         }
 
         let expected = initial_checksum.map(|checksum| {
+            if udp_checksum_disabled {
+                // The quote carries no checksum for the translation to update
+                return checksum;
+            }
             changes
                 .into_iter()
                 .fold(checksum, |checksum, (old_value, new_value)| {
-                    expected_incremental_checksum(checksum, old_value, new_value)
+                    let updated = expected_incremental_checksum(checksum, old_value, new_value);
+                    spell_udp_zero(updated, is_udp)
                 })
         });
         assert_eq!(
@@ -539,6 +580,8 @@ mod bolero_tests {
                             }
                             None => false,
                         };
+                    let (inner_is_udp, inner_udp_checksum_disabled) =
+                        inner_udp_state(&icmp_error_msg_clone);
 
                     let initial_outer_addresses =
                         get_outer_addresses(&icmp_error_msg_clone).unwrap();
@@ -642,6 +685,7 @@ mod bolero_tests {
                             initial_inner_addresses.unwrap(),
                             initial_ports,
                             new_ports,
+                            (inner_is_udp, inner_udp_checksum_disabled),
                         );
                     }
 
@@ -656,5 +700,65 @@ mod bolero_tests {
                     }
                 },
             );
+    }
+}
+
+#[cfg(test)]
+mod quoted_transport_checksum {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::headers::{TryEmbeddedTransport, TryEmbeddedTransportMut};
+    use net::ip::NextHeader;
+    use net::packet::test_utils::build_test_icmp4_destination_unreachable_packet;
+    use net::udp::UdpChecksum;
+    use std::net::Ipv4Addr;
+
+    const OUTER_SRC: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+    const OUTER_DST: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 2);
+    const INNER_SRC: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 7);
+    const INNER_DST: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 9);
+    const NAT_SRC: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 200);
+    const OLD_PORT: u16 = 1234;
+    const PEER_PORT: u16 = 5678;
+    const NEW_PORT: u16 = 4321;
+
+    fn quoted_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet
+            .try_embedded_transport()
+            .and_then(EmbeddedTransport::checksum)
+    }
+
+    // Translating both the address and the port of a quote that carries no checksum must not
+    // conjure one: this covers the IP version that we hand over to the net crate, too.
+    #[test]
+    fn a_disabled_ipv4_udp_quote_checksum_stays_disabled() {
+        let mut packet = build_test_icmp4_destination_unreachable_packet(
+            OUTER_SRC,
+            OUTER_DST,
+            INNER_SRC,
+            INNER_DST,
+            NextHeader::UDP,
+            OLD_PORT,
+            PEER_PORT,
+        )
+        .unwrap_or_else(|_| unreachable!());
+        match packet.try_embedded_transport_mut() {
+            Some(EmbeddedTransport::Udp(udp)) => {
+                udp.set_checksum(UdpChecksum::new(0))
+                    .unwrap_or_else(|_| unreachable!());
+            }
+            _ => unreachable!(),
+        }
+
+        let target_port =
+            NatPort::new_port(NonZero::new(NEW_PORT).unwrap_or_else(|| unreachable!()));
+        nat_translate_icmp_inner_src(&mut packet, IpAddr::V4(NAT_SRC), Some(target_port))
+            .unwrap_or_else(|_| unreachable!());
+
+        assert_eq!(
+            quoted_checksum(&packet),
+            Some(0),
+            "a quote that carried no checksum came out carrying one"
+        );
     }
 }

--- a/net/src/checksum.rs
+++ b/net/src/checksum.rs
@@ -233,7 +233,7 @@ pub enum ChecksumError<T: Checksum + ?Sized> {
 #[cfg(test)]
 mod tests {
     use crate::checksum::Checksum;
-    use crate::ipv4::Ipv4;
+    use crate::ipv4::{Ipv4, Ipv4Checksum};
     use std::net::Ipv4Addr;
 
     fn update_and_check_checksum(ipv4: &Ipv4, new_len_value: u16, new_addr_value: u32) {
@@ -274,6 +274,60 @@ mod tests {
             .with_type()
             .for_each(|(header, len, addr)| {
                 update_and_check_checksum(header, *len, *addr);
+            });
+    }
+
+    // Chain incremental updates for the given (old value, new value) changes, starting from the
+    // given checksum. The header is irrelevant: incremental_checksum() only works out the new
+    // checksum from the previous one and from the values that changed.
+    fn chain_incremental_checksums(
+        checksum: u16,
+        changes: impl IntoIterator<Item = (u16, u16)>,
+    ) -> u16 {
+        changes
+            .into_iter()
+            .fold(Ipv4Checksum::new(checksum), |checksum, (old, new)| {
+                Ipv4::incremental_checksum(checksum, old, new)
+            })
+            .into()
+    }
+
+    // The updates in a chain are additions in one's complement arithmetic, which is commutative:
+    // the order in which we apply them doesn't affect the resulting checksum, not even the
+    // representation that we get for it.
+    #[test]
+    fn incremental_checksum_chain_is_order_independent() {
+        bolero::check!()
+            .with_type()
+            .for_each(|changes: &(u16, [(u16, u16); 4])| {
+                let (checksum, changes) = changes;
+                let expected = chain_incremental_checksums(*checksum, *changes);
+                for rotation in 1..changes.len() {
+                    let mut rotated = *changes;
+                    rotated.rotate_left(rotation);
+                    assert_eq!(chain_incremental_checksums(*checksum, rotated), expected);
+                }
+                let mut reversed = *changes;
+                reversed.reverse();
+                assert_eq!(chain_incremental_checksums(*checksum, reversed), expected);
+            });
+    }
+
+    // Whether we apply an update to the checksum at all is not indifferent, even when the value
+    // that it accounts for didn't change: one's complement arithmetic has two representations for
+    // zero, and an update with no net effect turns the negative one, 0xffff, into the positive one,
+    // 0x0000. The two are equivalent for the sake of validating a checksum, but they are not
+    // interchangeable for UDP, where 0x0000 means "no checksum" (RFC 768).
+    //
+    // Make sure we never update when the old and new values are the same.
+    #[test]
+    fn test_incremental_update_checksum_without_change_is_noop() {
+        bolero::check!()
+            .with_type()
+            .for_each(|(raw, value): &(u16, u16)| {
+                let old_checksum = Ipv4Checksum::new(*raw);
+                let new_checksum = Ipv4::incremental_checksum(old_checksum, *value, *value);
+                assert_eq!(new_checksum, old_checksum);
             });
     }
 }

--- a/net/src/checksum.rs
+++ b/net/src/checksum.rs
@@ -110,19 +110,22 @@ pub trait Checksum {
         Ok(ret)
     }
 
-    /// Perform an incremental update of the checksum in the header, to account for the change of a
+    /// Compute an incremental update of the checksum in the header, to account for the change of a
     /// 16-bit value in the header, without recomputing the whole checksum but using the algorithm
     /// described in RFC 1624 "Computation of the Internet Checksum via Incremental Update"
     //
     // Implement this as a default method rather than relying on individual's Self::Checksum types
-    // implementations, because etherparse currendly doesn't offer a way to compute incremental
+    // implementations, because etherparse currently doesn't offer a way to compute incremental
     // updates for checksums.
-    fn increment_update_checksum(
-        &mut self,
+    fn incremental_checksum(
         current_checksum: Self::Checksum,
         old_value: u16,
         new_value: u16,
     ) -> Self::Checksum {
+        if old_value == new_value {
+            return current_checksum;
+        }
+
         // From RFC 1624:
         //
         // Given the following notation:
@@ -159,14 +162,34 @@ pub trait Checksum {
         result.into()
     }
 
-    /// Perform an incremental update of the checksum in the header, like `increment_update_checksum`
-    /// but for a 32-bit value change.
+    /// Perform an incremental update (in-place) of the checksum in the header for a 16-bit value
+    /// change.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `Self::Error` if setting the checksum fails,
+    fn increment_update_checksum(
+        &mut self,
+        current_checksum: Self::Checksum,
+        old_value: u16,
+        new_value: u16,
+    ) -> Result<&mut Self, Self::Error> {
+        let new_checksum = Self::incremental_checksum(current_checksum, old_value, new_value);
+        self.set_checksum(new_checksum)
+    }
+
+    /// Perform an incremental update (in-place) of the checksum in the header for a 32-bit value
+    /// change.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `Self::Error` if setting the checksum fails,
     fn increment_update_checksum_32bit(
         &mut self,
         current_checksum: Self::Checksum,
         old_value: u32,
         new_value: u32,
-    ) -> Self::Checksum {
+    ) -> Result<&mut Self, Self::Error> {
         let old_value_first_half = (old_value >> 16) as u16;
         #[allow(clippy::cast_possible_truncation)] // truncation is intentional
         let old_value_second_half = old_value as u16;
@@ -174,16 +197,14 @@ pub trait Checksum {
         #[allow(clippy::cast_possible_truncation)] // truncation is intentional
         let new_value_second_half = new_value as u16;
 
-        let intermediary_checksum = self.increment_update_checksum(
+        let tmp_checksum = Self::incremental_checksum(
             current_checksum,
             old_value_first_half,
             new_value_first_half,
         );
-        self.increment_update_checksum(
-            intermediary_checksum,
-            old_value_second_half,
-            new_value_second_half,
-        )
+        let new_checksum =
+            Self::incremental_checksum(tmp_checksum, old_value_second_half, new_value_second_half);
+        self.set_checksum(new_checksum)
     }
 }
 
@@ -229,8 +250,7 @@ mod tests {
         ipv4.0.total_len = new_len_value;
 
         // Update and validate checksum
-        let new_checksum = ipv4.increment_update_checksum(checksum, old_value, new_len_value);
-        ipv4.set_checksum(new_checksum)
+        ipv4.increment_update_checksum(checksum, old_value, new_len_value)
             .expect("set checksum failed");
         ipv4.validate_checksum(&())
             .expect("expected valid checksum after total length field change");
@@ -242,9 +262,7 @@ mod tests {
         ipv4.set_destination(new_ip);
 
         // Update and validate checksum
-        let new_checksum =
-            ipv4.increment_update_checksum_32bit(checksum, old_value, new_addr_value);
-        ipv4.set_checksum(new_checksum)
+        ipv4.increment_update_checksum_32bit(checksum, old_value, new_addr_value)
             .expect("set checksum failed");
         ipv4.validate_checksum(&())
             .expect("expected valid checksum after destination address change");

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -610,6 +610,25 @@ impl EmbeddedTransport {
         }
     }
 
+    /// Set the checksum of the embedded transport header, but discard the error if the header is
+    /// truncated.
+    pub fn set_checksum_if_possible(&mut self, checksum: u16) {
+        match self {
+            EmbeddedTransport::Tcp(tcp) => {
+                let _ = tcp.set_checksum(TcpChecksum::new(checksum));
+            }
+            EmbeddedTransport::Udp(udp) => {
+                let _ = udp.set_checksum(UdpChecksum::new(checksum));
+            }
+            EmbeddedTransport::Icmp4(icmp) => {
+                let _ = icmp.set_checksum(Icmp4Checksum::new(checksum));
+            }
+            EmbeddedTransport::Icmp6(icmp) => {
+                let _ = icmp.set_checksum(Icmp6Checksum::new(checksum));
+            }
+        }
+    }
+
     /// Incrementally update the checksum of the embedded transport header, but discard the error if
     /// the header is truncated and too short.
     pub fn update_checksum(&mut self, current_checksum: u16, old_value: u16, new_value: u16) {

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -610,43 +610,31 @@ impl EmbeddedTransport {
         }
     }
 
+    /// Incrementally update the checksum of the embedded transport header, but discard the error if
+    /// the header is truncated and too short.
     pub fn update_checksum(&mut self, current_checksum: u16, old_value: u16, new_value: u16) {
+        let (raw, old, new) = (current_checksum, old_value, new_value);
+        if old == new {
+            return;
+        }
         match self {
             EmbeddedTransport::Tcp(tcp) => {
-                let updated = tcp.increment_update_checksum(
-                    TcpChecksum::new(current_checksum),
-                    old_value,
-                    new_value,
-                );
-                let _ = tcp.set_checksum(updated);
+                let _ = tcp.increment_update_checksum(TcpChecksum::new(raw), old, new);
             }
             EmbeddedTransport::Udp(udp) => {
-                let updated = udp.increment_update_checksum(
-                    UdpChecksum::new(current_checksum),
-                    old_value,
-                    new_value,
-                );
-                let _ = udp.set_checksum(updated);
+                let _ = udp.increment_update_checksum(UdpChecksum::new(raw), old, new);
             }
             EmbeddedTransport::Icmp4(icmp) => {
-                let updated = icmp.increment_update_checksum(
-                    Icmp4Checksum::new(current_checksum),
-                    old_value,
-                    new_value,
-                );
-                let _ = icmp.set_checksum(updated);
+                let _ = icmp.increment_update_checksum(Icmp4Checksum::new(raw), old, new);
             }
             EmbeddedTransport::Icmp6(icmp) => {
-                let updated = icmp.increment_update_checksum(
-                    Icmp6Checksum::new(current_checksum),
-                    old_value,
-                    new_value,
-                );
-                let _ = icmp.set_checksum(updated);
+                let _ = icmp.increment_update_checksum(Icmp6Checksum::new(raw), old, new);
             }
         }
     }
 
+    /// Incrementally update the checksum of the embedded transport header for a change in the
+    /// source or destination address, but discard the error if the header is truncated and too short
     pub fn update_checksum_for_address(&mut self, old: IpAddr, new: IpAddr) {
         if matches!(self, EmbeddedTransport::Icmp4(_)) {
             return;

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -28,6 +28,7 @@ use std::num::NonZero;
 #[cfg(any(test, feature = "bolero"))]
 pub use contract::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EmbeddedIpVersion {
     Ipv4,
     Ipv6,
@@ -606,11 +607,32 @@ impl EmbeddedTransport {
         }
     }
 
+    /// Tell whether the header is a UDP header carrying no checksum, which RFC 768 allows over
+    /// IPv4 only: there is no sum to fold an update into, in that case.
+    fn udp_checksum_disabled(&self, quoted: EmbeddedIpVersion, current_checksum: u16) -> bool {
+        matches!(self, EmbeddedTransport::Udp(_))
+            && quoted == EmbeddedIpVersion::Ipv4
+            && current_checksum == 0
+    }
+
     /// Incrementally update the checksum of the embedded transport header, but discard the error if
     /// the header is truncated and too short.
-    pub fn update_checksum(&mut self, current_checksum: u16, old_value: u16, new_value: u16) {
+    ///
+    /// "quoted" is the IP version of the packet that the header comes from, which the UDP rules on
+    /// a zero checksum depend on.
+    pub fn update_checksum(
+        &mut self,
+        quoted: EmbeddedIpVersion,
+        current_checksum: u16,
+        old_value: u16,
+        new_value: u16,
+    ) {
         let (raw, old, new) = (current_checksum, old_value, new_value);
         if old == new {
+            return;
+        }
+        if self.udp_checksum_disabled(quoted, raw) {
+            // The sender computed no checksum, leave the marker alone
             return;
         }
         match self {
@@ -618,7 +640,14 @@ impl EmbeddedTransport {
                 let _ = tcp.increment_update_checksum(TcpChecksum::new(raw), old, new);
             }
             EmbeddedTransport::Udp(udp) => {
-                let _ = udp.increment_update_checksum(UdpChecksum::new(raw), old, new);
+                // RFC 768: a computed checksum of zero travels as all ones, so that it is not
+                // mistaken for the marker for "no checksum". IPv6 forbids the marker altogether.
+                let updated =
+                    match TruncatedUdp::incremental_checksum(UdpChecksum::new(raw), old, new) {
+                        zero if u16::from(zero) == 0 => UdpChecksum::new(u16::MAX),
+                        updated => updated,
+                    };
+                let _ = udp.set_checksum(updated);
             }
             EmbeddedTransport::Icmp4(icmp) => {
                 let _ = icmp.increment_update_checksum(Icmp4Checksum::new(raw), old, new);
@@ -638,11 +667,16 @@ impl EmbeddedTransport {
         if old.is_ipv4() != new.is_ipv4() {
             return;
         }
+        let quoted = if old.is_ipv4() {
+            EmbeddedIpVersion::Ipv4
+        } else {
+            EmbeddedIpVersion::Ipv6
+        };
         for (old_word, new_word) in address_words(old).into_iter().zip(address_words(new)) {
             let Some(current) = self.checksum() else {
                 return;
             };
-            self.update_checksum(current, old_word, new_word);
+            self.update_checksum(quoted, current, old_word, new_word);
         }
     }
 }
@@ -1387,6 +1421,77 @@ mod tests {
 
         // Before calling check_full_payload, should be false
         assert!(!headers.is_full_payload());
+    }
+
+    // A zero UDP checksum means "the sender computed none" over IPv4, and nothing at all over
+    // IPv6, where RFC 8200 makes the checksum mandatory
+    mod udp_zero_checksum {
+        use super::*;
+        use crate::udp::{Udp, UdpChecksum};
+
+        const OLD_PORT: u16 = 1234;
+        const NEW_PORT: u16 = 4321;
+
+        fn udp_quote(checksum: u16) -> EmbeddedTransport {
+            let mut udp = Udp::new(OLD_PORT.try_into().unwrap(), 5678.try_into().unwrap());
+            udp.set_checksum(UdpChecksum::new(checksum))
+                .unwrap_or_else(|()| unreachable!());
+            EmbeddedTransport::from(udp)
+        }
+
+        #[test]
+        fn a_disabled_ipv4_udp_checksum_is_left_alone() {
+            let mut quote = udp_quote(0);
+            quote.update_checksum(EmbeddedIpVersion::Ipv4, 0, OLD_PORT, NEW_PORT);
+            assert_eq!(
+                quote.checksum(),
+                Some(0),
+                "a quote that carried no checksum came out carrying one"
+            );
+        }
+
+        #[test]
+        fn a_zero_ipv6_udp_checksum_is_folded_into() {
+            let mut quote = udp_quote(0);
+            quote.update_checksum(EmbeddedIpVersion::Ipv6, 0, OLD_PORT, NEW_PORT);
+            assert_ne!(
+                quote.checksum(),
+                Some(0),
+                "an IPv6 quote kept a checksum that IPv6 forbids"
+            );
+        }
+
+        #[test]
+        fn a_udp_checksum_folding_onto_zero_travels_as_all_ones() {
+            // The update below folds this checksum onto zero, as the inverse update from zero
+            let folding_onto_zero = u16::from(TruncatedUdp::incremental_checksum(
+                UdpChecksum::new(0),
+                NEW_PORT,
+                OLD_PORT,
+            ));
+            assert_eq!(
+                u16::from(TruncatedUdp::incremental_checksum(
+                    UdpChecksum::new(folding_onto_zero),
+                    OLD_PORT,
+                    NEW_PORT,
+                )),
+                0,
+                "this test no longer exercises a fold onto zero"
+            );
+
+            let mut quote = udp_quote(folding_onto_zero);
+            quote.update_checksum(
+                EmbeddedIpVersion::Ipv6,
+                folding_onto_zero,
+                OLD_PORT,
+                NEW_PORT,
+            );
+            assert_eq!(
+                quote.checksum(),
+                Some(u16::MAX),
+                "a UDP checksum that folded onto zero was left spelled as the \"no checksum\" marker"
+            );
+        }
     }
 
     mod address_folding {

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -125,7 +125,7 @@ impl EmbeddedHeaders {
         self.full_payload_length
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
+    #[allow(clippy::cast_possible_truncation)]
     pub fn check_full_payload(
         &mut self,
         buf: &[u8],
@@ -175,7 +175,7 @@ impl EmbeddedHeaders {
         // Is size_headers_parsed - size_transport_header + size_ip_payload == size_icmp_payload?
 
         // Find the IP payload length
-        let ip_payload_length = match &self.net {
+        let (ip_payload_length, boundary) = match &self.net {
             None => {
                 return;
             }
@@ -183,7 +183,7 @@ impl EmbeddedHeaders {
                 let Ok(ipv4_payload_length) = ip.0.payload_len().map(usize::from) else {
                     return;
                 };
-                ipv4_payload_length
+                (ipv4_payload_length, 4)
             }
             Some(Net::Ipv6(ip)) => {
                 let ipv6_payload_length = ip.0.payload_length;
@@ -192,7 +192,7 @@ impl EmbeddedHeaders {
                     // unlikely it's all in the ICMP message payload anyway.
                     return;
                 }
-                ipv6_payload_length as usize
+                (ipv6_payload_length as usize, 8)
             }
         };
 
@@ -234,50 +234,27 @@ impl EmbeddedHeaders {
             // against this value.
             //
             // From RFC 4884: The length attribute represents the length of the padded "original
-            // datagram" field.
-            match self.net {
-                Some(Net::Ipv4(_)) => {
-                    if icmp_length < full_packet_length {
-                        // The embedded message is shorter than the original packet
-                        return;
-                    }
-                    if icmp_length > buf.len() || !icmp_length.is_multiple_of(32) {
-                        // Embedded payload is larger than our buffer? Or the size is not a multiple
-                        // of 32? Something's wrong
-                        return;
-                    }
-                    let padding_length = icmp_length - full_packet_length;
-                    // ICMPv4: Padding is on 32-bit boundaries
-                    if padding_length < 32
-                        && buf[full_packet_length..icmp_length].iter().all(|b| *b == 0)
-                    {
-                        self.full_payload_length = Some(transport_payload_length as u16);
-                    }
-                    return;
-                }
-                Some(Net::Ipv6(_)) => {
-                    if icmp_length < full_packet_length {
-                        // The embedded message is shorter than the original packet
-                        return;
-                    }
-                    if icmp_length > buf.len() || !icmp_length.is_multiple_of(64) {
-                        // Embedded payload is larger than our buffer? Or the size is not a multiple
-                        // of 64? Something's wrong
-                        return;
-                    }
-                    let padding_length = icmp_length - full_packet_length;
-                    // ICMPv6: Padding is on 64-bit boundaries
-                    if padding_length < 64
-                        && buf[full_packet_length..icmp_length].iter().all(|b| *b == 0)
-                    {
-                        self.full_payload_length = Some(transport_payload_length as u16);
-                    }
-                    return;
-                }
-                None => {
-                    unreachable!() // Checked earlier in the function
-                }
+            // datagram" field:
+            //
+            //     When the ICMP Extension Structure is appended to an ICMP message and that ICMP
+            //     message contains an "original datagram" field, the "original datagram" field MUST
+            //     contain at least 128 octets.
+            //
+            //     When the ICMP Extension Structure is appended to an ICMPv4 message [...] the
+            //     "original datagram" field MUST be zero padded to the nearest 32-bit boundary.
+            //
+            // ICMPv6 pads to the nearest 64-bit boundary instead. Either way, the length of the
+            // padded field is fully determined by the length of the original packet.
+            let padded_length = full_packet_length.max(128).next_multiple_of(boundary);
+
+            if icmp_length != padded_length || icmp_length > buf.len() {
+                // The message doesn't hold the original packet, padded as we expect
+                return;
             }
+            if buf[full_packet_length..icmp_length].iter().all(|b| *b == 0) {
+                self.full_payload_length = Some(transport_payload_length as u16);
+            }
+            return;
         }
 
         // Check that the full headers + payload are present

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -1962,12 +1962,9 @@ mod test {
                 let old_value = transport.source().into();
                 let new_value = 235;
                 transport.set_source(UdpPort::new_checked(new_value).unwrap());
-                let new_checksum = transport.increment_update_checksum(
-                    transport.checksum().unwrap(),
-                    old_value,
-                    new_value,
-                );
-                transport.set_checksum(new_checksum).unwrap();
+                transport
+                    .increment_update_checksum(transport.checksum().unwrap(), old_value, new_value)
+                    .unwrap();
 
                 transport
                     .validate_checksum(&UdpChecksumPayload::new(&net, &[]))
@@ -1978,12 +1975,9 @@ mod test {
                 let old_value = transport.destination().into();
                 let new_value = 116;
                 transport.set_destination(TcpPort::new_checked(new_value).unwrap());
-                let new_checksum = transport.increment_update_checksum(
-                    transport.checksum().unwrap(),
-                    old_value,
-                    new_value,
-                );
-                transport.set_checksum(new_checksum).unwrap();
+                transport
+                    .increment_update_checksum(transport.checksum().unwrap(), old_value, new_value)
+                    .unwrap();
 
                 transport
                     .validate_checksum(&TcpChecksumPayload::new(&net, &[]))
@@ -1997,12 +1991,12 @@ mod test {
                         let new_value = 0x10_20_30_40; // 16.32.48.64
                         let new_ip = UnicastIpv4Addr::try_from(Ipv4Addr::from(new_value)).unwrap();
                         ipv4.set_source(new_ip);
-                        let new_checksum = ipv4.increment_update_checksum_32bit(
+                        ipv4.increment_update_checksum_32bit(
                             ipv4.checksum().unwrap(),
                             old_value,
                             new_value,
-                        );
-                        ipv4.set_checksum(new_checksum).unwrap();
+                        )
+                        .unwrap();
                         ipv4.validate_checksum(&())
                             .expect("expected valid checksum");
                     }

--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -615,11 +615,14 @@ impl Icmp4 {
         )
     }
 
-    fn payload_length(&self, buf: &[u8]) -> usize {
+    // Expects a buffer starting at the beginning of the ICMP header
+    fn payload_length(&self, header: &[u8]) -> usize {
         if !self.supports_extensions() {
             return 0;
         }
-        let payload_length = buf[5];
+        let Some(&payload_length) = header.get(5) else {
+            return 0;
+        };
         payload_length as usize * 4
     }
 
@@ -627,19 +630,24 @@ impl Icmp4 {
         if !self.is_error_message() {
             return None;
         }
-        let (mut headers, consumed) = EmbeddedHeaders::parse_with(
-            EmbeddedIpVersion::Ipv4,
-            &cursor.inner[cursor.inner.len() - cursor.remaining as usize..],
-        )
-        .ok()?;
+        // We've just parsed the ICMP header: the bytes left in the cursor hold the whole ICMP
+        // payload, that is, the embedded IP packet fragment, optionally followed with some padding
+        // and ICMP Extension Structures
+        let icmp_payload_offset = cursor.inner.len() - cursor.remaining as usize;
+        let icmp_payload = &cursor.inner[icmp_payload_offset..];
+        let icmp_header =
+            &cursor.inner[icmp_payload_offset.saturating_sub(self.size().get() as usize)..];
+
+        let (mut headers, consumed) =
+            EmbeddedHeaders::parse_with(EmbeddedIpVersion::Ipv4, icmp_payload).ok()?;
         cursor.consume(consumed).ok()?;
 
         // Mark whether the payload of the embedded IP packet is full
         headers.check_full_payload(
-            &cursor.inner[cursor.inner.len() - cursor.remaining as usize..],
-            cursor.remaining as usize,
+            icmp_payload,
+            icmp_payload.len(),
             consumed.get() as usize,
-            self.payload_length(cursor.inner),
+            self.payload_length(icmp_header),
         );
 
         Some(headers)
@@ -1128,9 +1136,20 @@ mod contract {
 
 #[cfg(test)]
 mod test {
-    use crate::icmp4::{Icmp4, Icmp4Type};
+    use crate::buffer::TestBuffer;
+    use crate::eth::ethtype::EthType;
+    use crate::headers::{
+        EmbeddedHeadersBuilder, HeadersBuilder, Net, Transport, TryEmbeddedHeaders,
+    };
+    use crate::icmp4::{Icmp4, Icmp4DestUnreachable, Icmp4Type};
+    use crate::ip::NextHeader;
+    use crate::ipv4::Ipv4;
+    use crate::packet::Packet;
+    use crate::packet::test_utils::make_default_for_eth;
     use crate::parse::{DeParse, IntoNonZeroUSize, Parse};
+    use crate::tcp::{Tcp, TcpPort};
     use etherparse::Icmpv4Header;
+    use std::net::Ipv4Addr;
 
     /// A redirect with a multicast gateway should be treated as unknown
     /// ICMP, since RFC 1122 section 3.2.2.2 requires unicast.
@@ -1188,6 +1207,131 @@ mod test {
                     Icmp4::parse(buffer).unwrap_or_else(|e| unreachable!("{e:?}", e = e));
                 assert_eq!(parsed.size(), bytes_read);
                 parse_back_test_helper(&parsed);
+            });
+    }
+
+    // Detection of a full payload for the embedded IP packet fragment
+
+    const ETH_LEN: usize = 14;
+    const IPV4_LEN: usize = 20;
+    const ICMP4_LEN: usize = 8;
+    const TCP_LEN: u16 = 20;
+
+    // Build an ICMPv4 Destination Unreachable message quoting an IPv4/TCP packet.
+    //
+    // The message carries "payload_len" bytes of TCP payload, while the quoted IP header announces
+    // "announced_payload_len" bytes of TCP payload for the original packet: the two differ when
+    // the quoted packet is truncated. "trailer" is appended after the quoted packet fragment, to
+    // hold the padding and the ICMP Extension Structures, if any. "length_attribute" is the value
+    // for the optional length attribute of the ICMP header (RFC 4884), in units of 32-bit words.
+    fn build_icmp4_error_msg(
+        payload_len: usize,
+        announced_payload_len: u16,
+        trailer: &[u8],
+        length_attribute: u8,
+    ) -> Packet<TestBuffer> {
+        let mut inner_ipv4 = Ipv4::default();
+        inner_ipv4.set_source(Ipv4Addr::new(10, 20, 30, 40).try_into().unwrap());
+        inner_ipv4.set_destination(Ipv4Addr::new(50, 60, 70, 80));
+        inner_ipv4.set_next_header(NextHeader::TCP);
+
+        let inner_tcp = Tcp::new(
+            TcpPort::new_checked(80).unwrap(),
+            TcpPort::new_checked(443).unwrap(),
+        );
+
+        let mut embedded_headers = EmbeddedHeadersBuilder::default();
+        embedded_headers.net(Some(Net::Ipv4(inner_ipv4)));
+        embedded_headers.transport(Some(inner_tcp.into()));
+        let mut embedded_headers = embedded_headers.build().unwrap();
+        embedded_headers
+            .set_network_payload_length(TCP_LEN + announced_payload_len)
+            .unwrap();
+        let embedded_len = embedded_headers.size().get() as usize;
+        assert_eq!(embedded_len, IPV4_LEN + TCP_LEN as usize);
+
+        let icmp = Icmp4::with_type(Icmp4Type::DestUnreachable(Icmp4DestUnreachable::Network));
+        assert_eq!(icmp.size().get() as usize, ICMP4_LEN);
+
+        let mut ipv4 = Ipv4::default();
+        ipv4.set_source(Ipv4Addr::new(1, 2, 3, 4).try_into().unwrap());
+        ipv4.set_destination(Ipv4Addr::new(5, 6, 7, 8));
+        ipv4.set_next_header(NextHeader::ICMP);
+        let outer_payload_len = ICMP4_LEN + embedded_len + payload_len + trailer.len();
+        ipv4.set_payload_len(u16::try_from(outer_payload_len).unwrap())
+            .unwrap();
+
+        let mut headers = HeadersBuilder::default();
+        headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+        headers.net(Some(Net::Ipv4(ipv4)));
+        headers.transport(Some(Transport::Icmp4(icmp)));
+        headers.embedded_ip(Some(embedded_headers));
+        let headers = headers.build().unwrap();
+
+        let headers_len = headers.size().get() as usize;
+        assert_eq!(headers_len, ETH_LEN + IPV4_LEN + ICMP4_LEN + embedded_len);
+        let mut buf = vec![0u8; headers_len + payload_len + trailer.len()];
+        headers.deparse(&mut buf).unwrap();
+        buf[headers_len..headers_len + payload_len].fill(0xa5);
+        buf[headers_len + payload_len..].copy_from_slice(trailer);
+
+        // Set the optional length attribute of the ICMP header: etherparse zeroes the unused bytes
+        // that RFC 4884 repurposes for it
+        buf[ETH_LEN + IPV4_LEN + 5] = length_attribute;
+
+        Packet::new(TestBuffer::from_raw_data(&buf)).unwrap()
+    }
+
+    fn embedded_payload_length(packet: &Packet<TestBuffer>) -> Option<u16> {
+        let embedded_headers = packet.embedded_headers().unwrap();
+        assert_eq!(
+            embedded_headers.is_full_payload(),
+            embedded_headers.payload_length().is_some()
+        );
+        embedded_headers.payload_length()
+    }
+
+    // Tthe length announced by the header of the quoted IP packet tells whether the ICMP Error
+    // message carries the full payload of the original packet.
+    #[test]
+    fn detects_full_or_truncated_embedded_payload() {
+        bolero::check!()
+            .with_generator((0u16..=400, bolero::generator::produce::<Option<u16>>()))
+            .for_each(|(payload_len, missing_payload_len)| {
+                // The original packet may have carried more data than the message quotes
+                let missing_payload_len = missing_payload_len.map_or(0, |missing| missing % 401);
+                let announced_payload_len = payload_len + missing_payload_len;
+                let packet =
+                    build_icmp4_error_msg(usize::from(*payload_len), announced_payload_len, &[], 0);
+                let expected = (missing_payload_len == 0).then_some(*payload_len);
+                assert_eq!(embedded_payload_length(&packet), expected);
+            });
+    }
+
+    // When the message carries ICMP Extension Structures, the length of the quoted packet comes
+    // from the optional length attribute of the ICMP header (RFC 4884).
+    #[test]
+    fn detects_full_embedded_payload_with_icmp_extensions() {
+        const QUOTED_HEADERS_LEN: usize = IPV4_LEN + TCP_LEN as usize;
+        let min_payload_len = u16::try_from(128 - QUOTED_HEADERS_LEN).unwrap();
+        // RFC 4884: the "original datagram" field must hold at least 128 octets, and be zero-padded
+        // to the nearest 32-bit boundary. Keep the quoted packet large enough for the former, and
+        // small enough for the length attribute, in units of 32-bit words, to fit on a byte.
+        bolero::check!()
+            .with_generator((min_payload_len..=900, 0u8..=8))
+            .for_each(|(payload_len, extension_words)| {
+                let quoted_len = QUOTED_HEADERS_LEN + usize::from(*payload_len);
+                let padding_len = quoted_len.next_multiple_of(32) - quoted_len;
+                let mut trailer = vec![0u8; padding_len];
+                trailer.resize(padding_len + usize::from(*extension_words) * 4, 0x55);
+                let length_attribute = u8::try_from((quoted_len + padding_len) / 4).unwrap();
+                let packet = build_icmp4_error_msg(
+                    usize::from(*payload_len),
+                    *payload_len,
+                    &trailer,
+                    length_attribute,
+                );
+                assert_eq!(embedded_payload_length(&packet), Some(*payload_len));
             });
     }
 }

--- a/net/src/icmp4/mod.rs
+++ b/net/src/icmp4/mod.rs
@@ -1141,6 +1141,7 @@ mod test {
     use crate::headers::{
         EmbeddedHeadersBuilder, HeadersBuilder, Net, Transport, TryEmbeddedHeaders,
     };
+    use crate::icmp4::Icmp4ExtensionStructures;
     use crate::icmp4::{Icmp4, Icmp4DestUnreachable, Icmp4Type};
     use crate::ip::NextHeader;
     use crate::ipv4::Ipv4;
@@ -1313,15 +1314,15 @@ mod test {
     #[test]
     fn detects_full_embedded_payload_with_icmp_extensions() {
         const QUOTED_HEADERS_LEN: usize = IPV4_LEN + TCP_LEN as usize;
-        let min_payload_len = u16::try_from(128 - QUOTED_HEADERS_LEN).unwrap();
-        // RFC 4884: the "original datagram" field must hold at least 128 octets, and be zero-padded
-        // to the nearest 32-bit boundary. Keep the quoted packet large enough for the former, and
-        // small enough for the length attribute, in units of 32-bit words, to fit on a byte.
+        // Keep the quoted packet small enough for the length attribute of the ICMP header, in
+        // units of 32-bit words, to fit on a byte.
         bolero::check!()
-            .with_generator((min_payload_len..=900, 0u8..=8))
+            .with_generator((0u16..=900, 0u8..=8))
             .for_each(|(payload_len, extension_words)| {
                 let quoted_len = QUOTED_HEADERS_LEN + usize::from(*payload_len);
-                let padding_len = quoted_len.next_multiple_of(32) - quoted_len;
+                // Pad the "original datagram" field as RFC 4884 requires, the same way as the
+                // generator of ICMP Error messages does
+                let padding_len = Icmp4ExtensionStructures::padding_size(quoted_len);
                 let mut trailer = vec![0u8; padding_len];
                 trailer.resize(padding_len + usize::from(*extension_words) * 4, 0x55);
                 let length_attribute = u8::try_from((quoted_len + padding_len) / 4).unwrap();

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -630,12 +630,15 @@ impl Icmp6 {
         )
     }
 
-    fn payload_length(&self, buf: &[u8]) -> usize {
+    // Expects a buffer starting at the beginning of the ICMP header
+    fn payload_length(&self, header: &[u8]) -> usize {
         // See RFC 4884.
         if !self.supports_extensions() {
             return 0;
         }
-        let payload_length = buf[4];
+        let Some(&payload_length) = header.get(4) else {
+            return 0;
+        };
         payload_length as usize * 8
     }
 
@@ -643,19 +646,24 @@ impl Icmp6 {
         if !self.is_error_message() {
             return None;
         }
-        let (mut headers, consumed) = EmbeddedHeaders::parse_with(
-            EmbeddedIpVersion::Ipv6,
-            &cursor.inner[cursor.inner.len() - cursor.remaining as usize..],
-        )
-        .ok()?;
+        // We've just parsed the ICMP header: the bytes left in the cursor hold the whole ICMP
+        // payload, that is, the embedded IP packet fragment, optionally followed with some padding
+        // and ICMP Extension Structures
+        let icmp_payload_offset = cursor.inner.len() - cursor.remaining as usize;
+        let icmp_payload = &cursor.inner[icmp_payload_offset..];
+        let icmp_header =
+            &cursor.inner[icmp_payload_offset.saturating_sub(self.size().get() as usize)..];
+
+        let (mut headers, consumed) =
+            EmbeddedHeaders::parse_with(EmbeddedIpVersion::Ipv6, icmp_payload).ok()?;
         cursor.consume(consumed).ok()?;
 
         // Mark whether the payload of the embedded IP packet is full
         headers.check_full_payload(
-            &cursor.inner[cursor.inner.len() - cursor.remaining as usize..],
-            cursor.remaining as usize,
+            icmp_payload,
+            icmp_payload.len(),
             consumed.get() as usize,
-            self.payload_length(cursor.inner),
+            self.payload_length(icmp_header),
         );
 
         Some(headers)
@@ -1184,8 +1192,19 @@ mod contract {
 
 #[cfg(test)]
 mod test {
-    use crate::icmp6::{Icmp6, Icmp6Type};
+    use crate::buffer::TestBuffer;
+    use crate::eth::ethtype::EthType;
+    use crate::headers::{
+        EmbeddedHeadersBuilder, HeadersBuilder, Net, Transport, TryEmbeddedHeaders,
+    };
+    use crate::icmp6::{Icmp6, Icmp6DestUnreachable, Icmp6Type};
+    use crate::ip::NextHeader;
+    use crate::ipv6::Ipv6;
+    use crate::packet::Packet;
+    use crate::packet::test_utils::make_default_for_eth;
     use crate::parse::{DeParse, Parse};
+    use crate::tcp::{Tcp, TcpPort};
+    use std::net::Ipv6Addr;
 
     /// A Packet Too Big with MTU below 1280 should be treated as unknown
     /// `ICMPv6`, since RFC 8200 section 5 sets 1280 as the IPv6 minimum.
@@ -1232,6 +1251,138 @@ mod test {
                     Icmp6::parse(buffer).unwrap_or_else(|e| unreachable!("{e:?}", e = e));
                 assert_eq!(parsed.size(), bytes_read);
                 parse_back_test_helper(&parsed);
+            });
+    }
+
+    // Detection of a full payload for the embedded IP packet fragment
+
+    const ETH_LEN: usize = 14;
+    const IPV6_LEN: usize = 40;
+    const ICMP6_LEN: usize = 8;
+    const TCP_LEN: u16 = 20;
+
+    // Build an ICMPv6 Destination Unreachable message quoting an IPv6/TCP packet.
+    //
+    // The message carries "payload_len" bytes of TCP payload, while the quoted IP header announces
+    // "announced_payload_len" bytes of TCP payload for the original packet: the two differ when
+    // the quoted packet is truncated. "trailer" is appended after the quoted packet fragment, to
+    // hold the padding and the ICMP Extension Structures, if any. "length_attribute" is the value
+    // for the optional length attribute of the ICMP header (RFC 4884), in units of 64-bit words.
+    fn build_icmp6_error_msg(
+        payload_len: usize,
+        announced_payload_len: u16,
+        trailer: &[u8],
+        length_attribute: u8,
+    ) -> Packet<TestBuffer> {
+        let mut inner_ipv6 = Ipv6::default();
+        inner_ipv6.set_source(
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)
+                .try_into()
+                .unwrap(),
+        );
+        inner_ipv6.set_destination(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2));
+        inner_ipv6.set_next_header(NextHeader::TCP);
+
+        let inner_tcp = Tcp::new(
+            TcpPort::new_checked(80).unwrap(),
+            TcpPort::new_checked(443).unwrap(),
+        );
+
+        let mut embedded_headers = EmbeddedHeadersBuilder::default();
+        embedded_headers.net(Some(Net::Ipv6(inner_ipv6)));
+        embedded_headers.transport(Some(inner_tcp.into()));
+        let mut embedded_headers = embedded_headers.build().unwrap();
+        embedded_headers
+            .set_network_payload_length(TCP_LEN + announced_payload_len)
+            .unwrap();
+        let embedded_len = embedded_headers.size().get() as usize;
+        assert_eq!(embedded_len, IPV6_LEN + TCP_LEN as usize);
+
+        let icmp = Icmp6::with_type(Icmp6Type::DestUnreachable(Icmp6DestUnreachable::NoRoute));
+        assert_eq!(icmp.size().get() as usize, ICMP6_LEN);
+
+        let mut ipv6 = Ipv6::default();
+        ipv6.set_source(
+            Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 1)
+                .try_into()
+                .unwrap(),
+        );
+        ipv6.set_destination(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 2));
+        ipv6.set_next_header(NextHeader::ICMP6);
+        let outer_payload_len = ICMP6_LEN + embedded_len + payload_len + trailer.len();
+        ipv6.set_payload_length(u16::try_from(outer_payload_len).unwrap());
+
+        let mut headers = HeadersBuilder::default();
+        headers.eth(Some(make_default_for_eth(EthType::IPV6)));
+        headers.net(Some(Net::Ipv6(ipv6)));
+        headers.transport(Some(Transport::Icmp6(icmp)));
+        headers.embedded_ip(Some(embedded_headers));
+        let headers = headers.build().unwrap();
+
+        let headers_len = headers.size().get() as usize;
+        assert_eq!(headers_len, ETH_LEN + IPV6_LEN + ICMP6_LEN + embedded_len);
+        let mut buf = vec![0u8; headers_len + payload_len + trailer.len()];
+        headers.deparse(&mut buf).unwrap();
+        buf[headers_len..headers_len + payload_len].fill(0xa5);
+        buf[headers_len + payload_len..].copy_from_slice(trailer);
+
+        // Set the optional length attribute of the ICMP header: etherparse zeroes the unused bytes
+        // that RFC 4884 repurposes for it
+        buf[ETH_LEN + IPV6_LEN + 4] = length_attribute;
+
+        Packet::new(TestBuffer::from_raw_data(&buf)).unwrap()
+    }
+
+    fn embedded_payload_length(packet: &Packet<TestBuffer>) -> Option<u16> {
+        let embedded_headers = packet.embedded_headers().unwrap();
+        assert_eq!(
+            embedded_headers.is_full_payload(),
+            embedded_headers.payload_length().is_some()
+        );
+        embedded_headers.payload_length()
+    }
+
+    // The length announced by the header of the quoted IP packet tells whether the ICMP Error
+    // message carries the full payload of the original packet.
+    #[test]
+    fn detects_full_or_truncated_embedded_payload() {
+        bolero::check!()
+            .with_generator((0u16..=400, bolero::generator::produce::<Option<u16>>()))
+            .for_each(|(payload_len, missing_payload_len)| {
+                // The original packet may have carried more data than the message quotes
+                let missing_payload_len = missing_payload_len.map_or(0, |missing| missing % 401);
+                let announced_payload_len = payload_len + missing_payload_len;
+                let packet =
+                    build_icmp6_error_msg(usize::from(*payload_len), announced_payload_len, &[], 0);
+                let expected = (missing_payload_len == 0).then_some(*payload_len);
+                assert_eq!(embedded_payload_length(&packet), expected);
+            });
+    }
+
+    // When the message carries ICMP Extension Structures, the length of the quoted packet comes
+    // from the optional length attribute of the ICMP header (RFC 4884).
+    #[test]
+    fn detects_full_embedded_payload_with_icmp_extensions() {
+        const QUOTED_HEADERS_LEN: usize = IPV6_LEN + TCP_LEN as usize;
+        let min_payload_len = u16::try_from(128 - QUOTED_HEADERS_LEN).unwrap();
+        // RFC 4884: the "original datagram" field must hold at least 128 octets, and be zero-padded
+        // to the nearest 64-bit boundary. Keep the quoted packet large enough for the former, and
+        // small enough for the length attribute, in units of 64-bit words, to fit on a byte.
+        bolero::check!()
+            .with_generator((min_payload_len..=900, 0u8..=8))
+            .for_each(|(payload_len, extension_words)| {
+                let quoted_len = QUOTED_HEADERS_LEN + usize::from(*payload_len);
+                let padding_len = quoted_len.next_multiple_of(64) - quoted_len;
+                let mut trailer = vec![0u8; padding_len];
+                trailer.resize(padding_len + usize::from(*extension_words) * 8, 0x55);
+                let length_attribute = u8::try_from((quoted_len + padding_len) / 8).unwrap();
+                let packet = build_icmp6_error_msg(
+                    usize::from(*payload_len),
+                    *payload_len,
+                    &trailer,
+                    length_attribute,
+                );
+                assert_eq!(embedded_payload_length(&packet), Some(*payload_len));
             });
     }
 }

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -1099,7 +1099,7 @@ mod contract {
                     unreachable!()
                 }
                 Some(EmbeddedTransport::Icmp6(_)) => {
-                    let net_gen = GenWithNextHeader(NextHeader::ICMP);
+                    let net_gen = GenWithNextHeader(NextHeader::ICMP6);
                     Some(Net::Ipv6(net_gen.generate(driver)?))
                 }
                 None => {

--- a/net/src/icmp6/mod.rs
+++ b/net/src/icmp6/mod.rs
@@ -1197,6 +1197,7 @@ mod test {
     use crate::headers::{
         EmbeddedHeadersBuilder, HeadersBuilder, Net, Transport, TryEmbeddedHeaders,
     };
+    use crate::icmp6::Icmp6ExtensionStructures;
     use crate::icmp6::{Icmp6, Icmp6DestUnreachable, Icmp6Type};
     use crate::ip::NextHeader;
     use crate::ipv6::Ipv6;
@@ -1364,15 +1365,15 @@ mod test {
     #[test]
     fn detects_full_embedded_payload_with_icmp_extensions() {
         const QUOTED_HEADERS_LEN: usize = IPV6_LEN + TCP_LEN as usize;
-        let min_payload_len = u16::try_from(128 - QUOTED_HEADERS_LEN).unwrap();
-        // RFC 4884: the "original datagram" field must hold at least 128 octets, and be zero-padded
-        // to the nearest 64-bit boundary. Keep the quoted packet large enough for the former, and
-        // small enough for the length attribute, in units of 64-bit words, to fit on a byte.
+        // Keep the quoted packet small enough for the length attribute of the ICMP header, in
+        // units of 64-bit words, to fit on a byte.
         bolero::check!()
-            .with_generator((min_payload_len..=900, 0u8..=8))
+            .with_generator((0u16..=900, 0u8..=8))
             .for_each(|(payload_len, extension_words)| {
                 let quoted_len = QUOTED_HEADERS_LEN + usize::from(*payload_len);
-                let padding_len = quoted_len.next_multiple_of(64) - quoted_len;
+                // Pad the "original datagram" field as RFC 4884 requires, the same way as the
+                // generator of ICMP Error messages does
+                let padding_len = Icmp6ExtensionStructures::padding_size(quoted_len);
                 let mut trailer = vec![0u8; padding_len];
                 trailer.resize(padding_len + usize::from(*extension_words) * 8, 0x55);
                 let length_attribute = u8::try_from((quoted_len + padding_len) / 8).unwrap();

--- a/net/src/packet/mod.rs
+++ b/net/src/packet/mod.rs
@@ -661,12 +661,17 @@ pub mod contract {
             // Compute sizes
 
             let extensions_size = extensions.as_ref().map_or(0, IcmpExtensionStructures::size);
+            let quoted_packet_size = headers
+                .embedded_ip
+                .as_ref()
+                .map_or(0, |ip| ip.size().get() as usize)
+                + payload_size;
             let padding_size = match extensions {
                 Some(IcmpExtensionStructures::V4(_)) => {
-                    Icmp4ExtensionStructures::padding_size(payload_size)
+                    Icmp4ExtensionStructures::padding_size(quoted_packet_size)
                 }
                 Some(IcmpExtensionStructures::V6(_)) => {
-                    Icmp6ExtensionStructures::padding_size(payload_size)
+                    Icmp6ExtensionStructures::padding_size(quoted_packet_size)
                 }
                 None => 0,
             };
@@ -703,12 +708,11 @@ pub mod contract {
             let theoretical_inner_net_payload_size =
                 theoretical_inner_payload_size + inner_transport_header_size;
             // Offset of ICMP header in packet
-            let icmp_header_offset = headers_size
-                - headers
-                    .eth
-                    .as_ref()
-                    .map_or(0, |eth| eth.size().get() as usize)
-                - headers
+            let icmp_header_offset = headers
+                .eth
+                .as_ref()
+                .map_or(0, |eth| eth.size().get() as usize)
+                + headers
                     .net
                     .as_ref()
                     .map_or(0, |net| net.size().get() as usize);


### PR DESCRIPTION
This was meant to be a simple follow-up for https://github.com/githedgehog/dataplane/pull/1752#discussion_r3904802585, but one bug leading Claude to spot another, this now contains a bunch of fixes for ICMP Error messages' inner packets payload detection and checksum validation.