### PR TITLE
(16) races

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,7 +13,7 @@ CARGO_LLVM_COV_BUILD_DIR = { value = "target/llvm-cov/target", relative = true, 
 
 [build]
 # Register `emulated` and `instrumented` so cfg sites do not trip unexpected_cfgs natively.
-rustflags = ["--cfg=tokio_unstable", "--check-cfg=cfg(emulated)", "--check-cfg=cfg(instrumented)"]
+rustflags = ["--cfg=tokio_unstable", "--check-cfg=cfg(emulated)", "--check-cfg=cfg(instrumented)", "--check-cfg=cfg(sanitized)"]
 
 [target.wasm32-wasip1]
 # Trailing `--` separates wasmtime's CLI from the module + module args

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -199,6 +199,23 @@ threads-required = "num-test-threads"
 [test-groups]
 vm = { max-threads = 1 }
 
+# For chasing a hang, where the question is *which* tests wedge rather than what they report.
+#
+# Both bounds are deliberately impatient. `slow-timeout` reaps a test after 10s so that one hang
+# stops hiding every test queued behind it -- the default profile has no `terminate-after` at all,
+# so a single wedged test blocks the run until you notice, and `cross-qemu`'s 60s x 5 still costs
+# five minutes per hang. `global-timeout` then caps the whole run, because a suite of hangs
+# otherwise outlasts anyone's patience.
+#
+# Not for judging results: 10s will reap a legitimately slow test, and several of the model-checked
+# properties take longer than that when they are working. Use it to get the list, then re-run the
+# named test on a profile that gives it room.
+[profile.scratch]
+slow-timeout = { period = "10s", terminate-after = 1 }
+global-timeout = "300s"
+fail-fast = false
+final-status-level = "all"
+
 [profile.miri]
 slow-timeout = { period = "500s" }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ version = "0.27.0"
 dependencies = [
  "arc-swap",
  "dataplane-concurrency",
- "left-right 0.11.7",
+ "left-right 0.11.8 (git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle)",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ version = "0.27.0"
 dependencies = [
  "ahash",
  "dataplane-concurrency",
- "left-right 0.11.7",
+ "left-right 0.11.8 (git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle)",
  "serial_test",
  "thiserror",
 ]
@@ -1795,7 +1795,7 @@ dependencies = [
  "etherparse",
  "fixin",
  "indenter",
- "left-right 0.11.7",
+ "left-right 0.11.8 (git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle)",
  "linkme",
  "rand 0.10.2",
  "roaring",
@@ -1889,7 +1889,7 @@ dependencies = [
  "iai-callgrind",
  "inotify",
  "ipnet",
- "left-right 0.11.7",
+ "left-right 0.11.8 (git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle)",
  "linkme",
  "mio",
  "netdev",
@@ -1991,7 +1991,7 @@ dependencies = [
  "ahash",
  "bolero",
  "dataplane-net",
- "left-right 0.11.7",
+ "left-right 0.11.8 (git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle)",
  "serde",
  "thiserror",
 ]
@@ -2293,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2332,7 +2332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
 dependencies = [
  "hashbag",
- "left-right 0.11.8",
+ "left-right 0.11.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
 ]
 
@@ -3516,8 +3516,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "left-right"
-version = "0.11.7"
-source = "git+https://github.com/githedgehog/left-right.git?branch=fredi%2Ffix-writehandle-drop#765813aa25c8328746e93a7a5ccc75deb57b1d80"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc015ded5d9b3054dbbdb63332cdd6ee42352ccef19e911e25117490e2f48ee"
 dependencies = [
  "crossbeam-utils",
  "loom",
@@ -3527,11 +3528,11 @@ dependencies = [
 [[package]]
 name = "left-right"
 version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc015ded5d9b3054dbbdb63332cdd6ee42352ccef19e911e25117490e2f48ee"
+source = "git+https://github.com/githedgehog/left-right.git?branch=hh%2Fshuttle#8e8d1eaef4f22220ac115e551541967c706b361f"
 dependencies = [
  "crossbeam-utils",
  "loom",
+ "shuttle",
  "slab",
 ]
 
@@ -4089,7 +4090,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5128,7 +5129,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5185,7 +5186,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5860,10 +5861,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5882,7 +5883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6600,7 +6601,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,15 @@ kanal = { version = "0.1.1", default-features = false, features = [] }
 kube = { version = "4.2.0", default-features = false, features = [] }
 kube-core = { version = "4.2.0", default-features = false, features = [] }
 #left-right = { version = "0.11.7", default-features = false, features = [] }
-left-right = { git = "https://github.com/githedgehog/left-right.git", branch = "fredi/fix-writehandle-drop", default-features = false, features = [] }
+# `hh/shuttle`, which sits on upstream `main` and carries one commit: a shuttle arm in
+# `WriteHandle::wait`'s busy-wait. Without it the writer backs off to a bare `sched_yield`,
+# which shuttle does not instrument and so does not treat as a scheduling point, and the
+# reader whose epoch it waits on -- a green thread on the same OS thread -- can never run.
+# That livelocks `ci::shuttle` rather than failing it.
+#
+# It replaces `fredi/fix-writehandle-drop`, which is now dead weight: upstream `main` carries
+# that `WriteHandle::drop` fix character-for-character, and so does released 0.11.8.
+left-right = { git = "https://github.com/githedgehog/left-right.git", branch = "hh/shuttle", default-features = false, features = [] }
 libc = { version = "0.2.189", default-features = false, features = [] }
 linkme = { version = "0.3.37", default-features = false, features = [] }
 log = { version = "0.4.34", default-features = false, features = [] } # TODO: try to remove this

--- a/acl-filter/src/context.rs
+++ b/acl-filter/src/context.rs
@@ -402,35 +402,18 @@ impl<K: MatchKey, A> fmt::Debug for AnyTable<K, A> {
     }
 }
 
-concurrency::with_std! {
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+// A process-unique sequence for rte_acl context names. This is deliberately *not* scheduled:
+// the registry it feeds is rte_acl's own, which is process-global and outlives any model-checker
+// execution, so a facade atomic here would restart at zero on the second execution and collide.
+// It used to be spelled three times -- `with_std!` on the facade, `with_loom!` and
+// `with_shuttle!` on raw `std::sync` with four suppressions -- because there was no name for
+// "process-lifetime on purpose". There is now.
+use concurrency::process_global::atomic::{AtomicU64, Ordering};
 
-    static TABLE_SEQ: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+static TABLE_SEQ: AtomicU64 = AtomicU64::new(0);
 
-    fn next_in_sequence() -> u64 {
-        TABLE_SEQ.fetch_add(1, Ordering::Relaxed)
-    }
-}
-
-concurrency::with_loom! {
-    // nosemgrep: rust-no-direct-std-sync-import
-    static TABLE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-    fn next_in_sequence() -> u64 {
-        // nosemgrep: rust-no-direct-std-sync-import
-        TABLE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
-concurrency::with_shuttle! {
-    // nosemgrep: rust-no-direct-std-sync-import
-    static TABLE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-    fn next_in_sequence() -> u64 {
-        // nosemgrep: rust-no-direct-std-sync-import
-        TABLE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    }
+fn next_in_sequence() -> u64 {
+    TABLE_SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
 /// A process-unique rte_acl context name. rte_acl rejects duplicate names, and a hot-swap briefly

--- a/acl-filter/src/nf_fuzz.rs
+++ b/acl-filter/src/nf_fuzz.rs
@@ -91,7 +91,7 @@ fn filter(built: &crate::fuzz_gen::BuiltOverlay) -> AclFilter {
 fn judged(drawn: usize) -> bool {
     /// Sixteen cases' worth: far under any real run, far over a single replay.
     const ENOUGH_PROBES: usize = PROBES * 16;
-    !cfg!(instrumented) && !cfg!(emulated) && drawn >= ENOUGH_PROBES
+    !cfg!(instrumented) && !cfg!(emulated) && !cfg!(sanitized) && drawn >= ENOUGH_PROBES
 }
 
 #[derive(Default)]

--- a/acl-filter/src/tests.rs
+++ b/acl-filter/src/tests.rs
@@ -964,7 +964,7 @@ mod end_to_end {
         // Port forwarding
         let mut portfw_writer = PortFwTableWriter::new();
         portfw_writer
-            .update_from_vpc_table(overlay.vpc_table())
+            .update_from_vpc_table(overlay.vpc_table(), &flow_table, 1)
             .unwrap();
         pipeline = pipeline.add_stage(PortForwarder::new(
             "port-forwarder",

--- a/acl/benches/table_build.rs
+++ b/acl/benches/table_build.rs
@@ -7,8 +7,8 @@
 mod bench {
     use std::hint::black_box;
 
+    use concurrency::process_global::atomic::{AtomicU32, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU32, Ordering};
     use core::net::{Ipv4Addr, Ipv6Addr};
     use core::num::NonZero;
 

--- a/acl/src/dpdk/dyn_table.rs
+++ b/acl/src/dpdk/dyn_table.rs
@@ -431,8 +431,8 @@ mod failing_repros {
             offset,
         }
     }
+    use concurrency::process_global::atomic::{AtomicU32, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU32, Ordering};
 
     // Lazily initialized so this compiles under the loom backend, whose AtomicU32::new is not const
     static SEQ: LazyLock<AtomicU32> = LazyLock::new(|| AtomicU32::new(0));
@@ -507,8 +507,8 @@ mod tests {
 
     dpdk_table_alias!(type FiveTupleTable<A> = FiveTuple);
 
+    use concurrency::process_global::atomic::{AtomicU32, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU32, Ordering};
 
     // Lazily initialized so this compiles under the loom backend, whose AtomicU32::new is not const
     static CTX_SEQ: LazyLock<AtomicU32> = LazyLock::new(|| AtomicU32::new(0));

--- a/acl/tests/property_dyn_shape.rs
+++ b/acl/tests/property_dyn_shape.rs
@@ -4,8 +4,8 @@
 #![cfg(feature = "dpdk")]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+use concurrency::process_global::atomic::{AtomicU32, AtomicU64, Ordering};
 use concurrency::sync::LazyLock;
-use concurrency::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use core::num::NonZero;
 
 use bolero::TypeGenerator;

--- a/acl/tests/property_predicate.rs
+++ b/acl/tests/property_predicate.rs
@@ -4,8 +4,8 @@
 #![cfg(feature = "dpdk")]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+use concurrency::process_global::atomic::{AtomicU32, AtomicU64, Ordering};
 use concurrency::sync::LazyLock;
-use concurrency::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use core::net::{Ipv4Addr, Ipv6Addr};
 use core::num::NonZero;
 use core::ops::Bound;

--- a/config/src/external/overlay/vpcpeering.rs
+++ b/config/src/external/overlay/vpcpeering.rs
@@ -1868,7 +1868,7 @@ pub mod contract {
         //
         // Half the range rather than `usize::MAX`, which clippy reads as an absurd
         // comparison and rejects at the call sites.
-        const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) {
+        const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) || cfg!(sanitized) {
             usize::MAX / 2
         } else {
             200

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -1071,8 +1071,8 @@ impl<Buf: PacketBufferMut, F: Fn(&str, &Packet<Buf>) + 'static> NetworkFunction<
 
 mod contract {
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
 
     pub(super) static JUDGED: LazyLock<[AtomicU64; 4]> =
         LazyLock::new(|| std::array::from_fn(|_| AtomicU64::new(0)));
@@ -1356,8 +1356,8 @@ mod smoke {
 mod shapes {
     use super::*;
     use bolero::{Driver, ValueGenerator};
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::vpcpeering::contract::MasqueradeExposes;
     use lpm::prefix::Prefix;
     use net::headers::builder::ChainBase;
@@ -1596,8 +1596,8 @@ mod shapes {
 mod round_trip {
     use super::*;
     use bolero::{Driver, ValueGenerator};
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::vpcpeering::contract::MasqueradeExposes;
     use lpm::prefix::{Prefix, PrefixWithOptionalPorts};
     use net::headers::builder::HeaderStack;
@@ -1822,8 +1822,8 @@ mod round_trip {
 mod acl {
     use super::*;
     use bolero::{Driver, TypeGenerator, ValueGenerator};
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::acl::{
         Acl, AclAction, AclPattern, AclProtoMatch, AclRule, AclScope,
     };
@@ -2232,8 +2232,8 @@ mod port_forward {
     use super::round_trip::udp;
     use super::routed::{inside, tunnelled_from};
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::vpcpeering::VpcExpose;
     use lpm::prefix::{L4Protocol, PortRange, Prefix, PrefixWithOptionalPorts};
     use net::headers::TryVxlan;
@@ -2439,8 +2439,8 @@ mod port_forward {
 mod interleaved {
     use super::routed::{Blast, Conversation, Path, exposes};
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use std::ops::Bound::Included;
 
     const LOADS: usize = 6;
@@ -2602,8 +2602,8 @@ mod interleaved {
 mod offers {
     use super::derive::{Vary, loads_for};
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::vpcpeering::VpcExpose;
     use config::external::overlay::vpcpeering::contract::overlay_with_exposes;
     use lpm::prefix::{L4Protocol, PortRange, Prefix, PrefixWithOptionalPorts};
@@ -2782,8 +2782,8 @@ mod generated {
     use super::derive::{Named, Vary, loads_where};
     use super::*;
     use bolero::ValueGenerator;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::algebra::{Draft, Guard, Op, Sequence};
     use std::cell::Cell;
     use std::ops::Bound::Included;
@@ -3252,8 +3252,8 @@ mod burst {
     use super::round_trip::udp;
     use super::routed::{exposes, inside, tunnelled};
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use net::headers::TryVxlan;
 
     const BURST: usize = 8;
@@ -3559,8 +3559,8 @@ mod destination {
     use super::round_trip::udp;
     use super::routed::{inside, tunnelled};
     use super::*;
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use config::external::overlay::vpcpeering::contract::{overlay_with_peers, peer_vni};
     use lpm::prefix::Prefix;
     use net::headers::TryVxlan;
@@ -3700,8 +3700,8 @@ mod routed {
     use super::shapes::{Batch, Shape, aim, wire};
     use super::*;
     use super::{Load, drive};
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use net::buffer::TestBuffer;
     use net::headers::{TryEth, TryHeaders, TryHeadersMut, TryIpv4, TryVxlan};
     use net::ip::dscp::Dscp;
@@ -4509,9 +4509,9 @@ mod model {
     use super::derive::loads_carried;
     use super::routed::{Conversation, exposes, inner, inside, tunnelled};
     use super::*;
+    use concurrency::process_global::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use concurrency::process_global::{LazyLock, OnceLock};
     use concurrency::sync::Mutex;
-    use concurrency::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-    use concurrency::sync::{LazyLock, OnceLock};
     use concurrency::thread;
     #[cfg_attr(not(feature = "shuttle"), allow(unused_imports))]
     use concurrency::thread::BuilderExt;
@@ -6285,7 +6285,7 @@ mod model {
     #[ignore = "an instrument, not a property: prints one trace and asserts nothing"]
     #[allow(clippy::too_many_lines, reason = "one instrument, read top to bottom")]
     async fn report_why_the_masquerade_swap_disturbs_traffic() {
-        use concurrency::sync::atomic::AtomicBool;
+        use concurrency::process_global::atomic::AtomicBool;
         use config::external::overlay::algebra::{
             Draft, Flavour, Op, PeeringHandle, Side, VpcHandle,
         };

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -5283,6 +5283,13 @@ mod model {
         );
     }
 
+    #[cfg_attr(
+        any(feature = "shuttle", feature = "loom"),
+        allow(
+            clippy::unnecessary_wraps,
+            reason = "the model backends have no unwinding arm, so only this cfg is infallible"
+        )
+    )]
     fn without_unwinding<T>(body: impl FnOnce() -> T) -> Result<T, String> {
         cfg_select! {
             feature = "shuttle" => Ok(body()),

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -4631,6 +4631,279 @@ mod routed {
 }
 
 #[cfg(test)]
+mod icmp_error {
+    use super::routed::{exposes, inside, tunnelled, tunnelled_from};
+    use super::*;
+    use concurrency::process_global::LazyLock;
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
+    use net::flows::FlowInfo;
+    use net::headers::{TryEth, TryHeaders};
+    use net::icmp4::Icmp4DestUnreachable;
+    use net::packet::test_utils::build_icmp4_error_quoting;
+    use net::parse::DeParse;
+    use std::net::Ipv4Addr;
+
+    const PEER: &str = "3.3.3.1";
+
+    /// One case: a flow to open, and how the router on the far side quotes it back at us.
+    #[derive(Debug, Clone, Copy, bolero::TypeGenerator)]
+    struct Reported {
+        host: u8,
+        sport: u16,
+        dport: u16,
+        quoted: Quoted,
+        code: Code,
+        /// Quote the flow we opened, or a datagram shaped like it that names no flow at all.
+        names_a_live_flow: bool,
+    }
+
+    /// How much of the offending datagram the far-side router put in the quote.
+    ///
+    /// RFC 792 asks for the IP header plus eight octets and RFC 1812 asks for as much as will
+    /// fit, so everything from "the whole datagram" down to "not even a full IP header" is on
+    /// the wire somewhere, and each length is a different walk through the embedded parser.
+    /// `First` is the one that matters: a plain "trim n octets from the end" never reaches a
+    /// header boundary, because the datagrams this fixture emits are the better part of two
+    /// kilobytes and `n` is a byte.
+    #[derive(Debug, Clone, Copy, bolero::TypeGenerator)]
+    enum Quoted {
+        Whole,
+        First(u8),
+        AllBut(u8),
+    }
+
+    impl Quoted {
+        fn of(self, datagram: &[u8]) -> &[u8] {
+            let keep = match self {
+                Quoted::Whole => datagram.len(),
+                Quoted::First(n) => (n as usize).min(datagram.len()),
+                Quoted::AllBut(n) => datagram.len().saturating_sub(n as usize),
+            };
+            &datagram[..keep]
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, bolero::TypeGenerator)]
+    enum Code {
+        Network,
+        Host,
+        Protocol,
+        Port,
+        FragmentationNeeded,
+    }
+
+    impl From<Code> for Icmp4DestUnreachable {
+        fn from(code: Code) -> Self {
+            match code {
+                Code::Network => Icmp4DestUnreachable::Network,
+                Code::Host => Icmp4DestUnreachable::Host,
+                Code::Protocol => Icmp4DestUnreachable::Protocol,
+                Code::Port => Icmp4DestUnreachable::Port,
+                Code::FragmentationNeeded => Icmp4DestUnreachable::FragmentationNeeded {
+                    next_hop_mtu: Some(1400.try_into().unwrap_or_else(|_| unreachable!())),
+                },
+            }
+        }
+    }
+
+    /// A packet's bytes from its IP header onwards -- what a router quotes back at you.
+    fn datagram(packet: Packet<TestBuffer>) -> Option<Vec<u8>> {
+        let eth = packet.headers().try_eth()?.size().get() as usize;
+        let wire = packet.serialize().ok()?;
+        Some(wire.as_ref().get(eth..)?.to_vec())
+    }
+
+    fn v4(addr: IpAddr) -> Option<Ipv4Addr> {
+        match addr {
+            IpAddr::V4(addr) => Some(addr),
+            IpAddr::V6(_) => None,
+        }
+    }
+
+    fn peer() -> IpAddr {
+        PEER.parse().unwrap_or_else(|_| unreachable!())
+    }
+
+    /// Open a flow and hand back the frame the gateway put on the wire for it.
+    fn open(fabric: &mut Fabric, host: u8, sport: u16, dport: u16) -> Option<Packet<TestBuffer>> {
+        let src: IpAddr = format!("1.1.0.{host}")
+            .parse()
+            .unwrap_or_else(|_| unreachable!());
+        let request = super::round_trip::udp(src, peer(), sport, dport)?;
+        let out = fabric.send(tunnelled(&request));
+        matches!(verdict(&out), Verdict::Delivered { .. }).then_some(out)
+    }
+
+    fn live(fabric: &Fabric) -> Vec<Arc<FlowInfo>> {
+        fabric
+            .fleet()
+            .blueprint()
+            .flow_table
+            .snapshot(|_, flow| flow.is_active())
+            .collect()
+    }
+
+    /// What one case did, for the coverage guards to add up.
+    struct Outcome {
+        refused: bool,
+        tore_down: bool,
+        named_nobody: bool,
+    }
+
+    /// Open a flow, have the far side quote it back as an ICMP error, and see what happens.
+    ///
+    /// `None` when the case could not be set up -- an address or port the fixture will not
+    /// accept, a quote too mangled to assemble. Those are skipped rather than failed; the
+    /// coverage guards on the caller are what notice if too many of them are.
+    fn run_case(reported: &Reported) -> Option<Outcome> {
+        let &Reported {
+            host,
+            sport,
+            dport,
+            quoted,
+            code,
+            names_a_live_flow,
+        } = reported;
+        // A bystander on the same peering, opened first and never mentioned again. Its flows are
+        // what the containment assertion is about: an ICMP error is entitled to the pair it
+        // names and to nothing else.
+        let bystander = host.wrapping_add(1);
+        if bystander == host {
+            return None;
+        }
+
+        let mut fabric = Fabric::routed(&exposes(), None)?;
+        open(&mut fabric, bystander, 1024, 53)?;
+        let watched = live(&fabric);
+        if watched.is_empty() {
+            return None;
+        }
+        let delivered = open(&mut fabric, host, sport, dport)?;
+        let public = v4(delivered
+            .ip_source()
+            .unwrap_or_else(|| unreachable!("a delivered frame has a source")))?;
+
+        let offending = if names_a_live_flow {
+            inside(&delivered)?
+        } else {
+            // The same shape and the same public address, on a port the allocator has not handed
+            // out, so the reversed key misses the table entirely.
+            super::round_trip::udp(IpAddr::V4(public), peer(), sport ^ 0x8000, dport)?
+        };
+        let bytes = datagram(offending)?;
+        let peer_v4: Ipv4Addr = PEER.parse().unwrap_or_else(|_| unreachable!());
+        let error = build_icmp4_error_quoting(code.into(), peer_v4, public, quoted.of(&bytes))?;
+
+        let out = fabric.send(tunnelled_from(vni(REMOTE_VNI), &error));
+        let survivors = live(&fabric);
+
+        for flow in &watched {
+            assert!(
+                flow.is_active(),
+                "an icmp error quoting {}another flow invalidated a bystander's flow {}. Only \
+                 the pair the quote names may be torn down; the reversed embedded key is what \
+                 picks it, so a miss there must let the packet by, not take the nearest flow \
+                 with it",
+                if names_a_live_flow {
+                    ""
+                } else {
+                    "nothing, and "
+                },
+                flow.flowkey()
+            );
+        }
+
+        Some(Outcome {
+            refused: matches!(
+                verdict(&out),
+                Verdict::Dropped(DoneReason::IcmpErrorIncomplete)
+            ),
+            tore_down: survivors.len() < watched.len() + 2,
+            named_nobody: !names_a_live_flow,
+        })
+    }
+
+    /// An ICMP error quoting any prefix of a live flow is judged, and judges only that flow.
+    ///
+    /// The handler had never been driven by a generated packet. `fn stack` emits an ICMP header
+    /// with an error type and no quoted datagram at all, so every generated case died in
+    /// `IcmpErrorPacket::new`, and four of the handler's six outcomes were reached zero times by
+    /// the entire suite -- measured, not guessed. What gets past that gate is quoting a datagram
+    /// the pipeline really emitted for a flow it really holds, which is free: the fixture has
+    /// one in hand the moment the request is delivered.
+    ///
+    /// The coverage guards below are the point as much as the assertion is. Without them this
+    /// property would go on passing after a change that put it back to generating quotes nothing
+    /// can parse, which is exactly how the gap it closes came to exist.
+    #[tokio::test]
+    #[dpdk::with_eal]
+    async fn an_icmp_error_quoting_a_live_flow_judges_that_flow_and_no_other() {
+        static HANDLED: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+        static REFUSED: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+        static TORE_DOWN: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+        static SPARED: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+        static NAMED_NOBODY: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+
+        bolero::check!()
+            .with_max_len(MAX_INPUT_LEN)
+            .with_type::<Reported>()
+            .for_each(|reported| {
+                let Some(outcome) = run_case(reported) else {
+                    return;
+                };
+                if outcome.refused {
+                    REFUSED.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    HANDLED.fetch_add(1, Ordering::Relaxed);
+                }
+                if outcome.tore_down {
+                    TORE_DOWN.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    SPARED.fetch_add(1, Ordering::Relaxed);
+                }
+                if outcome.named_nobody {
+                    NAMED_NOBODY.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+
+        let (handled, refused) = (
+            HANDLED.load(Ordering::Relaxed),
+            REFUSED.load(Ordering::Relaxed),
+        );
+        let (tore_down, spared, nobody) = (
+            TORE_DOWN.load(Ordering::Relaxed),
+            SPARED.load(Ordering::Relaxed),
+            NAMED_NOBODY.load(Ordering::Relaxed),
+        );
+        eprintln!(
+            "handled={handled} refused={refused} tore-down={tore_down} spared={spared} \
+             named-nobody={nobody}"
+        );
+        super::assert_covered(
+            handled > 0,
+            "every quote was refused, so the handler was never driven -- the exact state this \
+             property exists to keep from returning",
+        );
+        super::assert_covered(
+            refused > 0,
+            "no quote was ever short enough to refuse, so the truncation is not being generated",
+        );
+        super::assert_covered(
+            tore_down > 0,
+            "no icmp error ever tore a flow down, so the teardown path is still unexercised",
+        );
+        super::assert_covered(
+            spared > 0,
+            "every icmp error tore a flow down, so nothing exercised the sparing path",
+        );
+        super::assert_covered(
+            nobody > 0,
+            "no quote ever named a flow that does not exist, so the miss path is unexercised",
+        );
+    }
+}
+
+#[cfg(test)]
 mod model {
     use super::derive::loads_carried;
     use super::routed::{Conversation, exposes, inner, inside, tunnelled};

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -120,7 +120,7 @@ impl Fleet {
 
         let mut portfw = PortFwTableWriter::new();
         portfw
-            .update_from_vpc_table(overlay.vpc_table())
+            .update_from_vpc_table(overlay.vpc_table(), &flow_table, FIRST_GENID)
             .expect("a validated overlay lowers to port forwarding");
 
         let mut masquerade = NatAllocatorWriter::new();
@@ -213,7 +213,11 @@ impl Fleet {
         if doing(Enact::PortForward) {
             self.portfw
                 .borrow_mut()
-                .update_from_vpc_table(overlay.vpc_table())
+                .update_from_vpc_table(
+                    overlay.vpc_table(),
+                    &self.blueprint.flow_table,
+                    self.genid.get(),
+                )
                 .expect("a validated overlay lowers to port forwarding");
         }
         if doing(Enact::Generation) {
@@ -2171,9 +2175,13 @@ mod acl {
         )
     }
 
+    /// Port forwarding did not migrate its own flows, so a port-forwarded connection lost its
+    /// flow-scoped `Allow` the moment *any* configuration was enacted -- however unrelated, a
+    /// byte-for-byte re-enactment included. `AclFilter` runs before `PortForwarder` and refuses a
+    /// flow a generation behind, so the stage that could have revalidated it never saw the reply.
     #[tokio::test]
     #[dpdk::with_eal]
-    async fn a_port_forwarded_flow_loses_its_acl_permission_on_any_configuration_change() {
+    async fn a_port_forwarded_flow_keeps_its_acl_permission_across_a_configuration_change() {
         let acl = flow_scoped_permit();
         let overlay = overlay_with_exposes_and_acl(forwarding(), Some(&acl))
             .expect("the fixture assembles")
@@ -2219,13 +2227,12 @@ mod acl {
         fabric.fleet().enact(&overlay, Enact::Everything);
 
         let after = answer(&mut fabric);
-        assert_eq!(
-            after,
-            Verdict::Dropped(DoneReason::AclDropped),
-            "a port-forwarded flow kept its acl permission across a configuration change. If \
-             `update_nat_allocator`'s generation upgrade now covers port-forwarded flows, this \
-             test has served its purpose -- delete it, and stop excluding flow-scoped peerings \
-             from `a_configuration_change_leaves_traffic_outside_its_footprint_alone`"
+        assert!(
+            matches!(after, Verdict::Forwarded { .. }),
+            "a port-forwarded flow lost its acl permission to a configuration change that did \
+             not touch it: {after:?}. `migrate_port_forwarded_flows` is what carries it, and it \
+             runs from `PortFwTableWriter::update_table_and_flows` -- check the enactment still \
+             calls that rather than bare `update_table`"
         );
     }
 
@@ -4584,7 +4591,7 @@ mod model {
     use concurrency::thread;
     #[cfg_attr(not(feature = "shuttle"), allow(unused_imports))]
     use concurrency::thread::BuilderExt;
-    use config::external::overlay::algebra::{Draft, Footprint, Guard, Sequence};
+    use config::external::overlay::algebra::{Draft, Footprint, Sequence};
     use net::packet::test_utils::build_test_udp_ipv4_packet;
 
     type Tuple = (Option<IpAddr>, Option<u16>);
@@ -5992,7 +5999,6 @@ mod model {
             let carried = derive::carried_by(draft);
             move |named| {
                 carried(named)
-                    && draft.guard_named(named.peering) != Some(Guard::PermitFlow)
                     && !footprint.touches_peering_named(named.peering)
                     && !footprint.touches_vpc_named(named.local)
                     && !footprint.touches_vpc_named(named.remote)

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -77,7 +77,7 @@ pub(crate) struct Blueprint {
     pipeline: Arc<PipelineData>,
     underlay: Option<Underlay>,
     flow_table: Arc<FlowTable>,
-    declared: Arc<[Prefix]>,
+    declared: Arc<[DeclaredPool]>,
 }
 
 struct Underlay {
@@ -143,7 +143,7 @@ impl Fleet {
                 adjacencies: tables.adjacency_factory(),
             }),
             flow_table,
-            declared: declared_public_ranges(overlay),
+            declared: declared_pools(overlay),
         };
 
         Self {
@@ -573,9 +573,9 @@ fn assert_covered(covered: bool, what: &str) {
 #[derive(Default)]
 pub(crate) struct Translations {
     was: std::collections::HashMap<u64, net::FlowKey>,
-    from: std::collections::HashMap<u64, IpAddr>,
+    from: std::collections::HashMap<u64, (IpAddr, Option<VpcDiscriminant>)>,
     given: std::collections::HashMap<net::FlowKey, (IpAddr, u16)>,
-    declared: Arc<[Prefix]>,
+    declared: Arc<[DeclaredPool]>,
 }
 
 #[cfg(test)]
@@ -590,7 +590,7 @@ impl Translations {
         };
         self.was.insert(test.id, key);
         if let Some(source) = packet.ip_source() {
-            self.from.insert(test.id, source);
+            self.from.insert(test.id, (source, packet.meta().dst_vpcd));
         }
     }
 
@@ -616,15 +616,16 @@ impl Translations {
             );
         }
 
-        if self
-            .from
-            .get(&test.id)
-            .is_some_and(|before| *before != source)
+        if let Some((before, towards)) = self.from.get(&test.id).copied()
+            && before != source
         {
             assert!(
-                self.declared.iter().any(|p| p.covers_addr(&source)),
-                "{at}: masquerade rewrote a source to {source}, which no declared public range \
-                 covers"
+                self.declared
+                    .iter()
+                    .any(|pool| pool.admits(before, source, towards)),
+                "{at}: masquerade rewrote {before} to {source} on the way to {towards:?}, which \
+                 is not a pool any expose publishing {before} declares towards that vpc; the \
+                 flow emerged on some other expose's pool"
             );
         }
     }
@@ -635,7 +636,7 @@ impl Translations {
         self.given.clear();
     }
 
-    fn declaring(declared: &Arc<[Prefix]>) -> Self {
+    fn declaring(declared: &Arc<[DeclaredPool]>) -> Self {
         Self {
             declared: declared.clone(),
             ..Self::default()
@@ -643,19 +644,68 @@ impl Translations {
     }
 }
 
+/// One expose's private side, and the public side a source from it may be rewritten to.
+///
+/// Kept as pairs rather than flattened into one list of public prefixes. Flattening asks only
+/// whether *some* expose in the overlay declares the address a source was rewritten to, which
+/// accepts a flow emerging on an unrelated tenant's pool -- the containment failure actually
+/// worth finding. Binding the two ends together means the pool has to be one the address being
+/// translated is entitled to.
 #[cfg(test)]
-fn declared_public_ranges(overlay: &ValidatedOverlay) -> Arc<[Prefix]> {
+pub(crate) struct DeclaredPool {
+    private: Vec<Prefix>,
+    public: Vec<Prefix>,
+    /// The vpc this expose publishes *towards*. A vpc that exposes the same addresses to two
+    /// peers under two pools is entitled to only one of them per destination, so without this
+    /// the check would still accept a flow drawn from the pool meant for the other peer.
+    towards: Option<VpcDiscriminant>,
+}
+
+#[cfg(test)]
+impl DeclaredPool {
+    /// Whether this expose is the one that would rewrite `private` to `public` on the way to
+    /// `towards`. An unknown destination falls back to the addresses alone -- it is the
+    /// flow-filter's job to place a packet, and a packet it has not placed is not this
+    /// assertion's to judge.
+    fn admits(&self, private: IpAddr, public: IpAddr, towards: Option<VpcDiscriminant>) -> bool {
+        (towards.is_none() || self.towards.is_none() || self.towards == towards)
+            && self.private.iter().any(|p| p.covers_addr(&private))
+            && self.public.iter().any(|p| p.covers_addr(&public))
+    }
+}
+
+#[cfg(test)]
+fn declared_pools(overlay: &ValidatedOverlay) -> Arc<[DeclaredPool]> {
+    fn prefixes<'a, S>(set: S) -> Vec<Prefix>
+    where
+        S: IntoIterator<Item = &'a lpm::prefix::PrefixWithOptionalPorts>,
+    {
+        set.into_iter()
+            .map(lpm::prefix::PrefixWithOptionalPorts::prefix)
+            .collect()
+    }
+
+    let discriminant = |name: &str| {
+        overlay
+            .vpc_table()
+            .values()
+            .find(|vpc| vpc.name() == name)
+            .map(|vpc| VpcDiscriminant::VNI(vpc.vni()))
+    };
+
     let mut declared = Vec::new();
     for vpc in overlay.vpc_table().values() {
         for peering in vpc.peerings() {
-            for manifest in [peering.local(), peering.remote()] {
-                for expose in manifest.valexp() {
-                    declared.extend(
-                        expose
-                            .public_ips()
-                            .into_iter()
-                            .map(lpm::prefix::PrefixWithOptionalPorts::prefix),
-                    );
+            let (local, remote) = (peering.local(), peering.remote());
+            // Each manifest publishes towards the vpc named by the *other* one.
+            for (mine, theirs) in [(local, remote), (remote, local)] {
+                let towards = discriminant(theirs.name());
+                for expose in mine.valexp() {
+                    declared.push(DeclaredPool {
+                        private: prefixes(expose.ips()),
+                        public: prefixes(expose.public_ips()),
+                        towards,
+                    });
                 }
             }
         }

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -5484,6 +5484,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn an_icmp_teardown_leaves_another_workers_flow_alone() {
         const CASES: usize = 64;
 
@@ -5781,6 +5786,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn a_next_hop_that_moves_is_never_seen_half_moved() {
         const CASES: usize = 64;
 

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -201,6 +201,9 @@ impl Fleet {
         }
         if doing(Enact::Masquerade) {
             self.genid.set(self.genid.get() + 1);
+            // `mgmt` opens the generation for stamping here, immediately before the first walk
+            // that migrates flows into it and long before `Enact::Generation` enforces it.
+            self.blueprint.pipeline.open_generation(self.genid.get());
             self.masquerade.borrow_mut().update_nat_allocator(
                 MasqueradeConfig::new(overlay.vpc_table()).set_randomize(self.randomize.get()),
                 self.genid.get(),
@@ -2223,6 +2226,72 @@ mod acl {
              `update_nat_allocator`'s generation upgrade now covers port-forwarded flows, this \
              test has served its purpose -- delete it, and stop excluding flow-scoped peerings \
              from `a_configuration_change_leaves_traffic_outside_its_footprint_alone`"
+        );
+    }
+
+    /// A configuration apply is not atomic: `mgmt` installs every table, migrates the flows of
+    /// the previous generation, and only then publishes the new generation id. A flow opened in
+    /// between was admitted by the new tables but used to stamp itself from the generation still
+    /// published, so the publish immediately made it look like a leftover of the generation
+    /// before -- and the ACL dropped its reply. Nothing rescues a port-forwarded flow from that:
+    /// unlike a masqueraded one it is never re-stamped from the allocator's generation, and the
+    /// ACL runs ahead of the port-forwarder, so the reply dies before the stage that would fix it.
+    #[tokio::test]
+    #[dpdk::with_eal]
+    async fn a_flow_opened_while_a_configuration_is_applied_survives_the_publish() {
+        let acl = flow_scoped_permit();
+        let overlay = overlay_with_exposes_and_acl(forwarding(), Some(&acl))
+            .expect("the fixture assembles")
+            .validate()
+            .expect("a port-forwarding side accepts a flow-scoped rule");
+        let mut fabric = Fabric::over(&overlay, None, Arc::new(FlowTable::default()));
+
+        // Re-enact the running configuration, stopping short of publishing the generation. This
+        // is the state `mgmt` is in from its first table swap until its last statement.
+        for step in [
+            Enact::FlowFilter,
+            Enact::Acl,
+            Enact::StaticNat,
+            Enact::Masquerade,
+            Enact::PortForward,
+        ] {
+            fabric.fleet().enact(&overlay, step);
+        }
+
+        let advertised: IpAddr = "172.16.0.5".parse().unwrap_or_else(|_| unreachable!());
+        let outside = peer(advertised);
+
+        // Open the flow inside the window.
+        let mut request = super::round_trip::udp(outside, advertised, 40000, 2003)
+            .expect("a well-formed request");
+        arrive(&mut request, remote());
+        let arrived = fabric.send(request);
+        let Verdict::Forwarded {
+            dst: Some(inside), ..
+        } = verdict(&arrived)
+        else {
+            panic!(
+                "the request never reached the service mid-apply: {:?}",
+                verdict(&arrived)
+            );
+        };
+        let inside_port = arrived
+            .transport_dst_port()
+            .expect("a forwarded request has a destination port");
+
+        // Close the apply.
+        fabric.fleet().enact(&overlay, Enact::Generation);
+
+        let mut answer = super::round_trip::udp(inside, outside, inside_port.get(), 40000)
+            .expect("a well-formed answer");
+        arrive(&mut answer, local());
+        let after = verdict(&fabric.send(answer));
+        assert!(
+            matches!(after, Verdict::Forwarded { .. }),
+            "a flow opened while the configuration was being applied was stale the moment the \
+             apply finished, and its answer was refused: {after:?}. The generation a new flow \
+             stamps itself with must be opened before the migration walks, not published after \
+             them -- see `PipelineData::open_generation`"
         );
     }
 }

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -541,11 +541,14 @@ fn assert_within_budget<G: bolero::ValueGenerator>(name: &str, generator: &G) {
 
 #[cfg(test)]
 fn assert_covered(covered: bool, what: &str) {
-    if (cfg!(instrumented) || cfg!(emulated)) && !covered {
-        // Coverage and emulation are both slow enough per case that bolero's
-        // budget buys a sample too small for "did anything reach this branch"
-        // to mean anything: qemu-user gets a couple of orders of magnitude
-        // fewer cases than a native run, and instrumentation is not far behind.
+    if (cfg!(instrumented) || cfg!(emulated) || cfg!(sanitized)) && !covered {
+        // Coverage, emulation and the sanitizers are all slow enough per case
+        // that bolero's budget buys a sample too small for "did anything reach
+        // this branch" to mean anything: qemu-user gets a couple of orders of
+        // magnitude fewer cases than a native run, and instrumentation is not
+        // far behind. A sanitizer keeps every iteration -- deliberately, races
+        // need them -- but bolero still stops on wall-clock, so the sample is
+        // just as small and this guard would be judging the sanitizer.
         // Say so and carry on -- the point of those runs is the line counts and
         // the target's own behaviour, and failing here loses both.
         eprintln!("{what} -- not asserted: too few cases under this build");

--- a/dataplane/src/packet_processor/fuzz.rs
+++ b/dataplane/src/packet_processor/fuzz.rs
@@ -4622,6 +4622,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn two_workers_are_not_given_the_same_public_tuple() {
         const CASES: usize = 64;
 
@@ -5595,6 +5600,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn re_enacting_a_configuration_under_load_disturbs_nothing() {
         const CASES: usize = 64;
 
@@ -5722,6 +5732,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn the_cli_can_be_read_while_the_dataplane_works() {
         const CASES: usize = 64;
 
@@ -5880,6 +5895,11 @@ mod model {
     }
 
     #[concurrency::model_test]
+    #[cfg_attr(
+        feature = "shuttle",
+        ignore = "walks the flow table, and dashmap's shard locks are real OS primitives that \
+                  park the single thread shuttle schedules its green threads onto"
+    )]
     fn a_configuration_change_leaves_traffic_outside_its_footprint_alone() {
         const CASES: usize = 64;
         const ROUNDS: u8 = 3;

--- a/default.nix
+++ b/default.nix
@@ -1431,7 +1431,7 @@ let
         cargoArtifacts = cargo-artifacts-tests;
         # `cargo test --doc` runs rustdoc, which does not inherit rustc's
         # registered cfg declarations either.
-        RUSTDOCFLAGS = "-D warnings --check-cfg=cfg(emulated) --check-cfg=cfg(instrumented)";
+        RUSTDOCFLAGS = "-D warnings --check-cfg=cfg(emulated) --check-cfg=cfg(instrumented) --check-cfg=cfg(sanitized)";
         # The sandbox cannot resolve the runner's `/usr/bin/env bash` shebang.
         preBuild = "patchShebangs scripts/test-runner.sh";
         buildPhaseCargoCommand = builtins.concatStringsSep " " (
@@ -1466,7 +1466,7 @@ let
         inherit pname;
         cargoArtifacts = cargo-artifacts;
         # Rustdoc does not inherit rustc's registered cfg declarations.
-        RUSTDOCFLAGS = "-D warnings --check-cfg=cfg(emulated) --check-cfg=cfg(instrumented)";
+        RUSTDOCFLAGS = "-D warnings --check-cfg=cfg(emulated) --check-cfg=cfg(instrumented) --check-cfg=cfg(sanitized)";
         buildPhaseCargoCommand = builtins.concatStringsSep " " (
           [
             "cargo"

--- a/default.nix
+++ b/default.nix
@@ -98,19 +98,25 @@ let
     profile = profile';
     platform = platform';
   };
+  # The package set as instantiated for the *build machine*, before any cross
+  # target is chosen. `pkgs.pkgsBuildHost` is not the same thing: a cross set's
+  # notion of its build host is a distinct instantiation, so a build-machine
+  # tool taken from it is a different derivation for every target -- built from
+  # source once per platform rather than once, ever.
+  native-pkgs = import sources.nixpkgs {
+    overlays = [
+      overlays.rust
+      overlays.llvm
+      overlays.dataplane
+      overlays.dataplane-dev
+      overlays.frr
+    ];
+  };
   pkgs =
-    let
-      over = import sources.nixpkgs {
-        overlays = [
-          overlays.rust
-          overlays.llvm
-          overlays.dataplane
-          overlays.dataplane-dev
-          overlays.frr
-        ];
-      };
-    in
-    if platform != "wasm32-wasip1" then over.pkgsCross.${platform'.info.nixarch} else over;
+    if platform != "wasm32-wasip1" then
+      native-pkgs.pkgsCross.${platform'.info.nixarch}
+    else
+      native-pkgs;
   sysroot-stamp = ''
     printf '%s' '${builtins.concatStringsSep "," sanitizers}' > "$out/.sanitize"
     printf '%s' '${builtins.concatStringsSep "," instrumentations}' > "$out/.instrumentation"
@@ -227,11 +233,6 @@ let
       zizmor
     ]);
   };
-  # Whether the guest architecture (= the test binary's target arch, i.e.
-  # the nix host platform) differs from the build machine's arch.  When it
-  # does, the test VM is software-emulated (TCG) rather than KVM-accelerated.
-  is-cross-guest = platform'.arch != host-arch;
-
   # The bootable kernel image filename as linux-fancy emits it.
   # x86_64 produces a `bzImage`; aarch64 produces a raw `Image`.  Both are
   # installed into the manifest as `vmlinuz`, so nothing downstream has to
@@ -709,32 +710,18 @@ let
   # `nixosTestRunner = true` is nixpkgs' headless "boot a VM" profile: it
   # disables exactly those backends and its only other effect is a 9p
   # uid0 patch we never exercise (we mount via vhost-user-fs, not -virtfs).
+  # `qemu_test` is that profile, and it builds *every* `*-softmmu` target --
+  # `hostCpuTargets` defaults to `null`, which QEMU's configure reads as "all"
+  # -- so one derivation covers the guest arch whatever it is.
   #
-  # - Native guest: `qemu_test` (= `qemu_kvm` + `nixosTestRunner`): the
-  #   prebuilt, cache-hit, host-cpu-only emulator (`qemu-system-<host>`
-  #   with KVM).  Headless, so no gtk in the common (native) devroot.
-  # - Cross guest: the base `qemu`, headless and restricted to just the
-  #   targets we need: the guest `*-softmmu` we actually emulate under TCG
-  #   (e.g. `aarch64-softmmu`) plus the build-host `*-softmmu` (so QEMU's
-  #   `qemu-kvm` compat symlink -> `qemu-system-<host>` resolves; omitting
-  #   it trips the `noBrokenSymlinks` install check).  A genuine-cross
-  #   `pkgsBuildHost` qemu is not in the binary cache regardless (Hydra
-  #   never builds that derivation), so trimming targets + dropping the GUI
-  #   keeps that unavoidable build small.
-  #
-  # Both provide `bin/qemu-system-<arch>`, matching
-  # `n_vm::Arch::qemu_system_binary`.
-  qemu-system =
-    if is-cross-guest then
-      pkgs.pkgsBuildHost.qemu.override {
-        nixosTestRunner = true;
-        hostCpuTargets = [
-          "${host-arch}-softmmu"
-          "${platform'.arch}-softmmu"
-        ];
-      }
-    else
-      pkgs.pkgsBuildHost.qemu_test;
+  # Taken from `native-pkgs`, not `pkgs.pkgsBuildHost`. Both are the build
+  # machine's own binaries, but they are not the same derivation: a cross set's
+  # `pkgsBuildHost` is a distinct instantiation, so asking it for a host tool
+  # yields a path Hydra has never built. That is what made a cross test job
+  # compile QEMU from source -- and with it brltty and bluez, which QEMU pulls
+  # for its BrlAPI braille chardev. 110 derivations and 476 MiB of source for
+  # an emulator the binary cache already had.
+  qemu-system = native-pkgs.qemu_test;
 
   # Container-tier tools for the scratch-container test infrastructure.
   #
@@ -751,14 +738,14 @@ let
   # binaries and their transitive library dependencies.
   #
   # See development/ideam.md for the design rationale.
-  # NOTE: cloud-hypervisor and virtiofsd stay on `pkgsBuildHost` (they run
-  # on the x86 container host).  Only the kernel is host-arch; the qemu
-  # choice is arch-aware (see `qemu-system`).
+  # NOTE: the hypervisors and virtiofsd come from `native-pkgs` -- they run on
+  # the x86 container host, and `pkgsBuildHost` would give a per-target
+  # rebuild of each (see `qemu-system`).  Only the kernel is guest-arch.
   testroot = pkgs.symlinkJoin {
     name = "dataplane-test-root";
     paths = [
-      pkgs.pkgsBuildHost.cloud-hypervisor
-      pkgs.pkgsBuildHost.virtiofsd
+      native-pkgs.cloud-hypervisor
+      native-pkgs.virtiofsd
       qemu-system
       kernel-image
     ];

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -307,6 +307,14 @@ impl FlowTable {
 
         let previous = val.update_status(FlowStatus::Active);
 
+        // `dashmap`'s entry guard is a real `parking_lot` shard lock, so nothing inside this
+        // block may be a scheduling point: under shuttle every green thread shares one OS
+        // thread, and a preemption while the shard is held leaves the next thread to want that
+        // shard parked on a futex with nobody able to release it. `self.live` is a *facade*
+        // atomic -- checkable, and therefore schedulable -- so the count is bumped after the
+        // guard drops rather than under it. The window that opens is a `live` that lags one
+        // insert, which `live_len` already documents as no less exact than `DashMap::len`.
+        let mut counted = false;
         let found = match table.entry(*flow_key) {
             dashmap::Entry::Occupied(mut occupied) => {
                 if occupied.get().is_active() {
@@ -320,11 +328,14 @@ impl FlowTable {
                     Found::Refused(e)
                 } else {
                     vacant.insert(val.clone());
-                    self.live.fetch_add(1, Ordering::Relaxed);
+                    counted = true;
                     Found::Inserted(None)
                 }
             }
         };
+        if counted {
+            self.live.fetch_add(1, Ordering::Relaxed);
+        }
         let displaced = match found {
             Found::Inserted(displaced) => displaced,
             Found::Held(held) => {

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -38,6 +38,7 @@ pub struct FlowTable {
     // TODO(mvachhar) move this to a cross beam sharded lock
     pub(crate) table: Arc<RwLock<Table>>,
     capacity: AtomicUsize,
+    live: Arc<AtomicUsize>,
 }
 
 impl Default for FlowTable {
@@ -84,6 +85,7 @@ impl FlowTable {
                 num_shards,
             ))),
             capacity: AtomicUsize::new(Self::DEFAULT_CAPACITY),
+            live: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -170,7 +172,7 @@ impl FlowTable {
 
     /// Start a timer task for a flow
     #[allow(unused)]
-    fn start_timer(table: Arc<RwLock<Table>>, flow_info: Arc<FlowInfo>) {
+    fn start_timer(table: Arc<RwLock<Table>>, live: Arc<AtomicUsize>, flow_info: Arc<FlowInfo>) {
         tokio::task::spawn(async move {
             let table = table;
             let flow_key = flow_info.flowkey();
@@ -212,6 +214,8 @@ impl FlowTable {
                     let res = table.remove_if(flow_key, |_, v| Arc::ptr_eq(v, &flow_info));
                     if res.is_none() {
                         debug!("Flow-timer: Unable to remove flow {flow_key}: not found");
+                    } else {
+                        live.fetch_sub(1, Ordering::Relaxed);
                     }
                     return;
                 }
@@ -224,8 +228,8 @@ impl FlowTable {
         });
     }
 
-    fn admit(&self, table: &Table, val: &Arc<FlowInfo>) -> Result<(), FlowTableError> {
-        self.admit_at_len(table.len(), val)
+    fn admit(&self, val: &Arc<FlowInfo>) -> Result<(), FlowTableError> {
+        self.admit_at_len(self.live.load(Ordering::Relaxed), val)
     }
 
     fn admit_at_len(&self, len: usize, val: &Arc<FlowInfo>) -> Result<(), FlowTableError> {
@@ -262,9 +266,12 @@ impl FlowTable {
         let flow_key = val.flowkey();
         debug!("insert: inserting flow {flow_key}");
 
-        self.admit(&table, val)?;
+        self.admit(val)?;
 
         let result = table.insert(*flow_key, val.clone());
+        if result.is_none() {
+            self.live.fetch_add(1, Ordering::Relaxed);
+        }
         // Set Active only after the insert so that the invariant holds: Active iff in the
         // table.  The narrow window where the entry is in the DashMap but not yet Active is
         // harmless: drain_stale's stale condition is (status != Active || expires_at <= now),
@@ -273,7 +280,7 @@ impl FlowTable {
         drop(table);
 
         #[cfg(not(any(feature = "shuttle", feature = "loom")))]
-        Self::start_timer(self.table.clone(), val.clone());
+        Self::start_timer(self.table.clone(), self.live.clone(), val.clone());
 
         Self::displace(result.as_ref());
 
@@ -296,7 +303,7 @@ impl FlowTable {
         let flow_key = val.flowkey();
         debug!("insert: inserting flow {flow_key} unless it is already held");
 
-        let len = table.len();
+        let len = self.live.load(Ordering::Relaxed);
 
         let previous = val.update_status(FlowStatus::Active);
 
@@ -313,6 +320,7 @@ impl FlowTable {
                     Found::Refused(e)
                 } else {
                     vacant.insert(val.clone());
+                    self.live.fetch_add(1, Ordering::Relaxed);
                     Found::Inserted(None)
                 }
             }
@@ -335,7 +343,7 @@ impl FlowTable {
         drop(table);
 
         #[cfg(not(any(feature = "shuttle", feature = "loom")))]
-        Self::start_timer(self.table.clone(), val.clone());
+        Self::start_timer(self.table.clone(), self.live.clone(), val.clone());
 
         Self::displace(displaced.as_ref());
 
@@ -370,6 +378,9 @@ impl FlowTable {
         debug!("remove: Removing flow key {flow_key}");
         let table = self.table.read();
         let result = table.remove(flow_key);
+        if result.is_some() {
+            self.live.fetch_sub(1, Ordering::Relaxed);
+        }
         if let Some((_key, flow_info)) = result.as_ref() {
             flow_info.update_status(FlowStatus::Detached);
             flow_info.token.cancel();
@@ -378,6 +389,16 @@ impl FlowTable {
     }
 
     #[allow(clippy::len_without_is_empty)]
+    /// The number of entries the table believes it holds, maintained alongside every insert and
+    /// removal so the capacity check does not have to read-lock every `DashMap` shard.
+    ///
+    /// `DashMap::len` sums the shards one at a time, so the figure it returns may never have
+    /// existed; this counter is no less exact and costs one atomic.
+    #[must_use]
+    pub fn live_len(&self) -> usize {
+        self.live.load(Ordering::Relaxed)
+    }
+
     /// Returns the total number of entries physically stored in the table, regardless of
     /// their expiration status.  This is mostly for testing.
     #[must_use]
@@ -716,6 +737,52 @@ mod tests {
 
             let () = tokio::time::sleep(Duration::from_secs(5)).await;
             assert_eq!(flow_table.active_len().unwrap(), 0);
+        }
+
+        #[tokio::test]
+        async fn the_live_counter_tracks_what_the_table_holds() {
+            use std::time::Instant;
+            let flow_table = FlowTable::default();
+            let far_future = Instant::now() + Duration::from_hours(1);
+            let keys: Vec<FlowKey> = (0u16..8).map(|i| key_for(3000 + i)).collect();
+
+            for key in &keys {
+                flow_table
+                    .insert_from_arc(&Arc::new(FlowInfo::new(*key, far_future)))
+                    .unwrap();
+            }
+            assert_eq!(flow_table.live_len(), flow_table.len().unwrap());
+
+            for key in keys.iter().take(3) {
+                flow_table.remove(key);
+            }
+            assert_eq!(flow_table.live_len(), flow_table.len().unwrap());
+
+            let held = Arc::new(FlowInfo::new(keys[4], far_future));
+            flow_table.insert_from_arc(&held).unwrap();
+            assert_eq!(
+                flow_table.live_len(),
+                flow_table.len().unwrap(),
+                "replacing an existing key must not change the count"
+            );
+
+            let fresh = Arc::new(FlowInfo::new(key_for(4999), far_future));
+            assert!(matches!(
+                flow_table.insert_if_absent(&fresh).unwrap(),
+                Insertion::Installed
+            ));
+            assert_eq!(flow_table.live_len(), flow_table.len().unwrap());
+
+            let second = Arc::new(FlowInfo::new(key_for(4999), far_future));
+            assert!(matches!(
+                flow_table.insert_if_absent(&second).unwrap(),
+                Insertion::Occupied(_)
+            ));
+            assert_eq!(
+                flow_table.live_len(),
+                flow_table.len().unwrap(),
+                "standing aside for a live flow must not change the count"
+            );
         }
 
         fn key_for(src_port: u16) -> FlowKey {

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -407,6 +407,14 @@ impl FlowTable {
         Some(table.len())
     }
 
+    /// Tells whether the table physically stores no entries at all, expired ones included.
+    /// `None` when the lock is held, exactly as [`Self::len`].
+    #[must_use]
+    pub fn is_empty(&self) -> Option<bool> {
+        let table = self.table.try_read()?;
+        Some(table.is_empty())
+    }
+
     /// Returns the number of *active* (non-expired, non-cancelled) flows in the table.
     /// This is mostly for testing.
     #[must_use]

--- a/flow-entry/src/flow_table/table.rs
+++ b/flow-entry/src/flow_table/table.rs
@@ -749,9 +749,8 @@ mod tests {
 
         #[tokio::test]
         async fn the_live_counter_tracks_what_the_table_holds() {
-            use std::time::Instant;
             let flow_table = FlowTable::default();
-            let far_future = Instant::now() + Duration::from_hours(1);
+            let far_future = clock::now() + Duration::from_hours(1);
             let keys: Vec<FlowKey> = (0u16..8).map(|i| key_for(3000 + i)).collect();
 
             for key in &keys {

--- a/flow-filter/src/context/fuzz.rs
+++ b/flow-filter/src/context/fuzz.rs
@@ -14,8 +14,8 @@
 use super::tables::{Backend, FlowFilterContext, LookupInput, LookupResult, SourceGate};
 use crate::NatRequirement;
 use crate::fuzz_gen::{OverlaySpec, Probe, ProbeSpec, bogus_vpcd};
+use concurrency::process_global::atomic::{AtomicU64, Ordering};
 use concurrency::sync::LazyLock;
-use concurrency::sync::atomic::{AtomicU64, Ordering};
 use config::external::overlay::ValidatedOverlay;
 use config::external::overlay::vpc::{ValidatedPeering, ValidatedVpc};
 use std::num::NonZero;

--- a/flow-filter/src/context/tables.rs
+++ b/flow-filter/src/context/tables.rs
@@ -345,35 +345,18 @@ impl<K: MatchKey, A> fmt::Debug for AnyTable<K, A> {
     }
 }
 
-concurrency::with_std! {
-    use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
+// A process-unique sequence for rte_acl context names. This is deliberately *not* scheduled:
+// the registry it feeds is rte_acl's own, which is process-global and outlives any model-checker
+// execution, so a facade atomic here would restart at zero on the second execution and collide.
+// It used to be spelled three times -- `with_std!` on the facade, `with_loom!` and
+// `with_shuttle!` on raw `std::sync` with four suppressions -- because there was no name for
+// "process-lifetime on purpose". There is now.
+use concurrency::process_global::atomic::{AtomicU64, Ordering};
 
-    static TABLE_SEQ: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
+static TABLE_SEQ: AtomicU64 = AtomicU64::new(0);
 
-    fn next_in_sequence() -> u64 {
-        TABLE_SEQ.fetch_add(1, Ordering::Relaxed)
-    }
-}
-
-concurrency::with_loom! {
-    // nosemgrep: rust-no-direct-std-sync-import
-    static TABLE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-    fn next_in_sequence() -> u64 {
-        // nosemgrep: rust-no-direct-std-sync-import
-        TABLE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
-concurrency::with_shuttle! {
-    // nosemgrep: rust-no-direct-std-sync-import
-    static TABLE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-    fn next_in_sequence() -> u64 {
-        // nosemgrep: rust-no-direct-std-sync-import
-        TABLE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    }
+fn next_in_sequence() -> u64 {
+    TABLE_SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
 /// A process-unique rte_acl context name (rte_acl rejects duplicate names).

--- a/flow-filter/src/tests.rs
+++ b/flow-filter/src/tests.rs
@@ -1538,8 +1538,8 @@ fn probe_packet(probe: &Probe) -> Option<(Packet<TestBuffer>, Probe)> {
 fn nf_metadata_matches_config_oracle() {
     use crate::context::fuzz::oracle_lookup;
     use crate::fuzz_gen::{OverlaySpec, ProbeSpec};
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
 
     // Lazily initialized so this compiles under the loom backend, whose AtomicU64::new is not const.
     static ROUTED: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(0));
@@ -1636,8 +1636,8 @@ mod adversarial_headers {
     use crate::context::fuzz::oracle_lookup;
     use crate::test_utils::{expose, expose_masquerade, expose_static, overlay, peering, vpcd};
     use bolero::{Driver, ValueGenerator};
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
     use config::external::overlay::ValidatedOverlay;
     use net::buffer::TestBuffer;
     use net::headers::Headers;

--- a/justfile
+++ b/justfile
@@ -227,7 +227,10 @@ test package="tests.all" *args: (setup-roots) (build (if package == "tests.all" 
 [script]
 fuzz-list *args="":
     {{ _just_debuggable_ }}
-    cargo bolero list {{ _cargo_feature_flags }} {{ args }}
+    # `--profile checked` for the same reason `fuzz` passes it: cargo-bolero defaults to a
+    # profile named `fuzz`, and this workspace renamed that profile. Without it the recipe
+    # dies with `profile 'fuzz' is not defined` before listing anything.
+    cargo bolero list --profile checked {{ _cargo_feature_flags }} {{ args }}
 
 # Fuzz one bolero target under libfuzzer. See development/code/running-tests.md
 [script]

--- a/mgmt/src/processor/confbuild/internal.rs
+++ b/mgmt/src/processor/confbuild/internal.rs
@@ -442,7 +442,7 @@ mod chain_properties {
     //
     // Half the range rather than `usize::MAX`, which clippy reads as an absurd
     // comparison and rejects at the call sites.
-    const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) {
+    const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) || cfg!(sanitized) {
         usize::MAX / 2
     } else {
         200

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -547,12 +547,14 @@ fn apply_masquerade_config(
 
 fn apply_port_forwarding_config(
     vpc_table: &ValidatedVpcTable,
+    flow_table: &FlowTable,
     portfw_w: &mut PortFwTableWriter,
+    genid: GenId,
 ) -> ConfigResult {
     let ruleset = build_port_forwarding_configuration(vpc_table)?;
     debug!("Port-forwarding configuration successfully built. Applying changes ...");
     portfw_w
-        .update_table(&ruleset)
+        .update_table_and_flows(&ruleset, flow_table, genid)
         .map_err(|e| ConfigError::PortForwarding(e.to_string()))?;
 
     debug!("Successfully updated the port-forwarding table");
@@ -661,7 +663,7 @@ impl ConfigProcessor {
         );
 
         /* apply port-forwarding config */
-        apply_port_forwarding_config(overlay.vpc_table(), portfw_w)?;
+        apply_port_forwarding_config(overlay.vpc_table(), flow_table.as_ref(), portfw_w, genid)?;
 
         /* update stats mappings and seed names to the stats store */
         let _ = update_stats_vpc_mappings(&config, vpcmapw);

--- a/mgmt/src/processor/proc.rs
+++ b/mgmt/src/processor/proc.rs
@@ -644,6 +644,14 @@ impl ConfigProcessor {
         /* apply static NAT config */
         apply_static_nat_config(overlay.vpc_table(), nattablesw)?;
 
+        /* open the new generation for stamping before the first walk that migrates flows into
+        it. A flow created from here on stamps itself `genid`, so neither the walk missing it
+        nor the publish at the end of this function can leave it stale. The flow-filter and
+        ACL tables -- the two that enforce the generation -- are already the new ones by this
+        point, so a flow stamped in the window really was validated against the configuration
+        `genid` names. */
+        self.proc_params.pipeline_data.open_generation(genid);
+
         /* apply masquerade config */
         apply_masquerade_config(
             overlay.vpc_table(),

--- a/mgmt/src/tests/mgmt.rs
+++ b/mgmt/src/tests/mgmt.rs
@@ -9,7 +9,7 @@
 /// handful of cases, where a ratio measures nothing and a threshold is pure flake. Below
 /// this many cases the counts are still printed, and coverage data is the thing to watch.
 #[cfg(test)]
-const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) {
+const ENOUGH_CASES: usize = if cfg!(instrumented) || cfg!(emulated) || cfg!(sanitized) {
     // Coverage is the third case this gate was built for, and the one that
     // slips through a plain count. Emulation buys a handful of cases, well
     // under the native floor, so the gate closes on its own. Instrumentation

--- a/n-vm/src/container.rs
+++ b/n-vm/src/container.rs
@@ -592,6 +592,33 @@ impl ContainerParams {
             shares,
         ));
 
+        Self::parents_first(mounts)
+    }
+
+    /// Order mounts so a target always follows any target it nests inside.
+    ///
+    /// `runc` mounts in the order it is given and creates a missing mountpoint
+    /// as it goes. The container's own rootfs is read-only, so creating one
+    /// there fails -- which is what happens when `/vm.root/test-bin` is
+    /// presented before `/vm.root`: the parent is not mounted yet, so the
+    /// mountpoint has to come from the rootfs rather than from the `vmroot`
+    /// derivation, which pre-creates `test-bin` for exactly this reason.
+    ///
+    ///     mkdirat /var/lib/docker/rootfs/overlayfs/<id>/vm.root/test-bin:
+    ///         read-only file system
+    ///
+    /// Some versions of the daemon sort `HostConfig.Mounts` by destination
+    /// before building the OCI spec and hide this; relying on that is a bet on
+    /// the runner's Docker, and the aarch64 CI runners lost it. Sorting by
+    /// component count is enough -- a parent always has fewer components than
+    /// anything nested in it -- and a stable sort leaves unrelated mounts in
+    /// the order they were declared.
+    fn parents_first(mut mounts: Vec<bollard::models::Mount>) -> Vec<bollard::models::Mount> {
+        mounts.sort_by_key(|mount| {
+            mount.target.as_deref().map_or(0, |target| {
+                target.split('/').filter(|s| !s.is_empty()).count()
+            })
+        });
         mounts
     }
 
@@ -2074,6 +2101,48 @@ mod tests {
         let mirror = mirror.unwrap();
         assert_eq!(mirror.source.as_deref(), Some("/target/debug/deps"));
         assert_eq!(mirror.read_only, Some(true));
+    }
+
+    /// `runc` creates a missing mountpoint as it goes, and the container rootfs is read-only,
+    /// so a nested target presented before the one it nests inside fails the whole container
+    /// with `read-only file system`. The daemon may or may not sort for us; this does not
+    /// depend on which.
+    #[test]
+    fn every_mount_follows_the_one_it_nests_inside() {
+        let params = sample_params();
+        let roots = ScratchRoots {
+            test_root: PathBuf::from("/nix/store/fake-test-root"),
+            vm_root: PathBuf::from("/nix/store/fake-vm-root"),
+        };
+        let params = ContainerParams {
+            scratch_roots: roots,
+            ..params
+        };
+        let mounts = ContainerParams::build_mounts_in(None, &params, &[], None);
+
+        let targets: Vec<&str> = mounts.iter().filter_map(|m| m.target.as_deref()).collect();
+        assert!(
+            targets.contains(&VM_ROOT_SHARE_PATH),
+            "the fixture did not produce the parent mount, so this proves nothing: {targets:?}"
+        );
+        let nested = format!("{VM_ROOT_SHARE_PATH}/{VM_TEST_BIN_DIR}");
+        assert!(
+            targets.contains(&nested.as_str()),
+            "the fixture did not produce a nested mount, so this proves nothing: {targets:?}"
+        );
+
+        for (later, target) in targets.iter().enumerate() {
+            for (earlier, parent) in targets.iter().enumerate() {
+                if earlier <= later || !target.starts_with(&format!("{parent}/")) {
+                    continue;
+                }
+                panic!(
+                    "{target} is mounted before {parent} that contains it. runc would have to \
+                     create the mountpoint in the read-only container rootfs, and the container \
+                     fails to start. Order: {targets:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/n-vm/src/container.rs
+++ b/n-vm/src/container.rs
@@ -604,8 +604,10 @@ impl ContainerParams {
     /// mountpoint has to come from the rootfs rather than from the `vmroot`
     /// derivation, which pre-creates `test-bin` for exactly this reason.
     ///
-    ///     mkdirat /var/lib/docker/rootfs/overlayfs/<id>/vm.root/test-bin:
-    ///         read-only file system
+    /// ```text
+    /// mkdirat /var/lib/docker/rootfs/overlayfs/<id>/vm.root/test-bin:
+    ///     read-only file system
+    /// ```
     ///
     /// Some versions of the daemon sort `HostConfig.Mounts` by destination
     /// before building the OCI spec and hide this; relying on that is a bet on

--- a/nat/Cargo.toml
+++ b/nat/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [features]
 loom = ["concurrency/loom"]
-shuttle = ["concurrency/shuttle", "dep:shuttle"]
+shuttle = ["concurrency/shuttle", "dep:shuttle", "left-right/shuttle"]
 shuttle_dfs = ["concurrency/shuttle_dfs", "shuttle"]
 
 [dependencies]

--- a/nat/src/common/mod.rs
+++ b/nat/src/common/mod.rs
@@ -9,6 +9,20 @@ use concurrency::sync::Arc;
 use concurrency::sync::atomic::{AtomicU8, Ordering};
 use std::fmt::Display;
 
+/// How much longer a flow lives when the test is emulated.
+///
+/// A qemu-user run interprets instructions a couple of orders of magnitude slower than native, so
+/// the wall-clock gap between two packet-driven refreshes of the same flow is correspondingly
+/// larger and a lifetime tuned for native expires mid-conversation. Masquerade has scaled its
+/// timeouts this way since they were written; port forwarding did not, and the two diverging is
+/// what let `time_passing_does_not_disturb_a_flow_inside_its_lifetime` draw a 30s wait -- bounded
+/// by the *masquerade* lifetime, 500s emulated -- against a port-forwarded flow still living the
+/// unscaled 10s. It lives here so the next timeout added to either flavour cannot miss it.
+pub(crate) const TIMEOUT_SCALE: u64 = cfg_select! {
+    emulated => 100,
+    _ => 1,
+};
+
 /// A type to represent a NAT action
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NatAction {

--- a/nat/src/masquerade/fuzz.rs
+++ b/nat/src/masquerade/fuzz.rs
@@ -44,24 +44,37 @@ impl ValueGenerator for Scenario {
 fn settled(body: impl FnOnce()) {
     const PAST_ANY_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(30);
     const GIVE_UP: usize = 4096;
-    // nosemgrep: rust-no-direct-std-sync-import
-    static CLOCK: std::sync::LazyLock<clock::virtual_time::Paused> =
-        std::sync::LazyLock::new(clock::virtual_time::Paused::new); // nosemgrep: rust-no-direct-std-sync-import
-    CLOCK.block_on(async {
-        body();
-        clock::virtual_time::advance(PAST_ANY_TIMEOUT).await;
-        let handle = tokio::runtime::Handle::current();
-        for _ in 0..GIVE_UP {
-            if handle.metrics().num_alive_tasks() == 0 {
-                return;
+    // One clock per *thread*, not per process. `cargo nextest` gives each test its own
+    // process, so a `static` looked equivalent -- but `cargo test` runs them as threads in
+    // one process, and then every property here shares a timeline. The 30-minute advance
+    // below is a cleanup step for the case that just ran; sharing it means it also lands on
+    // whatever a sibling property has live, expiring flows mid-assertion. That is the whole
+    // of the twelve-test failure `cargo test -p dataplane-nat` used to produce and
+    // `--test-threads=1` used to hide.
+    //
+    // A thread-local is enough because the rest of the facade is already per-thread:
+    // `Paused::new` bumps this thread's `IN_WORLD` depth, and the spawn hook hands the
+    // handle down to any thread the body starts, so a child still reads its parent's clock.
+    thread_local! {
+        static CLOCK: clock::virtual_time::Paused = clock::virtual_time::Paused::new();
+    }
+    CLOCK.with(|clock| {
+        clock.block_on(async {
+            body();
+            clock::virtual_time::advance(PAST_ANY_TIMEOUT).await;
+            let handle = tokio::runtime::Handle::current();
+            for _ in 0..GIVE_UP {
+                if handle.metrics().num_alive_tasks() == 0 {
+                    return;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        }
-        panic!(
-            "{} tasks from this case would not retire; the flow tables they hold will accumulate \
-             until the run is out of memory",
-            handle.metrics().num_alive_tasks()
-        );
+            panic!(
+                "{} tasks from this case would not retire; the flow tables they hold will \
+                 accumulate until the run is out of memory",
+                handle.metrics().num_alive_tasks()
+            );
+        });
     });
 }
 

--- a/nat/src/masquerade/fuzz.rs
+++ b/nat/src/masquerade/fuzz.rs
@@ -123,7 +123,7 @@ fn destination_of(packet: &Packet<TestBuffer>) -> (IpAddr, u16) {
 fn judged(built: usize) -> bool {
     /// One case cannot support a rate; anything above that, the ratios can speak to.
     const ENOUGH_CONFIGURATIONS: usize = 2;
-    !cfg!(instrumented) && !cfg!(emulated) && built >= ENOUGH_CONFIGURATIONS
+    !cfg!(instrumented) && !cfg!(emulated) && !cfg!(sanitized) && built >= ENOUGH_CONFIGURATIONS
 }
 
 #[derive(Default)]

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -95,10 +95,9 @@ pub struct Masquerade {
 
 impl Masquerade {
     // Slow emulated tests need more wall-clock time between packet-driven refreshes.
-    const TIMEOUT_SCALE: u64 = cfg_select! {
-        emulated => 100,
-        _ => 1,
-    };
+    // Shared with port forwarding so the two cannot drift apart again; see
+    // `crate::common::TIMEOUT_SCALE`.
+    const TIMEOUT_SCALE: u64 = crate::common::TIMEOUT_SCALE;
 
     // Internal flow timeouts for masquerading
     //= https://www.rfc-editor.org/rfc/rfc5382#section-5

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -53,6 +53,8 @@ pub(crate) enum MasqueradeError {
     UnexpectedKeyVariant,
     #[error("flow table capacity exceeded")]
     CapacityExceeded,
+    #[error("the allocated public tuple already serves a live flow")]
+    ReverseTupleInUse,
     #[error("unsupported ICMP message category")]
     IcmpUnsupportedCategory,
     #[error("attempted to masquerade ICMP error message")]
@@ -383,14 +385,48 @@ impl Masquerade {
             return Ok(MasqueradeFlow::Held(held));
         }
 
-        // The reverse insert is expected to always succeed: capacity enforcement
-        // recognises that reverse has a related flow (forward) already in the table
-        // and admits it unconditionally.  Remove the forward entry on the unlikely
-        // event of failure to avoid leaving a one-sided flow.
-        if let Err(e) = self.flow_table.insert_from_arc(&reverse) {
-            forward.invalidate();
-            debug_assert!(false, "reverse flow insert failed: {e:?}");
-            return Err(MasqueradeError::CapacityExceeded);
+        // The reverse insert is expected to succeed: capacity enforcement recognises that
+        // reverse has a related flow (forward) already in the table and admits it
+        // unconditionally.  Remove the forward entry on failure, of either kind, to avoid
+        // leaving a one-sided flow.
+        //
+        // It is arbitrated rather than unconditional because an allocator swap can issue one
+        // public tuple twice. An allocation lives on the creating worker's stack between
+        // `allocate` and this insert, so `check_masquerading_flows` cannot see it: the
+        // replacement allocator is built with empty bitmaps, re-reserves only what the flow
+        // table already holds, and therefore believes a mid-create tuple is free to hand out
+        // again.
+        //
+        // Two flows so issued collide here and only here. Their forward keys differ -- they
+        // have different private sources -- and two flows sharing a public tuple towards
+        // *different* peers are still told apart correctly on the way back, which is ordinary
+        // endpoint-dependent mapping rather than a fault. It is precisely a collision on the
+        // reverse key that misdelivers, and an unconditional insert made that silent: it
+        // evicted the first flow's reverse half, returning the displaced entry as an ignored
+        // `Option`, after which the first flow's replies were translated to the second flow's
+        // private source, i.e. handed to another tenant.
+        //
+        // Refusing a live occupant costs the loser its first packet instead, which its retry
+        // re-allocates around. It does not make the tuple unique -- the allocator can still
+        // double-issue, and closing that needs the create path to be visible to the migration
+        // walk -- but it does mean a reply is never delivered to a conversation that did not
+        // originate it.
+        match self.flow_table.insert_if_absent(&reverse) {
+            Ok(Insertion::Installed) => {}
+            Ok(Insertion::Occupied(_)) => {
+                debug!(
+                    "Reverse tuple {} already serves a live flow; dropping rather than taking \
+                     over its replies",
+                    reverse.flowkey()
+                );
+                forward.invalidate();
+                return Err(MasqueradeError::ReverseTupleInUse);
+            }
+            Err(e) => {
+                forward.invalidate();
+                debug_assert!(false, "reverse flow insert failed: {e:?}");
+                return Err(MasqueradeError::CapacityExceeded);
+            }
         }
         Ok(MasqueradeFlow::Installed(forward))
     }
@@ -639,6 +675,9 @@ impl From<&MasqueradeError> for DoneReason {
                 DoneReason::Malformed
             }
             MasqueradeError::CapacityExceeded => DoneReason::FlowCapacityExceeded,
+            // The allocator handed out a tuple that is already in service, so there is no
+            // usable resource for this flow -- not a filtering decision and not a bug here.
+            MasqueradeError::ReverseTupleInUse => DoneReason::NatOutOfResources,
             MasqueradeError::MissingDiscriminant => DoneReason::Unroutable,
             MasqueradeError::NoAllocator
             | MasqueradeError::PoolAddressNotUnicast(_)
@@ -760,6 +799,125 @@ mod race {
                 .unwrap_or_else(|e| unreachable!("{e}")),
         ];
         Fabric::build(&exposes).unwrap_or_else(|| unreachable!("a fixed expose builds"))
+    }
+
+    fn probe(source: &str, sport: u16) -> Packet<TestBuffer> {
+        let source: IpAddr = source.parse().unwrap_or_else(|_| unreachable!());
+        let destination: IpAddr = "3.3.3.1".parse().unwrap_or_else(|_| unreachable!());
+        let mut packet: Packet<TestBuffer> = build(source, destination, false, sport, 80);
+        let meta = packet.meta_mut();
+        meta.set_overlay(true);
+        meta.set_masquerade(true);
+        meta.src_vpcd = Some(VpcDiscriminant::from_vni(vni(LOCAL_VNI)));
+        meta.dst_vpcd = Some(VpcDiscriminant::from_vni(vni(REMOTE_VNI)));
+        packet
+    }
+
+    /// A replacement allocator can hand out a public tuple that is already in service.
+    ///
+    /// `update_nat_allocator` builds the replacement with empty bitmaps and re-reserves into it
+    /// only what the flow table already holds. An allocation taken by a worker that has not
+    /// reached its insert yet is held nowhere but that worker's stack, so the replacement
+    /// believes the tuple is free. This drives that shape directly rather than racing for it:
+    /// one flow is installed from the running allocator, and a freshly built one then issues the
+    /// same tuple to a second conversation.
+    ///
+    /// The reverse key carries the public tuple and the remote endpoint, and no part of the
+    /// initiator, so the two flows collide there. That collision is the whole of the harm: an
+    /// unconditional insert evicted the first flow's reverse half and sent its replies to the
+    /// second flow's private source.
+    #[tokio::test]
+    async fn a_reissued_public_tuple_does_not_take_over_the_replies_of_the_flow_holding_it() {
+        let fabric = fabric();
+        let (_lookup, masq) = fabric.stages();
+        let running = masq
+            .allocator
+            .get()
+            .unwrap_or_else(|| unreachable!("the fabric installed an allocator"));
+
+        let mut first = probe("10.0.0.1", 4000);
+        let mut second = probe("10.0.0.1", 4001);
+        let first_key =
+            FlowKey::try_from(&first).unwrap_or_else(|_| unreachable!("the probe keys"));
+        let second_key =
+            FlowKey::try_from(&second).unwrap_or_else(|_| unreachable!("the probe keys"));
+        assert_ne!(first_key, second_key, "the two probes are the same flow");
+        let (src_vpcd, dst_vpcd) =
+            Masquerade::discriminants(&first).unwrap_or_else(|_| unreachable!());
+
+        let held = running
+            .allocate(src_vpcd, dst_vpcd, first_key.src_ip(), first_key.proto())
+            .unwrap_or_else(|e| unreachable!("the pool has room: {e}"));
+
+        // Built the way `update_nat_allocator` builds one: same configuration, next generation,
+        // and nothing re-reserved into it, because the flow it would have to see is not in the
+        // table yet.
+        let replacement = NatAllocator::new(running.config().clone(), running.genid() + 1);
+        let reissued = replacement
+            .allocate(src_vpcd, dst_vpcd, second_key.src_ip(), second_key.proto())
+            .unwrap_or_else(|e| unreachable!("the pool has room: {e}"));
+
+        let tuple = (held.allocation.ip(), held.allocation.port());
+        assert_eq!(
+            (reissued.allocation.ip(), reissued.allocation.port()),
+            tuple,
+            "the replacement did not reissue the tuple, so this reproduces nothing"
+        );
+
+        let reverse_key = Masquerade::new_reverse_session(&first_key, &held, dst_vpcd)
+            .unwrap_or_else(|e| unreachable!("{e}"));
+
+        let installed = masq
+            .create_flow_pair(&mut first, &first_key, &first_key, held, running.genid())
+            .unwrap_or_else(|e| unreachable!("{e}"));
+        assert!(
+            matches!(installed, MasqueradeFlow::Installed(_)),
+            "the first conversation did not install its flow"
+        );
+
+        let refused = masq.create_flow_pair(
+            &mut second,
+            &second_key,
+            &second_key,
+            reissued,
+            replacement.genid(),
+        );
+        assert!(
+            matches!(refused, Err(MasqueradeError::ReverseTupleInUse)),
+            "a second conversation was allowed over the live reverse tuple {reverse_key}: {}",
+            match &refused {
+                Ok(flow) => format!("it installed {}", flow.flow().flowkey()),
+                Err(e) => format!("it was refused, but for the wrong reason -- {e}"),
+            }
+        );
+
+        let reverse = masq
+            .flow_table
+            .lookup(&reverse_key)
+            .unwrap_or_else(|| unreachable!("the winner's reverse half is in the table"));
+        let answers = reverse
+            .locked
+            .read()
+            .nat_state
+            .extract_ref::<MasqueradeState>()
+            .unwrap_or_else(|| unreachable!("the reverse half carries masquerade state"))
+            .as_translate();
+        assert_eq!(
+            (answers.use_ip.inner(), answers.nat_port),
+            (
+                first_key.src_ip(),
+                NatPort::new_port_checked(4000).unwrap_or_else(|_| unreachable!())
+            ),
+            "a reply arriving on {tuple:?} would be handed to the conversation that did not \
+             open it"
+        );
+
+        assert!(
+            masq.flow_table
+                .lookup(&second_key)
+                .is_none_or(|forward| !forward.is_active()),
+            "the refused conversation left a live forward half behind, with no reverse to answer it"
+        );
     }
 
     #[tokio::test]

--- a/nat/src/portfw/flow_state.rs
+++ b/nat/src/portfw/flow_state.rs
@@ -7,7 +7,7 @@
 
 use net::buffer::PacketBufferMut;
 use net::flow_key::FlowKeyError;
-use net::flows::{ExtractRef, FlowStatus};
+use net::flows::{ExtractMut, ExtractRef, FlowStatus};
 use net::ip::UnicastIpAddr;
 use net::packet::{Packet, VpcDiscriminant};
 use net::{FlowKey, IpProtoKey};
@@ -187,6 +187,19 @@ pub(crate) fn setup_reverse_flow(
         write_guard.dst_vpcd = Some(entry.key.src_vpcd());
     }
     debug!("Set up REVERSE flow for port-forwarding;\nkey={reverse_key}\ninfo={reverse_flow}");
+}
+
+/// Point a flow's port-forwarding state at `entry`, so that subsequent packets are
+/// fast-forwarded instead of taking the stale-rule path.
+///
+/// Shared by the two callers that establish which rule a live flow belongs to: the datapath,
+/// when a packet arrives on a flow whose rule has been dropped, and the migration in
+/// [`crate::portfw::flows`], which answers the same question for every flow at enactment.
+pub(crate) fn reassign_port_fw_rule(flow_info: &FlowInfo, entry: &Arc<PortFwEntry>) {
+    let mut flow_info_locked = flow_info.locked.write();
+    if let Some(state) = flow_info_locked.port_fw_state.extract_mut::<PortFwState>() {
+        state.rule = Arc::downgrade(entry);
+    }
 }
 
 /// Check if the flow entry that a packet was annotated with contains any _VALID_

--- a/nat/src/portfw/flows.rs
+++ b/nat/src/portfw/flows.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Carrying live port-forwarded flows across a configuration change.
+
+use concurrency::sync::{Arc, Weak};
+use config::GenId;
+use flow_entry::flow_table::FlowInfo;
+use flow_entry::flow_table::table::{FlowTable, FlowTableReadGuard};
+use net::FlowKey;
+use net::flows::ExtractRef;
+
+use crate::common::NatAction;
+use crate::portfw::flow_state::reassign_port_fw_rule;
+use crate::portfw::{PortFwEntry, PortFwKey, PortFwState, PortFwTable};
+
+#[allow(unused)]
+use tracing::{debug, error, warn};
+
+/// Carry every live port-forwarded flow onto `genid`, dropping the ones the new table no longer
+/// opens.
+///
+/// `PortForwarder` already revalidates a flow lazily, when the rule its state points at has been
+/// dropped -- but it does that in the port-forwarding stage, and the stages that care run before
+/// it. `AclFilter` refuses to honour a flow whose generation is older than the pipeline's, so a
+/// flow-scoped `Allow` -- the rule that says "this reply is permitted because something opened
+/// the flow" -- stopped applying the moment *any* configuration was enacted, however unrelated.
+/// Masquerade has owned this migration since it was written; port forwarding never did.
+///
+/// Revalidating every flow rather than taking a shortcut when the table is unchanged is the one
+/// difference from `check_masquerading_flows`, which splits the two cases because carrying a
+/// masquerade flow means re-reserving its address and port. Carrying a port-forwarded one is a
+/// lookup, so one path serves both and there is no "did it change" comparison to get wrong.
+pub(crate) fn migrate_port_forwarded_flows<'a>(
+    flow_table: &'a FlowTable,
+    table: &PortFwTable,
+    genid: GenId,
+) -> FlowTableReadGuard<'a> {
+    debug!("MIGRATING port-forwarded flows to gen {genid}...");
+    let (mut carried, mut dropped) = (0u64, 0u64);
+    let guard = flow_table.for_each_flow_filtered(
+        |_, flow_info| flow_info.is_active(),
+        |flow_key, flow_info| {
+            // Visit the pair by its reverse half. Both halves hold a `PortFwState`, but only the
+            // reverse one holds the tuple the *rule* matched: `setup_reverse_flow` stores the
+            // published address and port there, while the forward half stores the backend. The
+            // forward half's key is no substitute -- with static NAT in play it is the tuple
+            // from before that translation, not the one port forwarding matched on. Acting on
+            // either half moves both, which is why `check_masquerading_flow` likewise skips the
+            // half that cannot answer for itself.
+            let Some(state) = reverse_state(flow_info) else {
+                return;
+            };
+            if let Some(entry) = rule_for(&state, flow_key, flow_info, table) {
+                // The flow's `Weak` still names the entry from the configuration just replaced.
+                // Leaving it there sends the next packet of a flow we have just proved good
+                // down the stale-rule path.
+                reassign_port_fw_rule(flow_info, &entry);
+                if let Some(forward) = flow_info.related.as_ref().and_then(Weak::upgrade) {
+                    reassign_port_fw_rule(&forward, &entry);
+                }
+                flow_info.set_genid_pair(genid);
+                carried += 1;
+            } else {
+                debug!("Port-forwarded flow {flow_key} is not opened by the new configuration");
+                flow_info.invalidate_pair();
+                dropped += 1;
+            }
+        },
+    );
+    debug!("MIGRATING port-forwarded flows COMPLETED: carried {carried}, invalidated {dropped}");
+    guard
+}
+
+/// This flow's port-forwarding state, if it is the reverse half of a pair.
+///
+/// Cloned out rather than borrowed: the caller goes on to take write guards on this very flow.
+fn reverse_state(flow_info: &FlowInfo) -> Option<PortFwState> {
+    let locked = flow_info.locked.read();
+    let state = locked.port_fw_state.extract_ref::<PortFwState>()?;
+    (state.action() == NatAction::SrcNat).then(|| state.clone())
+}
+
+/// The rule in `table` that would open this flow again, if there is one.
+///
+/// This is `PortForwarder::get_rule_from_pkt_rev_path` with the reverse flow's key standing in
+/// for the packet. A reply on this flow carries exactly those addresses, ports and
+/// discriminants, so asking the new table what it would do with one answers whether the flow may
+/// live on -- and answers it at enactment, before the pipeline generation moves, rather than
+/// when a reply arrives to find its permission already gone.
+fn rule_for(
+    state: &PortFwState,
+    reverse_key: &FlowKey,
+    reverse_flow: &FlowInfo,
+    table: &PortFwTable,
+) -> Option<Arc<PortFwEntry>> {
+    let published_ip = state.use_ip().inner();
+    let published_port = state.use_port();
+
+    let key = PortFwKey::new(reverse_flow.get_dst_vpcd()?, reverse_key.proto());
+    let entry = table.lookup_matching_rule(key, published_ip, published_port)?;
+
+    // A rule that matches the published tuple is not enough: it has to still send that tuple to
+    // the backend this flow is using, in the VPC this flow is using. Otherwise the flow's replies
+    // would be attributed to a service the new configuration points somewhere else.
+    let (target_ip, target_port) = entry.map_address_port(published_ip, published_port)?;
+    (target_ip.inner() == reverse_key.src_ip()
+        && Some(target_port) == reverse_key.src_port()
+        && Some(entry.dst_vpcd) == reverse_key.src_vpcd())
+    .then(|| entry.clone())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::portfw::probe::{Arrival, Fabric};
+    use crate::static_nat::probe::build;
+    use config::external::overlay::vpcpeering::VpcExpose;
+    use lpm::prefix::{L4Protocol, PortRange, PrefixWithOptionalPorts};
+    use net::buffer::TestBuffer;
+    use net::packet::{Packet, VpcDiscriminant};
+    use pipeline::NetworkFunction;
+    use std::net::IpAddr;
+
+    const NEXT_GENID: GenId = 7;
+
+    fn side(prefix: &str, first: u16, last: u16) -> PrefixWithOptionalPorts {
+        PrefixWithOptionalPorts::new(
+            prefix.parse().unwrap_or_else(|_| unreachable!()),
+            Some(PortRange::new(first, last).unwrap_or_else(|_| unreachable!())),
+        )
+    }
+
+    /// `10.0.0.0/30:9000-9003` published as `published`.
+    fn publishing(published: &str) -> Vec<VpcExpose> {
+        vec![
+            VpcExpose::empty()
+                .make_port_forwarding(None, Some(L4Protocol::Tcp))
+                .unwrap_or_else(|e| unreachable!("{e}"))
+                .ip(side("10.0.0.0/30", 9000, 9003))
+                .as_range(side(published, 8000, 8003))
+                .unwrap_or_else(|e| unreachable!("{e}")),
+        ]
+    }
+
+    /// Drive one request in, so the fabric holds a live port-forwarded pair.
+    fn open_a_flow(fabric: &Fabric, published: &str) {
+        let (mut lookup, mut pfw) = fabric.stages();
+        let arrival = Arrival::inbound();
+        let peer: IpAddr = "3.3.3.1".parse().unwrap_or_else(|_| unreachable!());
+        let published: IpAddr = published.parse().unwrap_or_else(|_| unreachable!());
+
+        let mut packet: Packet<TestBuffer> = build(peer, published, true, 1234, 8001);
+        arrival.stamp(&mut packet);
+        let mut stamped = lookup.process(std::iter::once(packet));
+        let mut packet = stamped.next().unwrap_or_else(|| unreachable!());
+        drop(stamped);
+        packet.meta_mut().dst_vpcd = arrival.dst_vpcd.map(VpcDiscriminant::from_vni);
+        pfw.process(std::iter::once(packet)).for_each(drop);
+
+        assert_eq!(
+            live(fabric).len(),
+            2,
+            "the fixture did not open a port-forwarded pair, so nothing below is being tested"
+        );
+    }
+
+    fn live(fabric: &Fabric) -> Vec<Arc<FlowInfo>> {
+        fabric
+            .flows()
+            .snapshot(|_, flow| flow.is_active())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_flow_the_new_rules_still_open_is_carried_onto_the_new_generation() {
+        let mut fabric = Fabric::build(&publishing("172.16.0.0/30"))
+            .unwrap_or_else(|| unreachable!("a fixed expose builds"));
+        open_a_flow(&fabric, "172.16.0.1");
+
+        fabric.re_enact(&publishing("172.16.0.0/30"), NEXT_GENID);
+
+        let carried = live(&fabric);
+        assert_eq!(
+            carried.len(),
+            2,
+            "re-enacting the configuration that opened a flow invalidated it"
+        );
+        for flow in &carried {
+            assert_eq!(
+                flow.genid(),
+                NEXT_GENID,
+                "a carried flow kept its old generation, so the acl will refuse its next packet"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_flow_the_new_rules_no_longer_open_is_invalidated() {
+        let mut fabric = Fabric::build(&publishing("172.16.0.0/30"))
+            .unwrap_or_else(|| unreachable!("a fixed expose builds"));
+        open_a_flow(&fabric, "172.16.0.1");
+
+        // The same service, published somewhere else. Nothing now maps the tuple this flow was
+        // opened on, so carrying it would keep a withdrawn publication answering.
+        fabric.re_enact(&publishing("172.16.1.0/30"), NEXT_GENID);
+
+        assert!(
+            live(&fabric).is_empty(),
+            "a port-forwarded flow survived a configuration that no longer publishes its tuple. \
+             Re-stamping every flow is the cheap version of this migration and the wrong one -- \
+             `rule_for` has to actually find the flow's rule in the new table"
+        );
+    }
+}

--- a/nat/src/portfw/fuzz.rs
+++ b/nat/src/portfw/fuzz.rs
@@ -223,9 +223,10 @@ fn a_forwarded_packet_lands_inside_the_published_target() {
                     };
 
                     assert!(
-                        fabric.is_private(addr, port),
-                        "{published:?} was forwarded to {addr}:{port}, which no rule names as a \
-                         target; that address never published this service"
+                        fabric.is_target_of(published, addr, port),
+                        "{published:?} was forwarded to {addr}:{port}, which is not a target of \
+                         the rule that publishes {published:?}; the packet reached a backend \
+                         belonging to some other published service"
                     );
                     tally.reached.fetch_add(1, Ordering::Relaxed);
                 }

--- a/nat/src/portfw/fuzz.rs
+++ b/nat/src/portfw/fuzz.rs
@@ -102,7 +102,7 @@ fn source_of(packet: &Packet<TestBuffer>) -> (IpAddr, u16) {
 fn judged(built: usize) -> bool {
     /// One case cannot support a rate; anything above that, the ratios can speak to.
     const ENOUGH_CONFIGURATIONS: usize = 2;
-    !cfg!(instrumented) && !cfg!(emulated) && built >= ENOUGH_CONFIGURATIONS
+    !cfg!(instrumented) && !cfg!(emulated) && !cfg!(sanitized) && built >= ENOUGH_CONFIGURATIONS
 }
 
 #[derive(Default)]

--- a/nat/src/portfw/fuzz.rs
+++ b/nat/src/portfw/fuzz.rs
@@ -43,24 +43,29 @@ impl ValueGenerator for Scenario {
 fn settled(body: impl FnOnce()) {
     const PAST_ANY_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(30);
     const GIVE_UP: usize = 4096;
-    // nosemgrep: rust-no-direct-std-sync-import
-    static CLOCK: std::sync::LazyLock<clock::virtual_time::Paused> =
-        std::sync::LazyLock::new(clock::virtual_time::Paused::new); // nosemgrep: rust-no-direct-std-sync-import
-    CLOCK.block_on(async {
-        body();
-        clock::virtual_time::advance(PAST_ANY_TIMEOUT).await;
-        let handle = tokio::runtime::Handle::current();
-        for _ in 0..GIVE_UP {
-            if handle.metrics().num_alive_tasks() == 0 {
-                return;
+    // One clock per *thread*, not per process. See the twin in `masquerade::fuzz` for why:
+    // `cargo nextest` gives each test its own process, so a `static` looked equivalent, and
+    // under `cargo test` every property in this crate shared one timeline.
+    thread_local! {
+        static CLOCK: clock::virtual_time::Paused = clock::virtual_time::Paused::new();
+    }
+    CLOCK.with(|clock| {
+        clock.block_on(async {
+            body();
+            clock::virtual_time::advance(PAST_ANY_TIMEOUT).await;
+            let handle = tokio::runtime::Handle::current();
+            for _ in 0..GIVE_UP {
+                if handle.metrics().num_alive_tasks() == 0 {
+                    return;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        }
-        panic!(
-            "{} tasks from this case would not retire; the flow tables they hold will accumulate \
-             until the run is out of memory",
-            handle.metrics().num_alive_tasks()
-        );
+            panic!(
+                "{} tasks from this case would not retire; the flow tables they hold will \
+                 accumulate until the run is out of memory",
+                handle.metrics().num_alive_tasks()
+            );
+        });
     });
 }
 

--- a/nat/src/portfw/mod.rs
+++ b/nat/src/portfw/mod.rs
@@ -5,6 +5,7 @@
 
 mod expiry;
 mod flow_state;
+mod flows;
 mod fuzz;
 pub(crate) mod icmp_handling;
 mod nf;

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -8,7 +8,7 @@ use concurrency::sync::{Arc, Weak};
 use flow_entry::flow_table::table::{FlowTable, Insertion};
 
 use net::buffer::PacketBufferMut;
-use net::flows::{ExtractMut, ExtractRef, FlowInfo};
+use net::flows::{ExtractRef, FlowInfo};
 use net::headers::{Transport, TryHeaders, TryIp};
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
@@ -18,6 +18,7 @@ use std::num::NonZero;
 use crate::common::NatAction;
 use crate::portfw::flow_state::build_portfw_flow_keys;
 use crate::portfw::flow_state::get_packet_port_fw_state;
+use crate::portfw::flow_state::reassign_port_fw_rule;
 use crate::portfw::flow_state::refresh_port_fw_entry;
 use crate::portfw::flow_state::setup_forward_flow;
 use crate::portfw::flow_state::setup_reverse_flow;
@@ -304,13 +305,6 @@ impl PortForwarder {
         }
     }
 
-    fn reassign_port_fw_rule(flow_info: &FlowInfo, entry: &Arc<PortFwEntry>) {
-        let mut flow_info_locked = flow_info.locked.write();
-        if let Some(state) = flow_info_locked.port_fw_state.extract_mut::<PortFwState>() {
-            state.rule = Arc::downgrade(entry);
-        }
-    }
-
     fn get_rule_from_pkt<Buf: PacketBufferMut>(
         packet: &mut Packet<Buf>,
         pfwtable: &PortFwTable,
@@ -330,9 +324,9 @@ impl PortForwarder {
         // if we found an entry, let the port-forwarding state of the flow (and the one in the reverse path)
         // point to it so that subsequent packets are fast-forwarded.
         if let Some(entry) = entry.as_ref() {
-            Self::reassign_port_fw_rule(flow_info, entry);
+            reassign_port_fw_rule(flow_info, entry);
             if let Some(related) = flow_info.related.as_ref().and_then(Weak::upgrade) {
-                Self::reassign_port_fw_rule(&related, entry);
+                reassign_port_fw_rule(&related, entry);
             }
         }
 

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -136,8 +136,10 @@ impl PortForwarder {
             return;
         };
 
-        // set the generation id for the flow
-        fw_flow.set_genid_pair(self.pipeline_data.genid());
+        // set the generation id for the flow. This is the generation being installed, not the one
+        // being enforced: the two differ only while a configuration apply is in flight, and a flow
+        // born then belongs to the generation whose tables just admitted it.
+        fw_flow.set_genid_pair(self.pipeline_data.staging_genid());
 
         // set the flows in the FORWARD & REVERSE direction for subsequent packets
         let status = setup_forward_flow(&fw_key, &fw_flow, entry, new_dst_ip, new_dst_port);
@@ -344,7 +346,9 @@ impl PortForwarder {
         packet: &mut Packet<Buf>,
         pfwtable: &PortFwTable,
     ) {
-        let genid = self.pipeline_data.genid();
+        // The generation to re-stamp a flow with once we have re-checked it against the table
+        // below, which is the one being installed rather than the one being enforced.
+        let genid = self.pipeline_data.staging_genid();
 
         // fast-path based on the flow table
         if let Some(state) = get_packet_port_fw_state(packet) {

--- a/nat/src/portfw/nf.rs
+++ b/nat/src/portfw/nf.rs
@@ -27,6 +27,25 @@ use crate::portfw::packet::nat_packet;
 #[allow(unused)]
 use tracing::{debug, error, trace, warn};
 
+/// Which pair a create attempt ended up translating with, and so what there is to undo.
+///
+/// The same distinction `MasqueradeFlow` draws in the sibling stage: the loser of a race
+/// forwards with the winner's state but owns nothing, so a later failure must not invalidate a
+/// pair another worker installed and is using.
+#[derive(Debug)]
+enum PortFwFlow {
+    Installed(Arc<FlowInfo>),
+    Held(Arc<FlowInfo>),
+}
+
+impl PortFwFlow {
+    fn flow(&self) -> &Arc<FlowInfo> {
+        match self {
+            PortFwFlow::Installed(flow) | PortFwFlow::Held(flow) => flow,
+        }
+    }
+}
+
 /// A port-forwarding network function
 pub struct PortForwarder {
     name: String,
@@ -146,47 +165,74 @@ impl PortForwarder {
         let status = setup_forward_flow(&fw_key, &fw_flow, entry, new_dst_ip, new_dst_port);
         setup_reverse_flow(&rev_key, &rev_flow, entry, dst_ip, dst_port, status);
 
-        // get the state we just created for the FORWARD direction
-        let locked = fw_flow.locked.read();
-        let pfw_state = locked
-            .port_fw_state
-            .extract_ref::<PortFwState>()
-            .unwrap_or_else(|| unreachable!());
-
-        // translate destination according to the rule. If this fails, no state will be created
-        if let Err(e) = nat_packet(packet, pfw_state) {
-            debug!("Failed to port-forward packet (initial):{e}");
-            packet.done(DoneReason::InternalFailure);
-            return;
-        }
-        drop(locked);
-
-        let insertion = match self.flow_table.insert_if_absent(&fw_flow) {
-            Ok(insertion) => insertion,
+        // Arbitrate before touching the packet.
+        //
+        // The forward key is the tuple the client addressed, *before* translation, so it is the
+        // same for every worker racing to create this flow however far apart the backends they
+        // would pick. Those backends can differ: each worker holds its own read guard on the
+        // port-forwarding table, so a configuration published between two workers' batches has
+        // them mapping one public tuple two ways. Translating first and then discarding the
+        // winner emitted the packet to the loser's backend while the table held only the
+        // winner's pair -- and the reverse key is derived from the backend, so the reply came
+        // back from an address nothing mapped and was dropped.
+        let outcome = match self.flow_table.insert_if_absent(&fw_flow) {
+            Ok(Insertion::Occupied(held)) => {
+                debug!(
+                    "Lost the race to create port-forwarding flow {fw_key}; \
+                     forwarding with the winner's state"
+                );
+                PortFwFlow::Held(held)
+            }
+            Ok(Insertion::Installed) => {
+                // The reverse insert is expected to always succeed: capacity enforcement
+                // recognises that rev_flow has a related flow (fw_flow) already in the table
+                // and admits it unconditionally.  Remove the forward entry on the unlikely
+                // event of failure to avoid leaving a one-sided flow.
+                if let Err(e) = self.flow_table.insert_from_arc(&rev_flow) {
+                    fw_flow.invalidate();
+                    warn!("Failed to insert flow (reverse) in the flow table: {e}");
+                    packet.done(DoneReason::FlowCapacityExceeded);
+                    debug_assert!(false, "reverse port-forwarding flow insert failed: {e:?}");
+                    return;
+                }
+                debug!("Inserted forward and reverse port-forwarding flow entries");
+                PortFwFlow::Installed(fw_flow)
+            }
             Err(e) => {
                 warn!("Failed to insert flow (forward) in the flow table: {e}");
                 packet.done(DoneReason::FlowCapacityExceeded);
                 return;
             }
         };
-        if matches!(insertion, Insertion::Occupied(_)) {
-            debug!("Lost the race to create port-forwarding flow {fw_key}; kept the winner's");
-            return;
-        }
 
-        // The reverse insert is expected to always succeed: capacity enforcement
-        // recognises that rev_flow has a related flow (fw_flow) already in the table
-        // and admits it unconditionally.  Remove the forward entry on the unlikely
-        // event of failure to avoid leaving a one-sided flow.
-        if let Err(e) = self.flow_table.insert_from_arc(&rev_flow) {
-            fw_flow.invalidate();
-            warn!("Failed to insert flow (reverse) in the flow table: {e}");
-            packet.done(DoneReason::FlowCapacityExceeded);
-            debug_assert!(false, "reverse port-forwarding flow insert failed: {e:?}");
+        // Take a copy of the state rather than translating under the guard: on the losing path
+        // this flow belongs to another worker and is live in the table, which is also why the
+        // miss below is handled instead of asserted -- for a pair this call installed it cannot
+        // happen, but the winner's flow is not ours to make promises about.
+        let pfw_state = outcome
+            .flow()
+            .locked
+            .read()
+            .port_fw_state
+            .extract_ref::<PortFwState>()
+            .cloned();
+        let Some(pfw_state) = pfw_state else {
+            error!("Port-forwarding flow {fw_key} carries no port-forwarding state");
+            packet.done(DoneReason::InternalFailure);
+            if let PortFwFlow::Installed(installed) = &outcome {
+                installed.invalidate_pair();
+            }
             return;
-        }
+        };
 
-        debug!("Inserted forward and reverse port-forwarding flow entries");
+        // translate destination according to whichever pair the table now holds
+        if let Err(e) = nat_packet(packet, &pfw_state) {
+            debug!("Failed to port-forward packet (initial):{e}");
+            packet.done(DoneReason::InternalFailure);
+            if let PortFwFlow::Installed(installed) = &outcome {
+                installed.invalidate_pair();
+            }
+        }
     }
 
     fn try_port_forwarding<Buf: PacketBufferMut>(
@@ -433,10 +479,19 @@ mod race {
     }
 
     fn fabric() -> Fabric {
+        forwarding_to("10.0.0.0/30", 9000, 9003)
+    }
+
+    /// The same published range, `172.16.0.0/30:8000-8003`, forwarded to a chosen backend range.
+    ///
+    /// Two of these are two configuration generations: the public tuple a client addresses is
+    /// identical, so the forward flow key both workers race to install is identical, while the
+    /// backend each one would translate to is not.
+    fn forwarding_to(prefix: &str, first: u16, last: u16) -> Fabric {
         let expose = VpcExpose::empty()
             .make_port_forwarding(None, Some(L4Protocol::Tcp))
             .unwrap_or_else(|e| unreachable!("{e}"))
-            .ip(side("10.0.0.0/30", 9000, 9003))
+            .ip(side(prefix, first, last))
             .as_range(side("172.16.0.0/30", 8000, 8003))
             .unwrap_or_else(|e| unreachable!("{e}"));
         Fabric::build(&[expose]).unwrap_or_else(|| unreachable!("a fixed expose builds"))
@@ -560,6 +615,70 @@ mod race {
                 .snapshot(|_, _| true)
                 .all(|flow| flow.is_active()),
             "the burst left a half of the pair no longer live"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_loser_of_a_race_forwards_to_the_winners_backend() {
+        let old = forwarding_to("10.0.0.0/30", 9000, 9003);
+        let new = forwarding_to("10.0.1.0/30", 7000, 7003);
+
+        let (mut lookup, mut worker_on_old) = old.stages();
+        let mut worker_on_new = new.worker_over(old.flows());
+
+        let arrival = Arrival::inbound();
+        let peer: IpAddr = "3.3.3.1".parse().unwrap_or_else(|_| unreachable!());
+        let published: IpAddr = "172.16.0.1".parse().unwrap_or_else(|_| unreachable!());
+        let packet = || {
+            let mut packet: Packet<TestBuffer> = build(peer, published, true, 1234, 8001);
+            arrival.stamp(&mut packet);
+            packet
+        };
+
+        // Both clear flow lookup before either worker runs: neither finds a flow, so both take
+        // the create path with the snapshot its own worker is holding.
+        let mut stamped = lookup.process(vec![packet(), packet()].into_iter());
+        let mut first = stamped.next().unwrap_or_else(|| unreachable!());
+        let mut second = stamped.next().unwrap_or_else(|| unreachable!());
+        drop(stamped);
+        for packet in [&mut first, &mut second] {
+            packet.meta_mut().dst_vpcd = arrival.dst_vpcd.map(VpcDiscriminant::from_vni);
+        }
+
+        let out = |packet: Packet<TestBuffer>| {
+            (
+                packet
+                    .ip_destination()
+                    .unwrap_or_else(|| unreachable!("the fixture is an ip packet")),
+                packet.transport_dst_port().map_or(0, NonZero::get),
+            )
+        };
+
+        let mut won = worker_on_old.process(std::iter::once(first));
+        let winner = out(won
+            .next()
+            .unwrap_or_else(|| unreachable!("the winner is forwarded")));
+        drop(won);
+        let mut lost = worker_on_new.process(std::iter::once(second));
+        let loser = out(lost
+            .next()
+            .unwrap_or_else(|| unreachable!("the loser is forwarded")));
+        drop(lost);
+
+        assert_eq!(
+            winner,
+            ("10.0.0.1".parse().unwrap_or_else(|_| unreachable!()), 9001),
+            "the winner did not forward to the backend its own snapshot names"
+        );
+        assert_eq!(
+            entries(&old).len(),
+            2,
+            "the race installed something other than one pair"
+        );
+        assert_eq!(
+            loser, winner,
+            "the loser forwarded to the backend of a snapshot that lost the race; the flow \
+             table holds only the winner's reverse key, so this backend's reply has no mapping"
         );
     }
 }

--- a/nat/src/portfw/portfwtable/access.rs
+++ b/nat/src/portfw/portfwtable/access.rs
@@ -7,7 +7,10 @@
 use super::super::build_port_forwarding_configuration;
 use super::PortFwTableError;
 use super::objects::{PortFwEntry, PortFwTable};
+use crate::portfw::flows::migrate_port_forwarded_flows;
+use config::GenId;
 use config::external::overlay::vpc::ValidatedVpcTable;
+use flow_entry::flow_table::table::FlowTable;
 use left_right::{Absorb, ReadGuard, ReadHandle, ReadHandleFactory, WriteHandle};
 
 #[allow(unused)]
@@ -56,13 +59,45 @@ impl PortFwTableWriter {
         self.0.publish(); // intended
         Ok(())
     }
+    /// Install `ruleset` and carry the live port-forwarded flows onto `genid`.
+    ///
+    /// This is the entry point a configuration enactment wants, and the counterpart of
+    /// `NatAllocatorWriter::update_nat_allocator`, which has always taken the flow table and the
+    /// generation for the same reason: a stage that runs *before* port forwarding refuses a flow
+    /// whose generation is behind the pipeline's, so nothing the port-forwarding stage does
+    /// later can rescue it. [`Self::update_table`] alone installs the rules and leaves every
+    /// live flow a generation behind.
+    pub fn update_table_and_flows(
+        &mut self,
+        ruleset: &[PortFwEntry],
+        flow_table: &FlowTable,
+        genid: GenId,
+    ) -> Result<(), PortFwTableError> {
+        self.update_table(ruleset)?;
+        let Some(table) = self.enter() else {
+            error!("Port-forwarding table is unreadable; live flows keep their old generation");
+            debug_assert!(false, "a writer can always read its own table");
+            return Ok(());
+        };
+        drop(migrate_port_forwarded_flows(flow_table, &table, genid));
+        Ok(())
+    }
+
+    /// Lower `vpc_table` to rules, install them, and carry the live flows onto `genid`.
+    ///
+    /// Takes the flow table and the generation for the same reason
+    /// [`Self::update_table_and_flows`] does, and for the additional one that this is the shape
+    /// an enactment has: whoever is holding a validated configuration is also the one who knows
+    /// what generation it is.
     pub fn update_from_vpc_table(
         &mut self,
         vpc_table: &ValidatedVpcTable,
+        flow_table: &FlowTable,
+        genid: GenId,
     ) -> Result<(), PortFwTableError> {
         let ruleset = build_port_forwarding_configuration(vpc_table)
             .map_err(|e| PortFwTableError::Unsupported(e.to_string()))?;
-        self.update_table(&ruleset)
+        self.update_table_and_flows(&ruleset, flow_table, genid)
     }
 }
 

--- a/nat/src/portfw/portfwtable/objects.rs
+++ b/nat/src/portfw/portfwtable/objects.rs
@@ -47,9 +47,12 @@ impl PartialEq for PortFwEntry {
 }
 
 impl PortFwEntry {
-    pub const DEFAULT_INITIAL_TOUT: Duration = Duration::from_secs(10);
-    pub const DEFAULT_ESTABLISHED_TOUT_TCP: Duration = Duration::from_mins(30);
-    pub const DEFAULT_ESTABLISHED_TOUT_UDP: Duration = Duration::from_secs(30);
+    pub const DEFAULT_INITIAL_TOUT: Duration =
+        Duration::from_secs(10 * crate::common::TIMEOUT_SCALE);
+    pub const DEFAULT_ESTABLISHED_TOUT_TCP: Duration =
+        Duration::from_secs(30 * 60 * crate::common::TIMEOUT_SCALE);
+    pub const DEFAULT_ESTABLISHED_TOUT_UDP: Duration =
+        Duration::from_secs(30 * crate::common::TIMEOUT_SCALE);
 
     /// Provide the default established timeout for flows in port-forwarding,
     /// according to protocol

--- a/nat/src/portfw/probe.rs
+++ b/nat/src/portfw/probe.rs
@@ -195,10 +195,29 @@ impl Fabric {
         &self.flow_table
     }
 
-    pub(crate) fn is_private(&self, addr: IpAddr, port: u16) -> bool {
-        self.rules
-            .iter()
-            .any(|(_, private, _)| private.covers(addr, port))
+    /// Whether `addr:port` is a target of a rule that publishes `published`.
+    ///
+    /// The check this replaces asked only whether *some* rule names the address, which accepts a
+    /// packet delivered to a different tenant's backend so long as that backend is published
+    /// somewhere -- the containment failure actually worth finding. This binds the two ends
+    /// together: the rule that matched the packet's public tuple is the rule whose target it
+    /// has to land in.
+    ///
+    /// Measured 2026-09-07: over 8296 deliveries, half of them from two-rule overlays, the two
+    /// forms never disagree, and no case even *could* -- `port_forwarding_expose` gives each
+    /// expose its own address block, so a rule whose target covers the delivered address but
+    /// which did not publish the tuple does not exist. This closes the hole in the oracle; the
+    /// generator has to place two rules' targets in one block before it can bite.
+    ///
+    /// It deliberately checks membership of the matched rule's private side rather than
+    /// recomputing the exact address. The offset arithmetic lives in
+    /// `PortFwEntry::map_address_port`, and a test that reimplements it asserts the
+    /// reimplementation. `distinct_published_tuples_reach_distinct_targets` is what pins the
+    /// mapping itself down to one target per tuple.
+    pub(crate) fn is_target_of(&self, published: (IpAddr, u16), addr: IpAddr, port: u16) -> bool {
+        self.rules.iter().any(|(public, private, _)| {
+            public.covers(published.0, published.1) && private.covers(addr, port)
+        })
     }
 }
 

--- a/nat/src/portfw/probe.rs
+++ b/nat/src/portfw/probe.rs
@@ -161,6 +161,18 @@ impl Fabric {
         )
     }
 
+    /// A second worker over someone else's flow table: this fabric's port-forwarding
+    /// snapshot, `flows`'s shared table.
+    ///
+    /// Every worker builds its own pipeline and so holds its own left-right read guard on the
+    /// port-forwarding table, while the flow table is one `Arc` shared by all of them. A
+    /// configuration published between two workers' batches therefore leaves them translating
+    /// one public tuple to two different backends, racing to install the same forward key --
+    /// the key is the *pre*-translation tuple, so it collides however far apart the targets are.
+    pub(crate) fn worker_over(&self, flows: &Arc<FlowTable>) -> PortForwarder {
+        PortForwarder::new("port-forwarder-2", self.writer.reader(), flows.clone())
+    }
+
     /// Enact `exposes` over this fabric's live flow table, the way a configuration apply does:
     /// install the new rules, then carry the flows they still open onto `genid` and invalidate
     /// the rest. The rule *set* this fabric reports is deliberately left describing the fabric

--- a/nat/src/portfw/probe.rs
+++ b/nat/src/portfw/probe.rs
@@ -161,6 +161,20 @@ impl Fabric {
         )
     }
 
+    /// Enact `exposes` over this fabric's live flow table, the way a configuration apply does:
+    /// install the new rules, then carry the flows they still open onto `genid` and invalidate
+    /// the rest. The rule *set* this fabric reports is deliberately left describing the fabric
+    /// as built, so a caller can still ask what the flows were opened by.
+    pub(crate) fn re_enact(&mut self, exposes: &[VpcExpose], genid: config::GenId) {
+        let validated = overlay_with_exposes(exposes.to_vec())
+            .ok()
+            .and_then(|overlay| overlay.validate().ok())
+            .unwrap_or_else(|| unreachable!("the fixture exposes validate"));
+        self.writer
+            .update_from_vpc_table(validated.vpc_table(), &self.flow_table, genid)
+            .unwrap_or_else(|e| unreachable!("{e}"));
+    }
+
     pub(crate) fn is_probeable(&self) -> bool {
         !self.rules.is_empty()
     }

--- a/nat/src/static_nat/fuzz.rs
+++ b/nat/src/static_nat/fuzz.rs
@@ -116,7 +116,7 @@ fn five_tuple_destination(packet: &Packet<TestBuffer>) -> (IpAddr, u16) {
 fn judged(built: usize) -> bool {
     /// One case cannot support a rate; anything above that, the ratios can speak to.
     const ENOUGH_CONFIGURATIONS: usize = 2;
-    !cfg!(instrumented) && !cfg!(emulated) && built >= ENOUGH_CONFIGURATIONS
+    !cfg!(instrumented) && !cfg!(emulated) && !cfg!(sanitized) && built >= ENOUGH_CONFIGURATIONS
 }
 
 #[derive(Default)]

--- a/nat/src/test.rs
+++ b/nat/src/test.rs
@@ -112,7 +112,7 @@ fn setup_masq_pipeline(
     // Port forwarding
     let mut portfw_writer = PortFwTableWriter::new();
     portfw_writer
-        .update_from_vpc_table(overlay.vpc_table())
+        .update_from_vpc_table(overlay.vpc_table(), &flow_table, 0)
         .unwrap();
     let portfw = PortForwarder::new("port-forwarder", portfw_writer.reader(), flow_table.clone());
     if let Some(table) = portfw_writer.enter() {

--- a/net/src/headers/embedded_view.rs
+++ b/net/src/headers/embedded_view.rs
@@ -1836,8 +1836,8 @@ mod embedded_view_properties {
     use crate::icmp4::Icmp4;
     use crate::icmp6::Icmp6;
     use crate::vlan::Vlan;
+    use concurrency::process_global::atomic::AtomicUsize;
     use concurrency::sync::OnceLock;
-    use concurrency::sync::atomic::AtomicUsize;
 
     // `AtomicUsize::new` is not const under loom, so counters init on first use.
     fn counter(slot: &OnceLock<AtomicUsize>) -> &AtomicUsize {
@@ -1852,7 +1852,7 @@ mod embedded_view_properties {
         ) => {
             #[test]
             fn $read() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
                 static HIT: OnceLock<AtomicUsize> = OnceLock::new();
                 bolero::check!()
@@ -1888,7 +1888,7 @@ mod embedded_view_properties {
 
             #[test]
             fn $mutable() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
                 static HIT: OnceLock<AtomicUsize> = OnceLock::new();
                 bolero::check!()
@@ -2063,7 +2063,7 @@ mod embedded_view_properties {
 
     #[test]
     fn mutable_inner_transport_enum() {
-        use concurrency::sync::atomic::{AtomicUsize, Ordering};
+        use concurrency::process_global::atomic::{AtomicUsize, Ordering};
         static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
         static HIT: OnceLock<AtomicUsize> = OnceLock::new();
         bolero::check!()
@@ -2165,7 +2165,7 @@ mod embedded_view_properties {
         ($name:ident, $gen:expr, $outer:ty, $shape:ty, $($binding:ident),+) => {
             #[test]
             fn $name() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
                 static HIT: OnceLock<AtomicUsize> = OnceLock::new();
                 bolero::check!()

--- a/net/src/headers/pat.rs
+++ b/net/src/headers/pat.rs
@@ -2961,8 +2961,8 @@ mod tests {
 mod opt_properties {
     use super::*;
     use crate::headers::{Headers, ShapedIcmpError, ThinHeaders};
+    use concurrency::process_global::atomic::AtomicUsize;
     use concurrency::sync::OnceLock;
-    use concurrency::sync::atomic::AtomicUsize;
     use std::cell::Cell;
 
     // `AtomicUsize::new` is not const under loom, so counters init on first use.
@@ -2974,7 +2974,7 @@ mod opt_properties {
         ($read:ident, $mutable:ident, [$($pre:ident),*], $strict:ident, $opt:ident) => {
             #[test]
             fn $read() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static STRICT: OnceLock<AtomicUsize> = OnceLock::new();
                 static OPT_ONLY: OnceLock<AtomicUsize> = OnceLock::new();
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
@@ -3008,7 +3008,7 @@ mod opt_properties {
 
             #[test]
             fn $mutable() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static STRICT: OnceLock<AtomicUsize> = OnceLock::new();
                 static OPT_ONLY: OnceLock<AtomicUsize> = OnceLock::new();
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
@@ -3133,7 +3133,7 @@ mod opt_properties {
         ) => {
             #[test]
             fn $read() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static STRICT: OnceLock<AtomicUsize> = OnceLock::new();
                 static OPT_ONLY: OnceLock<AtomicUsize> = OnceLock::new();
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
@@ -3169,7 +3169,7 @@ mod opt_properties {
 
             #[test]
             fn $mutable() {
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static STRICT: OnceLock<AtomicUsize> = OnceLock::new();
                 static OPT_ONLY: OnceLock<AtomicUsize> = OnceLock::new();
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
@@ -3501,7 +3501,7 @@ mod opt_properties {
 
     #[test]
     fn the_embedded_combinators_track_the_inner_match_only() {
-        use concurrency::sync::atomic::{AtomicUsize, Ordering};
+        use concurrency::process_global::atomic::{AtomicUsize, Ordering};
         static DIVERGED: OnceLock<AtomicUsize> = OnceLock::new();
         bolero::check!()
             .with_generator(ShapedIcmpError)

--- a/net/src/headers/view.rs
+++ b/net/src/headers/view.rs
@@ -2647,8 +2647,8 @@ mod view_mut_properties {
     use crate::eth::Eth;
     use crate::headers::view::{Look, LookMut};
     use crate::headers::{Headers, Net, ShapedHeaders, SometimesHeadless, Transport};
+    use concurrency::process_global::atomic::AtomicUsize;
     use concurrency::sync::OnceLock;
-    use concurrency::sync::atomic::AtomicUsize;
 
     // `AtomicUsize::new` is not const under loom, so counters init on first use.
     fn counter(slot: &OnceLock<AtomicUsize>) -> &AtomicUsize {
@@ -2750,7 +2750,7 @@ mod view_mut_properties {
             #[test]
             fn $read() {
                 type Shape = shape_of!($($layer),+);
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
                 static HIT: OnceLock<AtomicUsize> = OnceLock::new();
                 bolero::check!()
@@ -2793,7 +2793,7 @@ mod view_mut_properties {
             #[test]
             fn $mutable() {
                 type Shape = shape_of!($($layer),+);
-                use concurrency::sync::atomic::{AtomicUsize, Ordering};
+                use concurrency::process_global::atomic::{AtomicUsize, Ordering};
                 static SEEN: OnceLock<AtomicUsize> = OnceLock::new();
                 static HIT: OnceLock<AtomicUsize> = OnceLock::new();
                 bolero::check!()

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -785,3 +785,98 @@ pub fn build_test_icmp6_echo(
     headers.deparse(buffer.as_mut()).unwrap();
     Packet::new(buffer)
 }
+
+/// Build an `ICMPv4` error whose quoted datagram is `quote`, copied in verbatim.
+///
+/// The typed builders above assemble the quote from `EmbeddedTransport` values, which can only
+/// ever produce a quote the deparser agrees with. `quote` here is raw bytes -- the offending
+/// packet from its IP header onwards, at whatever length the caller chose -- so the receiver's
+/// parser has to make sense of it rather than being handed the answer. That is the whole point:
+/// everything a NAT decides about a short or malformed quote lives in that parse.
+///
+/// The ICMP checksum is computed over the quote as parsed, so the result is a *valid* error
+/// unless the caller corrupts it afterwards.
+///
+/// Returns `None` if the assembled packet does not parse, which a sufficiently mangled quote can
+/// legitimately cause -- a caller generating quotes is expected to skip those rather than treat
+/// them as failures.
+#[must_use]
+pub fn build_icmp4_error_quoting(
+    unreachable: Icmp4DestUnreachable,
+    outer_src: Ipv4Addr,
+    outer_dst: Ipv4Addr,
+    quote: &[u8],
+) -> Option<Packet<TestBuffer>> {
+    let icmp = Icmp4(Icmpv4Header::new(Icmpv4Type::DestinationUnreachable(
+        DestUnreachableHeader::from(unreachable),
+    )));
+
+    let mut outer = Ipv4::default();
+    outer.set_source(UnicastIpv4Addr::new(outer_src).ok()?);
+    outer.set_destination(outer_dst);
+    outer.set_ttl(8);
+    outer.set_next_header(NextHeader::ICMP);
+    outer
+        .set_payload_len(
+            icmp.size()
+                .get()
+                .checked_add(u16::try_from(quote.len()).ok()?)?,
+        )
+        .ok()?;
+    outer.update_checksum(&()).ok()?;
+
+    let mut headers = HeadersBuilder::default();
+    headers.eth(Some(make_default_for_eth(EthType::IPV4)));
+    headers.net(Some(Net::Ipv4(outer)));
+    headers.transport(Some(Transport::Icmp4(icmp)));
+    assemble_quoted(&headers, quote)
+}
+
+/// Build an `ICMPv6` error whose quoted datagram is `quote`, copied in verbatim.
+///
+/// See [`build_icmp4_error_quoting`]; this is the same construction over `ICMPv6`.
+#[must_use]
+pub fn build_icmp6_error_quoting(
+    icmp_type: Icmp6Type,
+    outer_src: Ipv6Addr,
+    outer_dst: Ipv6Addr,
+    quote: &[u8],
+) -> Option<Packet<TestBuffer>> {
+    let icmp = Icmp6(Icmpv6Header::new(icmp_type.into()));
+
+    let mut outer = Ipv6::default();
+    outer.set_source(UnicastIpv6Addr::new(outer_src).ok()?);
+    outer.set_destination(outer_dst);
+    outer.set_hop_limit(8);
+    outer.set_next_header(NextHeader::ICMP6);
+    outer.set_payload_length(
+        icmp.size()
+            .get()
+            .checked_add(u16::try_from(quote.len()).ok()?)?,
+    );
+
+    let mut headers = HeadersBuilder::default();
+    headers.eth(Some(make_default_for_eth(EthType::IPV6)));
+    headers.net(Some(Net::Ipv6(outer)));
+    headers.transport(Some(Transport::Icmp6(icmp)));
+    assemble_quoted(&headers, quote)
+}
+
+/// Lay `headers` down, append `quote` behind them, and re-parse the result.
+///
+/// Re-parsing rather than building the embedded headers directly is the point of these two
+/// constructors: the packet that comes back carries whatever the *parser* made of the quote,
+/// which for a truncated one is not necessarily what the caller put in.
+fn assemble_quoted(headers: &HeadersBuilder, quote: &[u8]) -> Option<Packet<TestBuffer>> {
+    let headers = headers.build().ok()?;
+    let front = headers.size().get() as usize;
+    let mut data = vec![0u8; front + quote.len()];
+    headers.deparse(&mut data[..front]).ok()?;
+    data[front..].copy_from_slice(quote);
+
+    let mut packet = Packet::new(TestBuffer::from_raw_data(&data)).ok()?;
+    // The ICMP checksum covers the quote, so it can only be computed once the quote is in place
+    // and the parser has said what it is.
+    packet.update_checksums();
+    Some(packet)
+}

--- a/nix/profiles.nix
+++ b/nix/profiles.nix
@@ -48,6 +48,12 @@ let
     # Only coverage lowers counter-heavy loop counts; sanitizers retain the
     # iterations that help expose races.
     "--check-cfg=cfg(instrumented)"
+    # Separate from `instrumented` on purpose. That one means "this build runs
+    # fewer iterations"; this one means "this build runs them slowly". A
+    # sanitizer keeps every iteration -- which is the point, races need them --
+    # but bolero stops on wall-clock, so the *sample* is small either way and a
+    # coverage guard reading it is judging the sanitizer, not the code.
+    "--check-cfg=cfg(sanitized)"
     "-Cdebuginfo=full"
     "-Cdwarf-version=5"
     "-Csymbol-mangling-version=v0"
@@ -65,6 +71,7 @@ let
   )
   ++ (if is-emulated-test then [ "--cfg=emulated" ] else [ ])
   ++ (if builtins.elem "coverage" instrumentations then [ "--cfg=instrumented" ] else [ ])
+  ++ (if sanitizers != [ ] then [ "--cfg=sanitized" ] else [ ])
   ++ (map (flag: "-Clink-arg=${flag}") common.NIX_CFLAGS_LINK);
   optimize-for.debug.NIX_CFLAGS_COMPILE = [
     "-fno-inline"

--- a/pipeline/src/pipeline.rs
+++ b/pipeline/src/pipeline.rs
@@ -18,10 +18,20 @@ use std::any::Any;
 pub type StageId<Buf> = Id<Box<dyn DynNetworkFunction<Buf>>>;
 
 /// Data associated to a `Pipeline`
+///
+/// The generation id has two jobs that a single counter cannot do at once, so it is kept as two.
+/// `genid` is the generation the pipeline *enforces*: a flow stamped older than it has not been
+/// validated against the configuration in force, and the stages that check generations refuse it.
+/// `staging` is the generation a flow validated *right now* belongs to. Applying a configuration
+/// opens the new generation for stamping first and enforces it last, so that a flow created while
+/// the apply is in flight -- too late for the migration walks to see, too early to stamp itself
+/// from the published generation -- is not born stale.
 #[derive(Default, Debug)]
 pub struct PipelineData {
-    /// Current generation Id
-    pub genid: AtomicI64,
+    /// Generation Id enforced by the stages that check flows
+    genid: AtomicI64,
+    /// Generation Id stamped onto flows as they are created or revalidated
+    staging: AtomicI64,
 }
 impl PipelineData {
     #[must_use]
@@ -29,14 +39,30 @@ impl PipelineData {
     pub fn new(genid: i64) -> Self {
         Self {
             genid: AtomicI64::new(genid),
+            staging: AtomicI64::new(genid),
         }
     }
-    /// Read the generation id
+    /// Read the generation id the pipeline enforces
     pub fn genid(&self) -> i64 {
         self.genid.load(Ordering::Relaxed)
     }
-    /// Set the generation id
+    /// Read the generation id to stamp onto a flow that has just been validated
+    pub fn staging_genid(&self) -> i64 {
+        self.staging.load(Ordering::Relaxed)
+    }
+    /// Open `genid` for stamping without enforcing it yet.
+    ///
+    /// Call this before migrating the flows of the previous generation, and [`Self::set_genid`]
+    /// once the whole configuration is installed.
+    pub fn open_generation(&self, genid: i64) {
+        self.staging.store(genid, Ordering::Relaxed);
+    }
+    /// Set the generation id, enforcing it from now on.
+    ///
+    /// Stamping is brought up to `genid` too, so a caller that never opened the generation still
+    /// leaves the two coherent.
     pub fn set_genid(&self, genid: i64) {
+        self.staging.store(genid, Ordering::Relaxed);
         self.genid.store(genid, Ordering::Relaxed);
     }
 }

--- a/routing/Cargo.toml
+++ b/routing/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 
 [features]
 loom = ["concurrency/loom"]
-shuttle = ["concurrency/shuttle"]
+shuttle = ["concurrency/shuttle", "left-right/shuttle"]
 shuttle_dfs = ["concurrency/shuttle_dfs", "shuttle"]
 testing = []
 

--- a/routing/src/router/rio.rs
+++ b/routing/src/router/rio.rs
@@ -607,8 +607,16 @@ mod tests {
     // chosen for headroom over the last honest measurement rather than over
     // this one. If it is reached again, the thing to suspect is rio, not the
     // deadline.
+    //
+    // `sanitized` joins `instrumented` on the long arm for the same reason and
+    // on the same evidence: under ThreadSanitizer that test took 31.1 s against
+    // the old 30, and failed as a dead peer. A sanitizer does not reduce the
+    // work, it slows every bit of it down, so a deadline calibrated on an
+    // uninstrumented run is not a deadline there. That it is the same test and
+    // very nearly the same 31 s in both places is the argument for the long
+    // arm being generous rather than exact.
     const PATIENCE: Duration = Duration::from_secs(cfg_select! {
-        instrumented => 300,
+        any(instrumented, sanitized) => 300,
         _ => 120,
     });
 

--- a/stats/src/rate.rs
+++ b/stats/src/rate.rs
@@ -806,8 +806,8 @@ mod contract {
 #[cfg(test)]
 mod test {
     use crate::rate::{Derivative, DerivativeComparer, DerivativeError, SavitzkyGolayFilter};
+    use concurrency::process_global::atomic::{AtomicU64, Ordering};
     use concurrency::sync::LazyLock;
-    use concurrency::sync::atomic::{AtomicU64, Ordering};
 
     use crate::{PacketAndByte, TransmitSummary};
 


### PR DESCRIPTION
Split out of `(14) n-vm`, which had grown to 115 commits and 25k insertions.

Everything here is a concurrency or timing defect surfaced by the model
backends, the sanitizers and the paused clock -- `process_global` for the
primitives a `static` owns, the flow-entry live counter, the two
port-forwarding races, the masquerade reverse tuple, and the stats fixes
that came with them. None of it is about the in-VM harness, which is why
it is no longer filed under it.

No commit here is new. Three commits are gone: `build: Do not enable
left-right's shuttle arm; it deadlocks` and `build: Re-enable
left-right's shuttle arm; it does not deadlock` are exact inverses of one
another, so the branch move that precedes them already carries the net
state.

One commit was renamed. `fix(nat): Arbitrate the race to create a
port-forwarding flow` shared its subject, character for character, with a
different fix in `(08) icmp`. They address different races -- two packets
of one flow in a single burst there, two workers holding different table
generations here -- so they now say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)