### PR TITLE
ci(lint): Authenticate the advisory-database clone

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -275,6 +275,22 @@ jobs:
     env:
       USER: "runner"
       JUST_VARS: "" # the `.github/actions/just` composite action runs under `set -u`; must be set even when empty
+      # `check-dependencies` runs `cargo deny check`, which clones the RustSec
+      # advisory database from github.com on every run.  Anonymous clones are
+      # rate limited, and a throttled request is answered with an auth
+      # challenge rather than a 429, so git reports it as
+      #   fatal: could not read Username for 'https://github.com'
+      # and the lint job fails for a reason that has nothing to do with the
+      # diff.  Spending the job's own token raises the limit.
+      #
+      # This is a stopgap.  The durable fix is to stop fetching at lint time:
+      # pin the advisory database through npins and run `cargo deny --offline`,
+      # which 0.20.2 supports.  That trades this flake for a pinned database
+      # that only learns about new advisories when the pin is bumped, so it
+      # wants a scheduled job checking against a fresh copy.
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ github.token }}@github.com/.insteadOf"
+      GIT_CONFIG_VALUE_0: "https://github.com/"
     steps:
       - *checkout
       - *nix-setup


### PR DESCRIPTION
`check-dependencies` runs `cargo deny check`, which clones the RustSec advisory database from
github.com on every lint run. Anonymous clones are rate limited, and GitHub answers a throttled
request with an **auth challenge rather than a 429**, so git reports it as:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

The job then fails for a reason that has nothing to do with the diff. Observed on
[#1788](https://github.com/githedgehog/dataplane/pull/1788), where every other lint step passed
and the dependency graph was untouched.

This is **not** a RUSTSEC finding — no advisory was reported. The clone never completed.

## The change

Spend the job's own token on the clone. The lint job already declares `contents: read`, which
suffices to read a public repository, and passing it through `GIT_CONFIG_COUNT` keeps the URL
rewrite scoped to this job instead of mutating global git configuration.

## This is a stopgap

The durable fix is to stop fetching at lint time: pin the advisory database through npins --
this repository already pins eighteen other sources, including `opengrep` and `duvet` -- and run
`cargo deny --offline`, which 0.20.2 supports. I verified that path works: against a pre-fetched
database, `cargo deny --offline check advisories` reports `advisories ok`.

That trades the flake for a pinned database which only learns about new advisories when the pin
is bumped, so it wants a scheduled job checking against a fresh copy. That is a policy decision
rather than a mechanical one, and too large to ride along with a hotfix.

Worth noting this is the second CI failure of the same shape recently: `just opengrep` takes
1074 of its 1075 rules from an unauthenticated `--config auto` registry fetch and fails the same
way when that fetch does not resolve. There may be one lever worth pulling across both rather
than a fix per tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
