### PR TITLE
dpdk + incremental checksums

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -142,19 +142,26 @@ jobs:
         uses: *gate
         with:
           labels: "test/all-profiles"
-          # The build matrix has no fuzz container targets.
-          on-value: '["debug", "release"]'
-          # Pull-request lab labels require both debug and release images.
-          off-value: >-
-            ${{
-              github.event_name == 'pull_request'
-              && (
-                contains(github.event.pull_request.labels.*.name, 'ci:+vlab')
-                || contains(github.event.pull_request.labels.*.name, 'ci:+hlab')
-              )
-              && '["debug", "release"]'
-              || '["debug"]'
-            }}
+          # EXPERIMENT (dpdk in vlab): release only, both ways.
+          #
+          # The gateway is being debugged against physical hardware, and only CI can push images,
+          # so every one-line fix costs a full round trip. Half of that trip was building a debug
+          # image nothing in this loop installs. The lab wants the release artifact; the debug one
+          # comes back with the rest of the scaffolding.
+          on-value: '["release"]'
+          off-value: '["release"]'
+          # Restore with the scaffolding:
+          # on-value: '["debug", "release"]'
+          # off-value: >-
+          #   ${{
+          #     github.event_name == 'pull_request'
+          #     && (
+          #       contains(github.event.pull_request.labels.*.name, 'ci:+vlab')
+          #       || contains(github.event.pull_request.labels.*.name, 'ci:+hlab')
+          #     )
+          #     && '["debug", "release"]'
+          #     || '["debug"]'
+          #   }}
 
       - id: "wasm"
         uses: *gate
@@ -296,6 +303,14 @@ jobs:
           limit-access-to-actor: true
 
   lint:
+    # EXPERIMENT (dpdk in vlab): parked, like `check` and `coverage`.
+    #
+    # It already does not gate the images. Parking it too is about the runner: every push in this
+    # break-fix loop is a one-line change to hugepage or namespace handling being tried against
+    # real hardware, and a lint pass costs a lab runner to say nothing about whether the gateway
+    # comes up. The commits here are going to be rewritten wholesale before any of this lands, so
+    # the lint that matters is the one run over the rewritten series. Restore with the rest.
+    if: false
     name: "lint"
     runs-on: "lab"
     permissions:
@@ -844,6 +859,16 @@ jobs:
       - *tmate
 
   vlab:
+    # EXPERIMENT (dpdk in vlab): parked while the gateway is debugged on real hardware.
+    #
+    # This is the job the branch was named for, so parking it deserves a reason: the question has
+    # moved. vlab answers "does the gateway come up in a virtual lab", and the current failures --
+    # hugepage cgroup limits, the RDMA namespace mode -- are properties of the physical host that
+    # a virtual lab does not have and cannot reproduce. Until the physical run gets past EAL
+    # startup, a vlab pass would tell us nothing and a vlab failure would be about something else.
+    #
+    # Unpark before drawing any conclusion about the merged gateway, and before this lands.
+    if: false
     needs:
       - version
       - build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "dataplane-concurrency",
  "dataplane-config",
  "dataplane-dpdk",
+ "dataplane-errno",
  "dataplane-flow-entry",
  "dataplane-flow-filter",
  "dataplane-hardware",

--- a/args/src/lib.rs
+++ b/args/src/lib.rs
@@ -80,6 +80,14 @@ pub enum PortArg {
 pub struct InterfaceArg {
     pub interface: InterfaceName,
     pub port: Option<PortArg>,
+    /// MTU to configure the port with, when the configuration named one.
+    ///
+    /// `None` leaves the driver's default, which for DPDK is 1500 -- and on a fabric running
+    /// 9036 that is a path-MTU black hole rather than a slow link: the handshake and every small
+    /// packet pass, then the first full-size segment is untransmittable and the connection stops
+    /// dead with its window collapsed to a single segment. The kernel driver never showed this,
+    /// because an init container ran `ip l set mtu` in shell for it.
+    pub mtu: Option<u16>,
 }
 
 #[derive(
@@ -127,6 +135,22 @@ impl FromStr for PortArg {
 impl FromStr for InterfaceArg {
     type Err = String;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        // An optional `,mtu=N` suffix, so `name=pci@0000:02:01.0` keeps working untouched and
+        // `name=pci@0000:02:01.0,mtu=9036` sets the port's MTU. Split before the `=` handling
+        // because a PCI address contains no commas and an interface name cannot either.
+        let (input, mtu) = match input.split_once(",mtu=") {
+            Some((head, value)) => {
+                let mtu = value
+                    .parse::<u16>()
+                    .map_err(|e| format!("Bad mtu '{value}': {e}"))?;
+                if mtu < 68 {
+                    return Err(format!("Bad mtu {mtu}: below the IPv4 minimum of 68"));
+                }
+                (head, Some(mtu))
+            }
+            None => (input, None),
+        };
+
         if let Some((first, second)) = input.split_once('=') {
             let interface =
                 InterfaceName::try_from(first).map_err(|e| format!("Bad interface name: {e}"))?;
@@ -135,6 +159,7 @@ impl FromStr for InterfaceArg {
             Ok(InterfaceArg {
                 interface,
                 port: Some(port),
+                mtu,
             })
         } else {
             let interface =
@@ -142,6 +167,7 @@ impl FromStr for InterfaceArg {
             Ok(InterfaceArg {
                 interface,
                 port: None,
+                mtu,
             })
         }
     }
@@ -2006,5 +2032,52 @@ mod hugepage_plan_test {
             mib.to_string(),
             "4096 MiB in 2 MiB pages (node 0: 4096 MiB)"
         );
+    }
+}
+
+#[cfg(test)]
+mod interface_arg_mtu_test {
+    use super::{InterfaceArg, PortArg};
+    use std::str::FromStr;
+
+    /// The existing syntax must keep working, MTU absent.
+    #[test]
+    fn an_interface_without_an_mtu_parses_as_before() {
+        let arg = InterfaceArg::from_str("enp2s1np0=pci@0000:02:01.0").expect("should parse");
+        assert_eq!(arg.interface.to_string(), "enp2s1np0");
+        assert!(matches!(arg.port, Some(PortArg::PCI(_))));
+        assert_eq!(arg.mtu, None, "absent means the driver's default, not 0");
+    }
+
+    /// And the suffix sets it without disturbing the PCI address, which is full of colons.
+    #[test]
+    fn an_mtu_suffix_is_parsed_and_the_address_survives() {
+        let arg =
+            InterfaceArg::from_str("enp2s1np0=pci@0000:02:01.0,mtu=9036").expect("should parse");
+        assert_eq!(arg.interface.to_string(), "enp2s1np0");
+        assert_eq!(arg.mtu, Some(9036));
+        match arg.port {
+            Some(PortArg::PCI(addr)) => assert_eq!(addr.to_string(), "0000:02:01.0"),
+            other => panic!("the PCI address did not survive the split: {other:?}"),
+        }
+    }
+
+    /// A kernel interface takes one too, since both drivers have the same hole.
+    #[test]
+    fn a_kernel_interface_takes_an_mtu() {
+        let arg = InterfaceArg::from_str("eth0=kernel@eth0,mtu=1500").expect("should parse");
+        assert_eq!(arg.mtu, Some(1500));
+    }
+
+    /// Nonsense is refused rather than silently ignored, which would restore the black hole.
+    #[test]
+    fn a_bad_mtu_is_an_error() {
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=").is_err());
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=nine").is_err());
+        assert!(
+            InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=67").is_err(),
+            "below the IPv4 minimum of 68"
+        );
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=68").is_ok());
     }
 }

--- a/args/src/lib.rs
+++ b/args/src/lib.rs
@@ -82,6 +82,9 @@ pub struct InterfaceArg {
     pub port: Option<PortArg>,
     /// MTU to configure the port with, when the configuration named one.
     ///
+    /// Spelled `/mtu=N` on the command line rather than `,mtu=N`, because clap splits this
+    /// argument's values on commas before the parser sees them.
+    ///
     /// `None` leaves the driver's default, which for DPDK is 1500 -- and on a fabric running
     /// 9036 that is a path-MTU black hole rather than a slow link: the handshake and every small
     /// packet pass, then the first full-size segment is untransmittable and the connection stops
@@ -135,10 +138,14 @@ impl FromStr for PortArg {
 impl FromStr for InterfaceArg {
     type Err = String;
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        // An optional `,mtu=N` suffix, so `name=pci@0000:02:01.0` keeps working untouched and
-        // `name=pci@0000:02:01.0,mtu=9036` sets the port's MTU. Split before the `=` handling
-        // because a PCI address contains no commas and an interface name cannot either.
-        let (input, mtu) = match input.split_once(",mtu=") {
+        // An optional `/mtu=N` suffix, so `name=pci@0000:02:01.0` keeps working untouched and
+        // `name=pci@0000:02:01.0/mtu=9036` sets the port's MTU.
+        //
+        // **Not a comma.** This argument is declared with clap's `value_delimiter = ','`, so a
+        // comma is consumed by clap before this parser is ever called: the value arrives split in
+        // two and the second half fails as an interface name. `/` cannot appear in a PCI address
+        // or a kernel interface name, so it is unambiguous here.
+        let (input, mtu) = match input.split_once("/mtu=") {
             Some((head, value)) => {
                 let mtu = value
                     .parse::<u16>()
@@ -1509,12 +1516,14 @@ pub struct CmdArgs {
         value_name = "interface name",
         value_parser=InterfaceArg::from_str,
         value_delimiter=',',
-        help = "Interface name mapping, with syntax INTERFACE=DISCRIMINANT@{PCI,IFNAME}. Two discriminants are possible: pci and kernel.
+        help = "Interface name mapping, with syntax INTERFACE=DISCRIMINANT@{PCI,IFNAME}[/mtu=N]. Two discriminants are possible: pci and kernel.
 Pci should be followed by a PCI address. Kernel should be followed by a valid kernel interface name.
+An optional /mtu=N sets the port's MTU; without it the driver's default is used, which for DPDK is 1500.
 Examples:
    --interface eth0=pci@0000:02:01.0
+   --interface eth0=pci@0000:02:01.0/mtu=9036
    --interface eth1=kernel@enp2s1
-Note: multiple interfaces can be specified separated by commas and no spaces"
+Note: multiple interfaces can be specified separated by commas and no spaces, which is why the MTU suffix uses a slash"
     )]
     interface: Vec<InterfaceArg>,
 
@@ -2037,7 +2046,7 @@ mod hugepage_plan_test {
 
 #[cfg(test)]
 mod interface_arg_mtu_test {
-    use super::{InterfaceArg, PortArg};
+    use super::{CmdArgs, InterfaceArg, PortArg};
     use std::str::FromStr;
 
     /// The existing syntax must keep working, MTU absent.
@@ -2053,7 +2062,7 @@ mod interface_arg_mtu_test {
     #[test]
     fn an_mtu_suffix_is_parsed_and_the_address_survives() {
         let arg =
-            InterfaceArg::from_str("enp2s1np0=pci@0000:02:01.0,mtu=9036").expect("should parse");
+            InterfaceArg::from_str("enp2s1np0=pci@0000:02:01.0/mtu=9036").expect("should parse");
         assert_eq!(arg.interface.to_string(), "enp2s1np0");
         assert_eq!(arg.mtu, Some(9036));
         match arg.port {
@@ -2065,19 +2074,56 @@ mod interface_arg_mtu_test {
     /// A kernel interface takes one too, since both drivers have the same hole.
     #[test]
     fn a_kernel_interface_takes_an_mtu() {
-        let arg = InterfaceArg::from_str("eth0=kernel@eth0,mtu=1500").expect("should parse");
+        let arg = InterfaceArg::from_str("eth0=kernel@eth0/mtu=1500").expect("should parse");
         assert_eq!(arg.mtu, Some(1500));
+    }
+
+    /// The suffix must survive **clap**, not just this parser.
+    ///
+    /// The first attempt at this used `,mtu=N` and passed every test above, because those call
+    /// `from_str` directly. In the lab it failed instantly: the argument is declared with
+    /// `value_delimiter = \',\'`, so clap split the value in two and handed `mtu=8986` to the
+    /// parser on its own, where it died as an interface name with no `@`. Testing the parser in
+    /// isolation cannot see that -- only going through the real argument definition can.
+    #[test]
+    fn the_suffix_survives_clap_argument_splitting() {
+        use clap::Parser;
+        let args = CmdArgs::try_parse_from([
+            "dataplane",
+            "--driver",
+            "dpdk",
+            "--interface",
+            "enp2s1np0=pci@0000:02:01.0/mtu=9036",
+        ])
+        .expect("the interface argument should parse through clap");
+        let ifaces: Vec<_> = args.interfaces().collect();
+        assert_eq!(ifaces.len(), 1, "clap split one interface into {ifaces:?}");
+        assert_eq!(ifaces[0].mtu, Some(9036));
+
+        // And the delimiter clap *does* claim still separates interfaces, as it always did.
+        let args = CmdArgs::try_parse_from([
+            "dataplane",
+            "--driver",
+            "dpdk",
+            "--interface",
+            "a=pci@0000:02:01.0/mtu=9036,b=pci@0000:02:02.0",
+        ])
+        .expect("a comma-separated list should still parse");
+        let ifaces: Vec<_> = args.interfaces().collect();
+        assert_eq!(ifaces.len(), 2, "the comma still separates interfaces");
+        assert_eq!(ifaces[0].mtu, Some(9036));
+        assert_eq!(ifaces[1].mtu, None);
     }
 
     /// Nonsense is refused rather than silently ignored, which would restore the black hole.
     #[test]
     fn a_bad_mtu_is_an_error() {
-        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=").is_err());
-        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=nine").is_err());
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0/mtu=").is_err());
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0/mtu=nine").is_err());
         assert!(
-            InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=67").is_err(),
+            InterfaceArg::from_str("a=pci@0000:02:01.0/mtu=67").is_err(),
             "below the IPv4 minimum of 68"
         );
-        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0,mtu=68").is_ok());
+        assert!(InterfaceArg::from_str("a=pci@0000:02:01.0/mtu=68").is_ok());
     }
 }

--- a/args/src/lib.rs
+++ b/args/src/lib.rs
@@ -405,6 +405,78 @@ pub enum DriverConfigSection {
     Kernel(KernelDriverConfigSection),
 }
 
+/// Hugepages `dataplane-init` secured before the dataplane started, and where.
+///
+/// Crosses to the dataplane in the launch configuration so that the EAL can be asked for exactly
+/// what was verified to be free, rather than for a figure someone guessed. See
+/// `dataplane-init`'s `hugepages` module for why the reservation cannot be left to DPDK.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Archive,
+    CheckBytes,
+)]
+#[rkyv(attr(derive(Debug, PartialEq, Eq)))]
+pub struct HugepagePlan {
+    /// Page size actually used, in kilobytes: 1048576 for 1 GiB pages, 2048 for 2 MiB pages.
+    pub page_size_kb: u64,
+    /// Megabytes secured, per NUMA node id, ascending.
+    pub per_node_mb: Vec<(u32, u64)>,
+}
+
+impl HugepagePlan {
+    /// Render the EAL's per-node preallocation argument.
+    ///
+    /// DPDK 26.07 renamed `--socket-mem` to `--numa-mem` and keeps the old spelling as an alias;
+    /// the new name is used here. The value is positional -- one entry per NUMA node from 0 up to
+    /// the highest node named -- so nodes we secured nothing on are filled with `0`.
+    ///
+    /// Returns `None` when nothing was secured, so the caller can omit the flag entirely rather
+    /// than pass `0` and forbid the EAL from allocating at all.
+    #[must_use]
+    pub fn numa_mem_arg(&self) -> Option<String> {
+        let highest = self.per_node_mb.iter().map(|(node, _)| *node).max()?;
+        if self.per_node_mb.iter().all(|(_, mb)| *mb == 0) {
+            return None;
+        }
+        let mut per_node = vec![0u64; (highest as usize) + 1];
+        for (node, mb) in &self.per_node_mb {
+            per_node[*node as usize] = *mb;
+        }
+        Some(
+            per_node
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+    }
+}
+
+impl std::fmt::Display for HugepagePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let size = if self.page_size_kb >= 1024 * 1024 {
+            format!("{} GiB", self.page_size_kb / (1024 * 1024))
+        } else {
+            format!("{} MiB", self.page_size_kb / 1024)
+        };
+        let total: u64 = self.per_node_mb.iter().map(|(_, mb)| *mb).sum();
+        write!(f, "{total} MiB in {size} pages (")?;
+        for (i, (node, mb)) in self.per_node_mb.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "node {node}: {mb} MiB")?;
+        }
+        write!(f, ")")
+    }
+}
+
 /// Configuration for the DPDK (Data Plane Development Kit) driver.
 ///
 /// DPDK provides kernel-bypass networking for high-performance packet processing.
@@ -428,6 +500,11 @@ pub struct DpdkDriverConfigSection {
     pub eal_args: Vec<String>,
     /// Packet-processing worker threads to run, each owning one rx/tx queue pair per port
     pub num_workers: u16,
+    /// Hugepages `dataplane-init` reserved on the NUMA node(s) of the configured devices.
+    ///
+    /// `None` when nothing could be reserved, which leaves the EAL to take whatever the host
+    /// already has -- the behaviour from before the reservation existed.
+    pub hugepages: Option<HugepagePlan>,
     /// Whether to isolate the packet path in its own network namespace.
     ///
     /// When set, `dataplane-init` creates a network namespace, moves the configured devices into
@@ -1335,6 +1412,9 @@ impl TryFrom<CmdArgs> for LaunchConfiguration {
                         interfaces: value.interfaces().collect(),
                         eal_args,
                         num_workers: value.num_workers,
+                        // Filled in by `dataplane-init` once it knows which NUMA node the devices
+                        // are on and what the kernel was actually willing to reserve.
+                        hugepages: None,
                         netns: value.datapath_netns,
                     })
                 }
@@ -1852,5 +1932,79 @@ mod tests {
         assert_eq!(err, "Burst must be greater than 0");
         let err = TracingRateLimit::from_str("10:0").unwrap_err();
         assert_eq!(err, "Replenish-per-second must be greater than 0");
+    }
+}
+
+#[cfg(test)]
+mod hugepage_plan_test {
+    use super::HugepagePlan;
+
+    #[test]
+    fn a_single_node_plan_names_that_node_positionally() {
+        let plan = HugepagePlan {
+            page_size_kb: 1024 * 1024,
+            per_node_mb: vec![(0, 4096)],
+        };
+        assert_eq!(plan.numa_mem_arg().as_deref(), Some("4096"));
+    }
+
+    #[test]
+    fn a_plan_on_a_later_node_pads_the_earlier_ones_with_zero() {
+        // The EAL reads the list positionally, so node 1 has to be the *second* entry. Getting
+        // this wrong would preallocate on node 0 -- the exact cross-NUMA placement this exists to
+        // prevent, and it would look like it worked.
+        let plan = HugepagePlan {
+            page_size_kb: 1024 * 1024,
+            per_node_mb: vec![(1, 4096)],
+        };
+        assert_eq!(plan.numa_mem_arg().as_deref(), Some("0,4096"));
+    }
+
+    #[test]
+    fn a_plan_spanning_two_nodes_names_both() {
+        let plan = HugepagePlan {
+            page_size_kb: 2048,
+            per_node_mb: vec![(0, 4096), (2, 2048)],
+        };
+        assert_eq!(plan.numa_mem_arg().as_deref(), Some("4096,0,2048"));
+    }
+
+    #[test]
+    fn a_plan_that_secured_nothing_yields_no_argument() {
+        // Not `Some("0")`: passing zero would forbid the EAL from allocating at all, which is a
+        // worse outcome than letting it take whatever the host already has.
+        let plan = HugepagePlan {
+            page_size_kb: 2048,
+            per_node_mb: vec![(0, 0)],
+        };
+        assert_eq!(plan.numa_mem_arg(), None);
+        assert_eq!(
+            HugepagePlan {
+                page_size_kb: 2048,
+                per_node_mb: vec![]
+            }
+            .numa_mem_arg(),
+            None
+        );
+    }
+
+    #[test]
+    fn the_display_form_reports_the_page_size_an_operator_asked_for() {
+        let gib = HugepagePlan {
+            page_size_kb: 1024 * 1024,
+            per_node_mb: vec![(1, 4096)],
+        };
+        assert_eq!(
+            gib.to_string(),
+            "4096 MiB in 1 GiB pages (node 1: 4096 MiB)"
+        );
+        let mib = HugepagePlan {
+            page_size_kb: 2048,
+            per_node_mb: vec![(0, 4096)],
+        };
+        assert_eq!(
+            mib.to_string(),
+            "4096 MiB in 2 MiB pages (node 0: 4096 MiB)"
+        );
     }
 }

--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -26,6 +26,9 @@ concurrency = { workspace = true }
 config = { workspace = true }
 dpdk = { workspace = true }
 dyn-iter = { workspace = true }
+# `Dev::stats` reports a `dpdk::…::ErrorCode` from this crate, and the DPDK driver polls
+# those counters, so it has to be able to name what a failed read returns.
+errno = { workspace = true }
 flow-entry = { workspace = true }
 flow-filter = { workspace = true }
 futures = { workspace = true }

--- a/dataplane/src/drivers/cpbridge.rs
+++ b/dataplane/src/drivers/cpbridge.rs
@@ -627,6 +627,45 @@ mod test {
     /// to us, or making `NotIp` drop) fails this test.
     // The table below is data, not logic: every arm is one verdict, and the point is that all of
     // them are written out. Splitting it to satisfy a line count would only hide that.
+    /// A multicast frame must survive both layers, not just this one.
+    ///
+    /// `addressed_to` counts multicast, but that only matters if the pipeline hands this function
+    /// a verdict the table punts. It did not: ingress marked multicast `MacNotForUs`, which is an
+    /// unconditional drop, so the intent recorded in `addressed_to` was unreachable and every
+    /// neighbour solicitation and LLDP frame died in the pipeline. Measured on hardware as 767
+    /// frames dropped `Eth: not for us` with zero reaching the control plane.
+    ///
+    /// Asserted as the pair, because either half alone looks correct.
+    #[test]
+    fn a_multicast_frame_reaches_the_control_plane() {
+        let port = Mac([0x58, 0xa2, 0xe1, 0xb3, 0x3d, 0x94]);
+        // IPv6 all-nodes, i.e. what neighbour discovery actually arrives as.
+        let multicast = Mac([0x33, 0x33, 0x00, 0x00, 0x00, 0x01]);
+        assert!(multicast.is_multicast(), "the fixture must be multicast");
+        assert!(
+            !multicast.is_broadcast(),
+            "and must not be broadcast, or it would take the other arm"
+        );
+
+        assert!(
+            addressed_to(multicast, port),
+            "multicast is addressed to every port on the segment"
+        );
+        // `Unhandled` is what ingress now produces for multicast. Were it to go back to
+        // `MacNotForUs`, this is the line that fails.
+        assert_eq!(
+            disposition(Some(DoneReason::Unhandled), addressed_to(multicast, port)),
+            Disposition::Punt,
+            "a multicast frame addressed to this segment belongs to the control plane"
+        );
+        assert_eq!(
+            disposition(Some(DoneReason::MacNotForUs), addressed_to(multicast, port)),
+            Disposition::Drop,
+            "and MacNotForUs remains an unconditional drop, which is why ingress must not use it \
+             for multicast"
+        );
+    }
+
     #[allow(clippy::too_many_lines)]
     #[test]
     fn punt_policy_table() {

--- a/dataplane/src/drivers/dpdk/mod.rs
+++ b/dataplane/src/drivers/dpdk/mod.rs
@@ -18,13 +18,24 @@
 //! here is a plain thread running a loop, with no runtime, and one worker services every port
 //! rather than one task per interface.
 //!
+//! # How work is spread
+//!
+//! RSS distributes received frames across the per-worker receive queues by a Toeplitz hash over
+//! L3 addresses and L4 ports, so every packet of one flow reaches one worker and nothing within a
+//! flow is reordered. Which worker that is does not matter: flow state lives in a single
+//! [`FlowTable`](flow_entry::flow_table::FlowTable) shared by every worker, so any worker can
+//! service any packet.
+//!
+//! That is worth stating plainly because the obvious next thought -- "the two directions of a flow
+//! must reach the same worker, so the hash has to be symmetric" -- is wrong twice over here. The
+//! hardware route is closed (mlx5 rejects any hash function but the default at
+//! `rte_eth_dev_configure`; see [`RssConf`](dpdk::dev::RssConf)), and it would not help anyway: a
+//! NAT'd flow's reverse packet carries the *translated* tuple, not the reversed one, so no
+//! symmetry property the NIC can have would pair the two halves. Shared flow state is what makes
+//! that a non-problem.
+//!
 //! # What this does not do yet
 //!
-//! - **RSS is off**, so every frame lands on receive queue 0 and one worker does all the work. The
-//!   per-worker queues are real and exclusively owned either way; spreading across them needs a
-//!   *symmetric* hash key, so that both directions of a flow reach the same worker and the flow
-//!   table stays per-worker-coherent. That is its own change, and picking the key wrong is a
-//!   correctness bug rather than a performance one.
 //! - **Ports must have a kernel netdev.** The pipeline names interfaces by kernel `ifindex`, and
 //!   this driver takes that from `rte_eth_dev_info.if_index`. That is populated for a bifurcated
 //!   driver such as mlx5, where `mlx5_core` keeps the netdev while DPDK attaches through the RDMA
@@ -37,8 +48,8 @@
 //!
 //! With the kernel driver, FRR shares a namespace with the real NIC and peers through the kernel's
 //! own stack. Here the kernel has no NIC, so every control frame is carried across by
-//! [`cpbridge`], which is what makes a tap the kernel's end of each port. See that module for the
-//! punt policy and its costs.
+//! [`cpbridge`](crate::drivers::cpbridge), which is what makes a tap the kernel's end of each
+//! port. See that module for the punt policy and its costs.
 
 mod port;
 mod worker;
@@ -53,8 +64,9 @@ use concurrency::thread::ScopedJoinHandle;
 use dpdk::mem::Mbuf;
 use lifecycle::Subsystem;
 use pipeline::DynPipeline;
+use stats::PortMetrics;
 use tracectl::trace_target;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use super::DriverError;
 use super::status::{
@@ -166,17 +178,27 @@ impl DriverDpdk {
             });
         }
 
-        Self::spawn_supervisor(scope, workers_subsystem, monitors, status_writer)
+        Self::spawn_supervisor(scope, workers_subsystem, monitors, status_writer, ports)
     }
 
-    /// The supervisor thread: samples worker liveness, publishes status, joins on cancellation.
+    /// The supervisor thread: samples worker liveness, publishes status and port counters, joins on
+    /// cancellation.
+    ///
+    /// The port counters are polled *here* rather than from the metrics runtime because they are
+    /// the only thread that can be. `Dev::stats` needs the device, the devices are branded with
+    /// `'eal`, and `Eal` is `!Send` -- so the counters can only be read from a thread inside the
+    /// EAL's scope. The metrics server is a tokio task on the management runtime, which is neither.
     #[allow(clippy::too_many_lines)]
-    fn spawn_supervisor<'scope>(
+    fn spawn_supervisor<'p, 'scope>(
         scope: &'scope thread::Scope<'scope, '_>,
         workers_subsystem: &Subsystem,
         mut monitors: Vec<WorkerMonitor<'scope>>,
         status_writer: DriverStatusWriter,
-    ) -> Result<(), DriverError> {
+        ports: &'p [Port<'_>],
+    ) -> Result<(), DriverError>
+    where
+        'p: 'scope,
+    {
         let subsystem = workers_subsystem.clone();
         let check_period = Duration::from_secs(u64::from(Self::TASK_CHECK_PERIOD));
         let poll_period = Duration::from_secs(u64::from(Self::TASK_POLL_PERIOD));
@@ -198,6 +220,17 @@ impl DriverDpdk {
                         status
                     })
                     .collect();
+
+                // Registered once, here, rather than per poll: registration is configuration work
+                // and publishing follows traffic. Re-registering each time is what made the VPC
+                // collector quadratic.
+                let port_metrics: Vec<(&Port<'_>, PortMetrics)> = ports
+                    .iter()
+                    .map(|port| (port, PortMetrics::new(&port.name)))
+                    .collect();
+                // A PMD that implements no statistics reports `ENOTSUP` on every call. Complaining
+                // once per port beats a line per port per second for the life of the process.
+                let mut counters_unavailable: Vec<bool> = vec![false; port_metrics.len()];
 
                 let mut next_watchdog_check = std::time::Instant::now() + check_period;
 
@@ -279,11 +312,18 @@ impl DriverDpdk {
                         break;
                     }
 
+                    publish_port_counters(&port_metrics, &mut counters_unavailable);
+
                     status_writer.publish(DriverStatus {
                         workers: statuses.clone(),
                     });
                     thread::sleep(poll_period);
                 }
+
+                // One last read on the way out. A run that ends under load leaves its final drop
+                // count in the device, and without this the last thing a scrape ever sees is a
+                // poll_period old -- which is exactly the interval a shutdown is most interesting.
+                publish_port_counters(&port_metrics, &mut counters_unavailable);
 
                 status_writer.publish(DriverStatus {
                     workers: statuses.clone(),
@@ -296,6 +336,33 @@ impl DriverDpdk {
 
         info!("DPDK driver started successfully");
         Ok(())
+    }
+}
+
+/// Read every port's device counters and publish them.
+///
+/// `unavailable` is one flag per port, carried across calls so that a PMD which implements no
+/// statistics is complained about once rather than on every poll for the life of the process.
+fn publish_port_counters(port_metrics: &[(&Port<'_>, PortMetrics)], unavailable: &mut [bool]) {
+    for (slot, (port, metrics)) in port_metrics.iter().enumerate() {
+        match port.counters() {
+            Ok(counters) => {
+                metrics.publish(&counters);
+                // A port that starts reporting again after a failure is worth hearing about, so
+                // clear the flag rather than latching it.
+                unavailable[slot] = false;
+            }
+            Err(e) => {
+                if !unavailable[slot] {
+                    unavailable[slot] = true;
+                    warn!(
+                        "port {} would not report its counters: {e:?}. Receive drops on this port \
+                         are now invisible -- an overloaded dataplane will look like an idle wire.",
+                        port.name
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/dataplane/src/drivers/dpdk/port.rs
+++ b/dataplane/src/drivers/dpdk/port.rs
@@ -142,6 +142,7 @@ impl<'eal> Port<'eal> {
         info: DevInfo<'eal>,
         name: String,
         num_workers: u16,
+        mtu: Option<u16>,
     ) -> Result<Self, DriverError> {
         let index = info.index();
 
@@ -171,7 +172,10 @@ impl<'eal> Port<'eal> {
                 RxOffload::NONE
             }),
             tx_offloads: Some(TxOffloadConfig::default()),
-            mtu: None,
+            // From the configuration when it named one. Left `None` the device takes DPDK's
+            // default of 1500, which on a 9036 fabric stops every connection the moment slow
+            // start reaches a full-size segment.
+            mtu,
             rss,
         };
 

--- a/dataplane/src/drivers/dpdk/port.rs
+++ b/dataplane/src/drivers/dpdk/port.rs
@@ -104,6 +104,29 @@ fn report_link(
     }
 }
 
+/// How many mbufs a port's receive pool holds and how big each one's data room is.
+///
+/// Split out to keep `bring_up` within its line budget; it belongs to it.
+///
+/// The room is sized against the MTU the device was just configured with, not against
+/// `PoolParams::default()`. The cost is logged because it multiplies: one room per mbuf and a
+/// 24-worker port wants ~98k of them, so this is the difference between ~200 MiB and ~900 MiB of
+/// hugepages on a single port, and a port reserving most of a grant should say so.
+fn pool_shape(
+    dev: &Dev<'_, dpdk::dev::Stopped>,
+    index: dpdk::dev::DevIndex,
+    name: &str,
+    num_workers: u16,
+) -> (u32, u16) {
+    let data_room = dpdk::mem::mbuf_data_room(dev.mtu().unwrap_or(1500));
+    let pool_mbufs = POOL_MBUFS_PER_WORKER * u32::from(num_workers);
+    info!(
+        "port {index} ({name}) receive pool: {pool_mbufs} mbufs of {data_room} B = {} MiB",
+        (u64::from(pool_mbufs) * u64::from(data_room)) / (1024 * 1024)
+    );
+    (pool_mbufs, data_room)
+}
+
 /// A port that has been configured and started, with the pool its receive queues draw from.
 ///
 /// Held by the driver for the whole run. Workers borrow nothing from this; they are handed owned
@@ -197,13 +220,7 @@ impl<'eal> Port<'eal> {
             ))
         })?;
 
-        // Sized against the MTU the device was just configured with, not against the default.
-        let data_room = dpdk::mem::mbuf_data_room(dev.mtu().unwrap_or(1500));
-        let pool_mbufs = POOL_MBUFS_PER_WORKER * u32::from(num_workers);
-        info!(
-            "port {index} ({name}) receive pool: {pool_mbufs} mbufs of {data_room} B = {} MiB",
-            (u64::from(pool_mbufs) * u64::from(data_room)) / (1024 * 1024)
-        );
+        let (pool_mbufs, data_room) = pool_shape(&dev, index, &name, num_workers);
         let rx_pool = eal
             .mem
             .new_pkt_pool(

--- a/dataplane/src/drivers/dpdk/port.rs
+++ b/dataplane/src/drivers/dpdk/port.rs
@@ -197,6 +197,13 @@ impl<'eal> Port<'eal> {
             ))
         })?;
 
+        // Sized against the MTU the device was just configured with, not against the default.
+        let data_room = dpdk::mem::mbuf_data_room(dev.mtu().unwrap_or(1500));
+        let pool_mbufs = POOL_MBUFS_PER_WORKER * u32::from(num_workers);
+        info!(
+            "port {index} ({name}) receive pool: {pool_mbufs} mbufs of {data_room} B = {} MiB",
+            (u64::from(pool_mbufs) * u64::from(data_room)) / (1024 * 1024)
+        );
         let rx_pool = eal
             .mem
             .new_pkt_pool(
@@ -204,6 +211,7 @@ impl<'eal> Port<'eal> {
                     format!("rx_{index}"),
                     PoolParams {
                         size: POOL_MBUFS_PER_WORKER * u32::from(num_workers),
+                        data_size: data_room,
                         ..Default::default()
                     },
                 )

--- a/dataplane/src/drivers/dpdk/port.rs
+++ b/dataplane/src/drivers/dpdk/port.rs
@@ -68,6 +68,42 @@ fn rss_for(info: &DevInfo, name: &str, num_workers: u16) -> Option<RssConf> {
     rss
 }
 
+/// Say what the port's link is doing, loudly when it is down.
+///
+/// Separate from `bring_up` only to keep that function within its line budget; it belongs to it.
+///
+/// A port with no carrier is otherwise indistinguishable from a working one: every configuration
+/// step succeeds, the driver reports "started", the workers poll happily, and nothing arrives.
+/// Nothing is wrong from DPDK's side, so nothing in the driver complains. For a bifurcated device
+/// the usual cause is the kernel netdev being administratively down -- the port follows the netdev,
+/// and moving an interface between network namespaces clears `IFF_UP`.
+fn report_link(
+    dev: &Dev<'_, Started>,
+    index: dpdk::dev::DevIndex,
+    name: &str,
+    if_index: InterfaceIndex,
+    mac: Mac,
+    mtu: u16,
+    num_workers: u16,
+) {
+    match dev.link() {
+        Ok(link) if link.up => info!(
+            "DPDK port {index} ({name}) up: ifindex {if_index}, mac {mac}, mtu {mtu}, \
+             {num_workers} rx/tx queue pair(s), link {link}"
+        ),
+        Ok(link) => warn!(
+            "DPDK port {index} ({name}) is configured and started but its link is {link}: \
+             ifindex {if_index}, mac {mac}, mtu {mtu}, {num_workers} rx/tx queue pair(s). No \
+             traffic will pass. For a bifurcated device such as mlx5 the port follows its kernel \
+             netdev, so check that the netdev is up inside the datapath network namespace."
+        ),
+        Err(e) => info!(
+            "DPDK port {index} ({name}) up: ifindex {if_index}, mac {mac}, mtu {mtu}, \
+             {num_workers} rx/tx queue pair(s); link state unavailable ({e:?})"
+        ),
+    }
+}
+
 /// A port that has been configured and started, with the pool its receive queues draw from.
 ///
 /// Held by the driver for the whole run. Workers borrow nothing from this; they are handed owned
@@ -226,10 +262,7 @@ impl<'eal> Port<'eal> {
             ))
         })?;
 
-        info!(
-            "DPDK port {index} ({name}) up: ifindex {if_index}, mac {mac}, mtu {mtu}, \
-             {num_workers} rx/tx queue pair(s)"
-        );
+        report_link(&dev, index, &name, if_index, mac, mtu, num_workers);
 
         Ok(Port {
             dev,

--- a/dataplane/src/drivers/dpdk/port.rs
+++ b/dataplane/src/drivers/dpdk/port.rs
@@ -3,14 +3,16 @@
 
 //! Bringing DPDK ports up, and the queue split that gives each worker its own.
 
-use dpdk::dev::{Dev, DevConfig, DevInfo, RxOffload, Started, TxOffloadConfig};
+use dpdk::dev::{Dev, DevConfig, DevInfo, RssConf, RxOffload, Started, TxOffloadConfig};
 use dpdk::eal::Eal;
 use dpdk::mem::{Pool, PoolConfig, PoolParams};
 use dpdk::queue::rx::{RxQueue, RxQueueConfig, RxQueueIndex};
 use dpdk::queue::tx::{TxQueue, TxQueueConfig, TxQueueIndex};
 use dpdk::socket;
+use errno::ErrorCode;
 use net::eth::mac::Mac;
 use net::interface::InterfaceIndex;
+use stats::PortCounters;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -36,6 +38,35 @@ const TX_DESCRIPTORS: u16 = 1024;
 /// the pipeline and mbufs sitting in a transmit ring waiting to be reclaimed. Too small shows up as
 /// `rx_nombuf` on the port, not as an allocation error here.
 const POOL_MBUFS_PER_WORKER: u32 = 4 * RX_DESCRIPTORS as u32;
+
+/// Decide the RSS configuration for a port, warning if the device cannot spread at all.
+///
+/// RSS is what actually distributes received frames across the per-worker receive queues. Without
+/// it every frame lands on queue 0 and exactly one worker does all the work, however many were
+/// configured. The key is the standard Toeplitz one and the hash covers whatever subset of L3
+/// addresses and L4 ports the device advertises.
+///
+/// Deliberately *not* symmetric. Two reasons, and the second is the one that settles it: mlx5
+/// rejects any hash function but the default at `rte_eth_dev_configure`, so symmetric Toeplitz is
+/// reachable only through the `rte_flow` RSS action (see [`RssConf`]); and a NAT'd flow's reverse
+/// packet carries the *translated* tuple rather than the reversed one, so no symmetry property the
+/// NIC could have would land a flow's two halves on the same worker. It does not need to: flow
+/// state lives in one `FlowTable` shared by every worker, so any worker can service any packet.
+///
+/// Returns `None` for a device that advertises no RSS hash functions -- how the emulated NICs
+/// (e1000, e1000e, virtio without multi-queue negotiation) report. Such a port still works; it
+/// simply cannot use more than one worker.
+fn rss_for(info: &DevInfo, name: &str, num_workers: u16) -> Option<RssConf> {
+    let rss = RssConf::supported_on(info);
+    if rss.is_none() && num_workers > 1 {
+        warn!(
+            "port {index} ({name}) advertises no RSS hash functions, so all {num_workers} workers \
+             will share receive queue 0 and only one of them will do any work",
+            index = info.index()
+        );
+    }
+    rss
+}
 
 /// A port that has been configured and started, with the pool its receive queues draw from.
 ///
@@ -78,6 +109,8 @@ impl<'eal> Port<'eal> {
     ) -> Result<Self, DriverError> {
         let index = info.index();
 
+        let rss = rss_for(&info, &name, num_workers);
+
         // One queue per worker, on every port. That is what makes a queue exclusively owned: a
         // worker holds its rx and tx handles by value for the run, and no two workers ever touch
         // the same ring. `rte_eth_rx_burst` and `rte_eth_tx_burst` are not safe to call
@@ -92,15 +125,18 @@ impl<'eal> Port<'eal> {
             // segments -- changing what the pipeline sees -- and costs a factor of 32 in receive
             // buffering, because the PMD must reserve enough 2 KiB mbufs per packet to return a
             // 64 KiB coalesced segment.
-            rx_offloads: Some(RxOffload::NONE),
+            //
+            // `RSS_HASH` is the exception, and only when RSS is on (DPDK rejects the offload
+            // otherwise): it makes the NIC report the hash it steered by in each mbuf, which is
+            // the only way to see from software how well traffic is actually spreading.
+            rx_offloads: Some(if rss.is_some() {
+                RxOffload::RSS_HASH
+            } else {
+                RxOffload::NONE
+            }),
             tx_offloads: Some(TxOffloadConfig::default()),
             mtu: None,
-            // TODO: RSS is what actually spreads flows across the per-worker receive queues. With
-            // it off, every frame lands on queue 0 and exactly one worker does all the work. The
-            // queues and the workers are real either way, which is what this spike is establishing;
-            // turning RSS on needs a symmetric key so that both directions of a flow hash to the
-            // same worker, and that is its own change.
-            rss: None,
+            rss,
         };
 
         let mut dev = config.apply(info).map_err(|e| {
@@ -202,6 +238,31 @@ impl<'eal> Port<'eal> {
             mac,
             mtu,
             rx_pool,
+        })
+    }
+
+    /// Read the counters the device keeps for this port.
+    ///
+    /// These are the port's own totals, cumulative since it started, and they see what the
+    /// dataplane cannot: a frame dropped for want of a receive descriptor
+    /// ([`rx_missed`](PortCounters::rx_missed)) or for want of an mbuf
+    /// ([`rx_no_mbuf`](PortCounters::rx_no_mbuf)) never reaches a worker and so appears in no
+    /// pipeline counter at all. Without them an overloaded dataplane and an idle wire look alike.
+    ///
+    /// # Errors
+    ///
+    /// Returns the driver's error code; a PMD that implements no statistics reports `ENOTSUP`.
+    pub(crate) fn counters(&self) -> Result<PortCounters, ErrorCode> {
+        let stats = self.dev.stats()?;
+        Ok(PortCounters {
+            rx_packets: stats.ipackets,
+            tx_packets: stats.opackets,
+            rx_bytes: stats.ibytes,
+            tx_bytes: stats.obytes,
+            rx_missed: stats.imissed,
+            rx_errors: stats.ierrors,
+            tx_errors: stats.oerrors,
+            rx_no_mbuf: stats.rx_nombuf,
         })
     }
 

--- a/dataplane/src/drivers/dpdk/worker.rs
+++ b/dataplane/src/drivers/dpdk/worker.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use concurrency::sync::Arc;
+use dpdk::lcore::LCore;
 use dpdk::mem::{MBUF_BURST, Mbuf, MbufArray};
 use lifecycle::Subsystem;
 use net::buffer::Append;
@@ -78,6 +79,31 @@ impl<'p> Worker<'p> {
         subsystem: &Subsystem,
         setup_pipeline: &Arc<dyn Send + Sync + Fn() -> DynPipeline<'p, Mbuf<'p>> + 'p>,
     ) {
+        // Register with the EAL before anything allocates. An unregistered thread reports
+        // `LCORE_ID_ANY`, and `rte_mempool_default_cache` returns NULL for that -- so every
+        // `alloc_bulk` and every mbuf free would go to the shared ring under atomics, on every
+        // burst, in both directions. The token releases the id however this thread ends; leaking
+        // one strands it for the life of the process.
+        //
+        // It is bound rather than discarded because it is also the capability that unlocks
+        // `dpdk::power`: a sleep-until-a-packet-arrives loop is gated on `&LCore`, and this is the
+        // only place a worker can get one.
+        //
+        // A worker that cannot register is left to run anyway. It is slower, not wrong: the
+        // mempool falls back to the ring, which is correct, just contended. Refusing to forward
+        // traffic over a performance property would be the worse failure.
+        let _lcore = match LCore::register() {
+            Ok(lcore) => Some(lcore),
+            Err(e) => {
+                error!(
+                    worker = self.id,
+                    "could not register with the EAL ({e:?}); this worker will run without a \
+                     per-core mempool cache and will contend on every allocation"
+                );
+                None
+            }
+        };
+
         let mut pipeline = setup_pipeline();
 
         // Where a packet leaving the pipeline should go, by the interface index the pipeline names
@@ -91,6 +117,7 @@ impl<'p> Worker<'p> {
 
         debug!(
             worker = self.id,
+            lcore = dpdk::lcore::LCoreId::current().0,
             "DPDK worker started on {} port(s): {}",
             self.queues.len(),
             self.queues

--- a/dataplane/src/packet_processor/ingress.rs
+++ b/dataplane/src/packet_processor/ingress.rs
@@ -84,6 +84,36 @@ impl Ingress {
         packet.done(DoneReason::MacNotForUs);
     }
 
+    /// A multicast frame: not ours to route, but not nobody's either.
+    ///
+    /// Distinguished from [`interface_ingress_eth_non_local`] because the two mean different
+    /// things and the driver treats them differently. `MacNotForUs` is a drop, full stop;
+    /// `Unhandled` is "the datapath had nothing to do with it", which the control-plane bridge
+    /// punts when the frame was addressed to the port -- and `cpbridge::addressed_to` counts
+    /// multicast as addressed, with the comment that LLDP and IPv6 neighbour discovery "are the
+    /// control plane's business".
+    ///
+    /// They disagreed. Multicast fell to the non-local arm, was marked `MacNotForUs`, and was
+    /// dropped before the bridge ever got to apply that intent -- so every neighbour solicitation
+    /// and every LLDP frame died in the pipeline. IPv6 neighbour discovery is *entirely*
+    /// multicast, so nothing about it could have worked.
+    ///
+    /// `l2bcast` is deliberately not set: this is not a broadcast, and the flag drives replication
+    /// decisions further along.
+    #[tracing::instrument(level = "trace")]
+    fn interface_ingress_eth_mcast<Buf: PacketBufferMut>(
+        &self,
+        interface: &Interface,
+        packet: &mut Packet<Buf>,
+    ) {
+        trace!(
+            "{nfi}: Multicast frame over {ifname}; leaving it to the control plane",
+            nfi = self.name(),
+            ifname = interface.name
+        );
+        packet.done(DoneReason::Unhandled);
+    }
+
     #[tracing::instrument(level = "trace")]
     fn interface_ingress_eth_bcast<Buf: PacketBufferMut>(
         &self,
@@ -119,6 +149,8 @@ impl Ingress {
                         self.interface_ingress_eth_bcast(interface, packet);
                     } else if dmac == if_mac.inner() {
                         self.interface_ingress_eth_ucast_local(interface, packet);
+                    } else if dmac.is_multicast() {
+                        self.interface_ingress_eth_mcast(interface, packet);
                     } else {
                         self.interface_ingress_eth_non_local(interface, dmac, packet);
                     }
@@ -179,5 +211,98 @@ impl<Buf: PacketBufferMut> NetworkFunction<Buf> for Ingress {
             }
             packet.enforce()
         })
+    }
+}
+
+#[cfg(test)]
+mod eth_dispatch_test {
+    use super::Ingress;
+    use net::buffer::TestBuffer;
+    use net::eth::mac::{Mac, SourceMac};
+    use net::interface::InterfaceIndex;
+    use net::packet::test_utils::build_test_udp_ipv4_packet;
+    use net::packet::{DoneReason, Packet};
+    use routing::{IfDataEthernet, IfState, IfType, Interface};
+
+    const PORT_MAC: Mac = Mac([0x58, 0xa2, 0xe1, 0xb3, 0x3d, 0x94]);
+
+    fn ingress() -> Ingress {
+        // The ingress dispatch under test reads nothing from the table -- it is handed the
+        // `Interface` directly -- so an empty one is exactly right.
+        let tables = routing::testing::RouterTables::default();
+        Ingress::new("test-ingress", tables.interfaces())
+    }
+
+    fn interface() -> Interface {
+        Interface {
+            name: "enp2s1np0".to_string(),
+            description: None,
+            ifindex: InterfaceIndex::try_new(2).expect("a valid index"),
+            iftype: IfType::Ethernet(IfDataEthernet {
+                mac: SourceMac::new(PORT_MAC).expect("a valid source mac"),
+            }),
+            admin_state: IfState::Up,
+            mtu: None,
+            oper_state: IfState::Up,
+            addresses: std::collections::HashSet::new(),
+            attachment: None,
+        }
+    }
+
+    /// Drive the dispatch with a frame carrying `dst`, and report the verdict.
+    fn verdict_for(dst: Mac) -> Option<DoneReason> {
+        let mut packet: Packet<TestBuffer> =
+            build_test_udp_ipv4_packet("1.2.3.4", "5.6.7.8", 1111, 2222);
+        packet
+            .set_eth_destination(dst)
+            .expect("could not set the destination mac");
+        ingress().interface_ingress_eth(&interface(), &mut packet);
+        packet.get_done()
+    }
+
+    /// Multicast must not be `MacNotForUs`, because that verdict is an unconditional drop.
+    ///
+    /// The bridge's `addressed_to` counts multicast as the control plane's business, but that
+    /// intent is unreachable if ingress marks the frame `MacNotForUs` first. Measured on hardware
+    /// as 767 frames dropped `Eth: not for us` with nothing reaching the control plane -- IPv6
+    /// neighbour discovery is entirely multicast, so none of it could ever have worked.
+    #[test]
+    fn a_multicast_frame_is_not_marked_not_for_us() {
+        // IPv6 all-nodes: what neighbour discovery actually arrives as.
+        let verdict = verdict_for(Mac([0x33, 0x33, 0x00, 0x00, 0x00, 0x01]));
+        assert_ne!(
+            verdict,
+            Some(DoneReason::MacNotForUs),
+            "multicast marked MacNotForUs is dropped before the bridge can punt it"
+        );
+        assert_eq!(
+            verdict,
+            Some(DoneReason::Unhandled),
+            "and it should be Unhandled, which the bridge punts when addressed to the port"
+        );
+    }
+
+    /// The other three arms, so the multicast one cannot be made to pass by weakening them.
+    #[test]
+    fn the_other_destinations_keep_their_verdicts() {
+        assert_eq!(
+            verdict_for(Mac::BROADCAST),
+            Some(DoneReason::Unhandled),
+            "broadcast reaches the control plane"
+        );
+        // Not `None`: a frame for this port is ours, so the dispatch carries on into the
+        // attachment check -- and this fixture is deliberately attached to no VRF. What matters is
+        // that it got *past* the MAC test, which `InterfaceDetached` proves and `MacNotForUs`
+        // would not.
+        assert_eq!(
+            verdict_for(PORT_MAC),
+            Some(DoneReason::InterfaceDetached),
+            "a frame for this port is ours, and reaches the attachment check"
+        );
+        assert_eq!(
+            verdict_for(Mac([0x02, 0x00, 0x00, 0x00, 0x00, 0x99])),
+            Some(DoneReason::MacNotForUs),
+            "a unicast frame for somebody else is still not for us"
+        );
     }
 }

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -429,6 +429,7 @@ fn bring_up_ports<'eal>(
             info,
             interface.interface.to_string(),
             num_workers,
+            interface.mtu,
         )?);
     }
 

--- a/dataplane/src/runtime.rs
+++ b/dataplane/src/runtime.rs
@@ -322,6 +322,23 @@ fn init_eal(config: &LaunchConfiguration) -> dpdk::eal::Eal {
                 eal_args.push(addr.to_string());
             }
         }
+
+        // Preallocate on the NUMA node `dataplane-init` reserved the pages on.
+        //
+        // Without this the EAL still *prefers* the port's node -- it calls `numa_set_preferred`
+        // before faulting each page -- but `MPOL_PREFERRED` falls back to another node in silence
+        // when the preferred one is empty. The datapath then runs with its mbufs a hop away from
+        // the NIC and nothing anywhere says so. Naming the amount turns that into a startup
+        // failure, which is the outcome worth having: a benchmark that does not run beats one that
+        // quietly measures the wrong thing.
+        //
+        // `--numa-mem` is the DPDK 26.07 spelling; `--socket-mem` remains as an alias.
+        if let Some(plan) = &dpdk.hugepages
+            && let Some(arg) = plan.numa_mem_arg()
+        {
+            info!("EAL will preallocate {plan}");
+            eal_args.push(format!("--numa-mem={arg}"));
+        }
     } else {
         // Classifier-only: rte_acl needs the memory subsystem and nothing else.
         eal_args.push("--no-huge".to_string());

--- a/dpdk/examples/checksum_offload_probe.rs
+++ b/dpdk/examples/checksum_offload_probe.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! What checksum offloads the device advertises, and whether the receive verdicts actually arrive.
+//!
+//! Two separate questions, and only the second is worth anything on its own:
+//!
+//! 1. **Capability.** What `rx_offload_capa` / `tx_offload_capa` claim. Cheap to read, and a claim
+//!    -- `rte_flow_info_get` on this same card claims an async engine it then segfaults on, so a
+//!    reported bit is a starting point rather than an answer.
+//! 2. **Delivery.** Whether, with `RTE_ETH_RX_OFFLOAD_*_CKSUM` enabled, real received frames come
+//!    back with `RTE_MBUF_F_RX_IP_CKSUM_GOOD` / `L4_CKSUM_GOOD` in `ol_flags` rather than
+//!    `UNKNOWN`. That is the bit software would key off, and a NIC that reports `UNKNOWN` for
+//!    everything has given us nothing however many capability bits it sets.
+//!
+//! Send correct and corrupt checksums separately, because "everything came back GOOD" is also what
+//! a NIC that is not really checking would report.
+//!
+//! # What a BlueField-3 actually reports (measured 2026-09-08, 300 frames per mode)
+//!
+//! | sent | IP verdict | L4 verdict |
+//! |---|---|---|
+//! | all correct | GOOD 300 | GOOD 300 |
+//! | bad L4 only | GOOD 300 | **UNKNOWN** 300 |
+//! | bad IP only | **UNKNOWN** 300 | GOOD 300 |
+//!
+//! So the verdict is **one-sided**: `GOOD` means the NIC verified it, and anything else means only
+//! that the NIC did not vouch for it. **`BAD` is never reported.** That conflates "the checksum is
+//! wrong" with "I did not evaluate this" (an unrecognised protocol, a fragment, a tunnel), so the
+//! offload can be used to *skip* software validation but **not** to reject a packet.
+//!
+//! The two verdicts are independent, which is the useful part: a bad IP checksum does not suppress
+//! the L4 verdict, or vice versa.
+//!
+//! Inject from the cabled peer while this runs, one mode at a time:
+//!   python3 send_checksum_frames.py <peer-netdev> <this-port-mac> good|bad-ip|bad-l4|bad-both <n>
+//!
+//! Run:
+//!   ./checksum_offload_probe 0000:02:00.1 [seconds=10]
+
+use std::time::{Duration, Instant};
+
+use dataplane_dpdk::dev::{DevConfig, RssConf, RxOffload, TxOffloadConfig};
+use dataplane_dpdk::eal;
+use dataplane_dpdk::mem::{PoolConfig, PoolParams};
+use dataplane_dpdk::queue::rx::{RxQueueConfig, RxQueueIndex};
+use dataplane_dpdk::queue::tx::{TxQueueConfig, TxQueueIndex};
+use dataplane_dpdk::socket::Preference;
+
+type Err = Box<dyn std::error::Error>;
+
+/// The receive-side checksum offloads, and what each one buys.
+const RX_CKSUM_CAPS: [(u64, &str); 5] = [
+    (
+        dpdk_sys::rte_eth_rx_offload::RX_OFFLOAD_IPV4_CKSUM,
+        "IPV4_CKSUM       (inner/only IPv4 header)",
+    ),
+    (
+        dpdk_sys::rte_eth_rx_offload::RX_OFFLOAD_UDP_CKSUM,
+        "UDP_CKSUM        (the one that reads the payload in software)",
+    ),
+    (
+        dpdk_sys::rte_eth_rx_offload::RX_OFFLOAD_TCP_CKSUM,
+        "TCP_CKSUM        (likewise)",
+    ),
+    (
+        dpdk_sys::rte_eth_rx_offload::RX_OFFLOAD_OUTER_IPV4_CKSUM,
+        "OUTER_IPV4_CKSUM (the VXLAN outer header)",
+    ),
+    (
+        dpdk_sys::rte_eth_rx_offload::RX_OFFLOAD_OUTER_UDP_CKSUM,
+        "OUTER_UDP_CKSUM  (the VXLAN outer UDP)",
+    ),
+];
+
+const TX_CKSUM_CAPS: [(u64, &str); 5] = [
+    (
+        dpdk_sys::rte_eth_tx_offload::TX_OFFLOAD_IPV4_CKSUM,
+        "IPV4_CKSUM",
+    ),
+    (
+        dpdk_sys::rte_eth_tx_offload::TX_OFFLOAD_UDP_CKSUM,
+        "UDP_CKSUM",
+    ),
+    (
+        dpdk_sys::rte_eth_tx_offload::TX_OFFLOAD_TCP_CKSUM,
+        "TCP_CKSUM",
+    ),
+    (
+        dpdk_sys::rte_eth_tx_offload::TX_OFFLOAD_OUTER_IPV4_CKSUM,
+        "OUTER_IPV4_CKSUM",
+    ),
+    (
+        dpdk_sys::rte_eth_tx_offload::TX_OFFLOAD_OUTER_UDP_CKSUM,
+        "OUTER_UDP_CKSUM",
+    ),
+];
+
+/// How many frames landed in each receive verdict.
+#[derive(Default, Debug)]
+struct Verdicts {
+    ip_good: u64,
+    ip_bad: u64,
+    ip_none: u64,
+    ip_unknown: u64,
+    l4_good: u64,
+    l4_bad: u64,
+    l4_none: u64,
+    l4_unknown: u64,
+    total: u64,
+}
+
+impl Verdicts {
+    fn record(&mut self, ol_flags: u64) {
+        self.total += 1;
+        match ol_flags & u64::from(dpdk_sys::RTE_MBUF_F_RX_IP_CKSUM_MASK) {
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_IP_CKSUM_GOOD) => self.ip_good += 1,
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_IP_CKSUM_BAD) => self.ip_bad += 1,
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_IP_CKSUM_NONE) => self.ip_none += 1,
+            _ => self.ip_unknown += 1,
+        }
+        match ol_flags & u64::from(dpdk_sys::RTE_MBUF_F_RX_L4_CKSUM_MASK) {
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_L4_CKSUM_GOOD) => self.l4_good += 1,
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_L4_CKSUM_BAD) => self.l4_bad += 1,
+            f if f == u64::from(dpdk_sys::RTE_MBUF_F_RX_L4_CKSUM_NONE) => self.l4_none += 1,
+            _ => self.l4_unknown += 1,
+        }
+    }
+}
+
+fn report_caps(what: &str, mask: u64, caps: &[(u64, &str)]) {
+    println!("{what} (mask {mask:#x}):");
+    for (bit, name) in caps {
+        println!("  [{}] {name}", if mask & bit != 0 { "yes" } else { " no" });
+    }
+}
+
+fn main() -> Result<(), Err> {
+    let mut args = std::env::args().skip(1);
+    let bdf = args.next().unwrap_or_else(|| "0000:02:00.1".to_string());
+    let secs: u64 = args.next().unwrap_or_else(|| "10".into()).parse()?;
+
+    let eal = eal::init([
+        "-a",
+        bdf.as_str(),
+        "--in-memory",
+        "--no-telemetry",
+        "--no-shconf",
+        "--iova-mode=va",
+    ]);
+
+    let info = eal.dev.iter().next().ok_or("no DPDK port probed")?;
+    let index = info.index();
+    println!("port {} ({bdf}), driver {}", index, info.driver_name());
+    println!();
+
+    let rx_capa = info.rx_offload_caps().into();
+    let tx_capa: u64 = info.tx_offload_caps().into();
+    report_caps("receive checksum offloads", rx_capa, &RX_CKSUM_CAPS);
+    println!();
+    report_caps("transmit checksum offloads", tx_capa, &TX_CKSUM_CAPS);
+    println!();
+    println!(
+        "per-queue receive offload mask: {:#x} (a port-only offload is rejected at queue setup, \
+         so this is the one queue config may ask for)",
+        u64::from(info.rx_queue_offload_caps())
+    );
+    println!();
+
+    // Ask for every receive checksum offload the device advertises. Anything it does not advertise
+    // would be rejected by `rte_eth_dev_configure`.
+    let wanted: u64 = RX_CKSUM_CAPS.iter().map(|(bit, _)| bit).sum();
+    let rx_offloads = RxOffload::from(wanted & rx_capa);
+    if u64::from(rx_offloads) == 0 {
+        return Err("this device advertises no receive checksum offload at all".into());
+    }
+
+    let rss = RssConf::supported_on(&info);
+    let mut dev = DevConfig {
+        num_rx_queues: 1,
+        num_tx_queues: 1,
+        num_hairpin_queues: 0,
+        rx_offloads: Some(if rss.is_some() {
+            RxOffload::from(u64::from(rx_offloads) | u64::from(RxOffload::RSS_HASH))
+        } else {
+            rx_offloads
+        }),
+        tx_offloads: Some(TxOffloadConfig::default()),
+        mtu: None,
+        rss,
+    }
+    .apply(info)
+    .map_err(|e| format!("configure: {e:?}"))?;
+
+    let pool = eal
+        .mem
+        .new_pkt_pool(
+            PoolConfig::new("cksum_probe_pool", PoolParams::default())
+                .map_err(|e| format!("pool config: {e:?}"))?,
+        )
+        .map_err(|e| format!("pool create: {e:?}"))?;
+    // The per-queue mask is a subset of the port mask; requesting a port-only offload here is
+    // rejected, so intersect.
+    let queue_offloads = RxOffload::from(u64::from(rx_offloads) & u64::from(info_queue_caps(&dev)));
+    dev.new_rx_queue(RxQueueConfig {
+        dev: index,
+        queue_index: RxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(index),
+        offloads: queue_offloads,
+        pool,
+    })?;
+    dev.new_tx_queue(TxQueueConfig {
+        queue_index: TxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(index),
+        config: (),
+    })?;
+    let mut dev = dev.start().map_err(|e| format!("start: {e}"))?;
+    dev.set_promiscuous(true).ok();
+
+    let mac = dev.mac_address().map_err(|e| format!("mac: {e:?}"))?;
+    println!("port up, mac {mac}; polling for {secs}s");
+    println!("inject now, e.g.:");
+    println!(
+        "  python3 send_checksum_frames.py <peer-netdev> {mac} 200 200   # 200 good, 200 corrupt"
+    );
+    println!();
+
+    let mut queues = dev.take_queues().ok_or("queues")?;
+    let mut rx = queues.take_rx(RxQueueIndex(0)).ok_or("rx 0")?;
+
+    let mut verdicts = Verdicts::default();
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        let burst = rx.receive();
+        if burst.is_empty() {
+            std::thread::sleep(Duration::from_millis(1));
+            continue;
+        }
+        for mbuf in burst.into_iter() {
+            verdicts.record(mbuf.ol_flags());
+        }
+    }
+
+    println!("received {} frame(s)", verdicts.total);
+    println!(
+        "  IP  : good {} bad {} none {} unknown {}",
+        verdicts.ip_good, verdicts.ip_bad, verdicts.ip_none, verdicts.ip_unknown
+    );
+    println!(
+        "  L4  : good {} bad {} none {} unknown {}",
+        verdicts.l4_good, verdicts.l4_bad, verdicts.l4_none, verdicts.l4_unknown
+    );
+    println!();
+
+    let mut surprises: Vec<String> = Vec::new();
+    let mut check = |claim: &str, holds: bool| {
+        println!("  [{}] {claim}", if holds { "ok " } else { "!! " });
+        if !holds {
+            surprises.push(claim.to_string());
+        }
+    };
+
+    check("frames arrived at all", verdicts.total > 0);
+    check(
+        "no frame was reported BAD -- mlx5 reports GOOD or nothing, never BAD",
+        verdicts.ip_bad == 0 && verdicts.l4_bad == 0,
+    );
+    // Run this three times -- `good`, then `bad-ip`, then `bad-l4` -- and compare. A single run
+    // cannot tell a working offload from a NIC that stamps GOOD unconditionally; the discrimination
+    // is only visible across modes, which is why the sender takes one.
+    println!();
+    println!("interpretation:");
+    println!(
+        "  IP : {} verified, {} not vouched for",
+        verdicts.ip_good,
+        verdicts.total - verdicts.ip_good
+    );
+    println!(
+        "  L4 : {} verified, {} not vouched for",
+        verdicts.l4_good,
+        verdicts.total - verdicts.l4_good
+    );
+    println!(
+        "  Run the sender in `good`, `bad-ip` and `bad-l4` modes and compare: a real offload shows \
+         GOOD only in the mode where that layer's checksum was correct."
+    );
+
+    println!();
+    if surprises.is_empty() {
+        println!("receive checksum verdicts are real and usable");
+        Ok(())
+    } else {
+        for s in &surprises {
+            println!("[CHECK] {s}");
+        }
+        println!(
+            "(a failure here may just mean nothing was injected, or that no corrupt frames were \
+             sent -- read the counts above before concluding anything about the NIC)"
+        );
+        Ok(())
+    }
+}
+
+/// The device's per-queue receive offload capability mask.
+fn info_queue_caps(dev: &dataplane_dpdk::dev::Dev<'_, dataplane_dpdk::dev::Stopped>) -> RxOffload {
+    dev.info.rx_queue_offload_caps()
+}

--- a/dpdk/examples/flow_async_lcore_probe.rs
+++ b/dpdk/examples/flow_async_lcore_probe.rs
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Does the async / template `rte_flow` engine care which kind of thread drives it?
+//!
+//! Offloading forwarding to hardware is a mission-critical eventual goal, and it runs on the async
+//! (HWS) flow API: `rte_flow_async_create` / `rte_flow_push` / `rte_flow_pull`, each addressed to a
+//! **flow queue**. If those were tied to EAL lcore identity the way `rte_power_pmd_mgmt` is, then
+//! driving them from the registered non-EAL threads this dataplane uses as workers would be closed
+//! off, and the whole worker-thread design would need revisiting.
+//!
+//! Source says they are not: `lib/ethdev/rte_flow.c` contains **no** reference to lcores at all, and
+//! neither does mlx5's hardware-steering implementation (`drivers/net/mlx5/mlx5_flow_hw.c`). The
+//! only `rte_lcore_index` uses in the mlx5 tree are the generic `mlx5_list` per-lcore cache (which
+//! serves registered threads correctly on 26.07 -- see `examples/lcore_role_probe.rs`) and a dump
+//! routine belonging to the *legacy* software-steering engine.
+//!
+//! This probe checks that against the hardware, because "grep found nothing" is a weaker claim than
+//! "it ran". Setup happens on the main lcore, as it would in production -- flow queues are created
+//! before the port starts. Then three thread flavours each drive their **own** flow queue through a
+//! full create/push/pull cycle:
+//!
+//! - **main** -- a real EAL lcore, the control.
+//! - **registered** -- an ordinary thread holding an `LCore`; what a worker is.
+//! - **plain** -- an ordinary thread that never registered. Included because if even *this* works,
+//!   the API has no lcore coupling whatsoever and nothing about the thread model can threaten the
+//!   offload goal.
+//!
+//! # Prerequisite, and it is not optional
+//!
+//! The port must be in a mode where HWS actually works -- on a BlueField-3 that means switchdev
+//! with HW steering (`scripts/bf3-eswitch-reset.sh` puts a card there). On a card that is not,
+//! mlx5 reports the async engine as available through every public API and then **segfaults on the
+//! first call that uses it**. That is a PMD defect, it is orthogonal to everything this probe is
+//! asking about, and it takes the unrelated `examples/template_probe.rs` down identically.
+//!
+//! Run as root (or with the mlx5 capability set):
+//!   ./flow_async_lcore_probe 0000:02:00.1
+
+use core::ffi::c_void;
+use core::ptr::{null, null_mut};
+
+use dataplane_dpdk::dev::{DevConfig, RxOffload};
+use dataplane_dpdk::eal;
+use dataplane_dpdk::lcore::LCore;
+use dataplane_dpdk::mem::{PoolConfig, PoolParams};
+use dataplane_dpdk::queue::rx::{RxQueueConfig, RxQueueIndex};
+use dataplane_dpdk::queue::tx::{TxQueueConfig, TxQueueIndex};
+use dataplane_dpdk::socket::Preference;
+
+use dpdk_sys::{
+    rte_flow_action, rte_flow_action_queue, rte_flow_action_type, rte_flow_actions_template_attr,
+    rte_flow_actions_template_create, rte_flow_async_create, rte_flow_configure, rte_flow_error,
+    rte_flow_item, rte_flow_item_ipv4, rte_flow_item_type, rte_flow_op_attr, rte_flow_op_result,
+    rte_flow_op_status, rte_flow_pattern_template_attr, rte_flow_pattern_template_create,
+    rte_flow_port_attr, rte_flow_pull, rte_flow_push, rte_flow_queue_attr,
+    rte_flow_table_hash_func, rte_flow_table_insertion_type, rte_flow_template_table_attr,
+    rte_flow_template_table_create,
+};
+
+type Err = Box<dyn std::error::Error>;
+
+const QUEUE_SIZE: u32 = 64;
+/// One flow queue per driving thread, which is the production shape: a worker owns its queue the
+/// way it owns its rx and tx queues.
+const FLOW_QUEUES: u16 = 3;
+/// Rules per thread. Small: this is testing reachability, not insertion rate (`template_probe`
+/// measures that).
+const RULES: u32 = 16;
+
+fn err_msg(e: &rte_flow_error) -> String {
+    let msg = if e.message.is_null() {
+        "(no message)".to_string()
+    } else {
+        // SAFETY: a non-null message points to a static C string owned by the PMD.
+        unsafe { core::ffi::CStr::from_ptr(e.message) }
+            .to_string_lossy()
+            .into_owned()
+    };
+    format!("type {:?}: {msg}", e.type_)
+}
+
+fn item(
+    type_: rte_flow_item_type::Type,
+    spec: *const c_void,
+    mask: *const c_void,
+) -> rte_flow_item {
+    rte_flow_item {
+        type_,
+        spec,
+        last: null(),
+        mask,
+    }
+}
+
+fn action(type_: rte_flow_action_type::Type, conf: *const c_void) -> rte_flow_action {
+    rte_flow_action { type_, conf }
+}
+
+fn vp<T>(t: &T) -> *const c_void {
+    (t as *const T).cast()
+}
+
+/// A template table pointer that may be shared across the driving threads.
+///
+/// `rte_flow_template_table` is not `Sync` to Rust, but the async API's contract is per **flow
+/// queue**: distinct queues may be driven concurrently, and each thread here owns one. The table
+/// itself is only read.
+#[derive(Copy, Clone)]
+struct Table(*mut dpdk_sys::rte_flow_template_table);
+// SAFETY: see the type docs -- each thread drives a distinct flow queue, which is the granularity
+// the API serialises on.
+unsafe impl Send for Table {}
+unsafe impl Sync for Table {}
+
+/// Result of driving one flow queue to completion.
+struct Driven {
+    lcore_id: u32,
+    created: u32,
+    pushed: i32,
+    completed: u32,
+    failed: u32,
+    error: Option<String>,
+}
+
+/// Run a full async create/push/pull cycle on `queue`, entirely from the calling thread.
+fn drive(port: u16, table: Table, queue: u32) -> Driven {
+    let lcore_id = unsafe { dpdk_sys::rte_lcore_id_w() };
+    let mut err: rte_flow_error = unsafe { core::mem::zeroed() };
+    let mut op_attr: rte_flow_op_attr = unsafe { core::mem::zeroed() };
+    // Postpone every op, so the whole batch is submitted to hardware by the single `push` below --
+    // which is the shape a worker would use.
+    op_attr.set_postpone(1);
+
+    let mut created = 0;
+    let mut error = None;
+
+    for i in 0..RULES {
+        // Per-rule match: a distinct ipv4 destination, so every rule is a different entry. The
+        // high octet is the queue, so the three threads cannot collide on a rule.
+        let mut spec: rte_flow_item_ipv4 = unsafe { core::mem::zeroed() };
+        spec.hdr.dst_addr = (queue << 24) | (i + 1);
+        let pattern = [
+            item(rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ETH, null(), null()),
+            item(
+                rte_flow_item_type::RTE_FLOW_ITEM_TYPE_IPV4,
+                vp(&spec),
+                null(),
+            ),
+            item(rte_flow_item_type::RTE_FLOW_ITEM_TYPE_END, null(), null()),
+        ];
+        let q = rte_flow_action_queue { index: 0 };
+        let actions = [
+            action(rte_flow_action_type::RTE_FLOW_ACTION_TYPE_QUEUE, vp(&q)),
+            action(rte_flow_action_type::RTE_FLOW_ACTION_TYPE_END, null()),
+        ];
+        // SAFETY: pattern and actions are END-terminated and outlive the call; `queue` was
+        // configured by `rte_flow_configure` and is driven only by this thread.
+        let flow = unsafe {
+            rte_flow_async_create(
+                port,
+                queue,
+                &op_attr,
+                table.0,
+                pattern.as_ptr(),
+                0,
+                actions.as_ptr(),
+                0,
+                null_mut(),
+                &mut err,
+            )
+        };
+        if flow.is_null() {
+            error = Some(format!("async_create #{i}: {}", err_msg(&err)));
+            break;
+        }
+        created += 1;
+    }
+
+    // SAFETY: `queue` is this thread's alone.
+    let pushed = unsafe { rte_flow_push(port, queue, &mut err) };
+    if pushed != 0 && error.is_none() {
+        error = Some(format!("push: {}", err_msg(&err)));
+    }
+
+    let mut completed = 0;
+    let mut failed = 0;
+    let mut results: [rte_flow_op_result; RULES as usize] = unsafe { core::mem::zeroed() };
+    // Pull until every submitted op has been accounted for, bounded so a wedged queue ends the
+    // probe rather than hanging it.
+    for _ in 0..1000 {
+        if completed + failed >= created {
+            break;
+        }
+        // SAFETY: `results` has room for `RULES` entries; `queue` is this thread's alone.
+        let n = unsafe { rte_flow_pull(port, queue, results.as_mut_ptr(), RULES as u16, &mut err) };
+        if n < 0 {
+            error = Some(format!("pull: {}", err_msg(&err)));
+            break;
+        }
+        for result in results.iter().take(n as usize) {
+            if result.status == rte_flow_op_status::RTE_FLOW_OP_SUCCESS {
+                completed += 1;
+            } else {
+                failed += 1;
+            }
+        }
+    }
+
+    Driven {
+        lcore_id,
+        created,
+        pushed,
+        completed,
+        failed,
+        error,
+    }
+}
+
+fn report(what: &str, d: &Driven) {
+    let id = if d.lcore_id == u32::MAX {
+        "ANY".to_string()
+    } else {
+        d.lcore_id.to_string()
+    };
+    println!(
+        "  {what:<12} lcore={id:<4} created={:<3} push={:<3} completed={:<3} failed={:<3} {}",
+        d.created,
+        d.pushed,
+        d.completed,
+        d.failed,
+        d.error.as_deref().unwrap_or(""),
+    );
+}
+
+fn main() -> Result<(), Err> {
+    let bdf = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "0000:02:00.1".to_string());
+
+    // `dv_flow_en=2` selects the mlx5 HWS (hardware steering) template/async engine.
+    let devarg = format!("{bdf},dv_flow_en=2");
+    let eal = eal::init([
+        "-a",
+        devarg.as_str(),
+        "--in-memory",
+        "--no-telemetry",
+        "--no-shconf",
+        "--iova-mode=va",
+    ]);
+
+    let info = eal.dev.iter().next().ok_or("no DPDK port probed")?;
+    let pool = eal
+        .mem
+        .new_pkt_pool(
+            PoolConfig::new("flow_async_pool", PoolParams::default())
+                .map_err(|e| format!("pool: {e:?}"))?,
+        )
+        .map_err(|e| format!("pool create: {e:?}"))?;
+    let mut dev = DevConfig {
+        num_rx_queues: 1,
+        num_tx_queues: 1,
+        num_hairpin_queues: 0,
+        tx_offloads: None,
+        rx_offloads: None,
+        mtu: None,
+        rss: None,
+    }
+    .apply(info)
+    .map_err(|e| format!("dev configure: {e:?}"))?;
+    let idx = dev.info.index();
+    let port = idx.as_u16();
+    println!("port {port} ({bdf}), HWS async flow engine");
+
+    dev.new_rx_queue(RxQueueConfig {
+        dev: idx,
+        queue_index: RxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(idx),
+        offloads: RxOffload::from(0u64),
+        pool,
+    })?;
+    dev.new_tx_queue(TxQueueConfig {
+        queue_index: TxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(idx),
+        config: (),
+    })?;
+
+    // Report what the PMD claims, and then warn -- because the claim cannot be trusted.
+    //
+    // On a BlueField-3 whose eswitch is not in switchdev/HWS mode, mlx5 logs
+    //   [mlx5dr_cmd_query_caps]: Failed to query wire port regc value
+    //   [mlx5dr_context_check_hws_supp]: Required HWS WQE based insertion cap not supported
+    // and then **lies to every public API about it**: `rte_flow_info_get` reports
+    // `max_nb_queues = u32::MAX` and `rte_flow_configure` returns 0. The first HWS call after that
+    // -- `rte_eth_dev_start`, or `rte_flow_pattern_template_create` if you reorder them --
+    // dereferences the context that was never built and takes the process down with SIGSEGV.
+    // There is no pre-flight check available through the public API; this was tried.
+    //
+    // So this probe cannot defend itself. It prints its intent first, so that a core dump here is
+    // attributable to the device's mode rather than mistaken for a finding about threads.
+    let mut port_info: dpdk_sys::rte_flow_port_info = unsafe { core::mem::zeroed() };
+    let mut queue_info: dpdk_sys::rte_flow_queue_info = unsafe { core::mem::zeroed() };
+    let mut err: rte_flow_error = unsafe { core::mem::zeroed() };
+    // SAFETY: both out-params are live for the call.
+    let rc = unsafe {
+        dpdk_sys::rte_flow_info_get(port, &raw mut port_info, &raw mut queue_info, &mut err)
+    };
+    println!(
+        "rte_flow_info_get rc={rc}, max_nb_queues={} (NOT a reliable capability signal -- see the \
+         module docs)",
+        port_info.max_nb_queues
+    );
+    println!(
+        "about to configure the async engine; if this crashes, the port is not in switchdev/HWS \
+         mode (see scripts/bf3-eswitch-reset.sh) and the crash says nothing about lcores"
+    );
+
+    // One flow queue per driving thread. `rte_flow_configure` must run after dev configure and
+    // before dev start.
+    let port_attr: rte_flow_port_attr = unsafe { core::mem::zeroed() };
+    let queue_attr = rte_flow_queue_attr { size: QUEUE_SIZE };
+    let mut qa_ptrs = [&queue_attr as *const rte_flow_queue_attr; FLOW_QUEUES as usize];
+    // SAFETY: `FLOW_QUEUES` entries in `qa_ptrs`; attrs outlive the call.
+    let rc = unsafe {
+        rte_flow_configure(
+            port,
+            &port_attr,
+            FLOW_QUEUES,
+            qa_ptrs.as_mut_ptr(),
+            &mut err,
+        )
+    };
+    if rc != 0 {
+        return Err(format!("rte_flow_configure: {}", err_msg(&err)).into());
+    }
+    println!("rte_flow_configure: {FLOW_QUEUES} flow queues of {QUEUE_SIZE}");
+
+    let dev = dev.start().map_err(|e| format!("dev start: {e}"))?;
+
+    // Pattern template: eth / ipv4 with a templated destination.
+    let mut pt_attr: rte_flow_pattern_template_attr = unsafe { core::mem::zeroed() };
+    pt_attr.set_ingress(1);
+    let mut ipv4_mask: rte_flow_item_ipv4 = unsafe { core::mem::zeroed() };
+    ipv4_mask.hdr.dst_addr = u32::MAX;
+    let pattern_tmpl = [
+        item(rte_flow_item_type::RTE_FLOW_ITEM_TYPE_ETH, null(), null()),
+        item(
+            rte_flow_item_type::RTE_FLOW_ITEM_TYPE_IPV4,
+            null(),
+            vp(&ipv4_mask),
+        ),
+        item(rte_flow_item_type::RTE_FLOW_ITEM_TYPE_END, null(), null()),
+    ];
+    // SAFETY: END-terminated; attr and mask outlive the call.
+    let pt = unsafe {
+        rte_flow_pattern_template_create(port, &pt_attr, pattern_tmpl.as_ptr(), &mut err)
+    };
+    if pt.is_null() {
+        return Err(format!("pattern_template_create: {}", err_msg(&err)).into());
+    }
+
+    // Actions template: a fixed QUEUE(0).
+    let mut at_attr: rte_flow_actions_template_attr = unsafe { core::mem::zeroed() };
+    at_attr.set_ingress(1);
+    let queue = rte_flow_action_queue { index: 0 };
+    let queue_mask = rte_flow_action_queue { index: u16::MAX };
+    let acts_tmpl = [
+        action(rte_flow_action_type::RTE_FLOW_ACTION_TYPE_QUEUE, vp(&queue)),
+        action(rte_flow_action_type::RTE_FLOW_ACTION_TYPE_END, null()),
+    ];
+    let acts_mask = [
+        action(
+            rte_flow_action_type::RTE_FLOW_ACTION_TYPE_QUEUE,
+            vp(&queue_mask),
+        ),
+        action(rte_flow_action_type::RTE_FLOW_ACTION_TYPE_END, null()),
+    ];
+    // SAFETY: END-terminated; attr and confs outlive the call.
+    let at = unsafe {
+        rte_flow_actions_template_create(
+            port,
+            &at_attr,
+            acts_tmpl.as_ptr(),
+            acts_mask.as_ptr(),
+            &mut err,
+        )
+    };
+    if at.is_null() {
+        return Err(format!("actions_template_create: {}", err_msg(&err)).into());
+    }
+
+    let mut table_attr: rte_flow_template_table_attr = unsafe { core::mem::zeroed() };
+    table_attr.flow_attr.set_ingress(1);
+    table_attr.flow_attr.group = 1;
+    table_attr.nb_flows = 4096;
+    table_attr.insertion_type =
+        rte_flow_table_insertion_type::RTE_FLOW_TABLE_INSERTION_TYPE_PATTERN;
+    table_attr.hash_func = rte_flow_table_hash_func::RTE_FLOW_TABLE_HASH_FUNC_DEFAULT;
+    let mut pts = [pt];
+    let mut ats = [at];
+    // SAFETY: one pattern and one actions template, both live; attr outlives the call.
+    let table = unsafe {
+        rte_flow_template_table_create(
+            port,
+            &table_attr,
+            pts.as_mut_ptr(),
+            1,
+            ats.as_mut_ptr(),
+            1,
+            &mut err,
+        )
+    };
+    if table.is_null() {
+        return Err(format!("template_table_create: {}", err_msg(&err)).into());
+    }
+    let table = Table(table);
+    println!();
+
+    // Queue 0 from the main lcore: the control.
+    let main_driven = drive(port, table, 0);
+    report("main", &main_driven);
+
+    // Queues 1 and 2 from a registered and an unregistered thread, concurrently -- which is also a
+    // check that distinct flow queues really are independently drivable.
+    let (registered, plain) = std::thread::scope(|s| {
+        let r = s.spawn(|| {
+            let _registration = LCore::register().expect("could not register");
+            drive(port, table, 1)
+        });
+        let p = s.spawn(|| drive(port, table, 2));
+        (
+            r.join().expect("registered thread panicked"),
+            p.join().expect("plain thread panicked"),
+        )
+    });
+    report("registered", &registered);
+    report("plain", &plain);
+
+    println!();
+    let mut surprises: Vec<String> = Vec::new();
+    let mut check = |claim: &str, holds: bool| {
+        println!("  [{}] {claim}", if holds { "ok " } else { "!! " });
+        if !holds {
+            surprises.push(claim.to_string());
+        }
+    };
+
+    let ok = |d: &Driven| {
+        d.error.is_none() && d.created == RULES && d.completed == RULES && d.failed == 0
+    };
+
+    check("the main lcore can drive a flow queue", ok(&main_driven));
+    check(
+        "a REGISTERED thread can drive a flow queue (this is what a worker is)",
+        ok(&registered),
+    );
+    check(
+        "an UNREGISTERED thread can too -- the async flow API has no lcore coupling at all",
+        ok(&plain),
+    );
+    check(
+        "three threads drove three distinct flow queues concurrently",
+        main_driven.completed + registered.completed + plain.completed == RULES * 3,
+    );
+
+    dev.stop()
+        .map_err(|e| format!("stop: {e}"))?
+        .close()
+        .map_err(|e| format!("close: {e}"))?;
+
+    println!();
+    if surprises.is_empty() {
+        println!("the async flow engine does not care which kind of thread drives it");
+        Ok(())
+    } else {
+        for s in &surprises {
+            println!("[SURPRISE] {s}");
+        }
+        Err(format!("{} claim(s) did not hold", surprises.len()).into())
+    }
+}

--- a/dpdk/examples/lcore_capacity_probe.rs
+++ b/dpdk/examples/lcore_capacity_probe.rs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! How many threads can be registered with the EAL, and what happens at the limit.
+//!
+//! The DPDK driver registers every worker with
+//! [`LCore`](dataplane_dpdk::lcore::LCore). That is only safe at scale if
+//! the limit is knowable, the failure at the limit is clean, and released ids are actually reused.
+//!
+//! The bookkeeping is two fixed-size resources, both `RTE_MAX_LCORE` wide:
+//!
+//! - **`lcore_role[]`** -- `eal_lcore_non_eal_allocate` scans for the first `ROLE_OFF` slot, so
+//!   **every lcore the EAL enabled costs a registration slot**. That makes the answer depend on the
+//!   EAL's `--lcores`/coremask arguments, not just on `RTE_MAX_LCORE`.
+//! - **`core_indices`** -- a bitset added in 26.07, from which each registration takes a free
+//!   `core_index` (see `examples/lcore_role_probe.rs`).
+//!
+//! Run it both ways, because the difference is the whole point:
+//!   ./lcore_capacity_probe              # EAL enables every detected CPU
+//!   ./lcore_capacity_probe --one-lcore  # `--lcores 0@(all cpus)`, as the dataplane does
+
+use dataplane_dpdk::eal;
+use dataplane_dpdk::lcore::LCore;
+
+use std::sync::mpsc;
+
+type Err = Box<dyn std::error::Error>;
+
+fn enabled_lcores() -> u32 {
+    (0..dpdk_sys::RTE_MAX_LCORE)
+        .filter(|id| unsafe { dpdk_sys::rte_lcore_is_enabled(*id) } != 0)
+        .count() as u32
+}
+
+fn role_count(role: dpdk_sys::rte_lcore_role_t::Type) -> u32 {
+    (0..dpdk_sys::RTE_MAX_LCORE)
+        .filter(|id| unsafe { dpdk_sys::rte_lcore_has_role(*id, role) } != 0)
+        .count() as u32
+}
+
+/// Spawn threads that each register and then park until told to release.
+///
+/// Returns how many registered successfully and the error the first failure reported. Threads are
+/// held live simultaneously -- which is the point, since the resource is per-live-registration.
+fn saturate(limit: u32) -> (u32, Option<String>) {
+    let (report_tx, report_rx) = mpsc::channel::<Result<(), String>>();
+
+    let mut handles = Vec::new();
+    let mut releases = Vec::new();
+    let mut registered = 0;
+    let mut first_error = None;
+
+    for _ in 0..limit {
+        // One release channel per thread rather than a shared receiver behind a mutex: the
+        // workspace disallows `std::sync::Mutex` (there is a facade), and a channel each is
+        // simpler than borrowing one anyway.
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let report_tx = report_tx.clone();
+        handles.push(std::thread::spawn(move || {
+            match LCore::register() {
+                Ok(registration) => {
+                    let _ = report_tx.send(Ok(()));
+                    // Park until released, holding the registration. Every live registration is
+                    // what consumes a slot, so they must overlap for this to measure anything.
+                    let _ = release_rx.recv();
+                    drop(registration);
+                }
+                Err(e) => {
+                    let _ = report_tx.send(Err(format!("{e:?}")));
+                }
+            }
+        }));
+        releases.push(release_tx);
+        match report_rx.recv().expect("a probe thread vanished") {
+            Ok(()) => registered += 1,
+            Err(e) => {
+                first_error = Some(e);
+                break;
+            }
+        }
+    }
+
+    // Dropping every sender releases every parked thread.
+    drop(releases);
+    for handle in handles {
+        let _ = handle.join();
+    }
+    (registered, first_error)
+}
+
+fn main() -> Result<(), Err> {
+    let one_lcore = std::env::args().any(|a| a == "--one-lcore");
+
+    let mut args: Vec<String> = vec![
+        "--in-memory".into(),
+        "--no-telemetry".into(),
+        "--no-shconf".into(),
+        "--no-pci".into(),
+        "--no-huge".into(),
+    ];
+    if one_lcore {
+        // Exactly what `dataplane` passes: one lcore, mapped to every CPU the process may use.
+        args.push("--lcores".into());
+        args.push(dataplane_dpdk::eal::main_lcore_arg());
+    }
+    let _eal = eal::init(args);
+
+    let max = dpdk_sys::RTE_MAX_LCORE;
+    let enabled = enabled_lcores();
+    println!(
+        "RTE_MAX_LCORE = {max}, EAL-enabled (ROLE_RTE) lcores = {enabled}{}",
+        if one_lcore {
+            "  [--lcores 0@(...)]"
+        } else {
+            "  [default: every detected CPU]"
+        }
+    );
+
+    // What RTE_MAX_LCORE actually costs, since the obvious question is why it is not simply huge.
+    {
+        let cache = core::mem::size_of::<dpdk_sys::rte_mempool_cache>();
+        let stride = dpdk_sys::RTE_MAX_LCORE_VAR as usize;
+        let per_pool = cache * max as usize;
+        let per_lcore_var_buffer = stride * max as usize;
+        println!();
+        println!("what RTE_MAX_LCORE costs (all of these scale linearly with it):");
+        println!(
+            "  sizeof(rte_mempool_cache)            = {cache} B  \
+             (RTE_MEMPOOL_CACHE_MAX_SIZE * 2 pointers, cache-line aligned)"
+        );
+        println!(
+            "  per mempool with caching enabled     = {cache} x {max} = {:.2} MiB, \
+             allocated up front whatever the lcore count",
+            per_pool as f64 / (1024.0 * 1024.0)
+        );
+        println!(
+            "  RTE_MAX_LCORE_VAR (per-lcore stride) = {stride} B ({} KiB)",
+            stride / 1024
+        );
+        println!(
+            "  one lcore_var_buffer                 = {stride} x {max} = {:.2} MiB",
+            per_lcore_var_buffer as f64 / (1024.0 * 1024.0)
+        );
+        println!("  extrapolated, if RTE_MAX_LCORE were raised:");
+        for candidate in [128u64, 1024, 65536] {
+            println!(
+                "    {candidate:>6}: {:>9.2} MiB per cached mempool, {:>9.2} MiB per lcore_var_buffer",
+                (cache as u64 * candidate) as f64 / (1024.0 * 1024.0),
+                (stride as u64 * candidate) as f64 / (1024.0 * 1024.0),
+            );
+        }
+        println!(
+            "  note the per-lcore *stride* is fixed, so a bigger RTE_MAX_LCORE adds regions \
+             rather than spreading one lcore's data out: both lookups stay O(1) index arithmetic."
+        );
+    }
+    println!();
+
+    let expected = max - enabled;
+    println!("so the expected registration capacity is {max} - {enabled} = {expected}");
+    println!();
+
+    // Ask for more than should be possible, so the limit is observed rather than assumed.
+    let (registered, first_error) = saturate(expected + 8);
+    println!("registered {registered} threads simultaneously");
+    match &first_error {
+        Some(e) => println!("the next registration failed with: {e}"),
+        None => println!("no failure was observed (the limit was not reached)"),
+    }
+
+    println!();
+    println!("after releasing all of them:");
+    println!(
+        "  ROLE_RTE      = {}",
+        role_count(dpdk_sys::rte_lcore_role_t::ROLE_RTE)
+    );
+    println!(
+        "  ROLE_NON_EAL  = {}",
+        role_count(dpdk_sys::rte_lcore_role_t::ROLE_NON_EAL)
+    );
+    println!("  rte_lcore_count() = {}", unsafe {
+        dpdk_sys::rte_lcore_count()
+    });
+
+    // Everything must be reusable afterwards, or a restart would degrade until nothing could
+    // register at all.
+    let (again, _) = saturate(expected);
+    println!("  re-registered after release: {again}");
+
+    println!();
+    let mut surprises: Vec<String> = Vec::new();
+    let mut check = |claim: &str, holds: bool| {
+        println!("  [{}] {claim}", if holds { "ok " } else { "!! " });
+        if !holds {
+            surprises.push(claim.to_string());
+        }
+    };
+
+    check(
+        "capacity is RTE_MAX_LCORE minus the lcores the EAL enabled",
+        registered == expected,
+    );
+    check(
+        "exhaustion is a clean error, not a crash or a silent success",
+        first_error.is_some(),
+    );
+    check(
+        "every id is handed back on release (ROLE_NON_EAL returns to zero)",
+        role_count(dpdk_sys::rte_lcore_role_t::ROLE_NON_EAL) == 0,
+    );
+    check(
+        "rte_lcore_count() returns to the enabled count",
+        unsafe { dpdk_sys::rte_lcore_count() } == enabled,
+    );
+    check(
+        "the same capacity is available again afterwards",
+        again == expected,
+    );
+
+    println!();
+    if surprises.is_empty() {
+        println!("every claim held");
+        Ok(())
+    } else {
+        for s in &surprises {
+            println!("[SURPRISE] {s}");
+        }
+        Err(format!("{} claim(s) did not hold", surprises.len()).into())
+    }
+}

--- a/dpdk/examples/lcore_role_probe.rs
+++ b/dpdk/examples/lcore_role_probe.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! What a registered non-EAL thread gets, and what only a real EAL lcore gets.
+//!
+//! The DPDK driver's workers are ordinary Rust threads registered with
+//! [`LCore`](dataplane_dpdk::lcore::LCore) rather than lcores DPDK launched
+//! itself, because DPDK's own launch path takes an `int (*)(void *)` and cannot express the scoped
+//! borrows the driver rests on. That is only the right trade if a registered thread is not
+//! second-class in some way that matters later. This probe measures the difference instead of
+//! arguing about it.
+//!
+//! Three thread flavours are compared on every property a caller might reasonably depend on:
+//!
+//! - **main** -- the thread that called `rte_eal_init`, a real EAL lcore (`ROLE_RTE`).
+//! - **registered** -- an ordinary thread holding an `LCore` (`ROLE_NON_EAL`).
+//! - **plain** -- an ordinary thread that never registered (`LCORE_ID_ANY`).
+//!
+//! Run (needs `IPC_LOCK`; no traffic, no device):
+//!   ./lcore_role_probe [0000:02:00.1]
+
+use dataplane_dpdk::eal;
+use dataplane_dpdk::lcore::LCore;
+use dataplane_dpdk::mem::{PoolConfig, PoolParams};
+
+type Err = Box<dyn std::error::Error>;
+
+/// Everything worth knowing about how the EAL sees the calling thread.
+#[derive(Debug)]
+struct Seen {
+    lcore_id: u32,
+    /// `rte_socket_id()` -- a thread-local, so it answers for any thread.
+    socket_of_thread: i32,
+    /// `rte_lcore_to_socket_id(id)` -- reads `lcore_config[id].numa_id`.
+    socket_of_lcore: Option<u32>,
+    /// `rte_lcore_is_enabled(id)`, which is `lcore_role == ROLE_RTE` and nothing else.
+    is_enabled: bool,
+    /// Whether `RTE_LCORE_FOREACH` (i.e. `rte_get_next_lcore`) yields this id.
+    listed_by_foreach: bool,
+    /// `rte_lcore_index(id)`; `-1` when the EAL never indexed this lcore.
+    lcore_index: i32,
+    /// `rte_lcore_to_cpu_id(id)`; only meaningful for an lcore the EAL configured.
+    cpu_id: i32,
+    /// Whether this thread gets a per-core mempool cache -- the thing the registration is *for*.
+    has_mempool_cache: bool,
+}
+
+/// A mempool pointer that may cross into the probe thread.
+///
+/// `*mut rte_mempool` is not `Sync`, and rightly so in general. Here both threads only ever hand it
+/// to `rte_mempool_default_cache`, which reads `mp->cache_size` and returns an interior pointer --
+/// no mutation, no allocation. The pool outlives the scope.
+#[derive(Copy, Clone)]
+struct PoolPtr(*mut dpdk_sys::rte_mempool);
+
+// SAFETY: see the type docs -- the pointee is only read, and only through a function that does not
+// mutate it.
+unsafe impl Send for PoolPtr {}
+unsafe impl Sync for PoolPtr {}
+
+fn look(pool: PoolPtr) -> Seen {
+    let pool = pool.0;
+    let lcore_id = unsafe { dpdk_sys::rte_lcore_id_w() };
+    let in_range = lcore_id < dpdk_sys::RTE_MAX_LCORE;
+
+    let listed_by_foreach = in_range && {
+        let mut found = false;
+        let mut i = unsafe { dpdk_sys::rte_get_next_lcore(u32::MAX, 0, 0) };
+        while i < dpdk_sys::RTE_MAX_LCORE {
+            if i == lcore_id {
+                found = true;
+                break;
+            }
+            i = unsafe { dpdk_sys::rte_get_next_lcore(i, 0, 0) };
+        }
+        found
+    };
+
+    Seen {
+        lcore_id,
+        socket_of_thread: unsafe { dpdk_sys::rte_socket_id() } as i32,
+        socket_of_lcore: in_range.then(|| unsafe { dpdk_sys::rte_lcore_to_socket_id(lcore_id) }),
+        is_enabled: in_range && unsafe { dpdk_sys::rte_lcore_is_enabled(lcore_id) } != 0,
+        listed_by_foreach,
+        lcore_index: unsafe { dpdk_sys::rte_lcore_index(-1) },
+        cpu_id: unsafe { dpdk_sys::rte_lcore_to_cpu_id(-1) },
+        // The payoff. `rte_mempool_default_cache` returns NULL for `LCORE_ID_ANY`, and a NULL cache
+        // means every get/put goes to the shared ring under atomics.
+        has_mempool_cache: !unsafe { dpdk_sys::rte_mempool_default_cache_w(pool, lcore_id) }
+            .is_null(),
+    }
+}
+
+fn report(what: &str, seen: &Seen) {
+    let id = if seen.lcore_id == u32::MAX {
+        "ANY".to_string()
+    } else {
+        seen.lcore_id.to_string()
+    };
+    println!(
+        "  {what:<12} lcore_id={id:<4} socket(thread)={:<3} socket(lcore)={:<6} enabled={:<5} in_FOREACH={:<5} index={:<3} cpu={:<3} mempool_cache={}",
+        seen.socket_of_thread,
+        seen.socket_of_lcore
+            .map_or("-".to_string(), |s| s.to_string()),
+        seen.is_enabled,
+        seen.listed_by_foreach,
+        seen.lcore_index,
+        seen.cpu_id,
+        seen.has_mempool_cache,
+    );
+}
+
+fn main() -> Result<(), Err> {
+    let bdf = std::env::args().nth(1);
+    let mut args: Vec<String> = vec![
+        "--in-memory".into(),
+        "--no-telemetry".into(),
+        "--no-shconf".into(),
+    ];
+    match &bdf {
+        Some(bdf) => {
+            args.push("-a".into());
+            args.push(bdf.clone());
+        }
+        None => args.push("--no-pci".into()),
+    }
+    let eal = eal::init(args);
+
+    let _pool = eal
+        .mem
+        .new_pkt_pool(
+            PoolConfig::new("role_probe_pool", PoolParams::default())
+                .map_err(|e| format!("pool config: {e:?}"))?,
+        )
+        .map_err(|e| format!("pool create: {e:?}"))?;
+    // Looked up by name rather than reached through the safe handle: `Pool::as_mut_ptr` is
+    // crate-private, and widening it so an example can read a cache pointer would be a poor trade.
+    let raw = unsafe { dpdk_sys::rte_mempool_lookup(c"role_probe_pool".as_ptr()) };
+    if raw.is_null() {
+        return Err("could not look the probe pool back up by name".into());
+    }
+    let raw = PoolPtr(raw);
+
+    println!("RTE_MAX_LCORE = {}", dpdk_sys::RTE_MAX_LCORE);
+    {
+        // Dump the raw config around the boundary between detected CPUs and the first free slot,
+        // because `rte_lcore_index` reads `lcore_config[id].core_index` directly and the value it
+        // returns for a registered thread is not what the source alone predicts.
+        let mut enabled: u32 = 0;
+        for id in 0..dpdk_sys::RTE_MAX_LCORE {
+            if unsafe { dpdk_sys::rte_lcore_is_enabled(id) } != 0 {
+                enabled += 1;
+            }
+        }
+        println!("enabled (ROLE_RTE) lcores = {enabled}");
+        for id in [enabled.saturating_sub(1), enabled, enabled + 1] {
+            if id < dpdk_sys::RTE_MAX_LCORE {
+                println!(
+                    "  lcore_config[{id}]: core_index={} cpu_id={} numa={} enabled={}",
+                    unsafe { dpdk_sys::rte_lcore_index(id as core::ffi::c_int) },
+                    unsafe { dpdk_sys::rte_lcore_to_cpu_id(id as core::ffi::c_int) },
+                    unsafe { dpdk_sys::rte_lcore_to_socket_id(id) },
+                    unsafe { dpdk_sys::rte_lcore_is_enabled(id) } != 0,
+                );
+            }
+        }
+    }
+    println!(
+        "lcore_count (EAL-enabled + registered) before any registration: {}",
+        unsafe { dpdk_sys::rte_lcore_count() }
+    );
+    println!();
+
+    let main_seen = look(raw);
+    report("main", &main_seen);
+
+    // A plain thread, then the same thread registered, so the only variable is the registration.
+    let (plain_seen, registered_seen, count_while_registered) = std::thread::scope(|s| {
+        s.spawn(|| {
+            let plain = look(raw);
+            let registration = LCore::register().expect("could not register");
+            let registered = look(raw);
+            let count = unsafe { dpdk_sys::rte_lcore_count() };
+            drop(registration);
+            (plain, registered, count)
+        })
+        .join()
+        .expect("probe thread panicked")
+    });
+
+    report("plain", &plain_seen);
+    report("registered", &registered_seen);
+
+    // `core_index` for the registered id, read from main before / during / after, because the
+    // boundary dump above (taken before any registration) disagreed with what the registered
+    // thread itself saw.
+    println!();
+    let reg_id = registered_seen.lcore_id as core::ffi::c_int;
+    println!(
+        "  lcore_config[{reg_id}].core_index seen from main, after release: {}",
+        unsafe { dpdk_sys::rte_lcore_index(reg_id) }
+    );
+    let held = std::thread::scope(|s| {
+        s.spawn(|| {
+            let r = LCore::register().expect("register again");
+            let from_self = unsafe { dpdk_sys::rte_lcore_index(-1) };
+            let by_id = unsafe { dpdk_sys::rte_lcore_index(reg_id) };
+            drop(r);
+            (from_self, by_id)
+        })
+        .join()
+        .expect("probe thread panicked")
+    });
+    println!(
+        "  while registered, from that thread: rte_lcore_index(-1)={} rte_lcore_index({reg_id})={}",
+        held.0, held.1
+    );
+
+    println!();
+    println!("lcore_count while a thread was registered: {count_while_registered}");
+    println!("lcore_count after it released:             {}", unsafe {
+        dpdk_sys::rte_lcore_count()
+    });
+    println!();
+
+    // The findings, stated as assertions so this fails loudly if a DPDK bump changes any of them.
+    let mut surprises: Vec<String> = Vec::new();
+    let mut check = |claim: &str, holds: bool| {
+        println!("  [{}] {claim}", if holds { "ok " } else { "!! " });
+        if !holds {
+            surprises.push(claim.to_string());
+        }
+    };
+
+    println!("What registration buys:");
+    check(
+        "a registered thread gets a per-core mempool cache; a plain one does not",
+        registered_seen.has_mempool_cache && !plain_seen.has_mempool_cache,
+    );
+    check(
+        "a registered thread learns its NUMA node; a plain one reports SOCKET_ID_ANY",
+        registered_seen.socket_of_thread >= 0 && plain_seen.socket_of_thread < 0,
+    );
+    check(
+        "lcore_config[id].numa_id is populated for a registered thread",
+        registered_seen.socket_of_lcore == Some(registered_seen.socket_of_thread as u32),
+    );
+
+    println!();
+    println!("What it does NOT buy (real EAL lcores only):");
+    check(
+        "rte_lcore_is_enabled() is false for a registered thread (it tests ROLE_RTE)",
+        main_seen.is_enabled && !registered_seen.is_enabled,
+    );
+    check(
+        "RTE_LCORE_FOREACH does not list a registered thread",
+        main_seen.listed_by_foreach && !registered_seen.listed_by_foreach,
+    );
+    // NOT a gap, as of the version this links against. DPDK 26.07 changed
+    // `eal_lcore_non_eal_allocate` to allocate a real `core_index` for a registered thread out of a
+    // bitset of free indices, and `eal_lcore_non_eal_release` to hand it back. On 26.03 it stayed
+    // `-1`. This is checked rather than assumed because the *consumer* that matters is mlx5:
+    // `mlx5_list_register` treats `rte_lcore_index() == -1` as "take `lcore_lock` and use the
+    // shared bucket", so on the older behaviour every flow-list operation from a worker would
+    // serialise on one spinlock. Here they get the lock-free per-lcore path.
+    check(
+        "rte_lcore_index() gives a registered thread a real index (26.07+), not -1",
+        main_seen.lcore_index >= 0 && registered_seen.lcore_index >= 0,
+    );
+    check(
+        "that index is within mlx5's per-lcore cache array (RTE_MAX_LCORE + 2)",
+        (registered_seen.lcore_index as u32) < dpdk_sys::RTE_MAX_LCORE,
+    );
+    check(
+        "rte_lcore_count() counts a registered thread even though FOREACH skips it",
+        count_while_registered == unsafe { dpdk_sys::rte_lcore_count() } + 1,
+    );
+
+    println!();
+    if surprises.is_empty() {
+        println!("every claim held on this build of DPDK");
+        Ok(())
+    } else {
+        for s in &surprises {
+            println!("[SURPRISE] {s}");
+        }
+        Err(format!("{} claim(s) did not hold", surprises.len()).into())
+    }
+}

--- a/dpdk/examples/numa_mem_probe.rs
+++ b/dpdk/examples/numa_mem_probe.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! What `--numa-mem` does to EAL startup, at the exact figure the reservation would produce.
+//!
+//! Run with a page pool sized as the lab's: 4096 MiB of 2 MiB pages.
+//!   ./numa_mem_probe            # baseline: no --numa-mem
+//!   ./numa_mem_probe 4096       # ask for the whole pool, as the reservation does
+//!   ./numa_mem_probe 2048       # ask for half
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let arg: Option<String> = std::env::args().nth(1);
+
+    let mut args: Vec<String> = vec![
+        "dataplane".into(),
+        "--in-memory".into(),
+        "--no-telemetry".into(),
+        "--no-shconf".into(),
+        "--no-pci".into(),
+        "--iova-mode=va".into(),
+        "--lcores".into(),
+        dataplane_dpdk::eal::main_lcore_arg(),
+    ];
+    match &arg {
+        Some(mb) => {
+            args.push(format!("--numa-mem={mb}"));
+            println!("== asking the EAL to preallocate {mb} MiB ==");
+        }
+        None => println!("== baseline: no --numa-mem =="),
+    }
+    println!("args: {}", args.join(" "));
+
+    // `eal::init` calls rte_exit on failure, so this process either prints the line below or dies
+    // inside DPDK with its own message -- which is exactly the signal we want.
+    let before = std::fs::read_to_string(
+        "/sys/devices/system/node/node0/hugepages/hugepages-2048kB/free_hugepages",
+    )
+    .unwrap_or_default();
+    let _eal = dataplane_dpdk::eal::init(args);
+    let after = std::fs::read_to_string(
+        "/sys/devices/system/node/node0/hugepages/hugepages-2048kB/free_hugepages",
+    )
+    .unwrap_or_default();
+    // The question this probe exists to answer: did --numa-mem cause any hugepages to be taken?
+    println!("EAL came up");
+    println!(
+        "  physmem visible to DPDK: {} MiB",
+        unsafe { dpdk_sys::rte_eal_get_physmem_size() } / (1024 * 1024)
+    );
+    println!(
+        "  2MiB free pages before={} after={}",
+        before.trim(),
+        after.trim()
+    );
+    ExitCode::SUCCESS
+}

--- a/dpdk/examples/power_monitor_probe.rs
+++ b/dpdk/examples/power_monitor_probe.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Can a *registered* thread build a sleep-until-a-packet-arrives receive loop?
+//!
+//! The DPDK driver's workers are registered non-EAL threads rather than DPDK-launched lcores. The
+//! open question that leaves is whether that forecloses a halfway-between-interrupt-and-polling
+//! driver, which is a wanted goal for mlx5.
+//!
+//! There are two layers, and only one of them is closed to a registered thread:
+//!
+//! - **`rte_power_ethdev_pmgmt_queue_enable`**, the convenience layer, gates on
+//!   `rte_lcore_is_enabled()` (`lcore_role == ROLE_RTE`) and so rejects a registered thread
+//!   outright. It is *also* unusable in this build for an unrelated reason: it works by installing
+//!   an ethdev receive callback, and this build compiles those out
+//!   (`#undef RTE_ETHDEV_RXTX_CALLBACKS`), so `rte_eth_add_rx_callback` returns `ENOTSUP`. Same for
+//!   the cpufreq half (`rte_power_init`), whose `RTE_POWER_VALID_LCOREID_OR_ERR_RET` demands
+//!   `ROLE_RTE` or `ROLE_SERVICE`.
+//!
+//! - **The primitives it is built out of** -- `rte_eth_get_monitor_addr` plus `rte_power_monitor` /
+//!   `rte_power_pause` -- reject only `LCORE_ID_ANY`, not `ROLE_NON_EAL`. Those live in `libeal`
+//!   and `libethdev`, both already linked. This probe demonstrates that they are reachable from a
+//!   registered thread.
+//!
+//! The demonstration is a contrast, because a bare success proves nothing about *why*: the
+//! **same call on the same CPU** returns `-EINVAL` from an unregistered thread (the lcore check
+//! rejecting `LCORE_ID_ANY`) and whatever the main lcore gets from a registered one. Matching the
+//! main lcore is the evidence that a registered thread is not second-class here.
+//!
+//! `rte_power_monitor` is not Intel-only: DPDK dispatches on `RTE_CPUFLAG_MONITORX` to AMD's
+//! `MONITORX`/`MWAITX` and otherwise to Intel's `UMONITOR`/`UMWAIT`, and the Arm implementation
+//! uses `WFE` with no CPU feature gate at all. `rte_power_pause` *is* narrower -- it needs
+//! `TPAUSE`, which is `WAITPKG` and so Intel-only -- but that is a CPU property, identical on the
+//! main lcore, and not something registration costs.
+//!
+//! Run:
+//!   ./power_monitor_probe 0000:02:00.1
+
+use dataplane_dpdk::dev::{DevConfig, RssConf, RxOffload, TxOffloadConfig};
+use dataplane_dpdk::eal;
+use dataplane_dpdk::lcore::LCore;
+use dataplane_dpdk::mem::{PoolConfig, PoolParams};
+use dataplane_dpdk::queue::rx::{RxQueueConfig, RxQueueIndex};
+use dataplane_dpdk::queue::tx::{TxQueueConfig, TxQueueIndex};
+use dataplane_dpdk::socket::Preference;
+
+type Err = Box<dyn std::error::Error>;
+
+/// `errno` values, negated as DPDK returns them.
+const NEG_EINVAL: i32 = -22;
+const NEG_ENOTSUP: i32 = -95;
+
+fn describe(rc: i32) -> String {
+    match rc {
+        0 => "ok".to_string(),
+        NEG_EINVAL => "-EINVAL".to_string(),
+        NEG_ENOTSUP => "-ENOTSUP".to_string(),
+        other => format!("{other}"),
+    }
+}
+
+/// What the monitor primitives say when called from this thread.
+struct Attempt {
+    lcore_id: u32,
+    get_monitor_addr: i32,
+    power_monitor: i32,
+    power_pause: i32,
+}
+
+/// Ask the PMD for a monitor condition on `(port, queue)` and then try to sleep on it.
+///
+/// The sleep is given an already-elapsed deadline so that, on a host where it *is* supported, this
+/// returns immediately rather than parking the probe until a packet happens to arrive.
+fn attempt(port: u16, queue: u16) -> Attempt {
+    let mut pmc: dpdk_sys::rte_power_monitor_cond = unsafe { core::mem::zeroed() };
+    let get_monitor_addr = unsafe { dpdk_sys::rte_eth_get_monitor_addr(port, queue, &raw mut pmc) };
+
+    // A deadline already in the past: `rte_power_monitor` treats the timestamp as an absolute TSC
+    // wake time, so this asks it to wake immediately.
+    let already_expired = 1u64;
+    let power_monitor = if get_monitor_addr == 0 {
+        unsafe { dpdk_sys::rte_power_monitor(&raw const pmc, already_expired) }
+    } else {
+        // No condition to sleep on, so the call would be testing argument validation rather than
+        // the lcore gate.
+        i32::MIN
+    };
+
+    Attempt {
+        lcore_id: unsafe { dpdk_sys::rte_lcore_id_w() },
+        get_monitor_addr,
+        power_monitor,
+        power_pause: unsafe { dpdk_sys::rte_power_pause(already_expired) },
+    }
+}
+
+fn report(what: &str, a: &Attempt) {
+    let id = if a.lcore_id == u32::MAX {
+        "ANY".to_string()
+    } else {
+        a.lcore_id.to_string()
+    };
+    println!(
+        "  {what:<12} lcore={id:<4} get_monitor_addr={:<8} power_monitor={:<8} power_pause={}",
+        describe(a.get_monitor_addr),
+        if a.power_monitor == i32::MIN {
+            "(skipped)".to_string()
+        } else {
+            describe(a.power_monitor)
+        },
+        describe(a.power_pause),
+    );
+}
+
+fn main() -> Result<(), Err> {
+    let bdf = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "0000:02:00.1".to_string());
+
+    let eal = eal::init([
+        "-a",
+        bdf.as_str(),
+        "--in-memory",
+        "--no-telemetry",
+        "--no-shconf",
+        "--iova-mode=va",
+    ]);
+
+    let info = eal.dev.iter().next().ok_or("no DPDK port probed")?;
+    let index = info.index();
+    let port = index.as_u16();
+    println!("port {port} ({bdf}), driver {}", info.driver_name());
+
+    let rss = RssConf::supported_on(&info);
+    let mut dev = DevConfig {
+        num_rx_queues: 1,
+        num_tx_queues: 1,
+        num_hairpin_queues: 0,
+        rx_offloads: Some(if rss.is_some() {
+            RxOffload::RSS_HASH
+        } else {
+            RxOffload::NONE
+        }),
+        tx_offloads: Some(TxOffloadConfig::default()),
+        mtu: None,
+        rss,
+    }
+    .apply(info)
+    .map_err(|e| format!("configure: {e:?}"))?;
+
+    let pool = eal
+        .mem
+        .new_pkt_pool(
+            PoolConfig::new("pm_probe_pool", PoolParams::default())
+                .map_err(|e| format!("pool config: {e:?}"))?,
+        )
+        .map_err(|e| format!("pool create: {e:?}"))?;
+    dev.new_rx_queue(RxQueueConfig {
+        dev: index,
+        queue_index: RxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(index),
+        offloads: RxOffload::NONE,
+        pool,
+    })?;
+    dev.new_tx_queue(TxQueueConfig {
+        queue_index: TxQueueIndex(0),
+        num_descriptors: 1024,
+        socket_preference: Preference::Dev(index),
+        config: (),
+    })?;
+    let dev = dev.start().map_err(|e| format!("start: {e}"))?;
+
+    println!();
+    let main_attempt = attempt(port, 0);
+    report("main", &main_attempt);
+
+    let (plain, registered) = std::thread::scope(|s| {
+        s.spawn(|| {
+            let plain = attempt(port, 0);
+            let _registration = LCore::register().expect("could not register");
+            let registered = attempt(port, 0);
+            (plain, registered)
+        })
+        .join()
+        .expect("probe thread panicked")
+    });
+    report("plain", &plain);
+    report("registered", &registered);
+
+    println!();
+    let mut surprises: Vec<String> = Vec::new();
+    let mut check = |claim: &str, holds: bool| {
+        println!("  [{}] {claim}", if holds { "ok " } else { "!! " });
+        if !holds {
+            surprises.push(claim.to_string());
+        }
+    };
+
+    check(
+        "mlx5 supplies a receive monitor condition (it implements get_monitor_addr)",
+        registered.get_monitor_addr == 0,
+    );
+    check(
+        "an UNregistered thread is refused by rte_power_monitor's lcore check (-EINVAL)",
+        plain.power_monitor == NEG_EINVAL,
+    );
+    check(
+        "a REGISTERED thread gets past that lcore check (anything but -EINVAL)",
+        registered.power_monitor != NEG_EINVAL,
+    );
+    check(
+        "whatever a registered thread hits next is the same thing the main lcore hits",
+        registered.power_monitor == main_attempt.power_monitor,
+    );
+
+    println!();
+    match registered.power_monitor {
+        0 => println!(
+            "rte_power_monitor SUCCEEDS from a registered thread on this host: the halfway \
+             receive loop is available as-is."
+        ),
+        NEG_ENOTSUP => println!(
+            "rte_power_monitor returns -ENOTSUP from a registered thread AND from the main lcore. \
+             That is a CPU property, not an lcore one -- this host has neither WAITPKG nor \
+             MONITORX. The lcore check still passed. On Arm (a BF3's own cores) the same API is \
+             implemented with WFE and has no CPU feature gate at all."
+        ),
+        other => println!("rte_power_monitor returned {other} from a registered thread"),
+    }
+
+    dev.stop()
+        .map_err(|e| format!("stop: {e}"))?
+        .close()
+        .map_err(|e| format!("close: {e}"))?;
+
+    if surprises.is_empty() {
+        println!("\nevery claim held on this host");
+        Ok(())
+    } else {
+        for s in &surprises {
+            println!("[SURPRISE] {s}");
+        }
+        Err(format!("{} claim(s) did not hold", surprises.len()).into())
+    }
+}

--- a/dpdk/examples/rss_capability_probe.rs
+++ b/dpdk/examples/rss_capability_probe.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! RSS capability probe: what a real device will and will not accept at configure time.
+//!
+//! The driver's RSS configuration rests on three claims read out of the DPDK source. Each one is
+//! the kind that is cheap to get wrong and expensive to debug, because `rte_eth_dev_configure`
+//! reports every one of them as a bare `-EINVAL`. This probe checks all three against a live
+//! device rather than against `rte_ethdev.c`:
+//!
+//! 1. `dev_info.rss_algo_capa` advertises **only** `RTE_ETH_HASH_FUNCTION_DEFAULT` on mlx5, because
+//!    the ethdev layer initialises it to that and mlx5's `dev_infos_get` never widens it. So
+//!    symmetric Toeplitz cannot be requested here at all -- it is reachable only through the
+//!    `rte_flow` RSS action.
+//! 2. `dev_info.hash_key_size` is 40, which is the *exact* key length configure will accept.
+//! 3. `dev_info.flow_type_rss_offloads` covers the L3 and L4 hash types
+//!    [`RssConf::supported_on`] asks for, so the intersection does not silently narrow.
+//!
+//! It then does the two things that actually matter: configures the port the way the dataplane
+//! driver configures it (RSS on, `RSS_HASH` offload on) and confirms that succeeds, and asks for
+//! `RTE_ETH_HASH_FUNCTION_SYMMETRIC_TOEPLITZ` and confirms that it is *rejected*. A claim that
+//! something is impossible is worth nothing until the failure has been seen.
+//!
+//! Needs no traffic and no cabled peer -- it never starts the port.
+//!
+//! Run (see `dpdk-driver-spike` for the container recipe; needs `IPC_LOCK`):
+//!   ./rss_capability_probe 0000:02:00.1
+
+use dataplane_dpdk::dev::{DevConfig, RssConf, RxOffload, TxOffloadConfig};
+use dataplane_dpdk::eal;
+
+use dpdk_sys::{
+    rte_eth_dev_configure, rte_eth_dev_info, rte_eth_dev_info_get, rte_eth_hash_function,
+    rte_eth_rss_conf,
+};
+
+type Err = Box<dyn std::error::Error>;
+
+/// Names for the `rte_eth_hash_function` values, for reporting the capability mask readably.
+const ALGO_NAMES: [(u32, &str); 5] = [
+    (0, "DEFAULT"),
+    (1, "TOEPLITZ"),
+    (2, "SIMPLE_XOR"),
+    (3, "SYMMETRIC_TOEPLITZ"),
+    (4, "SYMMETRIC_TOEPLITZ_SORT"),
+];
+
+fn describe_algo_capa(capa: u32) -> String {
+    let named: Vec<&str> = ALGO_NAMES
+        .iter()
+        .filter(|(bit, _)| capa & (1u32 << bit) != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    if named.is_empty() {
+        "(none)".to_string()
+    } else {
+        named.join(" | ")
+    }
+}
+
+fn main() -> Result<(), Err> {
+    let mut args = std::env::args().skip(1);
+    let bdf = args.next().unwrap_or_else(|| "0000:02:00.1".to_string());
+
+    let eal = eal::init([
+        "-a",
+        bdf.as_str(),
+        "--in-memory",
+        "--no-telemetry",
+        "--no-shconf",
+        "--iova-mode=va",
+    ]);
+
+    let info = eal
+        .dev
+        .iter()
+        .next()
+        .ok_or("no DPDK port probed -- check the BDF and that the device is bound")?;
+    let port = info.index().as_u16();
+
+    // Read the raw dev_info too: `rss_algo_capa` is the field the whole question turns on and the
+    // safe wrapper deliberately does not expose it (nothing may usefully ask for a non-default
+    // algorithm, so exposing it would only invite trying).
+    let mut raw: rte_eth_dev_info = unsafe { core::mem::zeroed() };
+    let rc = unsafe { rte_eth_dev_info_get(port, &raw mut raw) };
+    if rc != 0 {
+        return Err(format!("rte_eth_dev_info_get failed: {rc}").into());
+    }
+
+    println!("port {port} ({bdf}), driver {}", info.driver_name());
+    println!("  hash_key_size           = {}", raw.hash_key_size);
+    println!(
+        "  flow_type_rss_offloads  = {:#x}",
+        raw.flow_type_rss_offloads
+    );
+    println!(
+        "  rss_algo_capa           = {:#x}  [{}]",
+        raw.rss_algo_capa,
+        describe_algo_capa(raw.rss_algo_capa)
+    );
+
+    let mut failures: Vec<String> = Vec::new();
+
+    // Claim 1: only the default hash function is advertised.
+    // `RTE_ETH_HASH_ALGO_TO_CAPA(x)` is `RTE_BIT32(x)`; a function-like macro, so bindgen does not
+    // emit it.
+    let symmetric_bit = 1u32 << rte_eth_hash_function::RTE_ETH_HASH_FUNCTION_SYMMETRIC_TOEPLITZ;
+    if raw.rss_algo_capa & symmetric_bit == 0 {
+        println!("[ok]   symmetric Toeplitz is NOT advertised, as expected");
+    } else {
+        println!("[NOTE] symmetric Toeplitz IS advertised -- the driver could use it after all");
+        failures.push("rss_algo_capa advertises SYMMETRIC_TOEPLITZ; revisit RssConf".to_string());
+    }
+
+    // Claim 2: the key length the crate hard-codes is the one the device demands.
+    if usize::from(raw.hash_key_size) == RssConf::DEFAULT_KEY.len() {
+        println!(
+            "[ok]   hash_key_size matches RssConf::DEFAULT_KEY ({} bytes)",
+            RssConf::DEFAULT_KEY.len()
+        );
+    } else {
+        failures.push(format!(
+            "hash_key_size is {} but RssConf::DEFAULT_KEY is {}; configure would reject it",
+            raw.hash_key_size,
+            RssConf::DEFAULT_KEY.len()
+        ));
+    }
+
+    // Claim 3: nothing we ask to hash on gets dropped by the intersection.
+    let Some(rss) = RssConf::supported_on(&info) else {
+        return Err("device advertises no RSS hash functions at all".into());
+    };
+    if rss.hf == RssConf::DEFAULT_HASH_TYPES {
+        println!(
+            "  hash types requested     = {:#x} (nothing narrowed)",
+            rss.hf
+        );
+    } else {
+        println!(
+            "[NOTE] hash types narrowed: wanted {:#x}, device supports {:#x}, using {:#x}",
+            RssConf::DEFAULT_HASH_TYPES,
+            raw.flow_type_rss_offloads,
+            rss.hf
+        );
+    }
+
+    // The negative control, and it runs FIRST. `DevConfig::apply` hands back a `Dev` whose `Drop`
+    // stops and closes the port, so doing this after a successful configure would attempt it on a
+    // closed port and get `-ENODEV` -- which is non-zero, and would read as the rejection this is
+    // looking for while proving nothing at all. Order is load-bearing here.
+    //
+    // Raw FFI because the safe API has no way to ask for a non-default hash function, which is the
+    // whole point; the impossibility has to be demonstrated at the level where someone would
+    // otherwise try it.
+    let mut key = RssConf::DEFAULT_KEY;
+    let mut eth_conf: dpdk_sys::rte_eth_conf = unsafe { core::mem::zeroed() };
+    eth_conf.rxmode.mq_mode = dpdk_sys::rte_eth_rx_mq_mode::RTE_ETH_MQ_RX_RSS;
+    eth_conf.rxmode.mtu = 1500;
+    eth_conf.txmode.mq_mode = dpdk_sys::rte_eth_tx_mq_mode::RTE_ETH_MQ_TX_NONE;
+    eth_conf.rx_adv_conf.rss_conf = rte_eth_rss_conf {
+        rss_key: key.as_mut_ptr(),
+        rss_key_len: key.len() as u8,
+        rss_hf: rss.hf,
+        algorithm: rte_eth_hash_function::RTE_ETH_HASH_FUNCTION_SYMMETRIC_TOEPLITZ,
+    };
+    // `-EINVAL` specifically, not merely non-zero: that is what says the *algorithm* was refused.
+    // `-ENODEV` would mean the port was gone and the check was vacuous.
+    const NEG_EINVAL: i32 = -22;
+    let rc = unsafe { rte_eth_dev_configure(port, 2, 2, &eth_conf) };
+    if rc == 0 {
+        failures.push(
+            "configure ACCEPTED symmetric Toeplitz -- the central claim in RssConf's docs is wrong"
+                .to_string(),
+        );
+    } else if rc == NEG_EINVAL {
+        println!("[ok]   configure rejected symmetric Toeplitz with -EINVAL, as expected");
+    } else {
+        failures.push(format!(
+            "configure refused symmetric Toeplitz with {rc}, not -EINVAL ({NEG_EINVAL}). \
+             Something other than the hash algorithm was wrong, so this proved nothing."
+        ));
+    }
+
+    // Now configure exactly as the dataplane driver does. Last, because the `Dev` it returns closes
+    // the port when it drops.
+    let cfg = DevConfig {
+        num_rx_queues: 2,
+        num_tx_queues: 2,
+        num_hairpin_queues: 0,
+        rx_offloads: Some(RxOffload::RSS_HASH),
+        tx_offloads: Some(TxOffloadConfig::default()),
+        mtu: None,
+        rss: Some(rss),
+    };
+    match cfg.apply(info) {
+        Ok(_dev) => println!("[ok]   configure with RSS + RSS_HASH offload succeeded"),
+        Err(e) => failures.push(format!(
+            "configure with RSS + RSS_HASH offload FAILED: {e:?}"
+        )),
+    }
+
+    if failures.is_empty() {
+        println!("\nall RSS capability claims hold on this device");
+        Ok(())
+    } else {
+        for f in &failures {
+            println!("[FAIL] {f}");
+        }
+        Err(format!("{} claim(s) did not hold", failures.len()).into())
+    }
+}

--- a/dpdk/src/acl/mod.rs
+++ b/dpdk/src/acl/mod.rs
@@ -522,8 +522,15 @@ mod tests {
     #[with_eal]
     #[test]
     fn classify_concurrent_arc_shared() {
-        use concurrency::sync::Arc;
-        use concurrency::thread;
+        // `std` rather than the concurrency facade, deliberately. This asserts that a built ACL
+        // context can be classified against from several **OS** threads at once, which is a
+        // property of DPDK's `rte_acl_classify` and of real hardware parallelism. Under a model
+        // checker the facade's `thread::spawn` yields coroutines multiplexed onto one OS thread,
+        // which would not exercise that at all -- and, since the DPDK side is uninstrumented C,
+        // there is nothing there for a checker to explore either. See `crate::sync`.
+        use std::sync::Arc;
+        // nosemgrep: rust-no-direct-std-thread-import
+        use std::thread;
 
         const WORKERS: usize = 4;
         const ITERS_PER_WORKER: usize = 1000;

--- a/dpdk/src/dev.rs
+++ b/dpdk/src/dev.rs
@@ -17,7 +17,7 @@ use crate::queue::rx::{RxQueue, RxQueueConfig};
 use crate::queue::tx::{TxQueue, TxQueueConfig};
 use crate::queue::{QueueStore, Queues};
 use crate::socket::SocketId;
-use concurrency::sync::Mutex;
+use crate::sync::Mutex;
 use dpdk_sys::rte_eth_rx_mq_mode::{RTE_ETH_MQ_RX_NONE, RTE_ETH_MQ_RX_RSS};
 use dpdk_sys::rte_eth_tx_mq_mode::RTE_ETH_MQ_TX_NONE;
 use dpdk_sys::*;
@@ -209,12 +209,93 @@ impl From<DevIndex> for u16 {
 /// context with hash delivery enabled; a runtime `rte_eth_dev_rss_hash_update` after queue setup
 /// does not retrofit this on mlx5.  Carrying it on [`DevConfig`] threads it into the single
 /// `rte_eth_dev_configure` call.
+///
+/// # Why there is no hash-function knob here
+///
+/// `rte_eth_rss_conf` has an `algorithm` field, and DPDK defines
+/// `RTE_ETH_HASH_FUNCTION_SYMMETRIC_TOEPLITZ` -- the obvious way to make a flow's two directions
+/// hash alike.  **It cannot be requested through `rte_eth_dev_configure` on mlx5.**  `rte_ethdev.c`
+/// initialises `dev_info.rss_algo_capa` to `RTE_ETH_HASH_ALGO_CAPA_MASK(DEFAULT)` -- bit 0 only --
+/// *before* calling the driver's `dev_infos_get`, and then validates the requested `algorithm`
+/// against that mask.  Only the `hns3`, `nfp`, `bnxt` and `ntnic` PMDs ever widen it; mlx5 sets
+/// `hash_key_size` and `flow_type_rss_offloads` and nothing else, so anything but
+/// `RTE_ETH_HASH_FUNCTION_DEFAULT` fails configure with `-EINVAL`.  mlx5 *does* implement symmetric
+/// Toeplitz, but only behind the `rte_flow` RSS action.
+///
+/// The same is true of tunnel-inner hashing: the `RTE_ETH_RSS_LEVEL_*` bits live at 50/51, outside
+/// mlx5's `flow_type_rss_offloads` (`RTE_ETH_RSS_IP | UDP | TCP | L3/L4_SRC/DST_ONLY | ESP`), so
+/// configure rejects those too.  Both are `rte_flow` territory.
+///
+/// So the `algorithm` field is deliberately left at its zero value
+/// (`RTE_ETH_HASH_FUNCTION_DEFAULT`) and is not exposed.  Adding a knob that every device this
+/// crate targets rejects would only invite a caller to set it.
 #[derive(Debug, PartialEq, Copy, Clone, Eq, PartialOrd, Ord, Hash)]
 pub struct RssConf {
     /// The Toeplitz RSS key.  mlx5 expects exactly 40 bytes (its `hash_key_size`).
     pub key: [u8; 40],
     /// The set of `RTE_ETH_RSS_*` hash types to hash over (e.g. `RTE_ETH_RSS_IPV4`).
     pub hf: u64,
+}
+
+impl RssConf {
+    /// The standard 40-byte Microsoft Toeplitz RSS key.
+    ///
+    /// This is the key nearly every NIC and driver defaults to, and the one
+    /// `dpdk/examples/rss_probe.rs` recomputes against to prove a device's reported
+    /// `mbuf.hash.rss` matches a software model of the same hash.
+    ///
+    /// It is *not* symmetric: `H(src, dst) != H(dst, src)`.  A key of period two
+    /// (`0x6d5a` repeated) would be, but symmetry is not worth buying here -- see the note on
+    /// [`RssConf`] for why the hardware route is closed, and note that a NAT'd flow's reverse
+    /// packet does not carry the reversed tuple anyway, so no hash property the NIC can have would
+    /// co-locate the two halves.
+    pub const DEFAULT_KEY: [u8; 40] = [
+        0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2, 0x41, 0x67, 0x25, 0x3d, 0x43, 0xa3, 0x8f,
+        0xb0, 0xd0, 0xca, 0x2b, 0xcb, 0xae, 0x7b, 0x30, 0xb4, 0x77, 0xcb, 0x2d, 0xa3, 0x80, 0x30,
+        0xf2, 0x0c, 0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
+    ];
+
+    /// The hash types worth asking for on a forwarding plane: L3 addresses for every IP packet,
+    /// plus L4 ports for TCP and UDP so that two flows between the same pair of hosts can land on
+    /// different queues.
+    ///
+    /// A device is not obliged to support all of these; [`RssConf::supported_on`] narrows the set
+    /// to what a given device advertises.
+    pub const DEFAULT_HASH_TYPES: u64 =
+        (RTE_ETH_RSS_IP as u64) | (RTE_ETH_RSS_TCP as u64) | (RTE_ETH_RSS_UDP as u64);
+
+    /// An RSS configuration for `dev` using [`DEFAULT_KEY`](Self::DEFAULT_KEY) and as much of
+    /// [`DEFAULT_HASH_TYPES`](Self::DEFAULT_HASH_TYPES) as the device advertises.
+    ///
+    /// Returns `None` if the device advertises no RSS hash functions at all, which is how the
+    /// emulated NICs (e1000, e1000e, and virtio without multi-queue negotiation) report.  Those
+    /// devices cannot spread across queues and must not be handed an RSS configuration.
+    ///
+    /// Intersecting rather than erroring is deliberate: `rte_eth_dev_configure` rejects an
+    /// `rss_hf` that is not a subset of `flow_type_rss_offloads`, and which hash types a device
+    /// supports is a property of the device rather than a thing a caller can be expected to know.
+    /// Asking for TCP ports on a device that only hashes L3 should cost L4 spread, not the port.
+    #[must_use]
+    pub fn supported_on(dev: &DevInfo) -> Option<RssConf> {
+        Self::from_hash_types(dev.rss_hash_types())
+    }
+
+    /// [`supported_on`](Self::supported_on) against a raw `flow_type_rss_offloads` mask.
+    ///
+    /// Split out from `supported_on` because a [`DevInfo`] can only be obtained from a real probed
+    /// device -- unit tests run under `--no-pci`, where none exists -- and the intersection is the
+    /// part with behaviour worth pinning down.
+    #[must_use]
+    pub fn from_hash_types(supported: u64) -> Option<RssConf> {
+        let hf = Self::DEFAULT_HASH_TYPES & supported;
+        if hf == 0 {
+            return None;
+        }
+        Some(RssConf {
+            key: Self::DEFAULT_KEY,
+            hf,
+        })
+    }
 }
 
 #[derive(Debug, PartialEq, Copy, Clone, Eq, PartialOrd, Ord, Hash)]
@@ -268,6 +349,27 @@ pub enum DevConfigError {
     },
     /// RSS hashing was requested but the device advertises no RSS hash functions.
     RssUnsupported,
+    /// The requested RSS key is not the length the device requires.
+    ///
+    /// `rte_eth_dev_configure` rejects a key whose length is not exactly the device's
+    /// `hash_key_size`, so this is checked here to report which device wanted what.
+    RssKeyLenMismatch {
+        /// The length of the key that was supplied.
+        requested: usize,
+        /// The key length the device requires.
+        device: u8,
+    },
+    /// The requested RSS hash types include bits the device does not support.
+    ///
+    /// `rte_eth_dev_configure` rejects any `rss_hf` that is not a subset of the device's
+    /// `flow_type_rss_offloads`.  Use [`RssConf::supported_on`] to intersect a wish list with what
+    /// a given device can actually hash on.
+    RssHashTypesUnsupported {
+        /// The `RTE_ETH_RSS_*` bits that were requested.
+        requested: u64,
+        /// The `RTE_ETH_RSS_*` bits the device advertises.
+        supported: u64,
+    },
 }
 
 impl DevConfig {
@@ -313,8 +415,26 @@ impl DevConfig {
         // same reason `resolve_mtu` rejects an out-of-range MTU: a misconfiguration that only
         // shows up as traffic landing on the wrong queue is far harder to diagnose than an error
         // at configure time.
-        if self.rss.is_some() && !dev.supports_rss() {
-            return Err(DevConfigError::RssUnsupported);
+        if let Some(rss) = self.rss {
+            if !dev.supports_rss() {
+                return Err(DevConfigError::RssUnsupported);
+            }
+            // Both of these are checks `rte_eth_dev_configure` performs itself, but it reports
+            // them as a bare `-EINVAL` that surfaces here as `DriverSpecificError("Invalid
+            // argument")` with no indication of which of a dozen fields was wrong.  Checking them
+            // up front is the difference between a one-line fix and an afternoon.
+            if rss.key.len() != dev.rss_hash_key_size() as usize {
+                return Err(DevConfigError::RssKeyLenMismatch {
+                    requested: rss.key.len(),
+                    device: dev.rss_hash_key_size(),
+                });
+            }
+            if rss.hf & !dev.rss_hash_types() != 0 {
+                return Err(DevConfigError::RssHashTypesUnsupported {
+                    requested: rss.hf,
+                    supported: dev.rss_hash_types(),
+                });
+            }
         }
         // The RSS key must outlive the `rte_eth_dev_configure` call below (the PMD copies it).
         // Left uninitialized: it is written and used only on the `self.rss.is_some()` path, so a
@@ -660,6 +780,21 @@ impl RxOffload {
     /// device supports -- including LRO, which drags DPDK's `max_lro_pkt_size` validation into
     /// configurations that have no use for it.
     pub const NONE: RxOffload = RxOffload(0);
+
+    /// Deliver the NIC's computed RSS hash in each mbuf's `hash.rss` field.
+    ///
+    /// Without this the hardware still steers by the hash but never reports it, so software cannot
+    /// see which flows the NIC believes it is spreading -- which is the first thing anyone wants
+    /// when RSS distributes badly.  Read it back with
+    /// [`Mbuf::rss_hash`](crate::mem::Mbuf::rss_hash).
+    ///
+    /// `rte_eth_dev_configure` rejects this offload unless the receive mq-mode has the RSS flag
+    /// set, so it is only legal alongside a [`DevConfig::rss`].
+    ///
+    /// Note that an `rte_flow` MARK or FDIR action overwrites the same union in the mbuf, so a
+    /// rule carrying one makes the hash unreadable -- the reason `flow_api_probe` sees
+    /// `rss_hash=None`.
+    pub const RSS_HASH: RxOffload = RxOffload(RTE_ETH_RX_OFFLOAD_RSS_HASH as u64);
 }
 
 impl BitOr for TxOffload {
@@ -930,6 +1065,25 @@ impl DevInfo<'_> {
     #[must_use]
     pub fn supports_rss(&self) -> bool {
         self.inner.flow_type_rss_offloads != 0
+    }
+
+    /// The set of `RTE_ETH_RSS_*` hash types the device advertises.
+    ///
+    /// `rte_eth_dev_configure` rejects any `rss_hf` that is not a subset of this, so a caller
+    /// building an [`RssConf`] by hand must intersect against it.  [`RssConf::supported_on`] does
+    /// that.
+    #[must_use]
+    pub fn rss_hash_types(&self) -> u64 {
+        self.inner.flow_type_rss_offloads
+    }
+
+    /// The exact RSS key length, in bytes, the device requires.
+    ///
+    /// `rte_eth_dev_configure` rejects a key of any other length -- not a shorter one, not a
+    /// longer one.  mlx5 reports 40; other drivers differ (i40e wants 52).
+    #[must_use]
+    pub fn rss_hash_key_size(&self) -> u8 {
+        self.inner.hash_key_size
     }
 }
 
@@ -1511,4 +1665,95 @@ pub enum SocketIdLookupError {
     DevDoesNotExist(DevIndex),
     #[error("Unknown error code set")]
     UnknownErrno(ErrorCode),
+}
+
+#[cfg(test)]
+mod rss_conf_tests {
+    use super::*;
+
+    /// mlx5's `flow_type_rss_offloads`: `~MLX5_RSS_HF_MASK` from `mlx5_defs.h`.
+    ///
+    /// The `L3_SRC_ONLY`/`L3_DST_ONLY`/`L4_*_ONLY` modifier bits mlx5 also advertises are left out.
+    /// They only narrow a hash type that is already selected, so they cannot change the
+    /// intersection under test -- and `RTE_ETH_RSS_L3_SRC_ONLY` is `RTE_BIT64(63)`, which bindgen
+    /// does not emit into `dpdk-sys` at all (`RTE_ETH_RSS_L3_DST_ONLY`, one bit lower, comes
+    /// through fine). That gap is real but belongs to `dpdk-sys`, not here.
+    const MLX5_RSS_OFFLOADS: u64 = (RTE_ETH_RSS_IP as u64)
+        | (RTE_ETH_RSS_UDP as u64)
+        | (RTE_ETH_RSS_TCP as u64)
+        | (RTE_ETH_RSS_ESP as u64);
+
+    /// The key length `rte_eth_dev_configure` demands must match what mlx5 reports
+    /// (`MLX5_RSS_HASH_KEY_LEN`). A key of any other length is rejected outright, so this is not a
+    /// style preference.
+    #[test]
+    fn the_default_key_is_the_length_mlx5_requires() {
+        assert_eq!(RssConf::DEFAULT_KEY.len(), 40);
+    }
+
+    /// On mlx5 every hash type this crate asks for is supported, so the intersection must not
+    /// silently narrow. If it does, flows stop spreading by L4 port and every connection between
+    /// one pair of hosts collapses onto a single worker.
+    #[test]
+    fn mlx5_supports_every_hash_type_we_ask_for() {
+        let conf = RssConf::from_hash_types(MLX5_RSS_OFFLOADS).expect("mlx5 supports RSS");
+        assert_eq!(conf.hf, RssConf::DEFAULT_HASH_TYPES);
+        assert_eq!(conf.key, RssConf::DEFAULT_KEY);
+
+        // Named individually rather than left to the equality above, which compares the
+        // intersection against the wish list and so would still hold if the wish list itself were
+        // narrowed. These are the bits whose loss is operationally visible: without L4, every
+        // connection between one pair of hosts hashes alike and lands on a single worker.
+        for (bit, what) in [
+            (RTE_ETH_RSS_IP as u64, "L3 addresses"),
+            (RTE_ETH_RSS_TCP as u64, "TCP ports"),
+            (RTE_ETH_RSS_UDP as u64, "UDP ports"),
+        ] {
+            assert_ne!(conf.hf & bit, 0, "RSS on mlx5 would not hash over {what}");
+        }
+    }
+
+    /// A device that hashes on L3 but not L4 must still get an RSS configuration -- just a
+    /// narrower one. Erroring instead would refuse to spread traffic at all on a device that can
+    /// perfectly well spread it by address.
+    #[test]
+    fn an_l3_only_device_gets_a_narrowed_configuration() {
+        let conf = RssConf::from_hash_types(RTE_ETH_RSS_IP as u64).expect("L3 hashing is enough");
+        assert_eq!(conf.hf, RTE_ETH_RSS_IP as u64);
+        assert_eq!(conf.hf & RTE_ETH_RSS_TCP as u64, 0);
+    }
+
+    /// The emulated NICs (e1000, e1000e, virtio without multi-queue negotiation) report no hash
+    /// functions at all. Handing such a device an RSS configuration makes `rte_eth_dev_configure`
+    /// fail outright, so this case must produce `None` rather than an empty-but-present config.
+    #[test]
+    fn a_device_that_cannot_hash_gets_no_configuration() {
+        assert_eq!(RssConf::from_hash_types(0), None);
+    }
+
+    /// A device advertising only hash types we do not ask for is the same case: the intersection
+    /// is empty, and an `rss_hf` of zero under `RTE_ETH_MQ_RX_RSS` would configure a hash over
+    /// nothing, sending every packet to queue 0 while looking configured.
+    #[test]
+    fn an_empty_intersection_is_not_a_configuration() {
+        assert_eq!(RssConf::from_hash_types(RTE_ETH_RSS_ESP as u64), None);
+    }
+
+    /// The standard Toeplitz key is deliberately **not** symmetric, and this test exists to say so
+    /// where someone would otherwise "fix" it.
+    ///
+    /// A key of period two (`0x6d5a` repeated) would make `H(src, dst) == H(dst, src)`. That is
+    /// not wanted here: mlx5 aside, a NAT'd flow's reverse packet carries the translated tuple
+    /// rather than the reversed one, so symmetry would buy nothing while measurably worsening the
+    /// hash's distribution. See the note on [`RssConf`].
+    #[test]
+    fn the_default_key_is_not_symmetric() {
+        let (pairs, _) = RssConf::DEFAULT_KEY.as_chunks::<2>();
+        let symmetric = pairs.iter().all(|pair| pair == &pairs[0]);
+        assert!(
+            !symmetric,
+            "the default RSS key has become period-2 (symmetric); \
+             see the RssConf docs for why that is not the fix it looks like"
+        );
+    }
 }

--- a/dpdk/src/dev.rs
+++ b/dpdk/src/dev.rs
@@ -1289,6 +1289,40 @@ impl<'eal, S: DevState> Dev<'eal, S> {
     }
 }
 
+/// What a port's link is doing, as returned by [`Dev::link`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LinkStatus {
+    /// Carrier is present.
+    pub up: bool,
+    /// Negotiated speed in Mbit/s. `u32::MAX` is DPDK's "unknown".
+    pub speed_mbps: u32,
+    /// Full duplex rather than half.
+    pub full_duplex: bool,
+    /// The speed was autonegotiated rather than fixed.
+    pub autoneg: bool,
+}
+
+impl core::fmt::Display for LinkStatus {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if !self.up {
+            return write!(f, "down");
+        }
+        if self.speed_mbps == u32::MAX {
+            return write!(f, "up at an unknown speed");
+        }
+        write!(
+            f,
+            "up at {} Mbit/s {}",
+            self.speed_mbps,
+            if self.full_duplex {
+                "full duplex"
+            } else {
+                "half duplex"
+            }
+        )
+    }
+}
+
 /// A port's I/O counters, as returned by [`Dev::stats`].
 ///
 /// A plain owned snapshot rather than a borrow of DPDK's `rte_eth_stats`: the counters are read by
@@ -1367,6 +1401,43 @@ impl<'eal, S: Open> Dev<'eal, S> {
     /// bifurcated driver such as mlx5 it reports a frame delivered to the port while saying nothing
     /// about whether any DPDK queue received it. [`PortStats::imissed`] and
     /// [`PortStats::rx_nombuf`] are where a frame that reached the port and never reached a
+    /// Whether the port has carrier, and at what speed.
+    ///
+    /// Worth having because a port with no link is otherwise **invisible**: DPDK will configure a
+    /// device, set up every queue and report it started with the link down, and the datapath then
+    /// runs perfectly while carrying nothing. Nothing in the driver is wrong in that state, so
+    /// nothing in the driver complains.
+    ///
+    /// For a bifurcated device this most often means the kernel netdev is administratively down --
+    /// `mlx5_core` keeps the netdev, and the physical port follows its state. Moving an interface
+    /// between network namespaces clears `IFF_UP`, which is exactly how a port ends up here.
+    ///
+    /// The `_nowait` form deliberately: this is for reporting, and the blocking variant can sit for
+    /// up to nine seconds per port waiting for autonegotiation.
+    ///
+    /// # Errors
+    ///
+    /// Returns the driver's [`ErrorCode`]; a PMD without link support reports `ENOTSUP`.
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub fn link(&self) -> Result<LinkStatus, ErrorCode> {
+        let mut raw: dpdk_sys::rte_eth_link = unsafe { core::mem::zeroed() };
+        // SAFETY: `raw` is live for the call and the port index comes from a started device.
+        let ret =
+            unsafe { dpdk_sys::rte_eth_link_get_nowait(self.info.index().as_u16(), &raw mut raw) };
+        if ret != 0 {
+            return Err(ErrorCode::parse_i32(ret));
+        }
+        // SAFETY: the union's struct arm is the documented way to read the fields; the `val64` arm
+        // exists only so the PMD can write the whole thing atomically.
+        let inner = unsafe { raw.annon1.annon1 };
+        Ok(LinkStatus {
+            up: u32::from(inner.link_status()) == dpdk_sys::RTE_ETH_LINK_UP,
+            speed_mbps: inner.link_speed,
+            full_duplex: u32::from(inner.link_duplex()) == dpdk_sys::RTE_ETH_LINK_FULL_DUPLEX,
+            autoneg: inner.link_autoneg() != 0,
+        })
+    }
+
     /// receive burst is accounted for.
     ///
     /// # Errors

--- a/dpdk/src/eal.rs
+++ b/dpdk/src/eal.rs
@@ -257,6 +257,38 @@ pub fn main_lcore_arg() -> String {
 /// 4. The EAL has already been initialized.
 #[cold]
 pub fn init(args: impl IntoIterator<Item = impl AsRef<str>>) -> Eal {
+    // Refuse, loudly and early, to bring the EAL up against a model-checker backend.
+    //
+    // Nothing below this line can be modelled: shuttle multiplexes its threads onto one OS thread
+    // (it is built on `corosensei` coroutines) while every piece of DPDK per-thread state is
+    // OS-thread-local, `Mbuf`/`Eal`/`LCore` are `!Send` about a thread notion the checker
+    // redefines, and DPDK is uninstrumented C whose real synchronisation a checker cannot see.
+    // See `crate::sync` for the long form.
+    //
+    // This is a runtime refusal rather than a `compile_error!` in this crate's root, which was
+    // tried: the two lines of `concurrency::with_shuttle!`/`with_loom!` do work and need no new
+    // features, but `dataplane-nat` carries `dpdk` as a **dev-dependency** for its `#[with_eal]`
+    // tests, and Cargo cannot make a dependency conditional on a feature -- so a compile error here
+    // takes `nat`'s genuine shuttle coverage down with it. Untangling that means moving nat's
+    // EAL-requiring tests into their own package; until then, failing here is the honest gate.
+    //
+    // The message matters: without it the symptom is a bare `ExecutionState is not set` from
+    // somewhere deep inside a facade primitive, which reads like a bug in the test rather than a
+    // category error.
+    concurrency::with_shuttle! {
+        panic!(
+            "the DPDK EAL cannot be initialised under the shuttle backend: DPDK's per-thread state \
+             is OS-thread-local and shuttle multiplexes its threads onto one OS thread. Nothing \
+             here is model-checkable; see dpdk::sync."
+        );
+    }
+    concurrency::with_loom! {
+        panic!(
+            "the DPDK EAL cannot be initialised under the loom backend: DPDK's per-thread state is \
+             OS-thread-local and loom does not model OS threads. Nothing here is model-checkable; \
+             see dpdk::sync."
+        );
+    }
     let mut args = ValidatedEalArgs::new(args).unwrap_or_else(|e| {
         Eal::fatal_error(e.to_string());
     });
@@ -392,6 +424,34 @@ impl Drop for Eal {
     fn drop(&mut self) {
         info!("waiting on EAL threads");
         unsafe { dpdk_sys::rte_eal_mp_wait_lcore() };
+
+        // `rte_eal_mp_wait_lcore` waits for EAL lcores (`ROLE_RTE`) and **nothing else**. A thread
+        // registered with [`LCore`](crate::lcore::LCore) is `ROLE_NON_EAL`,
+        // so DPDK will neither wait for it nor warn about it -- and `rte_eal_cleanup` below calls
+        // `eal_lcore_var_cleanup` and `rte_eal_memory_detach`, after which, in DPDK's own words,
+        // "any DPDK pointers will become dangling". A registered thread still running past this
+        // point is therefore a use-after-free, and it would present as a segfault somewhere
+        // unrelated during shutdown.
+        //
+        // The Rust side already prevents this structurally: workers live in a
+        // `concurrency::thread::scope` which cannot return until every one is joined, and the ports
+        // they borrow are branded with this EAL's lifetime, so the compiler orders
+        // scope-ends-before-ports-drop-before-EAL-drops. This check exists because that ordering is
+        // a property of the *callers*, not of this type, and a future caller that registers a
+        // thread outside such a scope would get no diagnostic at all.
+        let stragglers = (0..dpdk_sys::RTE_MAX_LCORE)
+            .filter(|id| unsafe {
+                dpdk_sys::rte_lcore_has_role(*id, dpdk_sys::rte_lcore_role_t::ROLE_NON_EAL) != 0
+            })
+            .count();
+        if stragglers > 0 {
+            error!(
+                "{stragglers} thread(s) are still registered with the EAL as it is torn down. \
+                 Every registered thread must be joined first: cleanup detaches DPDK memory and \
+                 frees per-lcore storage, so anything still running will read freed memory. This \
+                 is a bug in whatever spawned them."
+            );
+        }
 
         // Retire every mempool and wait for the workers to release them.
         //

--- a/dpdk/src/lcore.rs
+++ b/dpdk/src/lcore.rs
@@ -4,6 +4,7 @@
 use crate::eal::{Eal, EalErrno};
 use core::ffi::{c_int, c_uint, c_void};
 use core::fmt::Debug;
+use errno::ErrorCode;
 use tracing::{info, warn};
 
 #[repr(transparent)]
@@ -100,8 +101,25 @@ struct LCoreIndexIterator {
     inner: LCoreIdIterator,
 }
 
+/// A thread spawned and registered with the EAL for its lifetime.
+///
+/// # This is not a DPDK "service core"
+///
+/// It was called `ServiceThread`, which invited exactly the wrong reading. DPDK has a distinct and
+/// unrelated concept: a **service core** is an lcore with `ROLE_SERVICE` that runs registered
+/// service *functions* (`rte_service_component_register`) on a scheduler DPDK owns. This type is
+/// nothing of the kind -- it is an ordinary Rust thread that happens to hold an
+/// [`LCore`], and it is `ROLE_NON_EAL`. `rte_service_lcore_add` would refuse it.
+///
+/// The two are not interchangeable and the names should not be either.
+///
+/// # What it is for
+///
+/// It spawns a thread, registers it, and **lends the resulting [`LCore`] token to the body**. That
+/// is the whole job: the body cannot run without a registration, cannot outlive it, and cannot move
+/// it elsewhere, so every API gated on `&LCore` is reachable inside and nowhere outside.
 #[allow(unused)]
-pub struct ServiceThread<'scope> {
+pub struct RegisteredThread<'scope> {
     thread_id: RteThreadId,
     priority: LCorePriority,
     handle: std::thread::ScopedJoinHandle<'scope, ()>,
@@ -110,56 +128,180 @@ pub struct ServiceThread<'scope> {
 // TODO: take stack size as an EAL argument instead of hard coding it
 const STACK_SIZE: usize = 8 << 20;
 
-/// Releases this thread's EAL lcore registration when it goes out of scope, including on unwind.
+/// Proof, held by value, that **this** thread is registered with the EAL.
 ///
-/// Constructed only after a successful [`rte_thread_register`](dpdk_sys::rte_thread_register), and
-/// never moved off the thread that registered -- `rte_thread_unregister` releases the *calling*
-/// thread's id, so running it anywhere else would strand this one and corrupt another.
+/// This is a capability token, not merely a guard. Some DPDK calls are only meaningful -- or only
+/// safe -- on a thread the EAL knows about, and those take an `&LCore` so that the requirement is
+/// discharged at the type level instead of being a comment nobody reads. Registration is released
+/// when the token drops.
+///
+/// # Why a thread wants to be registered
+///
+/// A thread the EAL does not know about reports `LCORE_ID_ANY` (`u32::MAX`) from `rte_lcore_id()`,
+/// and DPDK reads that in more places than is obvious:
+///
+/// - **Mempool caches.** `rte_mempool_default_cache` returns `NULL` for `LCORE_ID_ANY`, so an
+///   unregistered thread has no per-core object cache and every `alloc_bulk` and every mbuf free
+///   goes to the shared ring under atomics -- on every burst, in both directions. This one is a
+///   silent performance cliff rather than an error, which is why it is not gated on the token.
+/// - **Per-lcore variables.** `RTE_LCORE_VAR` indexes `handle + lcore_id * RTE_MAX_LCORE_VAR`. At
+///   `LCORE_ID_ANY` that is a wild pointer, which is why DPDK documents the accessor as usable only
+///   by EAL threads and registered non-EAL threads. Anything this crate builds on lcore variables
+///   **must** take an `&LCore`.
+/// - **The power-monitor family** ([`crate::power`]) rejects an unregistered caller with `-EINVAL`.
+/// - `socket::Preference::CurrentThread` answers `SOCKET_ID_ANY` rather than a real NUMA node.
+///
+/// # Why `&LCore` is sound proof about the *current* thread
+///
+/// [`LCore`] is `!Send` **and** `!Sync`. `!Send` keeps the token itself on the registering thread;
+/// `!Sync` is what makes `&LCore` also `!Send`, so a *reference* cannot be handed to another thread
+/// either. Both are needed: with only `!Send`, a `&LCore` could be shared with an unregistered
+/// thread and would then prove nothing about it.
+///
+/// # Why it releases on drop
+///
+/// `rte_thread_unregister` releases the *calling* thread's id, so it must run on the thread that
+/// registered and it must run however that thread ends. A bare call after the work is skipped when
+/// the work unwinds, and **every skipped unregister strands an lcore id for the life of the
+/// process** -- there are `RTE_MAX_LCORE` of them, after which nothing can register at all. A
+/// panicking worker is exactly the case where that matters, being also the one most likely to be
+/// restarted.
+///
+/// Note the token deliberately carries no `'eal` brand. The invariant that a registration must not
+/// outlive the EAL is real -- `rte_eal_cleanup` detaches DPDK memory and frees per-lcore storage --
+/// but it is already enforced where it arises: workers live in a `thread::scope` that cannot return
+/// until they are joined, and the ports they borrow *are* `'eal`-branded. `Eal::drop` also counts
+/// any stragglers and complains. Branding this token too would prove the same property a second
+/// time at the cost of threading an `EalShared` into every registration site.
 #[allow(missing_debug_implementations)]
-struct LcoreRegistration;
+pub struct LCore {
+    id: LCoreId,
+    /// Pins the token to the registering thread, and `&LCore` with it. See the type docs.
+    _not_send: core::marker::PhantomData<*const ()>,
+}
 
-impl Drop for LcoreRegistration {
+/// The token cannot be sent to another thread, so it cannot release someone else's id.
+///
+/// ```compile_fail,E0277
+/// # use dataplane_dpdk::lcore::LCore;
+/// fn assert_send<T: Send>(_: T) {}
+/// fn not_send(lcore: LCore) {
+///     assert_send(lcore);
+/// }
+/// ```
+///
+/// Nor can a *reference* to it, which is what makes `&LCore` proof about the calling thread rather
+/// than about some other thread that once registered. This is the property `!Sync` buys, and it is
+/// the one that would be easy to lose by deriving something careless.
+///
+/// ```compile_fail,E0277
+/// # use dataplane_dpdk::lcore::LCore;
+/// fn assert_send<T: Send>(_: T) {}
+/// fn ref_not_send(lcore: &LCore) {
+///     assert_send(lcore);
+/// }
+/// ```
+///
+/// And a gated API cannot be reached without one.
+///
+/// ```compile_fail,E0061
+/// # use dataplane_dpdk::power;
+/// # fn call(cond: &power::MonitorCond<'_>) {
+/// power::monitor(cond, 0).unwrap();
+/// # }
+/// ```
+impl LCore {
+    /// Register the calling thread with the EAL.
+    ///
+    /// Prefer [`LCore::with`], which cannot leave the registration held past the work it was for.
+    ///
+    /// # Errors
+    ///
+    /// Returns `EEXIST` if this thread already has an lcore id, and the EAL's `rte_errno`
+    /// (typically `ENOMEM`) if no id was available -- see
+    /// `dpdk/examples/lcore_capacity_probe.rs` for what the capacity actually is.
+    pub fn register() -> Result<LCore, ErrorCode> {
+        // `rte_thread_register` does **not** check whether the calling thread already has an lcore
+        // id -- it allocates a fresh non-EAL one and `__rte_thread_init` overwrites the thread's
+        // id with it. Doing that on an EAL lcore (the main one, say) silently costs that thread its
+        // real identity, and the matching unregister then leaves it as `LCORE_ID_ANY` rather than
+        // restoring what it was. Nothing downstream would report an error; the thread would simply
+        // stop being the main lcore. Refuse instead.
+        if LCoreId::current().as_u32() != u32::MAX {
+            warn!("this thread is already an lcore; refusing to register it a second time");
+            return Err(ErrorCode::parse_i32(-errno::EEXIST));
+        }
+        // SAFETY: no preconditions; the EAL is initialised by construction, since nothing can hold
+        // an `Eal` handle to reach this otherwise.
+        let ret = unsafe { dpdk_sys::rte_thread_register() };
+        if ret != 0 {
+            let errno = unsafe { dpdk_sys::rte_errno_get() };
+            warn!("could not register this thread with the EAL: ret {ret}, errno {errno}");
+            return Err(ErrorCode::parse_i32(errno));
+        }
+        Ok(LCore {
+            id: LCoreId::current(),
+            _not_send: core::marker::PhantomData,
+        })
+    }
+
+    /// Register this thread, run `f` with the token, and release the registration.
+    ///
+    /// # Errors
+    ///
+    /// Returns whatever [`LCore::register`] would.
+    pub fn with<R>(f: impl FnOnce(&LCore) -> R) -> Result<R, ErrorCode> {
+        let lcore = LCore::register()?;
+        Ok(f(&lcore))
+    }
+
+    /// The lcore id the EAL assigned to this thread.
+    ///
+    /// Never `LCORE_ID_ANY`: the token only exists after a successful registration, and cannot
+    /// outlive it or leave this thread.
+    #[must_use]
+    pub fn id(&self) -> LCoreId {
+        self.id
+    }
+}
+
+impl Drop for LCore {
     fn drop(&mut self) {
-        // SAFETY: paired with the `rte_thread_register` that preceded this guard's construction,
-        // on the same thread, and runs exactly once because the guard is never cloned or moved.
+        // SAFETY: paired with the `rte_thread_register` in `register`, on the same thread (the
+        // token is `!Send`), and runs exactly once because it is neither `Clone` nor `Copy`.
         unsafe { dpdk_sys::rte_thread_unregister() };
     }
 }
 
-impl ServiceThread<'_> {
+impl RegisteredThread<'_> {
     #[cold]
     #[allow(clippy::expect_used)]
     #[tracing::instrument(level = "debug", skip(run))]
     pub fn new<'scope>(
         scope: &'scope std::thread::Scope<'scope, '_>,
         name: impl AsRef<str> + Debug,
-        run: impl FnOnce() + 'scope + Send,
-    ) -> ServiceThread<'scope> {
+        run: impl FnOnce(&LCore) + 'scope + Send,
+    ) -> RegisteredThread<'scope> {
         let (send, recv) = std::sync::mpsc::sync_channel(1);
         let handle = std::thread::Builder::new()
             .name(name.as_ref().to_string())
             .stack_size(STACK_SIZE)
             .spawn_scoped(scope, move || {
                 info!("Initializing RTE Lcore");
-                let ret = unsafe { dpdk_sys::rte_thread_register() };
-                if ret != 0 {
-                    let errno = unsafe { dpdk_sys::rte_errno_get() };
-                    let msg = format!("rte thread exited with code {ret}, errno: {errno}");
-                    Eal::fatal_error(msg)
-                }
-                // Unregister on the way out however this thread ends.  A bare call after `run()`
-                // is skipped when `run()` unwinds, and every skipped unregister strands an lcore
-                // id for the life of the process -- `RTE_MAX_LCORE` of them and no further thread
-                // can register at all.  A panicking service thread is exactly the situation where
-                // that matters, since it is also the one most likely to be retried.
-                let _registration = LcoreRegistration;
+                // The registration is created here and lent to `run`, which is the point of this
+                // type: the body cannot run without one, cannot keep it afterwards, and cannot send
+                // it anywhere. Everything gated on `&LCore` is reachable inside `run` and nowhere
+                // else.
+                let lcore = LCore::register().unwrap_or_else(|e| {
+                    Eal::fatal_error(format!("could not register an EAL thread: {e:?}"))
+                });
                 let thread_id = unsafe { dpdk_sys::rte_thread_self() };
                 send.send(thread_id).expect("could not send thread id");
-                run();
+                run(&lcore);
             })
             .expect("could not create EalThread");
         let thread_id = RteThreadId(recv.recv().expect("could not receive thread id"));
-        ServiceThread {
+        RegisteredThread {
             thread_id,
             priority: LCorePriority::RealTime,
             handle,
@@ -198,42 +340,6 @@ impl WorkerThread {
                 lcore.0 as c_uint,
             )
         });
-    }
-}
-
-pub struct LCoreParams {
-    priority: LCorePriority,
-    name: String,
-}
-
-pub trait LCoreParameters {
-    fn priority(&self) -> &LCorePriority;
-    fn name(&self) -> &String;
-}
-
-#[allow(unused)]
-pub struct LCore {
-    params: LCoreParams,
-    id: RteThreadId,
-}
-
-impl LCoreParameters for LCoreParams {
-    fn priority(&self) -> &LCorePriority {
-        &self.priority
-    }
-
-    fn name(&self) -> &String {
-        &self.name
-    }
-}
-
-impl LCoreParameters for LCore {
-    fn priority(&self) -> &LCorePriority {
-        &self.params.priority
-    }
-
-    fn name(&self) -> &String {
-        &self.params.name
     }
 }
 
@@ -452,6 +558,228 @@ mod tests {
             u32::MAX,
             "expected LCORE_ID_ANY on an unregistered thread"
         );
+    }
+
+    /// The guard registers, so a thread holding one has a real lcore id.
+    ///
+    /// That id is the whole point: `rte_mempool_default_cache` returns NULL for `LCORE_ID_ANY`, so
+    /// without it a thread allocates and frees mbufs straight out of the shared ring.
+    #[test]
+    #[with_eal]
+    fn the_guard_registers_the_calling_thread() {
+        // Spawned deliberately. Whether the *harness's* thread is registered is not a property of
+        // this code: under `cargo test` a test body runs on a spawned thread and is unregistered,
+        // while under `nextest` (one process per test) it runs on the thread that initialised the
+        // EAL and so *is* the main lcore. A freshly spawned thread is unregistered under both, and
+        // is what the real callers are.
+        std::thread::spawn(|| {
+            assert_eq!(
+                LCoreId::current().as_u32(),
+                u32::MAX,
+                "a freshly spawned thread should start unregistered"
+            );
+
+            let registration = LCore::register().expect("could not register");
+            let here = LCoreId::current();
+            assert_ne!(here.as_u32(), u32::MAX, "the guard did not register");
+            assert_ne!(
+                here,
+                LCoreId::main(),
+                "a registered thread is not the main lcore"
+            );
+
+            drop(registration);
+            assert_eq!(
+                LCoreId::current().as_u32(),
+                u32::MAX,
+                "the guard did not release the id when dropped"
+            );
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
+
+    /// Registering a thread that already has an lcore id is refused.
+    ///
+    /// `rte_thread_register` itself does not check: it allocates a fresh non-EAL id and overwrites
+    /// the thread's with it, so calling it on the main lcore silently costs that thread its
+    /// identity, and the matching unregister then leaves it `LCORE_ID_ANY` rather than restoring
+    /// lcore 0. Nothing downstream reports an error, which is what makes it worth refusing here.
+    #[test]
+    #[with_eal]
+    fn a_thread_that_is_already_an_lcore_is_refused() {
+        std::thread::spawn(|| {
+            let first = LCore::register().expect("first registration");
+            let id = LCoreId::current();
+
+            assert!(
+                LCore::register().is_err(),
+                "registering twice on one thread was allowed; the second would have overwritten \
+                 the first's lcore id"
+            );
+            assert_eq!(
+                LCoreId::current(),
+                id,
+                "the refused registration changed this thread's lcore id anyway"
+            );
+            drop(first);
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
+
+    /// Dropping the guard returns the id to the pool, so registrations can be made indefinitely.
+    ///
+    /// This is the property the guard exists for. A leaked registration strands an id for the life
+    /// of the process, and there are only `RTE_MAX_LCORE` of them -- so a worker that is restarted
+    /// enough times without releasing would eventually be unable to register at all. Iterating
+    /// well past any plausible `RTE_MAX_LCORE` is what makes a leak show up as a failure here
+    /// rather than as an exhaustion months later.
+    #[test]
+    #[with_eal]
+    fn registrations_are_released_and_can_be_reused() {
+        // Spawned, for the same reason as `the_guard_registers_the_calling_thread`.
+        std::thread::spawn(|| {
+            for round in 0..1024 {
+                let registration = LCore::register()
+                    .unwrap_or_else(|e| panic!("registration {round} failed: {e:?} -- ids leaked"));
+                assert_ne!(LCoreId::current().as_u32(), u32::MAX);
+                drop(registration);
+            }
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
+
+    /// `LCore::with` registers for the duration of the closure and releases after it.
+    #[test]
+    #[with_eal]
+    fn with_scopes_the_registration_to_the_closure() {
+        std::thread::spawn(|| {
+            let seen = LCore::with(|lcore| {
+                assert_ne!(lcore.id().as_u32(), u32::MAX, "the token has no lcore id");
+                assert_eq!(
+                    lcore.id(),
+                    LCoreId::current(),
+                    "the token disagrees with the thread it was made on"
+                );
+                lcore.id()
+            })
+            .expect("could not register");
+            assert_ne!(seen.as_u32(), u32::MAX);
+            assert_eq!(
+                LCoreId::current().as_u32(),
+                u32::MAX,
+                "the registration outlived the closure"
+            );
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
+
+    /// The id a token reports stays put for its whole life.
+    ///
+    /// It is cached at construction rather than read on each call, so this is the test that says
+    /// the cache cannot go stale -- which it could if a token were ever reachable from a thread
+    /// other than the one that made it.
+    #[test]
+    #[with_eal]
+    fn a_token_reports_a_stable_id() {
+        std::thread::spawn(|| {
+            let lcore = LCore::register().expect("could not register");
+            let first = lcore.id();
+            for _ in 0..100 {
+                assert_eq!(lcore.id(), first);
+                assert_eq!(lcore.id(), LCoreId::current());
+            }
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
+
+    /// Concurrent registrations get distinct lcore ids.
+    ///
+    /// The allocator hands out the first `ROLE_OFF` slot under a write lock; if that were racy two
+    /// threads could share an id, and an lcore id is the index into per-lcore state -- most
+    /// visibly a mempool's `local_cache`, where two threads sharing a cache would corrupt it.
+    ///
+    /// Deliberately a small number rather than a saturating one. Capacity is process-global, and
+    /// under `cargo test` (which shares one process across tests, unlike nextest) a test that
+    /// consumed every id would starve whatever ran beside it. Exhaustion behaviour is covered by
+    /// `examples/lcore_capacity_probe.rs` instead, where the process is the probe's own.
+    #[test]
+    #[with_eal]
+    fn concurrent_registrations_get_distinct_ids() {
+        const THREADS: usize = 16;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(THREADS));
+        let ids: Vec<u32> = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..THREADS)
+                .map(|_| {
+                    let barrier = barrier.clone();
+                    scope.spawn(move || {
+                        let _registration = LCore::register().expect("could not register");
+                        let id = LCoreId::current().as_u32();
+                        // Hold every registration at once; ids are only distinct if they overlap.
+                        barrier.wait();
+                        id
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| h.join().expect("a registering thread panicked"))
+                .collect()
+        });
+
+        let mut unique = ids.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            unique.len(),
+            THREADS,
+            "concurrent registrations shared an lcore id: {ids:?}"
+        );
+        assert!(
+            ids.iter().all(|id| *id != u32::MAX),
+            "a registration reported no lcore id: {ids:?}"
+        );
+    }
+
+    /// An unwinding thread still releases its id.
+    ///
+    /// The guard is a `Drop` impl precisely so that a panicking worker -- the case most likely to
+    /// be retried, and so the one where exhaustion would compound -- does not strand its id.
+    #[test]
+    #[with_eal]
+    fn a_panicking_thread_releases_its_registration() {
+        let before = std::thread::spawn(|| {
+            let _registration = LCore::register().expect("register");
+            LCoreId::current().as_u32()
+        })
+        .join()
+        .expect("thread should not have panicked");
+        assert_ne!(before, u32::MAX);
+
+        // Panic while holding a guard, many times over. If unwinding skipped the release, this
+        // would strand an id per iteration and the assertion below would eventually fail.
+        for _ in 0..512 {
+            let panicked = std::thread::spawn(|| {
+                let _registration = LCore::register().expect("register");
+                panic!("deliberate");
+            })
+            .join();
+            assert!(panicked.is_err(), "the thread was supposed to panic");
+        }
+
+        let after = std::thread::spawn(|| {
+            let _registration = LCore::register().expect(
+                "could not register after panicking threads ran -- unwinding leaked lcore ids",
+            );
+            LCoreId::current().as_u32()
+        })
+        .join()
+        .expect("thread should not have panicked");
+        assert_ne!(after, u32::MAX);
     }
 
     /// ...whereas a registered thread does get one, and it is not the main lcore.

--- a/dpdk/src/lib.rs
+++ b/dpdk/src/lib.rs
@@ -39,9 +39,11 @@ pub mod eal;
 pub mod flow;
 pub mod lcore;
 pub mod mem;
+pub mod power;
 pub mod queue;
 pub mod ring;
 pub mod socket;
+mod sync;
 
 #[cfg(any(test, feature = "test"))]
 pub mod test_support;

--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -345,6 +345,37 @@ pub struct PoolParams {
     pub socket_id: SocketId,
 }
 
+/// What [`PoolParams::default`] offers for a data room, and the floor [`mbuf_data_room`] keeps.
+pub const DEFAULT_MBUF_DATA_ROOM: u16 = 2048;
+
+/// The mbuf data room a port needs to receive a full frame at `mtu` in a single buffer.
+///
+/// A receive queue is set up against a pool, and the driver checks that the pool's mbufs can hold
+/// a whole frame. An mlx5 whose mbufs are too small refuses the queue with `ENOMEM` -- which reads
+/// as "out of memory" and actually means "these buffers are too small for the MTU you configured".
+///
+/// [`PoolParams::default`] offers 2048 bytes, 128 of which is DPDK's headroom, so 1920 usable.
+/// That was invisible while every port silently took the 1500 MTU default, and became a startup
+/// failure the moment one was configured for a 9000-byte fabric.
+///
+/// The frame is the MTU plus its Ethernet header, a VLAN tag it may carry and the CRC, with the
+/// headroom in front of all of it; rounded up to a kibibyte because a pool is allocated once and
+/// the slack is worth more than the bytes.
+///
+/// **This multiplies.** A pool holds one of these per mbuf and a busy port wants on the order of a
+/// hundred thousand, so the difference between a 2 KiB and a 9 KiB room is the difference between
+/// roughly 200 MiB and 900 MiB of hugepages. Callers should say what they reserved.
+#[must_use]
+pub fn mbuf_data_room(mtu: u16) -> u16 {
+    #[allow(clippy::cast_possible_truncation)] // every constant here is far below u16::MAX
+    let overhead = (dpdk_sys::RTE_PKTMBUF_HEADROOM
+        + dpdk_sys::RTE_ETHER_HDR_LEN
+        + dpdk_sys::RTE_VLAN_HLEN
+        + dpdk_sys::RTE_ETHER_CRC_LEN) as u16;
+    let needed = mtu.saturating_add(overhead).max(DEFAULT_MBUF_DATA_ROOM);
+    needed.checked_next_multiple_of(1024).unwrap_or(u16::MAX)
+}
+
 impl Default for PoolParams {
     // TODO: not sure if these defaults are sensible.
     fn default() -> PoolParams {
@@ -1394,5 +1425,48 @@ mod tests {
         }
         let ok = pool.alloc_bulk(15).expect("pool should still be full");
         assert_eq!(ok.len(), 15);
+    }
+}
+
+#[cfg(test)]
+mod mbuf_data_room_test {
+    use super::{DEFAULT_MBUF_DATA_ROOM, mbuf_data_room};
+
+    /// A jumbo MTU must get a room that actually holds the frame.
+    ///
+    /// This is the check that was missing. Every port took the 1500 default, the pool's 1920
+    /// usable bytes covered it, and the first port configured for a 9000-byte fabric failed its
+    /// receive-queue setup with `ENOMEM` -- a message that points at memory exhaustion rather than
+    /// at a buffer that cannot hold a frame.
+    #[test]
+    fn a_jumbo_mtu_gets_a_room_that_holds_the_frame() {
+        let room = mbuf_data_room(8986);
+        // 128 headroom + 14 eth + 4 vlan + 4 crc = 150 bytes in front of and behind the MTU.
+        assert!(
+            room >= 8986 + 150,
+            "{room} cannot hold an 8986 MTU frame plus headroom"
+        );
+        assert!(room > DEFAULT_MBUF_DATA_ROOM, "and must exceed the default");
+    }
+
+    /// A small MTU must not shrink the pool below what a burst needs.
+    #[test]
+    fn a_small_mtu_keeps_the_default_floor() {
+        assert_eq!(mbuf_data_room(1500), DEFAULT_MBUF_DATA_ROOM);
+        assert_eq!(mbuf_data_room(68), DEFAULT_MBUF_DATA_ROOM);
+        assert_eq!(mbuf_data_room(0), DEFAULT_MBUF_DATA_ROOM);
+    }
+
+    /// The result is a whole number of kibibytes, and an absurd MTU saturates rather than wraps.
+    #[test]
+    fn the_room_is_rounded_and_never_wraps() {
+        for mtu in [1500u16, 4000, 8986, 9000, 9216, 16384] {
+            let room = mbuf_data_room(mtu);
+            assert_eq!(room % 1024, 0, "{room} for mtu {mtu} is not a whole KiB");
+            assert!(room >= mtu, "{room} is smaller than the mtu {mtu} itself");
+        }
+        // Wrapping here would hand the pool a tiny room and fail queue setup in a way that looks
+        // like the bug this function exists to prevent.
+        assert_eq!(mbuf_data_room(u16::MAX), u16::MAX);
     }
 }

--- a/dpdk/src/mem.rs
+++ b/dpdk/src/mem.rs
@@ -4,10 +4,10 @@
 //! DPDK memory management wrappers.
 
 use crate::socket::SocketId;
+use crate::sync::Mutex;
 use alloc::format;
 use alloc::string::String;
 use arrayvec::ArrayVec;
-use concurrency::sync::Mutex;
 use core::ffi::c_uint;
 use core::ffi::{CStr, c_int};
 use core::fmt::{Debug, Display};

--- a/dpdk/src/power.rs
+++ b/dpdk/src/power.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Sleeping until a receive queue has something, instead of spinning on it.
+//!
+//! This is the machinery for a driver halfway between interrupt-driven and poll-mode: ask the PMD
+//! what memory location changes when a packet lands ([`MonitorCond::for_rx_queue`]), then park the
+//! core on that address until it changes or a deadline passes ([`monitor`]). On x86 that compiles
+//! to `UMONITOR`/`UMWAIT` (Intel) or `MONITORX`/`MWAITX` (AMD); on Arm it is `WFE`.
+//!
+//! # Why these take an [`LCore`]
+//!
+//! `rte_power_monitor` reads `rte_lcore_id()` and refuses `LCORE_ID_ANY` with `-EINVAL`, then
+//! indexes a per-lcore variable with it. An unregistered thread cannot use it at all. Requiring an
+//! `&LCore` turns that from a runtime `-EINVAL` on a datapath thread into a compile error, and
+//! `LCore` being `!Send + !Sync` is what makes the reference honest proof about the *calling*
+//! thread.
+//!
+//! [`wake`] is the exception and deliberately takes no token: it targets *another* lcore, and the
+//! caller's own registration is irrelevant to DPDK there.
+//!
+//! # What is deliberately absent
+//!
+//! **CPU frequency scaling.** `rte_power_init` and the `rte_power_freq_*` family demand `ROLE_RTE`
+//! or `ROLE_SERVICE` (`RTE_POWER_VALID_LCOREID_OR_ERR_RET`), which a registered non-EAL thread is
+//! not, so they cannot be offered here at all. That is fine: frequency is the firmware's and the
+//! kernel governor's decision, made with thermal information this process does not have.
+//!
+//! **`rte_power_ethdev_pmgmt_queue_enable`**, the convenience layer that installs all of this for
+//! you. It gates on `rte_lcore_is_enabled()` (`ROLE_RTE`) and so refuses registered threads, and it
+//! works by installing an ethdev receive callback -- which this build compiles out
+//! (`#undef RTE_ETHDEV_RXTX_CALLBACKS`). It is also the wrong layer for a run-to-completion driver,
+//! which owns its poll loop and already knows whether its queues came back empty. The primitives
+//! here are what it would have been built from.
+
+use core::marker::PhantomData;
+
+use errno::ErrorCode;
+
+use crate::lcore::{LCore, LCoreId};
+use crate::queue::rx::RxQueue;
+
+/// The condition a core sleeps on: an address, and what counts as a change.
+///
+/// Obtained from the PMD, which knows which descriptor word the hardware writes. Borrows the queue
+/// it describes, because the address points into that queue's rings -- sleeping on a condition
+/// whose queue has been torn down would be a use-after-free.
+#[allow(missing_debug_implementations)]
+pub struct MonitorCond<'q> {
+    inner: dpdk_sys::rte_power_monitor_cond,
+    _queue: PhantomData<&'q ()>,
+}
+
+impl<'q> MonitorCond<'q> {
+    /// Ask the PMD what to watch for traffic arriving on `queue`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the driver's error code; a PMD that does not implement `get_monitor_addr` reports
+    /// `ENOTSUP`, and there is then no sleep-until-a-packet-arrives path for that device.
+    pub fn for_rx_queue(queue: &'q RxQueue<'_>) -> Result<MonitorCond<'q>, ErrorCode> {
+        let mut inner: dpdk_sys::rte_power_monitor_cond = unsafe { core::mem::zeroed() };
+        // SAFETY: `inner` is live for the call; the port and queue indices come from a live queue
+        // handle, so both are valid and the queue is configured.
+        let ret = unsafe {
+            dpdk_sys::rte_eth_get_monitor_addr(
+                queue.dev.as_u16(),
+                queue.config.queue_index.0,
+                &raw mut inner,
+            )
+        };
+        if ret != 0 {
+            return Err(ErrorCode::parse_i32(ret));
+        }
+        Ok(MonitorCond {
+            inner,
+            _queue: PhantomData,
+        })
+    }
+}
+
+/// Park this core until `cond`'s address changes or `deadline` (a TSC value) passes.
+///
+/// A deadline already in the past returns immediately, which makes this usable as a "check without
+/// committing to a sleep".
+///
+/// Takes `&LCore` because DPDK refuses an unregistered caller; see the module docs.
+///
+/// # Errors
+///
+/// - `ENOTSUP` if the CPU has no monitor instruction. On x86 that means neither `WAITPKG`
+///   (Intel `UMONITOR`/`UMWAIT`) nor `MONITORX` (AMD `MONITORX`/`MWAITX`); Arm uses `WFE` and has no
+///   such gate.
+/// - `EINVAL` if the condition is malformed. It should not be reachable for a `MonitorCond` that
+///   came from [`MonitorCond::for_rx_queue`], and cannot be reached by an unregistered thread,
+///   which is what the token rules out.
+pub fn monitor(_lcore: &LCore, cond: &MonitorCond<'_>, deadline: u64) -> Result<(), ErrorCode> {
+    // SAFETY: `cond` borrows a live rx queue, so its address is still mapped; the calling thread is
+    // registered, which `&LCore` proves.
+    let ret = unsafe { dpdk_sys::rte_power_monitor(&raw const cond.inner, deadline) };
+    if ret != 0 {
+        return Err(ErrorCode::parse_i32(ret));
+    }
+    Ok(())
+}
+
+/// Pause this core until `deadline` (a TSC value) without watching an address.
+///
+/// The cheaper sibling of [`monitor`] for a short backoff, and narrower in support: it needs
+/// `TPAUSE`, which is `WAITPKG` and therefore Intel-only.
+///
+/// # Errors
+///
+/// `ENOTSUP` where `TPAUSE` is unavailable, which includes every AMD part.
+pub fn pause(_lcore: &LCore, deadline: u64) -> Result<(), ErrorCode> {
+    // SAFETY: no preconditions beyond CPU support, which the call itself checks.
+    let ret = unsafe { dpdk_sys::rte_power_pause(deadline) };
+    if ret != 0 {
+        return Err(ErrorCode::parse_i32(ret));
+    }
+    Ok(())
+}
+
+/// Wake `lcore` out of [`monitor`], from anywhere.
+///
+/// Deliberately takes no [`LCore`] token: DPDK checks the *target* id, not the caller's
+/// registration, so a control-plane thread may use this to knock a sleeping worker awake. That
+/// asymmetry is the whole reason this is a free function taking an id rather than a method.
+///
+/// # Errors
+///
+/// `EINVAL` if `lcore` is not a valid id, `ENOTSUP` where the CPU has no monitor instruction.
+pub fn wake(lcore: LCoreId) -> Result<(), ErrorCode> {
+    // SAFETY: no preconditions; the id is range-checked by DPDK.
+    let ret = unsafe { dpdk_sys::rte_power_monitor_wakeup(lcore.as_u32()) };
+    if ret != 0 {
+        return Err(ErrorCode::parse_i32(ret));
+    }
+    Ok(())
+}

--- a/dpdk/src/socket.rs
+++ b/dpdk/src/socket.rs
@@ -236,9 +236,29 @@ impl SocketId {
         if id.as_u32() >= LCoreId::MAX {
             return None;
         }
-        // Checked before the lookup rather than relying on `rte_lcore_is_enabled` to range-check
-        // for us, so the ordering here does not depend on a DPDK internal.
-        if unsafe { dpdk_sys::rte_lcore_is_enabled(id.as_u32()) } == 0 {
+        // `rte_lcore_is_enabled` is `lcore_role == ROLE_RTE` and *nothing else*, so on its own it
+        // rejects a thread registered with
+        // [`LCore`](crate::lcore::LCore) -- which is `ROLE_NON_EAL`, and is
+        // what every DPDK worker in this dataplane now is. That would make
+        // `Preference::LCore(LCoreId::current())` fail on a worker, which is exactly the thread
+        // most likely to ask.
+        //
+        // A registered lcore does have a real NUMA answer: `thread_update_affinity` populates
+        // `lcore_config[id].numa_id` from the registering thread's cpuset (measured, see
+        // `examples/lcore_role_probe.rs`). So accept both roles and reject only the ids the EAL
+        // never gave meaning to -- which is the check this was always trying to be.
+        //
+        // Checked before the lookup rather than relying on DPDK to range-check for us, so the
+        // ordering here does not depend on a DPDK internal.
+        // `rte_lcore_has_role` returns *positive* when the lcore has the role, 0 otherwise.
+        let usable = unsafe {
+            dpdk_sys::rte_lcore_has_role(id.as_u32(), dpdk_sys::rte_lcore_role_t::ROLE_RTE) != 0
+                || dpdk_sys::rte_lcore_has_role(
+                    id.as_u32(),
+                    dpdk_sys::rte_lcore_role_t::ROLE_NON_EAL,
+                ) != 0
+        };
+        if !usable {
             return None;
         }
         Some(SocketId(unsafe {
@@ -297,6 +317,48 @@ impl TryFrom<Preference> for SocketId {
 mod tests {
     use super::*;
     use crate::with_eal;
+
+    /// A registered (non-EAL) lcore resolves to a socket.
+    ///
+    /// `rte_lcore_is_enabled` is `lcore_role == ROLE_RTE` and nothing else, so gating on it alone
+    /// rejected every thread registered with
+    /// [`LCore`](crate::lcore::LCore) -- which is what every DPDK worker in
+    /// this dataplane is. `Preference::LCore(LCoreId::current())` on a worker would then fail,
+    /// and a worker is the thread most likely to ask.
+    ///
+    /// The answer is real, not a placeholder: `thread_update_affinity` populates
+    /// `lcore_config[id].numa_id` from the registering thread's cpuset.
+    #[test]
+    #[with_eal]
+    fn a_registered_lcore_resolves_to_a_socket() {
+        use crate::lcore::LCore;
+
+        // Spawned: a registered thread is what is under test, and under nextest the harness
+        // thread is already the main lcore.
+        std::thread::spawn(|| {
+            let _registration = LCore::register().expect("could not register");
+            let here = LCoreId::current();
+
+            let socket = SocketId::get_by_lcore_id(here);
+            assert!(
+                socket.is_some(),
+                "a registered lcore ({here:?}) did not resolve to a socket"
+            );
+            assert_eq!(
+                SocketId::try_from(Preference::LCore(here)).ok(),
+                socket,
+                "Preference::LCore disagreed with the direct lookup"
+            );
+            // And it agrees with what the thread reports for itself.
+            assert_eq!(
+                socket,
+                Some(SocketId::current()),
+                "the lcore's socket and the thread's own socket disagree"
+            );
+        })
+        .join()
+        .expect("the test thread panicked");
+    }
 
     /// Regression test for a segfault reachable from safe code.
     ///
@@ -378,14 +440,25 @@ mod tests {
     #[test]
     #[with_eal]
     fn an_in_range_but_disabled_lcore_is_rejected() {
-        let enabled = enabled_lcores();
-        let Some(disabled) = (0..LCoreId::MAX).find(|id| !enabled.contains(id)) else {
-            return; // every lcore enabled; nothing to assert
+        // Selected by `ROLE_OFF`, not by "not enabled". Those used to be the same set and are not
+        // any more: a thread registered with `LCore` is `ROLE_NON_EAL`, which
+        // `rte_lcore_is_enabled` reports as *not enabled* while it legitimately does resolve to a
+        // socket. Keeping the old predicate made this test fail whenever another test in the same
+        // process held a registration -- which `cargo test` allows, since it shares one process
+        // across tests where nextest does not.
+        //
+        // Scanned from the top because `eal_lcore_non_eal_allocate` always takes the *lowest* free
+        // slot, so the highest ids are the ones a concurrent registration will not take between
+        // this search and the assertion below.
+        let Some(unused) = (0..LCoreId::MAX).rev().find(|id| unsafe {
+            dpdk_sys::rte_lcore_has_role(*id, dpdk_sys::rte_lcore_role_t::ROLE_OFF) != 0
+        }) else {
+            return; // every lcore has a role; nothing to assert
         };
         let manager = Manager::init();
         assert!(
-            manager.id_for_lcore(disabled).is_none(),
-            "lcore {disabled} is not enabled and must not resolve"
+            manager.id_for_lcore(unused).is_none(),
+            "lcore {unused} has no role and must not resolve"
         );
     }
 

--- a/dpdk/src/sync.rs
+++ b/dpdk/src/sync.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Locks that guard real DPDK resources, and why they are not the concurrency facade.
+//!
+//! Everywhere else in this workspace, a lock should come from `concurrency::sync` so that the
+//! `loom` and `shuttle` backends can swap in an instrumented primitive and explore interleavings.
+//! **Inside this crate that is wrong**, and not as a matter of taste.
+//!
+//! # Why the facade cannot work here
+//!
+//! Three independent reasons, any one of which would be sufficient:
+//!
+//! 1. **Shuttle multiplexes its threads onto one OS thread** (it is built on `corosensei`
+//!    coroutines). DPDK's per-thread state is OS thread-local: `RTE_PER_LCORE(_lcore_id)` and
+//!    everything indexed by it -- the per-lcore mempool cache, lcore variables, the power-monitor
+//!    wait status. Under shuttle, N shuttle threads would share one lcore identity. A second
+//!    [`LCore::register`](crate::lcore::LCore::register) would be refused as `EEXIST` (correctly --
+//!    the OS thread really does already have an id), so a multi-worker datapath cannot even be
+//!    expressed, let alone modelled.
+//! 2. **`!Send` stops meaning what this crate needs it to mean.** `Mbuf`, `Eal` and `LCore` are
+//!    `!Send` to pin them to the OS thread that owns the corresponding DPDK state. `!Send` prevents
+//!    a value crossing a *Rust* thread boundary, and under shuttle those boundaries are between
+//!    coroutines sharing one OS thread -- so the guarantee would be stated in terms of a thread
+//!    notion that is no longer the one DPDK cares about.
+//! 3. **DPDK is C, and none of it is instrumented.** The mempool ring, `rte_flow`, and every PMD
+//!    carry their own atomics that a model checker cannot see. Exploring interleavings of the thin
+//!    Rust locks while the real synchronisation stays opaque would model something that is not the
+//!    system, which is worse than not modelling it.
+//!
+//! # What this means concretely
+//!
+//! A `concurrency::sync::Mutex` constructed under a model-checker backend registers with that
+//! checker's scheduler, and touching one outside a `shuttle::check_*` body aborts with
+//! *"`ExecutionState` is not set"*. Since `mem::Manager`'s registry is built by `eal::init`, that
+//! made **every** `#[with_eal]` test in this crate abort under `--features shuttle`. It went
+//! unnoticed only because the justfile filters shuttle runs down to tests whose names contain
+//! `shuttle`, which excludes all of them -- a convention, not a boundary, and one that would break
+//! the moment a test here were routed through `#[concurrency::test]`.
+//!
+//! So: locks that guard DPDK resources use [`std::sync::Mutex`] on every backend. The model
+//! checkers keep their proper domain -- the pipeline's shared state, the flow table, the NAT
+//! allocator -- which is where the concurrency worth checking actually lives.
+//!
+//! [`Mutex`] wraps the std type to keep the parking-lot-style `lock()` this crate already reads
+//! with, rather than sprinkling `.unwrap()` over a `LockResult` at every call site.
+
+// The workspace disallows `std::sync` types so that everything routes through the concurrency
+// facade. This module is the deliberate exception, and the whole reason it exists is to be the
+// *only* one -- confining the allow here means no other file in this crate needs it, and a reviewer
+// has exactly one place to check the reasoning. `acl/context.rs` escapes the same lint only because
+// its `std` branches sit inside `with_loom!`/`with_shuttle!` macros that expand to nothing on the
+// default backend; this module is unconditional, so it must say so out loud.
+#[allow(clippy::disallowed_types)]
+mod dpdk_resource_lock {
+    /// A mutex guarding a DPDK resource.
+    ///
+    /// Deliberately `std`-backed on every backend; see the module docs. The API is the subset this
+    /// crate uses, with `lock` returning the guard directly rather than a `LockResult`.
+    #[derive(Debug, Default)]
+    pub(crate) struct Mutex<T> {
+        // nosemgrep: rust-no-direct-std-sync-import
+        inner: std::sync::Mutex<T>,
+    }
+
+    impl<T> Mutex<T> {
+        /// Wrap `value`.
+        pub(crate) fn new(value: T) -> Mutex<T> {
+            Mutex {
+                // nosemgrep: rust-no-direct-std-sync-import
+                inner: std::sync::Mutex::new(value),
+            }
+        }
+
+        /// Lock, blocking until the lock is available.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the lock is poisoned. Every critical section under this type is a short,
+        /// panic-free registry update against DPDK state; a poisoned lock means one of them unwound,
+        /// which leaves the DPDK-side bookkeeping in a state this crate has no way to reason about.
+        /// Continuing with a forced-open lock would be the more dangerous choice.
+        #[allow(clippy::expect_used)]
+        // nosemgrep: rust-no-direct-std-sync-import
+        pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, T> {
+            self.inner
+                .lock()
+                .expect("a lock guarding DPDK state is poisoned; a critical section unwound")
+        }
+    }
+}
+
+pub(crate) use dpdk_resource_lock::Mutex;

--- a/init/Cargo.toml
+++ b/init/Cargo.toml
@@ -23,7 +23,7 @@ command-fds = { workspace = true }
 # the half DPDK attaches through.
 devlink = { workspace = true }
 futures = { workspace = true }
-nix = { workspace = true, features = ["mount", "fs", "process", "signal", "user"] }
+nix = { workspace = true, features = ["mount", "fs", "process", "signal", "user", "mman"] }
 procfs = { workspace = true, features = [] }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true, features = [] }

--- a/init/examples/hugepage_probe.rs
+++ b/init/examples/hugepage_probe.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Read-only check of what the hugepage reservation would see on this host.
+//!
+//! Reads the same sysfs the reservation reads, without writing anything, so the path arithmetic
+//! and the `-1` handling can be checked on a real machine before the reservation is trusted on the
+//! benchmark host.
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).map_or_else(|e| format!("<{e}>"), |s| s.trim().to_string())
+}
+
+fn main() {
+    let nodes: Vec<String> = fs::read_dir("/sys/devices/system/node")
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let n = e.file_name().to_string_lossy().to_string();
+            n.starts_with("node").then_some(n)
+        })
+        .collect();
+    println!("NUMA nodes: {nodes:?}");
+
+    for node in &nodes {
+        for size in ["1048576", "2048"] {
+            let dir = format!("/sys/devices/system/node/{node}/hugepages/hugepages-{size}kB");
+            if fs::metadata(&dir).is_err() {
+                continue;
+            }
+            println!(
+                "  {node} {size}kB: nr={} free={} (writable={})",
+                read(&format!("{dir}/nr_hugepages")),
+                read(&format!("{dir}/free_hugepages")),
+                // The check the reservation depends on: can we grow the pool at all?
+                fs::OpenOptions::new()
+                    .write(true)
+                    .open(format!("{dir}/nr_hugepages"))
+                    .is_ok()
+            );
+        }
+        let compact = format!("/sys/devices/system/node/{node}/compact");
+        println!(
+            "  {node} compact present: {}",
+            fs::metadata(&compact).is_ok()
+        );
+    }
+
+    println!("\nPCI devices and their NUMA affinity (first 5 with a real node):");
+    let mut shown = 0;
+    for entry in fs::read_dir("/sys/bus/pci/devices")
+        .into_iter()
+        .flatten()
+        .flatten()
+    {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let node = read(&format!("/sys/bus/pci/devices/{name}/numa_node"));
+        if node != "-1" && shown < 5 {
+            println!("  {name} -> node {node}");
+            shown += 1;
+        }
+    }
+    if shown == 0 {
+        println!("  (every device reports -1: single-node machine, node-agnostic path taken)");
+    }
+}

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Reserving hugepages on the NUMA node the NIC is attached to, before the dataplane starts.
+//!
+//! # Why this is not the EAL's job
+//!
+//! DPDK *is* NUMA-aware: `librte_eal` is linked against `libnuma` and calls `numa_set_preferred`
+//! before faulting a hugepage in, so a mempool created for the port's socket really does try to
+//! land on that socket. What it cannot do is **create** the pages. The kernel's hugepage pool is
+//! host state, sized through sysfs, and an application only ever consumes what is already there.
+//!
+//! That matters more than it sounds, because `numa_set_preferred` is `MPOL_PREFERRED`: when the
+//! preferred node has no free pages the kernel **silently satisfies the allocation from another
+//! node**. Nothing fails, nothing warns, and the datapath runs with its packet buffers a QPI hop
+//! away from the NIC. For a benchmark that is the worst possible failure -- a number that looks
+//! like a result.
+//!
+//! So this module reserves the pages up front, on the right node, and reports what it actually got.
+//! The dataplane then asks the EAL for exactly that much with `--numa-mem`, which turns a silent
+//! fallback into a loud startup failure.
+//!
+//! # Best-effort, deliberately
+//!
+//! Every step here is allowed to fail. In a container without `CAP_SYS_ADMIN` the sysfs files are
+//! read-only, and on a host that has been up for a while a 1 GiB reservation will usually fail no
+//! matter how much memory is free -- a gigabyte page needs a gigabyte of *physically contiguous,
+//! gigabyte-aligned* memory, which is why 1 GiB pages are normally reserved on the kernel command
+//! line at boot (`hugepagesz=1G hugepages=N`). Refusing to start over that would be wrong: the
+//! dataplane can still run on 2 MiB pages, and `--in-memory` means it does not even need a mount.
+//! What this module owes the operator is an honest log line about which of those happened.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use args::HugepagePlan;
+use hardware::pci::address::PciAddress;
+use tracing::{debug, info, warn};
+
+/// A 1 GiB page, in kilobytes, as sysfs names it.
+const ONE_GIB_KB: u64 = 1024 * 1024;
+
+/// A 2 MiB page, in kilobytes, as sysfs names it.
+const TWO_MIB_KB: u64 = 2 * 1024;
+
+/// How much hugepage memory the datapath wants per NUMA node it has a device on.
+///
+/// Four gigabytes: enough for the mbuf pools of a multi-queue port pair with headroom for the
+/// rings and the heap, and small enough to be plausible on a machine that is also doing other
+/// things. Expressed in kilobytes so it divides evenly by either page size.
+const WANT_KB_PER_NODE: u64 = 4 * 1024 * 1024;
+
+/// Which NUMA node a PCI device is attached to.
+///
+/// `None` when the kernel reports `-1`, which it does on a single-node machine and on any system
+/// whose firmware did not describe the affinity. `None` is not an error: it means node-agnostic,
+/// and the caller should size the pool without naming a node.
+#[must_use]
+pub fn numa_node_of(address: PciAddress) -> Option<u32> {
+    let path = format!("/sys/bus/pci/devices/{address}/numa_node");
+    let raw = fs::read_to_string(&path)
+        .inspect_err(|e| debug!("could not read {path}: {e}; treating {address} as node-agnostic"))
+        .ok()?;
+    match raw.trim().parse::<i32>() {
+        Ok(node) if node >= 0 => u32::try_from(node).ok(),
+        Ok(_) => {
+            debug!("{address} reports no NUMA affinity");
+            None
+        }
+        Err(e) => {
+            warn!("{path} did not contain a number ({e}); treating {address} as node-agnostic");
+            None
+        }
+    }
+}
+
+/// The sysfs directory holding a page size's pool counters, per node or system-wide.
+fn pool_dir(node: Option<u32>, page_size_kb: u64) -> PathBuf {
+    match node {
+        Some(n) => PathBuf::from(format!(
+            "/sys/devices/system/node/node{n}/hugepages/hugepages-{page_size_kb}kB"
+        )),
+        None => PathBuf::from(format!(
+            "/sys/kernel/mm/hugepages/hugepages-{page_size_kb}kB"
+        )),
+    }
+}
+
+/// Read a single unsigned number out of a sysfs file.
+fn read_count(path: &Path) -> Option<u64> {
+    fs::read_to_string(path).ok()?.trim().parse::<u64>().ok()
+}
+
+/// Ask the kernel to compact memory, so a large contiguous reservation has a chance.
+///
+/// Best-effort in the strongest sense: this is a hint, it is synchronous and can take a while, and
+/// there is no way to find out whether it helped other than trying the reservation again. Prefers
+/// the per-node trigger, because compacting one node is cheaper than compacting the machine and is
+/// the only part we care about.
+fn compact(node: Option<u32>) {
+    let path = match node {
+        Some(n) => PathBuf::from(format!("/sys/devices/system/node/node{n}/compact")),
+        None => PathBuf::from("/proc/sys/vm/compact_memory"),
+    };
+    match fs::write(&path, "1") {
+        Ok(()) => debug!("requested memory compaction via {}", path.display()),
+        Err(e) => debug!(
+            "could not request compaction via {}: {e}; continuing, as compaction is only a hint",
+            path.display()
+        ),
+    }
+}
+
+/// Try to make `want_pages` of `page_size_kb` free on `node`, and report how many actually are.
+///
+/// Grows the pool by the shortfall rather than setting it to `want_pages`: `nr_hugepages` is the
+/// *total* pool size and other things on the host may already be holding pages out of it, so
+/// writing the bare figure could shrink a pool someone else is using.
+fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
+    let dir = pool_dir(node, page_size_kb);
+    let nr_path = dir.join("nr_hugepages");
+    let free_path = dir.join("free_hugepages");
+
+    let Some(free_now) = read_count(&free_path) else {
+        debug!(
+            "no {page_size_kb} kB pool at {} on this kernel",
+            dir.display()
+        );
+        return 0;
+    };
+    if free_now >= want_pages {
+        debug!(
+            "{free_now} free {page_size_kb} kB page(s) already available{}",
+            node.map_or(String::new(), |n| format!(" on node {n}"))
+        );
+        return free_now;
+    }
+
+    let Some(nr_now) = read_count(&nr_path) else {
+        return free_now;
+    };
+    let target = nr_now.saturating_add(want_pages - free_now);
+    if let Err(e) = fs::write(&nr_path, target.to_string()) {
+        warn!(
+            "could not grow the {page_size_kb} kB pool to {target} via {}: {e}. \
+             This usually means the process lacks CAP_SYS_ADMIN or sysfs is mounted read-only.",
+            nr_path.display()
+        );
+        return free_now;
+    }
+
+    // The kernel silently gives less than asked when it cannot find the contiguous memory, so the
+    // write succeeding proves nothing. Only the read-back is evidence.
+    read_count(&free_path).unwrap_or(free_now)
+}
+
+/// Reserve hugepages for every NUMA node the configured devices sit on.
+///
+/// Tries 1 GiB pages first and falls back to 2 MiB, compacting before each attempt. Returns the
+/// plan that was actually achieved, or `None` when nothing could be secured -- in which case the
+/// dataplane is left to whatever the host already has, exactly as before this existed.
+#[must_use]
+pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
+    let mut nodes: Vec<Option<u32>> = devices.iter().copied().map(numa_node_of).collect();
+    nodes.sort_unstable();
+    nodes.dedup();
+    if nodes.is_empty() {
+        return None;
+    }
+    info!(
+        "reserving hugepages for NUMA node(s) {}",
+        nodes
+            .iter()
+            .map(|n| n.map_or("(node-agnostic)".to_string(), |n| n.to_string()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    for page_size_kb in [ONE_GIB_KB, TWO_MIB_KB] {
+        let want_pages = WANT_KB_PER_NODE / page_size_kb;
+        let mut secured: BTreeMap<u32, u64> = BTreeMap::new();
+        let mut short = false;
+
+        for &node in &nodes {
+            compact(node);
+            let got = try_reserve(node, page_size_kb, want_pages);
+            if got < want_pages {
+                short = true;
+            }
+            // A node-agnostic device still contributes its pages, under node 0, because that is
+            // the only index `--numa-mem` can name on a machine with no NUMA topology to speak of.
+            let key = node.unwrap_or(0);
+            let mb = (got * page_size_kb) / 1024;
+            secured
+                .entry(key)
+                .and_modify(|e| *e = (*e).max(mb))
+                .or_insert(mb);
+        }
+
+        let total: u64 = secured.values().sum();
+        if total == 0 {
+            continue;
+        }
+        let plan = HugepagePlan {
+            page_size_kb,
+            per_node_mb: secured.into_iter().collect(),
+        };
+        if short {
+            info!(
+                "could not get the full {} MiB of {page_size_kb} kB pages on every node; \
+                 proceeding with {plan}",
+                WANT_KB_PER_NODE / 1024
+            );
+        } else {
+            info!("reserved {plan}");
+        }
+        return Some(plan);
+    }
+
+    warn!(
+        "could not reserve any hugepages; the dataplane will use whatever the host already has. \
+         On a host that has been up for a while, reserve 1 GiB pages at boot with \
+         `hugepagesz=1G hugepages=N` on the kernel command line."
+    );
+    None
+}

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -277,6 +277,73 @@ fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
     claimable(read_count(&free_path).unwrap_or(free_now), want_pages)
 }
 
+/// Why the reservation was skipped, when it was.
+///
+/// A named reason rather than a bare `bool` so each can be tested for. Returning `None` from
+/// `reserve_for` covers several very different situations, and a test that only sees `None` cannot
+/// tell the escape hatch from a machine that simply had nothing to place -- which is exactly the
+/// vacuity that let a broken hatch pass its own test once already.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Skip {
+    /// An operator asked for this to stay out of the way.
+    Disabled,
+    /// One NUMA node, so there is nowhere to place memory wrongly.
+    SingleNode,
+}
+
+impl Skip {
+    /// The reason, phrased for a log line.
+    fn why(self) -> &'static str {
+        match self {
+            Skip::Disabled => "DATAPLANE_HUGEPAGE_RESERVE=off",
+            Skip::SingleNode => {
+                "this machine has a single NUMA node, so placement is not a question"
+            }
+        }
+    }
+}
+
+/// Decide whether to reserve at all, before touching anything.
+///
+/// The escape hatch is checked first so it works whatever the machine looks like: it exists to be
+/// reached for when this code is suspected, and a hatch that only worked on some hosts would be
+/// worse than none.
+///
+/// The single-node case is not an optimisation. `--numa-mem` places memory *across* nodes, so with
+/// one node it can only constrain the EAL and never help it -- while every failure this code has
+/// caused was in computing that figure. There is nothing on one node to weigh against that risk,
+/// so the EAL is left to allocate lazily within whatever the cgroup permits.
+fn skip_reason() -> Option<Skip> {
+    if let Ok(setting) = std::env::var(DISABLE_ENV)
+        && setting.eq_ignore_ascii_case("off")
+    {
+        return Some(Skip::Disabled);
+    }
+    if numa_node_count() <= 1 {
+        return Some(Skip::SingleNode);
+    }
+    None
+}
+
+/// How many NUMA nodes this machine has.
+///
+/// Counted from sysfs rather than from the devices, because the question is about the machine.
+fn numa_node_count() -> usize {
+    let Ok(entries) = fs::read_dir("/sys/devices/system/node") else {
+        return 1;
+    };
+    entries
+        .flatten()
+        .filter(|e| {
+            e.file_name().to_str().is_some_and(|n| {
+                n.strip_prefix("node")
+                    .is_some_and(|r| r.parse::<u32>().is_ok())
+            })
+        })
+        .count()
+        .max(1)
+}
+
 /// Reserve hugepages for every NUMA node the configured devices sit on.
 ///
 /// Tries 1 GiB pages first and falls back to 2 MiB, compacting before each attempt. Returns the
@@ -284,15 +351,11 @@ fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
 /// dataplane is left to whatever the host already has, exactly as before this existed.
 #[must_use]
 pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
-    // An escape hatch, because this touches host state and pins the EAL to a figure. When a lab
-    // run fails somewhere in memory setup, the first question is whether this is the cause, and
-    // answering it should not need a rebuild -- set DATAPLANE_HUGEPAGE_RESERVE=off and the
-    // dataplane is back to taking whatever the host already has, which is how it behaved before
-    // any of this existed.
-    if let Ok(setting) = std::env::var(DISABLE_ENV)
-        && setting.eq_ignore_ascii_case("off")
-    {
-        info!("{DISABLE_ENV}=off: leaving hugepages to the host and omitting --numa-mem");
+    if let Some(skip) = skip_reason() {
+        info!(
+            "{}; leaving memory to the EAL and omitting --numa-mem",
+            skip.why()
+        );
         return None;
     }
 
@@ -394,8 +457,8 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
 #[cfg(test)]
 mod pool_test {
     use super::{
-        DISABLE_ENV, ONE_GIB_KB, TWO_MIB_KB, WANT_KB_PER_NODE, claimable, page_size_is_usable,
-        reserve_for,
+        DISABLE_ENV, ONE_GIB_KB, Skip, TWO_MIB_KB, WANT_KB_PER_NODE, claimable, numa_node_count,
+        page_size_is_usable, reserve_for, skip_reason,
     };
     use hardware::pci::address::PciAddress;
 
@@ -437,37 +500,45 @@ mod pool_test {
         assert!(!page_size_is_usable(4), "4 kB is not a hugepage size");
         assert!(!page_size_is_usable(0), "0 is not a page size");
 
-        // 3. The escape hatch suppresses the plan, and a `None` plan is what drops `--numa-mem`.
-        //    Note the device list is non-empty: `reserve_for(&[])` returns `None` because there
-        //    are no nodes to reserve on, which would pass whether the hatch worked or not.
+        // 3. The escape hatch is honoured, and is honoured *first* -- so it works on any machine,
+        //    including a single-node one where the reservation would be skipped anyway. Asserting
+        //    the reason rather than a bare `None` is what keeps this from going vacuous: `None`
+        //    covers several unrelated situations and cannot tell them apart.
         for value in ["off", "OFF", "Off"] {
-            // SAFETY: this test owns its process, and the pool-touching tests are all here.
+            // SAFETY: this test owns its process, and every pool-touching test lives here.
             unsafe { std::env::set_var(DISABLE_ENV, value) };
+            let reason = skip_reason();
             let plan = reserve_for(&device);
             unsafe { std::env::remove_var(DISABLE_ENV) };
-            assert!(plan.is_none(), "{value} should disable the reservation");
+            assert_eq!(
+                reason,
+                Some(Skip::Disabled),
+                "{value} should be recognised as the escape hatch, not as something else"
+            );
+            assert!(plan.is_none(), "{value} should suppress the plan");
         }
 
-        // 4. Never claim more than was asked for, however much the host has free. This is the
-        //    defect that produced `--numa-mem=7168` against a 4096 MiB grant: the host had 3584
-        //    free 2 MiB pages, the datapath wanted 2048, and the whole pool was claimed.
-        assert_eq!(
-            claimable(3584, 2048),
-            2048,
-            "a large free pool must not inflate the claim"
-        );
-        assert_eq!(
-            claimable(1000, 2048),
-            1000,
-            "a small free pool is reported honestly"
-        );
-        assert_eq!(claimable(2048, 2048), 2048);
-        assert_eq!(claimable(0, 2048), 0);
-
-        // ...and the same property end to end: whatever this host has, the plan never exceeds what
-        // was wanted. On a machine with a large pool this is the assertion that would have caught
-        // the defect above.
+        // 4. Without the variable, the decision is made on the machine rather than the hatch.
         unsafe { std::env::remove_var(DISABLE_ENV) };
+        assert_ne!(
+            skip_reason(),
+            Some(Skip::Disabled),
+            "the hatch must not latch: removing the variable has to change the answer"
+        );
+        match numa_node_count() {
+            1 => assert_eq!(
+                skip_reason(),
+                Some(Skip::SingleNode),
+                "one node means --numa-mem cannot help, so it must be skipped"
+            ),
+            _ => assert_eq!(
+                skip_reason(),
+                None,
+                "more than one node means the placement question is real"
+            ),
+        }
+
+        // 5. Whatever this host decides, a plan it does produce never claims more than was wanted.
         if let Some(plan) = reserve_for(&device) {
             let total: u64 = plan.per_node_mb.iter().map(|(_, mb)| *mb).sum();
             let wanted_mb = WANT_KB_PER_NODE / 1024;
@@ -476,15 +547,5 @@ mod pool_test {
                 "the plan claims {total} MiB but only {wanted_mb} MiB was wanted"
             );
         }
-
-        // 5. The guard that makes step 3 mean something: without the variable, the same call must
-        //    reach the reservation. If this host has no usable hugepages it says so, rather than
-        //    letting step 3 pass for the wrong reason.
-        unsafe { std::env::remove_var(DISABLE_ENV) };
-        assert!(
-            reserve_for(&device).is_some(),
-            "no plan without the hatch set: this host has no usable hugepages, so the escape-hatch \
-             assertions above cannot tell the hatch from the absence of pages"
-        );
     }
 }

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -365,3 +365,63 @@ mod usability_test {
         assert!(!page_size_is_usable(0), "0 is not a page size");
     }
 }
+
+#[cfg(test)]
+mod escape_hatch_test {
+    use super::{DISABLE_ENV, reserve_for};
+    use hardware::pci::address::PciAddress;
+
+    /// A device that is not on this machine, so `numa_node_of` reports node-agnostic.
+    ///
+    /// It must be a *non-empty* list: `reserve_for(&[])` returns `None` because there are no nodes
+    /// to reserve on, which would make every assertion below pass whether the hatch works or not.
+    /// That vacuity is not hypothetical -- the first version of this test had it.
+    fn a_device() -> Vec<PciAddress> {
+        vec![PciAddress::try_from("0000:02:01.0").expect("a valid PCI address")]
+    }
+
+    /// The hatch has to work without being forwarded anywhere.
+    ///
+    /// It is read in `dataplane-init`'s own process, and what reaches the dataplane is the
+    /// *effect* -- a `None` plan sealed into the launch configuration -- not the variable. A
+    /// `None` plan is what makes `init_eal` omit `--numa-mem`.
+    #[test]
+    fn off_yields_no_plan_and_therefore_no_numa_mem() {
+        // SAFETY: nextest runs each test in its own process, so nothing else reads the
+        // environment concurrently.
+        unsafe { std::env::set_var(DISABLE_ENV, "off") };
+        let plan = reserve_for(&a_device());
+        unsafe { std::env::remove_var(DISABLE_ENV) };
+        assert!(
+            plan.is_none(),
+            "the escape hatch must suppress the plan, and a None plan is what drops --numa-mem"
+        );
+    }
+
+    /// Case-insensitively, because an operator setting this in a pod spec should not have to guess.
+    #[test]
+    fn the_hatch_is_case_insensitive() {
+        for value in ["off", "OFF", "Off"] {
+            unsafe { std::env::set_var(DISABLE_ENV, value) };
+            let plan = reserve_for(&a_device());
+            unsafe { std::env::remove_var(DISABLE_ENV) };
+            assert!(plan.is_none(), "{value} should disable the reservation");
+        }
+    }
+
+    /// Guards the guard: without the variable the same call must reach the reservation.
+    ///
+    /// This is what makes the two tests above mean something. If this ever starts returning `None`
+    /// -- because the machine has no usable hugepages, say -- then those tests are vacuous again
+    /// and this one says so instead of passing quietly.
+    #[test]
+    fn without_the_variable_the_reservation_is_attempted() {
+        unsafe { std::env::remove_var(DISABLE_ENV) };
+        let plan = reserve_for(&a_device());
+        assert!(
+            plan.is_some(),
+            "no plan without the hatch set: this host has no usable hugepages, so the escape-hatch \
+             tests above cannot distinguish the hatch from the absence of pages"
+        );
+    }
+}

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -38,6 +38,9 @@ use args::HugepagePlan;
 use hardware::pci::address::PciAddress;
 use tracing::{debug, info, warn};
 
+/// Set this to `off` to skip the reservation entirely and omit `--numa-mem`.
+const DISABLE_ENV: &str = "DATAPLANE_HUGEPAGE_RESERVE";
+
 /// A 1 GiB page, in kilobytes, as sysfs names it.
 const ONE_GIB_KB: u64 = 1024 * 1024;
 
@@ -162,6 +165,18 @@ fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
 /// dataplane is left to whatever the host already has, exactly as before this existed.
 #[must_use]
 pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
+    // An escape hatch, because this touches host state and pins the EAL to a figure. When a lab
+    // run fails somewhere in memory setup, the first question is whether this is the cause, and
+    // answering it should not need a rebuild -- set DATAPLANE_HUGEPAGE_RESERVE=off and the
+    // dataplane is back to taking whatever the host already has, which is how it behaved before
+    // any of this existed.
+    if let Ok(setting) = std::env::var(DISABLE_ENV)
+        && setting.eq_ignore_ascii_case("off")
+    {
+        info!("{DISABLE_ENV}=off: leaving hugepages to the host and omitting --numa-mem");
+        return None;
+    }
+
     let mut nodes: Vec<Option<u32>> = devices.iter().copied().map(numa_node_of).collect();
     nodes.sort_unstable();
     nodes.dedup();

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -180,6 +180,57 @@ fn compact(node: Option<u32>) {
     }
 }
 
+/// How many pages may honestly be claimed, given how many are free and how many were wanted.
+///
+/// Never more than was asked for. The bug this exists to prevent was real and silent: with more
+/// free pages on the host than the datapath wanted, the whole free pool was claimed and handed to
+/// the EAL as `--numa-mem`. On a node where the pod's cgroup permitted less than the host had
+/// free, DPDK then asked for memory it was never going to be given and failed in
+/// `rte_eal_memory_init` -- reported as an out-of-memory, on a host with pages to spare.
+fn claimable(free_pages: u64, want_pages: u64) -> u64 {
+    free_pages.min(want_pages)
+}
+
+/// The pages this *cgroup* will allow, which inside a container is the limit that actually binds.
+///
+/// `free_hugepages` describes the host. Kubernetes hands a pod a slice of that through the hugetlb
+/// controller, and the pod may not exceed it however much the host has spare -- so a plan built
+/// only from sysfs can be honest about the machine and still wrong about this process.
+///
+/// Returns `None` when there is no limit to read (no controller, cgroup v1 layout absent, or the
+/// limit is literally `max`), in which case the host figures stand on their own.
+fn cgroup_limit_pages(page_size_kb: u64) -> Option<u64> {
+    let suffix = match page_size_kb {
+        ONE_GIB_KB => "1GB",
+        TWO_MIB_KB => "2MB",
+        _ => return None,
+    };
+    // cgroup v2 first; in a container with a cgroup namespace this is the pod's own root.
+    let candidates = [
+        format!("/sys/fs/cgroup/hugetlb.{suffix}.max"),
+        format!("/sys/fs/cgroup/hugetlb/hugetlb.{suffix}.limit_in_bytes"),
+    ];
+    for path in &candidates {
+        let Ok(raw) = fs::read_to_string(path) else {
+            continue;
+        };
+        let raw = raw.trim();
+        if raw == "max" {
+            return None;
+        }
+        if let Ok(bytes) = raw.parse::<u64>() {
+            // v1 reports a sentinel near u64::MAX for "unlimited" rather than the word.
+            if bytes == u64::MAX || bytes > u64::MAX / 2 {
+                return None;
+            }
+            let pages = bytes / (page_size_kb * 1024);
+            debug!("cgroup permits {pages} page(s) of {page_size_kb} kB (from {path})");
+            return Some(pages);
+        }
+    }
+    None
+}
+
 /// Try to make `want_pages` of `page_size_kb` free on `node`, and report how many actually are.
 ///
 /// Grows the pool by the shortfall rather than setting it to `want_pages`: `nr_hugepages` is the
@@ -199,14 +250,17 @@ fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
     };
     if free_now >= want_pages {
         debug!(
-            "{free_now} free {page_size_kb} kB page(s) already available{}",
+            "{free_now} free {page_size_kb} kB page(s) already available{}, taking {want_pages}",
             node.map_or(String::new(), |n| format!(" on node {n}"))
         );
-        return free_now;
+        // `want_pages`, **not** `free_now`. Claiming everything the host happens to have free is
+        // how `--numa-mem=7168` reached an EAL whose cgroup permitted 4096: the figure has to be
+        // what was asked for, not what was lying around. See `claimable`.
+        return want_pages;
     }
 
     let Some(nr_now) = read_count(&nr_path) else {
-        return free_now;
+        return claimable(free_now, want_pages);
     };
     let target = nr_now.saturating_add(want_pages - free_now);
     if let Err(e) = fs::write(&nr_path, target.to_string()) {
@@ -215,12 +269,12 @@ fn try_reserve(node: Option<u32>, page_size_kb: u64, want_pages: u64) -> u64 {
              This usually means the process lacks CAP_SYS_ADMIN or sysfs is mounted read-only.",
             nr_path.display()
         );
-        return free_now;
+        return claimable(free_now, want_pages);
     }
 
     // The kernel silently gives less than asked when it cannot find the contiguous memory, so the
     // write succeeding proves nothing. Only the read-back is evidence.
-    read_count(&free_path).unwrap_or(free_now)
+    claimable(read_count(&free_path).unwrap_or(free_now), want_pages)
 }
 
 /// Reserve hugepages for every NUMA node the configured devices sit on.
@@ -265,7 +319,20 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
             info!("{page_size_kb} kB pages are not usable by this process; trying a smaller size");
             continue;
         }
-        let want_pages = WANT_KB_PER_NODE / page_size_kb;
+        let mut want_pages = WANT_KB_PER_NODE / page_size_kb;
+        if let Some(permitted) = cgroup_limit_pages(page_size_kb)
+            && permitted < want_pages
+        {
+            info!(
+                "this cgroup permits {permitted} page(s) of {page_size_kb} kB, fewer than the \
+                 {want_pages} wanted; asking the EAL only for what it may have"
+            );
+            want_pages = permitted;
+        }
+        if want_pages == 0 {
+            info!("{page_size_kb} kB pages are permitted but capped at zero here; trying smaller");
+            continue;
+        }
         let mut secured: BTreeMap<u32, u64> = BTreeMap::new();
         let mut short = false;
 
@@ -326,7 +393,10 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
 
 #[cfg(test)]
 mod pool_test {
-    use super::{DISABLE_ENV, ONE_GIB_KB, TWO_MIB_KB, page_size_is_usable, reserve_for};
+    use super::{
+        DISABLE_ENV, ONE_GIB_KB, TWO_MIB_KB, WANT_KB_PER_NODE, claimable, page_size_is_usable,
+        reserve_for,
+    };
     use hardware::pci::address::PciAddress;
 
     /// Everything that touches the host hugepage pool lives in **one** test, deliberately.
@@ -378,7 +448,36 @@ mod pool_test {
             assert!(plan.is_none(), "{value} should disable the reservation");
         }
 
-        // 4. The guard that makes step 3 mean something: without the variable, the same call must
+        // 4. Never claim more than was asked for, however much the host has free. This is the
+        //    defect that produced `--numa-mem=7168` against a 4096 MiB grant: the host had 3584
+        //    free 2 MiB pages, the datapath wanted 2048, and the whole pool was claimed.
+        assert_eq!(
+            claimable(3584, 2048),
+            2048,
+            "a large free pool must not inflate the claim"
+        );
+        assert_eq!(
+            claimable(1000, 2048),
+            1000,
+            "a small free pool is reported honestly"
+        );
+        assert_eq!(claimable(2048, 2048), 2048);
+        assert_eq!(claimable(0, 2048), 0);
+
+        // ...and the same property end to end: whatever this host has, the plan never exceeds what
+        // was wanted. On a machine with a large pool this is the assertion that would have caught
+        // the defect above.
+        unsafe { std::env::remove_var(DISABLE_ENV) };
+        if let Some(plan) = reserve_for(&device) {
+            let total: u64 = plan.per_node_mb.iter().map(|(_, mb)| *mb).sum();
+            let wanted_mb = WANT_KB_PER_NODE / 1024;
+            assert!(
+                total <= wanted_mb,
+                "the plan claims {total} MiB but only {wanted_mb} MiB was wanted"
+            );
+        }
+
+        // 5. The guard that makes step 3 mean something: without the variable, the same call must
         //    reach the reservation. If this host has no usable hugepages it says so, rather than
         //    letting step 3 pass for the wrong reason.
         unsafe { std::env::remove_var(DISABLE_ENV) };

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -32,11 +32,76 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+
+use nix::sys::memfd::{MFdFlags, memfd_create};
 
 use args::HugepagePlan;
 use hardware::pci::address::PciAddress;
 use tracing::{debug, info, warn};
+
+/// Can this process actually obtain a hugepage of `page_size_kb`, here and now?
+///
+/// **This, and not sysfs, is the oracle.** `free_hugepages` reports the *host's* pool, and inside
+/// a container that is not what binds. Kubernetes treats hugepages as a scheduled resource: a pod
+/// that asked for `hugepages-2Mi` gets `hugetlb.1GB.max = 0` in its cgroup, so the host can show
+/// gigabyte pages sitting free while this process may not touch one. Believing sysfs there means
+/// choosing a page size the EAL cannot use, and DPDK reports that as `Cannot init memory` -- an
+/// out-of-memory story on a machine with thousands of free pages.
+///
+/// So: ask the kernel for one, the same way DPDK does under `--in-memory`. A hugetlb-backed memfd
+/// that can be sized and faulted is proof; anything else is a guess. Costs one page, briefly.
+fn page_size_is_usable(page_size_kb: u64) -> bool {
+    let size_flag = match page_size_kb {
+        ONE_GIB_KB => MFdFlags::MFD_HUGE_1GB,
+        TWO_MIB_KB => MFdFlags::MFD_HUGE_2MB,
+        _ => return false,
+    };
+    let Ok(fd) = memfd_create(
+        c"dataplane-hugepage-probe",
+        MFdFlags::MFD_HUGETLB | size_flag,
+    ) else {
+        debug!("{page_size_kb} kB pages are not available to this process (memfd refused)");
+        return false;
+    };
+    let len = page_size_kb * 1024;
+    #[allow(clippy::cast_possible_wrap)]
+    if nix::unistd::ftruncate(&fd, len as i64).is_err() {
+        debug!("{page_size_kb} kB pages: could not size a hugetlb memfd");
+        return false;
+    }
+    // ftruncate on hugetlbfs does not commit; the fault does. Map and touch one byte, which is
+    // where a cgroup limit or an empty pool actually says no.
+    let Ok(len) = NonZeroUsize::try_from(usize::try_from(len).unwrap_or(0)) else {
+        return false;
+    };
+    let mapped = unsafe {
+        nix::sys::mman::mmap(
+            None,
+            len,
+            nix::sys::mman::ProtFlags::PROT_READ | nix::sys::mman::ProtFlags::PROT_WRITE,
+            nix::sys::mman::MapFlags::MAP_SHARED,
+            &fd,
+            0,
+        )
+    };
+    match mapped {
+        Ok(addr) => {
+            // SAFETY: `addr` is a live mapping of `len` bytes, and one byte is in bounds.
+            unsafe { addr.as_ptr().cast::<u8>().write_volatile(0) };
+            // SAFETY: unmapping exactly what was just mapped.
+            unsafe {
+                let _ = nix::sys::mman::munmap(addr, len.get());
+            }
+            true
+        }
+        Err(e) => {
+            debug!("{page_size_kb} kB pages: could not fault one ({e}); unusable here");
+            false
+        }
+    }
+}
 
 /// Set this to `off` to skip the reservation entirely and omit `--numa-mem`.
 const DISABLE_ENV: &str = "DATAPLANE_HUGEPAGE_RESERVE";
@@ -193,6 +258,13 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
     );
 
     for page_size_kb in [ONE_GIB_KB, TWO_MIB_KB] {
+        // Before believing any counter, prove this process can get one. Skipping straight past an
+        // unusable size is the whole point: the host may have gigabyte pages free while this pod's
+        // cgroup forbids them, and choosing them anyway hands the EAL a figure it cannot honour.
+        if !page_size_is_usable(page_size_kb) {
+            info!("{page_size_kb} kB pages are not usable by this process; trying a smaller size");
+            continue;
+        }
         let want_pages = WANT_KB_PER_NODE / page_size_kb;
         let mut secured: BTreeMap<u32, u64> = BTreeMap::new();
         let mut short = false;
@@ -217,6 +289,17 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
         if total == 0 {
             continue;
         }
+        // A short result at a large page size is a reason to try a smaller one, not to proceed.
+        // Accepting it was the original mistake: the EAL is then told to preallocate an amount
+        // that the pages behind it cannot cover.
+        if short && page_size_kb != TWO_MIB_KB {
+            info!(
+                "only {total} MiB of the {} MiB wanted is available in {page_size_kb} kB pages; \
+                 trying a smaller size",
+                WANT_KB_PER_NODE / 1024
+            );
+            continue;
+        }
         let plan = HugepagePlan {
             page_size_kb,
             per_node_mb: secured.into_iter().collect(),
@@ -239,4 +322,46 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
          `hugepagesz=1G hugepages=N` on the kernel command line."
     );
     None
+}
+
+#[cfg(test)]
+mod usability_test {
+    use super::{ONE_GIB_KB, TWO_MIB_KB, page_size_is_usable};
+
+    /// The probe must answer for a real page size without lying in either direction.
+    ///
+    /// Deliberately not asserting *which* answer: a machine with no 1 GiB pool should say no and a
+    /// machine with one should say yes, and both are correct. What is asserted is that the probe
+    /// leaks nothing and agrees with itself, since a probe that consumed a page per call would
+    /// drain the pool it is measuring.
+    #[test]
+    fn the_probe_is_repeatable_and_leaks_nothing() {
+        let free = |kb: u64| -> Option<u64> {
+            std::fs::read_to_string(format!(
+                "/sys/kernel/mm/hugepages/hugepages-{kb}kB/free_hugepages"
+            ))
+            .ok()?
+            .trim()
+            .parse()
+            .ok()
+        };
+        for size in [ONE_GIB_KB, TWO_MIB_KB] {
+            let before = free(size);
+            let first = page_size_is_usable(size);
+            let second = page_size_is_usable(size);
+            let after = free(size);
+            assert_eq!(first, second, "{size} kB: the probe disagreed with itself");
+            if let (Some(b), Some(a)) = (before, after) {
+                assert_eq!(b, a, "{size} kB: the probe leaked {} page(s)", b - a);
+            }
+            println!("{size} kB usable = {first} (free before={before:?} after={after:?})");
+        }
+    }
+
+    /// A size the kernel has no pool for must be refused, not guessed at.
+    #[test]
+    fn an_unsupported_page_size_is_refused() {
+        assert!(!page_size_is_usable(4), "4 kB is not a hugepage size");
+        assert!(!page_size_is_usable(0), "0 is not a page size");
+    }
 }

--- a/init/src/hugepages.rs
+++ b/init/src/hugepages.rs
@@ -325,17 +325,19 @@ pub fn reserve_for(devices: &[PciAddress]) -> Option<HugepagePlan> {
 }
 
 #[cfg(test)]
-mod usability_test {
-    use super::{ONE_GIB_KB, TWO_MIB_KB, page_size_is_usable};
+mod pool_test {
+    use super::{DISABLE_ENV, ONE_GIB_KB, TWO_MIB_KB, page_size_is_usable, reserve_for};
+    use hardware::pci::address::PciAddress;
 
-    /// The probe must answer for a real page size without lying in either direction.
+    /// Everything that touches the host hugepage pool lives in **one** test, deliberately.
     ///
-    /// Deliberately not asserting *which* answer: a machine with no 1 GiB pool should say no and a
-    /// machine with one should say yes, and both are correct. What is asserted is that the probe
-    /// leaks nothing and agrees with itself, since a probe that consumed a page per call would
-    /// drain the pool it is measuring.
+    /// nextest gives each test its own process, but the pool is kernel-global: a second test
+    /// calling `reserve_for` transiently takes a page while this one is counting, and the leak
+    /// assertion below then fails for a reason that has nothing to do with the code. Process
+    /// isolation does not isolate the kernel. Split these apart again and the suite goes flaky in
+    /// a way that passes when run alone -- which is how it was found.
     #[test]
-    fn the_probe_is_repeatable_and_leaks_nothing() {
+    fn the_pool_is_probed_reserved_and_released_correctly() {
         let free = |kb: u64| -> Option<u64> {
             std::fs::read_to_string(format!(
                 "/sys/kernel/mm/hugepages/hugepages-{kb}kB/free_hugepages"
@@ -345,6 +347,10 @@ mod usability_test {
             .parse()
             .ok()
         };
+        let device = vec![PciAddress::try_from("0000:02:01.0").expect("a valid PCI address")];
+
+        // 1. The usability probe answers consistently and gives back what it takes. A probe that
+        //    leaked a page per call would drain the pool it exists to measure.
         for size in [ONE_GIB_KB, TWO_MIB_KB] {
             let before = free(size);
             let first = page_size_is_usable(size);
@@ -356,72 +362,30 @@ mod usability_test {
             }
             println!("{size} kB usable = {first} (free before={before:?} after={after:?})");
         }
-    }
 
-    /// A size the kernel has no pool for must be refused, not guessed at.
-    #[test]
-    fn an_unsupported_page_size_is_refused() {
+        // 2. A size the kernel has no pool for is refused rather than guessed at.
         assert!(!page_size_is_usable(4), "4 kB is not a hugepage size");
         assert!(!page_size_is_usable(0), "0 is not a page size");
-    }
-}
 
-#[cfg(test)]
-mod escape_hatch_test {
-    use super::{DISABLE_ENV, reserve_for};
-    use hardware::pci::address::PciAddress;
-
-    /// A device that is not on this machine, so `numa_node_of` reports node-agnostic.
-    ///
-    /// It must be a *non-empty* list: `reserve_for(&[])` returns `None` because there are no nodes
-    /// to reserve on, which would make every assertion below pass whether the hatch works or not.
-    /// That vacuity is not hypothetical -- the first version of this test had it.
-    fn a_device() -> Vec<PciAddress> {
-        vec![PciAddress::try_from("0000:02:01.0").expect("a valid PCI address")]
-    }
-
-    /// The hatch has to work without being forwarded anywhere.
-    ///
-    /// It is read in `dataplane-init`'s own process, and what reaches the dataplane is the
-    /// *effect* -- a `None` plan sealed into the launch configuration -- not the variable. A
-    /// `None` plan is what makes `init_eal` omit `--numa-mem`.
-    #[test]
-    fn off_yields_no_plan_and_therefore_no_numa_mem() {
-        // SAFETY: nextest runs each test in its own process, so nothing else reads the
-        // environment concurrently.
-        unsafe { std::env::set_var(DISABLE_ENV, "off") };
-        let plan = reserve_for(&a_device());
-        unsafe { std::env::remove_var(DISABLE_ENV) };
-        assert!(
-            plan.is_none(),
-            "the escape hatch must suppress the plan, and a None plan is what drops --numa-mem"
-        );
-    }
-
-    /// Case-insensitively, because an operator setting this in a pod spec should not have to guess.
-    #[test]
-    fn the_hatch_is_case_insensitive() {
+        // 3. The escape hatch suppresses the plan, and a `None` plan is what drops `--numa-mem`.
+        //    Note the device list is non-empty: `reserve_for(&[])` returns `None` because there
+        //    are no nodes to reserve on, which would pass whether the hatch worked or not.
         for value in ["off", "OFF", "Off"] {
+            // SAFETY: this test owns its process, and the pool-touching tests are all here.
             unsafe { std::env::set_var(DISABLE_ENV, value) };
-            let plan = reserve_for(&a_device());
+            let plan = reserve_for(&device);
             unsafe { std::env::remove_var(DISABLE_ENV) };
             assert!(plan.is_none(), "{value} should disable the reservation");
         }
-    }
 
-    /// Guards the guard: without the variable the same call must reach the reservation.
-    ///
-    /// This is what makes the two tests above mean something. If this ever starts returning `None`
-    /// -- because the machine has no usable hugepages, say -- then those tests are vacuous again
-    /// and this one says so instead of passing quietly.
-    #[test]
-    fn without_the_variable_the_reservation_is_attempted() {
+        // 4. The guard that makes step 3 mean something: without the variable, the same call must
+        //    reach the reservation. If this host has no usable hugepages it says so, rather than
+        //    letting step 3 pass for the wrong reason.
         unsafe { std::env::remove_var(DISABLE_ENV) };
-        let plan = reserve_for(&a_device());
         assert!(
-            plan.is_some(),
+            reserve_for(&device).is_some(),
             "no plan without the hatch set: this host has no usable hugepages, so the escape-hatch \
-             tests above cannot distinguish the hatch from the absence of pages"
+             assertions above cannot tell the hatch from the absence of pages"
         );
     }
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -228,6 +228,50 @@ fn prepare_devices(devices: &[ResolvedDevice]) -> Result<(), String> {
 /// `init_net` -- and DPDK would then find nothing from inside the namespace. That is a boot-time
 /// setting, `ib_core.netns_mode=0`, and it is checked here so the failure is reported where it can
 /// be understood rather than as an empty device list much later.
+/// Whether the RDMA subsystem will let a network namespace own a device.
+///
+/// `ib_core`'s `netns_mode` is a bool parameter: `Y` is *shared* (the kernel default) and `N` is
+/// *exclusive*. It is settable at boot as `ib_core.netns_mode=0`, and effectively only at boot --
+/// `rdma system set netns exclusive` is permitted only while no network namespace other than the
+/// initial one exists, which on a node running containers is never.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RdmaNetnsMode {
+    /// A device can be moved into a namespace and is invisible outside it. What the design needs.
+    Exclusive,
+    /// Devices are visible everywhere and a namespace cannot own one.
+    Shared,
+    /// `ib_core` is not loaded, or the parameter is not where it is expected.
+    Unknown,
+}
+
+/// Where the kernel exposes the RDMA namespace mode.
+const IB_CORE_NETNS_MODE: &str = "/sys/module/ib_core/parameters/netns_mode";
+
+/// Interpret the contents of [`IB_CORE_NETNS_MODE`].
+///
+/// Split from the read so both answers can be tested on a machine that can only be in one of them.
+fn parse_netns_mode(raw: &str) -> RdmaNetnsMode {
+    match raw.trim() {
+        "N" | "0" => RdmaNetnsMode::Exclusive,
+        "Y" | "1" => RdmaNetnsMode::Shared,
+        other => {
+            warn!("{IB_CORE_NETNS_MODE} contained {other:?}, which is neither Y nor N");
+            RdmaNetnsMode::Unknown
+        }
+    }
+}
+
+/// Read the RDMA namespace mode from the `ib_core` module parameter.
+fn rdma_netns_mode() -> RdmaNetnsMode {
+    match std::fs::read_to_string(IB_CORE_NETNS_MODE) {
+        Ok(raw) => parse_netns_mode(&raw),
+        Err(e) => {
+            debug!("could not read {IB_CORE_NETNS_MODE}: {e}");
+            RdmaNetnsMode::Unknown
+        }
+    }
+}
+
 async fn move_devices_to_netns(
     devices: &[ResolvedDevice],
     netns: &NetworkNamespace,
@@ -241,6 +285,37 @@ async fn move_devices_to_netns(
             )
         })
         .collect();
+
+    // Refuse here rather than let this surface as an empty device list.
+    //
+    // In shared mode `_ib_alloc_device` discards the requested net: the devlink instance moves and
+    // the reload *succeeds*, while the RDMA device -- the half the mlx5 PMD attaches through --
+    // stays in `init_net`. The datapath then enumerates nothing, which is indistinguishable from
+    // absent hardware, and the reason is a boot parameter no message in the failure path mentions.
+    if !bifurcated.is_empty() {
+        match rdma_netns_mode() {
+            RdmaNetnsMode::Exclusive => {}
+            RdmaNetnsMode::Shared => {
+                return Err(format!(
+                    "the RDMA subsystem is in shared mode, so a network namespace cannot own {}. \
+                     Boot the host with `ib_core.netns_mode=0` (`rdma system show` should then say \
+                     `netns exclusive`), or run without --datapath-netns. Changing it at runtime \
+                     with `rdma system set netns exclusive` is only permitted while no network \
+                     namespace but the initial one exists, which is not the case on a node running \
+                     containers.",
+                    bifurcated
+                        .iter()
+                        .map(|d| d.address.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            RdmaNetnsMode::Unknown => warn!(
+                "could not determine the RDMA namespace mode; if the datapath finds no device, \
+                 check `rdma system show` for `netns exclusive`"
+            ),
+        }
+    }
 
     for device in devices {
         if matches!(
@@ -948,4 +1023,44 @@ fn main() {
     }
 
     std::process::exit(supervise_gateway(config, netns, host_netns, supervise_frr));
+}
+
+#[cfg(test)]
+mod rdma_netns_mode_test {
+    use super::{IB_CORE_NETNS_MODE, RdmaNetnsMode, parse_netns_mode, rdma_netns_mode};
+
+    /// Both answers, on a machine that can only be in one of them.
+    ///
+    /// The host-reading test below can only exercise whichever mode this machine happens to be in,
+    /// so a mistake in the other arm would go unnoticed -- and the arm that matters is `Y`, the
+    /// kernel default, which is what a misconfigured lab host reports.
+    #[test]
+    fn shared_and_exclusive_are_both_recognised() {
+        assert_eq!(parse_netns_mode("Y"), RdmaNetnsMode::Shared);
+        assert_eq!(parse_netns_mode("1"), RdmaNetnsMode::Shared);
+        assert_eq!(parse_netns_mode("Y\n"), RdmaNetnsMode::Shared);
+        assert_eq!(parse_netns_mode("N"), RdmaNetnsMode::Exclusive);
+        assert_eq!(parse_netns_mode("0"), RdmaNetnsMode::Exclusive);
+        assert_eq!(parse_netns_mode("N\n"), RdmaNetnsMode::Exclusive);
+        // Anything else is not guessed at: an unrecognised value warns and only warns, which is
+        // the right way round -- refusing to start over a parameter we cannot read would be worse.
+        assert_eq!(parse_netns_mode("maybe"), RdmaNetnsMode::Unknown);
+        assert_eq!(parse_netns_mode(""), RdmaNetnsMode::Unknown);
+    }
+
+    /// And the reader must agree with what this machine actually reports.
+    #[test]
+    fn a_readable_parameter_is_never_reported_unknown() {
+        let Ok(raw) = std::fs::read_to_string(IB_CORE_NETNS_MODE) else {
+            // No ib_core here; Unknown is the honest answer and the guard only warns.
+            assert_eq!(rdma_netns_mode(), RdmaNetnsMode::Unknown);
+            return;
+        };
+        assert_eq!(rdma_netns_mode(), parse_netns_mode(&raw));
+        assert_ne!(
+            rdma_netns_mode(),
+            RdmaNetnsMode::Unknown,
+            "{IB_CORE_NETNS_MODE} is readable ({raw:?}), so the mode must be decided, not guessed"
+        );
+    }
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -392,6 +392,202 @@ async fn move_devices_to_netns(
 /// Returns the namespace, which the descriptor alone keeps alive. Nothing is registered under
 /// `/run/netns`, so there is no name for anything to collide with and nothing to clean up: when the
 /// dataplane exits, however it exits, the kernel closes the descriptor and the namespace goes.
+/// Bring every interface in the datapath namespace administratively up.
+///
+/// # Why this is needed at all
+///
+/// Moving an interface between network namespaces brings it **down**: the kernel's
+/// `dev_change_net_namespace` closes the device before it moves. It arrives in the new namespace
+/// with `IFF_UP` clear, and nothing put it back.
+///
+/// For a bifurcated device that is the whole ballgame. `mlx5_core` keeps the netdev while the PMD
+/// attaches through RDMA, and the physical port follows the *netdev's* administrative state -- so
+/// DPDK will configure the port, set up every queue, report "started", and move not one packet.
+/// Nothing in the datapath complains, because from DPDK's side nothing is wrong.
+///
+/// The kernel driver had the same hole and did not show it: an init container ran
+/// `ip l set dev <iface> up` in shell, guarded by `if driver == "kernel"`, so only the DPDK path
+/// ever went without. Doing it here covers both, and puts it next to the move that made it
+/// necessary.
+///
+/// # Why by index rather than by name
+///
+/// A device that came through devlink was torn down and reprobed in the new namespace, and it does
+/// not have to come back under the name it left with. Everything in this namespace was put there
+/// by this process, so bringing up whatever is in it is both sufficient and immune to a rename.
+///
+/// # Loopback included
+///
+/// `lo` is not an exception, though it is easy to assume it is. A fresh network namespace gets a
+/// loopback device but the kernel leaves it **down** -- `<LOOPBACK> state DOWN`, with `IFF_UP`
+/// clear -- so anything in this namespace that binds or connects to `127.0.0.1` fails until
+/// somebody raises it. Every container runtime does this for the same reason.
+async fn bring_up_interfaces_in_netns() -> Result<(), String> {
+    let (connection, handle, _) =
+        rtnetlink::new_connection().map_err(|e| format!("could not open a netlink socket: {e}"))?;
+    let connection = tokio::spawn(connection);
+
+    let result = async {
+        let mut links = handle.link().get().execute();
+        let mut problems = Vec::new();
+        let mut brought_up = 0usize;
+        loop {
+            match links.try_next().await {
+                Ok(Some(link)) => {
+                    let index = link.header.index;
+                    let name = link
+                        .attributes
+                        .iter()
+                        .find_map(|a| match a {
+                            rtnetlink::packet_route::link::LinkAttribute::IfName(n) => {
+                                Some(n.clone())
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_else(|| format!("index {index}"));
+                    match handle
+                        .link()
+                        .set(rtnetlink::LinkUnspec::new_with_index(index).up().build())
+                        .execute()
+                        .await
+                    {
+                        Ok(()) => {
+                            info!("brought {name} up in the datapath network namespace");
+                            if name != "lo" {
+                                brought_up += 1;
+                            }
+                        }
+                        Err(e) => problems.push(format!("could not bring '{name}' up: {e}")),
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    problems.push(format!("could not list interfaces: {e}"));
+                    break;
+                }
+            }
+        }
+        // Counted excluding `lo`, which is always there and says nothing about whether the move
+        // landed. Not an error either way: a vfio-pci device has no netdev to bring up at all.
+        if brought_up == 0 && problems.is_empty() {
+            warn!(
+                "the datapath namespace holds no interface but loopback; expected for a vfio-pci \
+                 device, and a sign the move did not land for a bifurcated one"
+            );
+        }
+        if problems.is_empty() {
+            Ok(())
+        } else {
+            Err(problems.join("; "))
+        }
+    }
+    .await;
+
+    connection.abort();
+    result
+}
+
+/// Run [`bring_up_interfaces_in_netns`] inside `netns`, on a thread that can be spared.
+///
+/// `setns` is per-thread and there is no going back, so this cannot happen on the caller: the rest
+/// of init still has to see the namespace it started in. A scratch thread enters, brings the
+/// interfaces up, and ends there.
+fn bring_up_datapath_interfaces(netns: &NetworkNamespace) -> Result<(), String> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| {
+                netns
+                    .enter()
+                    .map_err(|e| format!("could not enter the datapath namespace: {e}"))?;
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| format!("could not build a runtime for netlink: {e}"))?
+                    .block_on(bring_up_interfaces_in_netns())
+            })
+            .join()
+            .map_err(|_| "the thread bringing datapath interfaces up panicked".to_string())?
+    })
+}
+
+/// Where `ip netns` looks for named network namespaces.
+const NETNS_DIR: &str = "/run/netns";
+
+/// Give a namespace a name under `/run/netns`, so `ip netns` can reach it.
+///
+/// # Why, given the design deliberately avoids this
+///
+/// Namespaces here are held by descriptor and nothing else: they need no name, they die with the
+/// process tree, and there is no stale mount to clean up after a crash. That is the right property
+/// for production and it is why there was never a bind mount.
+///
+/// It is the wrong property for debugging. A namespace with no name cannot be entered with
+/// `ip netns exec`, does not appear in `ip netns list`, and leaves an operator holding a log line
+/// like `net:[4026532427]` with no way to look inside it -- which is how "the datapath is up and
+/// carries nothing" took a full lab cycle to become "the netdev is down". Naming them costs a bind
+/// mount and buys `ip netns exec datapath ip link`.
+///
+/// # Best-effort, on purpose
+///
+/// A failure here must not stop the gateway starting. This exists to make a working system easier
+/// to inspect, and refusing to run because an inspection aid could not be set up would be exactly
+/// backwards.
+///
+/// A stale entry from a previous run is unmounted first. The file is left behind on shutdown --
+/// `ip netns delete` clears it, and so does the next start.
+fn pin_netns(name: &str, source: &str) {
+    if let Err(e) = std::fs::DirBuilder::new().recursive(true).create(NETNS_DIR) {
+        warn!("could not create {NETNS_DIR}: {e}; network namespaces will not be named");
+        return;
+    }
+    let target = format!("{NETNS_DIR}/{name}");
+
+    // A previous run's mount would otherwise be silently shadowed, leaving `ip netns exec` running
+    // in a namespace that no longer has anything to do with this process.
+    match nix::mount::umount2(target.as_str(), nix::mount::MntFlags::MNT_DETACH) {
+        Ok(()) => debug!("detached a stale {target}"),
+        Err(nix::errno::Errno::EINVAL | nix::errno::Errno::ENOENT) => {}
+        Err(e) => debug!("could not detach a stale {target}: {e}"),
+    }
+    if let Err(e) = std::fs::File::create(&target) {
+        warn!("could not create {target}: {e}; this namespace will not be named");
+        return;
+    }
+
+    // The datapath and host namespaces are ones no thread here is in, so they have no
+    // `/proc/<pid>/ns/net` path and are bound from the descriptor instead; the control namespace
+    // is the one this thread is in, and names itself.
+    match nix::mount::mount(
+        Some(source),
+        target.as_str(),
+        None::<&str>,
+        nix::mount::MsFlags::MS_BIND,
+        None::<&str>,
+    ) {
+        Ok(()) => info!("network namespace available as `ip netns exec {name}`"),
+        Err(e) => warn!("could not bind {source} to {target}: {e}; {name} will not be named"),
+    }
+}
+
+/// Give all three namespaces names under `/run/netns`.
+fn name_namespaces(netns: Option<&NetworkNamespace>, host_netns: Option<&NetworkNamespace>) {
+    // `thread-self`, not `self`: this thread is the one that entered the control namespace, and
+    // the distinction is the trap `hardware::netns` documents.
+    pin_netns("control", "/proc/thread-self/ns/net");
+    if let Some(netns) = netns {
+        pin_netns(
+            "datapath",
+            &format!("/proc/self/fd/{}", netns.as_raw().as_raw_fd()),
+        );
+    }
+    if let Some(host) = host_netns {
+        pin_netns(
+            "host",
+            &format!("/proc/self/fd/{}", host.as_raw().as_raw_fd()),
+        );
+    }
+}
+
 fn isolate_devices(devices: &[ResolvedDevice]) -> Result<NetworkNamespace, String> {
     let netns = NetworkNamespace::create()
         .map_err(|e| format!("could not create a network namespace for the datapath: {e}"))?;
@@ -404,6 +600,9 @@ fn isolate_devices(devices: &[ResolvedDevice]) -> Result<NetworkNamespace, Strin
         .map_err(|e| format!("could not build a runtime to talk to devlink: {e}"))?;
 
     runtime.block_on(move_devices_to_netns(devices, &netns))?;
+    // The move left them down; a bifurcated device's port follows its netdev, so without this the
+    // datapath starts cleanly and carries nothing.
+    bring_up_datapath_interfaces(&netns)?;
     Ok(netns)
 }
 
@@ -506,6 +705,9 @@ fn isolate_interfaces(interfaces: &[String]) -> Result<NetworkNamespace, String>
         .map_err(|e| format!("could not build a runtime to talk to netlink: {e}"))?;
 
     runtime.block_on(move_interfaces_to_netns(interfaces, &netns))?;
+    // Same reason as the DPDK path. This one was covered by an init container running
+    // `ip l set dev <iface> up` in shell, which is why only DPDK ever showed the hole.
+    bring_up_datapath_interfaces(&netns)?;
     Ok(netns)
 }
 
@@ -1025,6 +1227,12 @@ fn main() {
             }
         }
     };
+
+    // Named here rather than where each is created: this is the last point where all three are in
+    // hand, and it is after `enter_control_netns` unshared the mount namespace -- so these land in
+    // the namespace a `kubectl exec` into this container will see, which is the only one an
+    // operator can reach.
+    name_namespaces(netns.as_ref(), host_netns.as_ref());
 
     // Recorded before the configuration is sealed. The dataplane turns this into `--numa-mem`,
     // which makes the EAL fail loudly if the memory is not where we said it would be, instead of

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::pedantic, missing_docs)]
 
 mod frr;
+mod hugepages;
 mod supervisor;
 
 use std::collections::BTreeMap;
@@ -818,7 +819,7 @@ fn main() {
     let wants_datapath_netns = args.datapath_netns();
     let supervise_frr = args.supervise_frr();
 
-    let config = match LaunchConfiguration::try_from(args) {
+    let mut config = match LaunchConfiguration::try_from(args) {
         Ok(config) => config,
         Err(e) => fail("invalid command line arguments", &e.to_string()),
     };
@@ -835,6 +836,9 @@ fn main() {
         );
     }
 
+    // Declared out here because the match borrows `config.driver`, and the plan has to be written
+    // back into it afterwards -- before `dataplane_process` seals it into the memfd.
+    let mut hugepage_plan = None;
     let (netns, host_netns) = match &config.driver {
         DriverConfigSection::Dpdk(dpdk) => {
             mount_hugepages();
@@ -842,6 +846,12 @@ fn main() {
                 Ok(devices) => devices,
                 Err(problems) => fail("cannot use the requested network devices", &problems),
             };
+            // Reserved here, after the devices are resolved, because the whole point is to put the
+            // pages on the node the NIC is attached to -- which is not knowable until we have the
+            // PCI addresses in hand. The result rides to the dataplane in the launch
+            // configuration; see `hugepages` for why the EAL cannot be left to do this itself.
+            hugepage_plan =
+                hugepages::reserve_for(&devices.iter().map(|d| d.address).collect::<Vec<_>>());
             if devices.is_empty() {
                 fail(
                     "no network devices to drive",
@@ -922,6 +932,13 @@ fn main() {
             }
         }
     };
+
+    // Recorded before the configuration is sealed. The dataplane turns this into `--numa-mem`,
+    // which makes the EAL fail loudly if the memory is not where we said it would be, instead of
+    // falling back to another node without a word.
+    if let DriverConfigSection::Dpdk(dpdk) = &mut config.driver {
+        dpdk.hugepages = hugepage_plan;
+    }
 
     std::process::exit(supervise_gateway(config, netns, host_netns, supervise_frr));
 }

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -30,15 +30,22 @@ use tracing::{Level, debug, error, info, span, warn};
 /// Where the dataplane is installed.
 const DATAPLANE_BINARY: &str = "/bin/dataplane";
 
-/// Hugetlbfs mount points, and how much to back each with.
+/// Hugetlbfs mount points.
 ///
 /// Mounting these is best-effort. The dataplane asks the EAL for `--in-memory`, which backs its
 /// hugepages with memfd rather than files under a mount, so it starts without them; a mount is
 /// what a multi-process DPDK setup would need, and what makes the pages visible to an operator
 /// looking at the filesystem.
+///
+/// **Deliberately no `size=`.** hugetlbfs treats that option as a hard ceiling on the mount, not
+/// as a reservation, so a figure here silently caps what DPDK can take however many pages the
+/// kernel actually has. The 2 MiB mount carried `size=128M`, which is far below what a datapath
+/// asks for -- and the symptom is an allocation failure blamed on the host being short of pages,
+/// on a host with thousands of them free. Left off, the mount is bounded by the pool, which is the
+/// only limit that should apply.
 const HUGETLBFS_MOUNTS: &[(&str, &str)] = &[
-    ("/dev/hugepages/1G", "pagesize=1G,size=20G,rw"),
-    ("/dev/hugepages/2M", "pagesize=2M,size=128M,rw"),
+    ("/dev/hugepages/1G", "pagesize=1G,rw"),
+    ("/dev/hugepages/2M", "pagesize=2M,rw"),
 ];
 
 /// A device named in the configuration, resolved against the hardware actually present.

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -286,30 +286,41 @@ async fn move_devices_to_netns(
         })
         .collect();
 
-    // Refuse here rather than let this surface as an empty device list.
+    // Say so here rather than let this surface only as an empty device list.
     //
-    // In shared mode `_ib_alloc_device` discards the requested net: the devlink instance moves and
-    // the reload *succeeds*, while the RDMA device -- the half the mlx5 PMD attaches through --
-    // stays in `init_net`. The datapath then enumerates nothing, which is indistinguishable from
-    // absent hardware, and the reason is a boot parameter no message in the failure path mentions.
+    // This warns; it used to refuse, and refusing was wrong. In shared mode `_ib_alloc_device`
+    // discards the requested net, so the devlink instance moves while the RDMA device -- the half
+    // the mlx5 PMD attaches through -- stays in `init_net`. That says where the device *lives*,
+    // not whether it can be reached: shared mode also means every RDMA device is visible from
+    // every namespace, and if the kernel does not namespace-tag them in that mode, the datapath
+    // finds it exactly as it would have in `init_net` and the arrangement works.
+    //
+    // What could be measured was: on an *exclusive*-mode host, a fresh network namespace with a
+    // fresh sysfs lists no infiniband devices, so the class is tagged and visibility follows the
+    // device's net. Whether that tagging still applies under shared mode is the part that decides
+    // this, and it cannot be answered on a machine that is not in shared mode.
+    //
+    // A refusal would stop the only kind of host that could settle it from starting at all, to
+    // prevent a failure that is now understood and reported when it happens.
+    // `hardware/tests/dpdk_in_netns.rs` is the probe that answers it properly.
     if !bifurcated.is_empty() {
         match rdma_netns_mode() {
             RdmaNetnsMode::Exclusive => {}
-            RdmaNetnsMode::Shared => {
-                return Err(format!(
-                    "the RDMA subsystem is in shared mode, so a network namespace cannot own {}. \
-                     Boot the host with `ib_core.netns_mode=0` (`rdma system show` should then say \
-                     `netns exclusive`), or run without --datapath-netns. Changing it at runtime \
-                     with `rdma system set netns exclusive` is only permitted while no network \
-                     namespace but the initial one exists, which is not the case on a node running \
-                     containers.",
-                    bifurcated
-                        .iter()
-                        .map(|d| d.address.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
-            }
+            RdmaNetnsMode::Shared => warn!(
+                "the RDMA subsystem is in shared mode, so {} cannot be given to a namespace: the \
+                 devlink instance moves while the RDMA device stays in init_net. Whether the \
+                 datapath can still reach it there is what this run will find out. If it reports \
+                 no devices, that is the answer, and the fix is to boot with \
+                 `ib_core.netns_mode=0` (`rdma system show` should then say `netns exclusive`) or \
+                 to run without --datapath-netns -- it cannot be changed at runtime, because \
+                 `rdma system set netns exclusive` is permitted only while no network namespace \
+                 but the initial one exists.",
+                bifurcated
+                    .iter()
+                    .map(|d| d.address.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
             RdmaNetnsMode::Unknown => warn!(
                 "could not determine the RDMA namespace mode; if the datapath finds no device, \
                  check `rdma system show` for `netns exclusive`"

--- a/interface-manager/src/monitor/mod.rs
+++ b/interface-manager/src/monitor/mod.rs
@@ -21,6 +21,7 @@
 //! rather than to this monitor.
 
 use concurrency::sync::Arc;
+use net::eth::mac::{Mac, SourceMac};
 use net::interface::{InterfaceIndex, InterfaceName};
 use rtnetlink::MulticastGroup;
 use rtnetlink::packet_core::{NetlinkMessage, NetlinkPayload};
@@ -44,6 +45,19 @@ pub struct EthEvent {
     pub carrier: bool,
     pub carrierup: u32,
     pub carrierdown: u32,
+    /// The interface's link-layer address, when the message carried one.
+    ///
+    /// Carried because it *changes*, and because nothing else propagates that. The routing
+    /// `Interface` takes its MAC from the configuration, captured once when the config was built,
+    /// and the datapath tests every arriving frame's destination against it. A MAC set after that
+    /// moment -- which is exactly what happens to the control-plane bridge's taps, since a tap is
+    /// born with a random address and only later takes its port's -- left the datapath comparing
+    /// against an address the interface no longer had, and every unicast frame for it was dropped
+    /// as `MacNotForUs`.
+    ///
+    /// `None` when the message had no address attribute, which is not the same as "no MAC" and
+    /// must not be treated as a change to nothing.
+    pub mac: Option<SourceMac>,
 }
 impl std::fmt::Display for EthEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -53,8 +67,13 @@ impl std::fmt::Display for EthEvent {
         let carrier = if self.carrier { "yes" } else { "no" };
         write!(
             f,
-            "ifname:{} ({}) ifup:{ifup} iflowerup:{ifloup} ifrun:{ifrun} carrier:{carrier} carrierup:{} carrierdown:{}",
-            self.name, self.ifindex, self.carrierup, self.carrierdown
+            "ifname:{} ({}) ifup:{ifup} iflowerup:{ifloup} ifrun:{ifrun} carrier:{carrier} carrierup:{} carrierdown:{} mac:{}",
+            self.name,
+            self.ifindex,
+            self.carrierup,
+            self.carrierdown,
+            self.mac
+                .map_or_else(|| "none".to_string(), |mac| mac.to_string())
         )
     }
 }
@@ -111,6 +130,17 @@ impl InterfaceMonitor {
             LinkAttribute::CarrierDownCount(value) => Some(*value),
             _ => None,
         })?;
+        // Optional, unlike the attributes above: a message that does not carry an address is not
+        // a message saying the address was removed, and the `?` used for the others would throw
+        // away an otherwise perfectly good event.
+        let mac = link_msg.attributes.iter().find_map(|a| match a {
+            LinkAttribute::Address(bytes) => {
+                let octets: [u8; 6] = bytes.as_slice().try_into().ok()?;
+                SourceMac::new(Mac::from(octets)).ok()
+            }
+            _ => None,
+        });
+
         // `LinkAttribute::OperState` is not reliable for events, so we ignore it.
         // N.B. the above attributes are required (watch the ?)
 
@@ -124,6 +154,7 @@ impl InterfaceMonitor {
             carrier: *carrier != 0,
             carrierup,
             carrierdown,
+            mac,
         };
         info!("Got event for {event}");
         Some(event)

--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -623,9 +623,13 @@ impl Masquerade {
         if let Err(error) = self.masquerade_packet(packet) {
             packet.done((&error).into());
             debug!("Did not masquerade packet: {error}");
-        } else {
-            packet.meta_mut().set_checksum_refresh(true);
         }
+        // Deliberately *not* setting `checksum_refresh` on success. `snat`/`dnat` fold their own
+        // changes into the transport checksum incrementally and set the flag only where they
+        // cannot. Setting it here unconditionally -- as this did -- silently reinstated the full
+        // payload sum for every masqueraded packet, so the incremental work was done and then
+        // thrown away. Nothing failed, which is why it survived: the packets were correct, just
+        // needlessly expensive.
     }
 }
 

--- a/nat/src/masquerade/packet.rs
+++ b/nat/src/masquerade/packet.rs
@@ -22,9 +22,9 @@ pub(crate) enum NatPacketError {
     UpdateNet(#[from] NetError),
     #[error("Failed to update transport header")]
     UpdateTransport(#[from] TransportError),
-    #[error("Failed to update ICMPv4 header")]
+    #[error("Failed to update `ICMPv4` header")]
     UpdateIcmpv4(#[from] Icmp4Error),
-    #[error("Failed to update ICMPv6 header")]
+    #[error("Failed to update `ICMPv6` header")]
     UpdateIcmpv6(#[from] Icmp6Error),
     #[error("Failed to NAT packet: unsupported traffic")]
     UnsupportedTraffic,
@@ -36,6 +36,10 @@ fn snat<Buf: PacketBufferMut>(
     natport: NatPort,
 ) -> Result<(), NatPacketError> {
     let mut modified = false;
+    // Set only where an incremental update is not possible (an ICMP path that carries no usable
+    // old value, or an IP version change). `ipforward` then does the full payload recompute; the
+    // ordinary case skips it entirely.
+    let mut needs_full_recompute = false;
     match packet
         .headers_mut()
         .pat_mut()
@@ -45,41 +49,57 @@ fn snat<Buf: PacketBufferMut>(
         .done()
     {
         Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
-            if ip.src_addr() != new_src.inner() {
+            // Both fields are covered by the TCP/UDP pseudo-header, so each change is folded into
+            // the transport checksum incrementally (RFC 1624) rather than by re-summing the
+            // payload. The old value has to be read *before* the set, which is the only reason
+            // these are bound rather than compared inline.
+            let old_addr = ip.src_addr();
+            if old_addr != new_src.inner() {
                 ip.try_set_source(new_src)?;
-                modified = true;
+                if tp.increment_checksum_for_address(old_addr, new_src.inner()) {
+                    modified = true;
+                } else {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                    modified = true;
+                }
             }
             if let NatPort::Port(port) = natport {
+                let old_port = tp.src_port();
                 tp.try_set_source(port)?;
+                if let Some(old_port) = old_port {
+                    tp.increment_checksum_for_u16(old_port.get(), port.get());
+                } else {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
         Some((_, Net::Ipv6(_), Transport::Icmp4(_)) | (_, Net::Ipv4(_), Transport::Icmp6(_))) => {
             return Err(NatPacketError::UnsupportedTraffic);
         }
-        Some((_, ip, Transport::Icmp4(icmp))) => {
-            if ip.src_addr() != new_src.inner() {
+        // Matched on the `Transport` rather than destructured into the inner `Icmp4`/`Icmp6`, so
+        // the checksum helpers -- which know that `ICMPv4` has no pseudo-header and `ICMPv6` does --
+        // stay reachable. Destructuring hands out an `&mut Icmp4`, which cannot answer that
+        // question, and that is precisely how the two get confused.
+        Some((_, ip, tp)) if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) => {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src.inner() {
                 ip.try_set_source(new_src)?;
+                // A no-op for `ICMPv4` (the address is not covered) and a real delta for `ICMPv6`.
+                if !tp.increment_checksum_for_address(old_addr, new_src.inner()) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
+                && let Some(current) = tp.identifier()
                 && current != id
             {
-                icmp.try_set_identifier(id)?;
-                modified = true;
-            }
-        }
-        Some((_, ip, Transport::Icmp6(icmp))) => {
-            if ip.src_addr() != new_src.inner() {
-                ip.try_set_source(new_src)?;
-                modified = true;
-            }
-            if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
-                && current != id
-            {
-                icmp.try_set_identifier(id)?;
+                tp.try_set_identifier(id)?;
+                // The identifier lives inside the ICMP header, which the ICMP checksum covers --
+                // for both versions.
+                tp.increment_checksum_for_u16(current, id);
                 modified = true;
             }
         }
@@ -87,7 +107,7 @@ fn snat<Buf: PacketBufferMut>(
     }
     if modified {
         packet.meta_mut().src_natted(true);
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
     }
     Ok(())
 }
@@ -98,6 +118,9 @@ fn dnat<Buf: PacketBufferMut>(
     natport: NatPort,
 ) -> Result<(), NatPacketError> {
     let mut modified = false;
+    // See `snat`: set only where an incremental update is impossible, so the ordinary case skips
+    // the full payload recompute in `ipforward`.
+    let mut needs_full_recompute = false;
 
     match packet
         .headers_mut()
@@ -109,12 +132,23 @@ fn dnat<Buf: PacketBufferMut>(
     {
         // ipv4|ipv6 + UDP/TCP
         Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
-            if ip.dst_addr() != new_dst_ip {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Port(port) = natport {
+                let old_port = tp.dst_port();
                 tp.try_set_destination(port)?;
+                if let Some(old_port) = old_port {
+                    tp.increment_checksum_for_u16(old_port.get(), port.get());
+                } else {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -122,32 +156,26 @@ fn dnat<Buf: PacketBufferMut>(
             return Err(NatPacketError::UnsupportedTraffic);
         }
 
-        // ipv4 + Icmp4
-        Some((_, ip, Transport::Icmp4(icmp))) => {
-            if ip.dst_addr() != new_dst_ip {
+        // `ICMPv4` and `ICMPv6`. Matched on the `Transport` rather than destructured, so the checksum
+        // helpers can apply the rule that differs between them: `ICMPv4` has no pseudo-header and so
+        // is untouched by an address change, `ICMPv6` has one and is not.
+        Some((_, ip, tp)) if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) => {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
+                && let Some(current) = tp.identifier()
                 && current != id
             {
-                icmp.try_set_identifier(id)?;
-                modified = true;
-            }
-        }
-
-        // ipv6 + Icmp6
-        Some((_, ip, Transport::Icmp6(icmp))) => {
-            if ip.dst_addr() != new_dst_ip {
-                ip.try_set_destination(new_dst_ip)?;
-                modified = true;
-            }
-            if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
-                && current != id
-            {
-                icmp.try_set_identifier(id)?;
+                tp.try_set_identifier(id)?;
+                // The identifier is inside the ICMP header, which the checksum covers, for both
+                // versions.
+                tp.increment_checksum_for_u16(current, id);
                 modified = true;
             }
         }
@@ -156,7 +184,7 @@ fn dnat<Buf: PacketBufferMut>(
 
     if modified {
         packet.meta_mut().dst_natted(true);
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
     }
     Ok(())
 }
@@ -186,5 +214,175 @@ pub(super) fn masquerade<Buf: PacketBufferMut>(
     match xlate.action {
         NatAction::SrcNat => snat(packet, xlate.use_ip, xlate.nat_port),
         NatAction::DstNat => dnat(packet, xlate.use_ip.inner(), xlate.nat_port),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod checksum_test {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::checksum::Checksum;
+    use net::headers::{TryHeaders, TryTransport};
+    use net::ip::NextHeader;
+    use net::packet::test_utils::build_test_tcp_ipv4_packet;
+    use std::num::NonZero;
+
+    /// Same requirement, for the ICMP paths.
+    ///
+    /// Separate from the TCP case because the rules differ and getting them confused is exactly how
+    /// this breaks: an **`ICMPv4`** checksum does not cover the address (no pseudo-header) but *does*
+    /// cover the identifier, while an **`ICMPv6`** checksum covers both. A conversion that handles
+    /// only TCP/UDP leaves these arms mutating the packet with no checksum update at all -- which
+    /// is worse than the full recompute it replaced, and invisible until something far away drops
+    /// the packet.
+    fn icmp_translation_agrees_with_a_recompute(next_header: NextHeader, ipv6: bool, source: bool) {
+        use net::packet::test_utils::{
+            build_test_ipv4_packet_with_transport, build_test_ipv6_packet_with_transport,
+        };
+
+        let mut packet: Packet<TestBuffer> = if ipv6 {
+            build_test_ipv6_packet_with_transport(64, Some(next_header)).unwrap()
+        } else {
+            build_test_ipv4_packet_with_transport(64, Some(next_header)).unwrap()
+        };
+        packet.update_checksums();
+
+        let new_src = if ipv6 {
+            UnicastIpAddr::try_from(IpAddr::from([
+                0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9,
+            ]))
+            .unwrap()
+        } else {
+            UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap()
+        };
+        if source {
+            snat(&mut packet, new_src, NatPort::Identifier(4321)).expect("snat");
+        } else {
+            dnat(&mut packet, new_src.inner(), NatPort::Identifier(4321)).expect("dnat");
+        }
+
+        let before = icmp_checksum(&packet);
+        if packet.meta().checksum_refresh() {
+            // Falling back is allowed; it is silently doing neither that is not.
+            return;
+        }
+        packet.update_checksums();
+        assert_eq!(
+            before,
+            icmp_checksum(&packet),
+            "after an ICMP translation the checksum disagrees with a full recompute, and \
+             checksum_refresh was not set either -- so nothing would ever fix it"
+        );
+    }
+
+    fn icmp_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet.headers().try_transport().and_then(|tp| match tp {
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn icmp4_snat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP, false, true);
+    }
+
+    #[test]
+    fn icmp6_snat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP6, true, true);
+    }
+
+    #[test]
+    fn icmp4_dnat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP, false, false);
+    }
+
+    #[test]
+    fn icmp6_dnat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP6, true, false);
+    }
+
+    /// The destination-translation counterpart of
+    /// [`snat_leaves_a_checksum_a_full_recompute_would_agree_with`]. Return traffic goes through
+    /// `dnat`, so leaving it on the full recompute would have halved the benefit and hidden any
+    /// mistake behind the direction that was tested.
+    #[test]
+    fn dnat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80);
+        packet.update_checksums();
+
+        let new_dst = IpAddr::from([9, 9, 9, 9]);
+        dnat(
+            &mut packet,
+            new_dst,
+            NatPort::Port(NonZero::new(4321).unwrap()),
+        )
+        .expect("dnat");
+
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "dnat asked for a full payload recompute; the incremental path was not taken"
+        );
+
+        let checksum_of = |p: &Packet<TestBuffer>| {
+            p.headers().try_transport().map(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+        };
+        let incremental = checksum_of(&packet).expect("a transport header");
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            checksum_of(&packet).expect("a transport header"),
+            "the incremental checksum after dnat disagrees with a full recompute"
+        );
+    }
+
+    /// After a source translation, the transport checksum must equal what a full recompute gives.
+    ///
+    /// This is the test that makes the incremental path trustworthy, and it did not exist before:
+    /// **no NAT test validated a checksum at all** (only the ICMP handler did), so the whole suite
+    /// would have passed just as happily with the arithmetic wrong. A bad checksum is not rejected
+    /// here -- it is rejected several hops away, by someone else, long after the fact.
+    #[test]
+    fn snat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80);
+        // Start from a packet whose checksum is right, or the comparison proves nothing.
+        packet.update_checksums();
+
+        let new_src = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        let new_port = NatPort::Port(NonZero::new(4321).unwrap());
+        snat(&mut packet, new_src, new_port).expect("snat");
+
+        // The whole point: the ordinary path must not ask for a full recompute.
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "snat asked for a full payload recompute; the incremental path was not taken"
+        );
+
+        let checksum_of = |p: &Packet<TestBuffer>| {
+            p.headers().try_transport().map(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+        };
+        let incremental = checksum_of(&packet).expect("a transport header");
+
+        // Force the full recompute over the same, already-translated packet and compare. Done in
+        // place rather than on a copy because `Packet` deliberately has no `Clone`.
+        packet.update_checksums();
+        let expected = checksum_of(&packet).expect("a transport header");
+
+        assert_eq!(
+            incremental, expected,
+            "the incremental checksum after snat disagrees with a full recompute"
+        );
     }
 }

--- a/nat/src/masquerade/test.rs
+++ b/nat/src/masquerade/test.rs
@@ -542,6 +542,48 @@ fn translation(packet: &Packet<TestBuffer>) -> (Ipv4Addr, u16) {
     )
 }
 
+/// Every masqueraded packet must leave with a correct checksum **and** without asking for a full
+/// payload recompute.
+///
+/// Folded into the shared helper so that every NF-level masquerade test is a guard for it. It
+/// exists because the incremental conversion was, for a while, entirely wasted: `snat`/`dnat` did
+/// the delta correctly and then `Masquerade::process` set `checksum_refresh` unconditionally,
+/// reinstating the full sum. Nothing failed -- the packets were correct, just needlessly
+/// expensive -- and the unit tests missed it because they call `snat`/`dnat` directly rather than
+/// through the network function.
+fn assert_masquerade_checksum_is_incremental(packet: &mut Packet<TestBuffer>) {
+    use net::checksum::Checksum;
+    use net::headers::{Transport, TryHeaders, TryTransport};
+
+    if packet.get_done().is_some() {
+        return; // dropped or filtered; nothing was translated
+    }
+    if !packet.meta().is_src_natted() && !packet.meta().is_dst_natted() {
+        return; // no translation happened, so there is no delta to check
+    }
+    let checksum_of = |p: &Packet<TestBuffer>| -> Option<u16> {
+        TryHeaders::headers(p)
+            .try_transport()
+            .and_then(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+    };
+    assert!(
+        !packet.meta().checksum_refresh(),
+        "a masqueraded packet asked for a full payload recompute; the incremental path was \
+         overridden somewhere above `snat`/`dnat`"
+    );
+    let incremental = checksum_of(packet);
+    packet.update_checksums();
+    assert_eq!(
+        incremental,
+        checksum_of(packet),
+        "a masqueraded packet's incremental checksum disagrees with a full recompute"
+    );
+}
+
 fn check_packet(
     nat: &mut Masquerade,
     src_vni: Vni,
@@ -565,8 +607,13 @@ fn check_packet(
     packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
 
     flow_lookup(nat.sessions(), &mut packet);
+    // Start from a correct checksum, so the assertion below is about this code and not about a
+    // malformed test packet: an incremental update is a delta and faithfully preserves an error in
+    // its input.
+    packet.update_checksums();
 
-    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let mut packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    assert_masquerade_checksum_is_incremental(&mut packets_out[0]);
     let hdr_out = packets_out[0].try_ipv4().unwrap();
     let udp_out = packets_out[0].try_udp().unwrap();
     let done_reason = packets_out[0].get_done();

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -52,6 +52,9 @@ fn snat_packet<Buf: PacketBufferMut>(
     );
 
     let mut modified = false;
+    // See `masquerade::packet`: set only where an incremental update is impossible, so the ordinary
+    // case skips the full payload recompute in `ipforward`.
+    let mut needs_full_recompute = false;
     let proto = packet.upper_layer_proto();
     match packet
         .headers_mut()
@@ -63,21 +66,35 @@ fn snat_packet<Buf: PacketBufferMut>(
     {
         // traffic can be port forwarded: it's Ip + UDP/TCP
         Some((_, ip, tp)) if is_port_forwardable(proto) => {
-            if ip.src_addr() != new_src_ip.inner() {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src_ip.inner() {
                 ip.try_set_source(new_src_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_src_ip.inner()) {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let Some(p) = tp.src_port()
                 && p != new_src_port
             {
                 tp.try_set_source(new_src_port)?;
+                tp.increment_checksum_for_u16(p.get(), new_src_port.get());
                 modified = true;
             }
         }
-        // needed for ICMP error handling
-        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(proto, ip) => {
-            if ip.src_addr() != new_src_ip.inner() {
+        // needed for ICMP error handling. Only the address changes here -- the identifier is left
+        // alone -- so this is a no-op for `ICMPv4` (no pseudo-header) and a real delta for `ICMPv6`.
+        // Matched on the `Transport` rather than the inner header so the helper can tell them apart.
+        Some((_, ip, tp))
+            if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) && is_icmp(proto, ip) =>
+        {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src_ip.inner() {
                 ip.try_set_source(new_src_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_src_ip.inner()) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -86,7 +103,7 @@ fn snat_packet<Buf: PacketBufferMut>(
         }
     }
     if modified {
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
         packet.meta_mut().src_natted(true);
     }
     Ok(modified)
@@ -105,6 +122,7 @@ fn dnat_packet<Buf: PacketBufferMut>(
     );
 
     let mut modified = false;
+    let mut needs_full_recompute = false;
     let proto = packet.upper_layer_proto();
     match packet
         .headers_mut()
@@ -115,21 +133,32 @@ fn dnat_packet<Buf: PacketBufferMut>(
         .done()
     {
         Some((_, ip, tp)) if is_port_forwardable(proto) => {
-            if ip.dst_addr() != new_dst_ip {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let Some(p) = tp.dst_port()
                 && p != new_dst_port
             {
                 tp.try_set_destination(new_dst_port)?;
+                tp.increment_checksum_for_u16(p.get(), new_dst_port.get());
                 modified = true;
             }
         }
-        // needed for ICMP error handling
-        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(proto, ip) => {
-            if ip.dst_addr() != new_dst_ip {
+        // needed for ICMP error handling; see `snat_packet` for why this matches on `Transport`.
+        Some((_, ip, tp))
+            if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) && is_icmp(proto, ip) =>
+        {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -138,7 +167,7 @@ fn dnat_packet<Buf: PacketBufferMut>(
         }
     }
     if modified {
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
         packet.meta_mut().dst_natted(true);
     }
     Ok(modified)
@@ -152,5 +181,127 @@ pub(crate) fn nat_packet<Buf: PacketBufferMut>(
     match state.action() {
         NatAction::DstNat => dnat_packet(packet, state.use_ip().inner(), state.use_port()),
         NatAction::SrcNat => snat_packet(packet, state.use_ip(), state.use_port()),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod checksum_test {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::checksum::Checksum;
+    use net::headers::{TryHeaders, TryTransport};
+    use net::ip::NextHeader;
+    use net::packet::test_utils::{
+        build_test_ipv4_packet_with_transport, build_test_ipv6_packet_with_transport,
+        build_test_tcp_ipv4_packet,
+    };
+
+    fn transport_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet.headers().try_transport().and_then(|tp| match tp {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => udp.checksum().map(u16::from),
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        })
+    }
+
+    /// The incremental result must equal a full recompute, and the recompute must be skipped.
+    ///
+    /// Asserting both matters: a conversion that silently keeps setting `checksum_refresh` would
+    /// still be *correct*, and would look like it passed while delivering none of the benefit.
+    fn agrees_with_recompute(mut packet: Packet<TestBuffer>, source: bool) {
+        packet.update_checksums();
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        let new_port = NonZero::new(4321).unwrap();
+        let modified = if source {
+            snat_packet(&mut packet, new_ip, new_port).expect("snat_packet")
+        } else {
+            dnat_packet(&mut packet, new_ip.inner(), new_port).expect("dnat_packet")
+        };
+        assert!(modified, "the test packet was not actually translated");
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "port forwarding asked for a full payload recompute; the incremental path was skipped"
+        );
+
+        let incremental = transport_checksum(&packet);
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            transport_checksum(&packet),
+            "the incremental checksum disagrees with a full recompute"
+        );
+    }
+
+    #[test]
+    fn tcp_snat_agrees_with_a_recompute() {
+        agrees_with_recompute(
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80),
+            true,
+        );
+    }
+
+    #[test]
+    fn tcp_dnat_agrees_with_a_recompute() {
+        agrees_with_recompute(
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80),
+            false,
+        );
+    }
+
+    /// `ICMPv4` has no pseudo-header, so translating the address must leave its checksum *alone*.
+    ///
+    /// The interesting assertion is the negative one: an implementation that folded the address
+    /// delta into an `ICMPv4` checksum would corrupt every forwarded ICMP error, and it would look
+    /// exactly like working code until something downstream dropped the packet.
+    #[test]
+    fn icmp4_address_translation_does_not_move_the_checksum() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_ipv4_packet_with_transport(64, Some(NextHeader::ICMP)).unwrap();
+        packet.update_checksums();
+        let before = transport_checksum(&packet);
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        snat_packet(&mut packet, new_ip, NonZero::new(4321).unwrap()).expect("snat_packet");
+
+        assert_eq!(
+            transport_checksum(&packet),
+            before,
+            "an ICMPv4 checksum moved when only the IP address changed; ICMPv4 has no \
+             pseudo-header, so the address is not covered"
+        );
+        // And it still agrees with a recompute, i.e. it was right to leave it alone.
+        packet.update_checksums();
+        assert_eq!(transport_checksum(&packet), before);
+    }
+
+    /// `ICMPv6` *does* have a pseudo-header, so the same translation must move its checksum.
+    #[test]
+    fn icmp6_address_translation_does_move_the_checksum() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_ipv6_packet_with_transport(64, Some(NextHeader::ICMP6)).unwrap();
+        packet.update_checksums();
+        let before = transport_checksum(&packet);
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([
+            0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9,
+        ]))
+        .unwrap();
+        snat_packet(&mut packet, new_ip, NonZero::new(4321).unwrap()).expect("snat_packet");
+
+        let incremental = transport_checksum(&packet);
+        assert_ne!(
+            incremental, before,
+            "an ICMPv6 checksum did not move when the address changed; ICMPv6 has a \
+             pseudo-header, so the address is covered"
+        );
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            transport_checksum(&packet),
+            "the incremental ICMPv6 checksum disagrees with a full recompute"
+        );
     }
 }

--- a/nat/src/static_nat/fuzz.rs
+++ b/nat/src/static_nat/fuzz.rs
@@ -427,6 +427,22 @@ fn a_packet_that_cannot_be_looked_up_says_so() {
     drive_attribution!(Scenario::addresses(true));
 }
 
+/// The transport checksum, for the marking properties below.
+fn transport_checksum<Buf: net::buffer::PacketBufferMut>(
+    packet: &net::packet::Packet<Buf>,
+) -> Option<u16> {
+    use net::checksum::Checksum;
+    use net::headers::{Transport, TryHeaders, TryTransport};
+    TryHeaders::headers(packet)
+        .try_transport()
+        .and_then(|tp| match tp {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => udp.checksum().map(u16::from),
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        })
+}
+
 macro_rules! drive_marking {
     ($scenario:expr) => {{
     let tally = Tally::default();
@@ -443,8 +459,14 @@ macro_rules! drive_marking {
             for spec in &probes {
                 let mut probe = (*spec).resolve(&fabric);
                 let before = (probe.source, probe.sport);
-                let out = run(&mut nf, vec![probe.take()]);
-                let packet = &out[0];
+                let mut input = probe.take();
+                // Give the probe a correct checksum first. An incremental update is a *delta*: it
+                // faithfully carries forward whatever error the input had, which is right, but it
+                // means comparing it against a full recompute is only meaningful when the input
+                // started correct. `probe.rs` never computes one.
+                input.update_checksums();
+                let mut out = run(&mut nf, vec![input]);
+                let packet = &mut out[0];
 
                 if five_tuple_source(packet) == before {
                     continue;
@@ -456,11 +478,20 @@ macro_rules! drive_marking {
                     "{source}:{sport} was translated without the source-natted mark, so a later \
                      stage would translate it again"
                 );
-                assert!(
-                    packet.meta().checksum_refresh(),
-                    "{source}:{sport} was translated without asking for a checksum refresh, so the \
-                     packet goes out with a checksum for headers it no longer carries"
-                );
+                // The invariant is that the packet leaves with a *correct* checksum -- not that it
+                // asked for a particular mechanism. It used to ask for a full recompute; it now
+                // folds the change in incrementally and asks only where it cannot. Asserting the
+                // mechanism would have failed that improvement while the property still held.
+                if !packet.meta().checksum_refresh() {
+                    let incremental = transport_checksum(packet);
+                    packet.update_checksums();
+                    assert_eq!(
+                        incremental,
+                        transport_checksum(packet),
+                        "{source}:{sport} was translated, did not ask for a checksum refresh, and \
+                         its checksum does not match a recompute -- so it goes out wrong"
+                    );
+                }
                 tally.reached.fetch_add(1, Ordering::Relaxed);
             }
         },

--- a/nat/src/static_nat/nf.rs
+++ b/nat/src/static_nat/nf.rs
@@ -10,7 +10,10 @@ use crate::icmp_handler::icmp_error_msg::{
 };
 pub use crate::static_nat::natrw::{NatTablesReader, NatTablesWriter}; // re-export
 use net::buffer::PacketBufferMut;
-use net::headers::{Net, NetError, TryEmbeddedTransport, TryInnerIp, TryIpMut, TryTcpUdpMut};
+use net::headers::{
+    Net, NetError, TryEmbeddedTransport, TryHeadersMut, TryInnerIp, TryIpMut, TryTcpUdpMut,
+    TryTransportMut,
+};
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use net::tcp_udp::TcpUdpMut;
@@ -108,6 +111,34 @@ impl StaticNat {
         transport.set_dst_port(new_port);
     }
 
+    /// Fold an address and/or port change into the transport checksum (RFC 1624), or ask for a full
+    /// recompute if that is not possible.
+    ///
+    /// Split out because this file mutates through `TcpUdpMut`, which cannot reach a checksum, so
+    /// unlike `masquerade` and `portfw` the delta has to be applied after the fact from values
+    /// captured before. Same arithmetic, awkwarder plumbing.
+    fn fold_checksum_deltas<Buf: PacketBufferMut>(
+        packet: &mut Packet<Buf>,
+        addr_change: Option<(IpAddr, IpAddr)>,
+        port_change: Option<(NonZero<u16>, NonZero<u16>)>,
+    ) {
+        let Some(transport) = packet.headers_mut().try_transport_mut() else {
+            // No transport header to update; nothing to do and nothing to fall back to.
+            return;
+        };
+        let mut incremental_ok = true;
+        if let Some((old, new)) = addr_change {
+            incremental_ok &= transport.increment_checksum_for_address(old, new);
+        }
+        if let Some((old, new)) = port_change {
+            transport.increment_checksum_for_u16(old.get(), new.get());
+        }
+        if !incremental_ok {
+            // An IP version change; the pseudo-header changes shape, so only a recompute will do.
+            packet.meta_mut().set_checksum_refresh(true);
+        }
+    }
+
     fn translate_icmp_inner_packet_src_if_any<Buf: PacketBufferMut>(
         table: &PerVniTable,
         packet: &mut Packet<Buf>,
@@ -177,22 +208,45 @@ impl StaticNat {
             table.find_src_mapping(&src_addr, src_port_opt, dst_vni)
         {
             let net = packet.try_ip_mut().ok_or(StaticNatError::NoIpHeader)?;
-            if new_src_addr.inner() != src_addr {
+            let addr_changed = new_src_addr.inner() != src_addr;
+            if addr_changed {
                 self.translate_src(net, new_src_addr)?;
                 modified = true;
             }
+            // Captured for the checksum delta below. The mutation happens through a
+            // `TcpUdpMut`, which cannot reach the transport's checksum, so the old value has to
+            // survive past the borrow rather than being folded in on the spot the way
+            // `masquerade` and `portfw` do it.
+            let mut port_change = None;
             if let (Some(mut transport), Some(new_src_port)) =
                 (packet.try_tcp_udp_mut(), new_src_port_opt)
                 && new_src_port.get() != transport.src_port().get()
             {
+                port_change = Some((transport.src_port(), new_src_port));
                 self.translate_src_port(&mut transport, new_src_port);
                 modified = true;
             }
+            if modified {
+                Self::fold_checksum_deltas(
+                    packet,
+                    addr_changed.then_some((src_addr, new_src_addr.inner())),
+                    port_change,
+                );
+            }
         }
 
-        // ICMP Error messages
+        // ICMP Error messages.
+        //
+        // Left on the full recompute. `icmp_error_msg` already maintains the embedded headers'
+        // checksums incrementally, and says the outer ICMP checksum "will not be updated again
+        // when deparsing" -- but the outer ICMP checksum covers the whole quoted packet, and
+        // proving the two agree needs its own test. Correct and slower is the right default for a
+        // path this rare; revisit with a test rather than by assertion.
         if icmp_err {
             modified |= Self::translate_icmp_inner_packet_dst_if_any(table, packet, dst_vni)?;
+            if modified {
+                packet.meta_mut().set_checksum_refresh(true);
+            }
         }
 
         if modified {
@@ -222,22 +276,41 @@ impl StaticNat {
             table.find_dst_mapping(&dst_addr, dst_port_opt)
         {
             let net = packet.try_ip_mut().ok_or(StaticNatError::NoIpHeader)?;
-            if new_dst_addr != dst_addr {
+            let addr_changed = new_dst_addr != dst_addr;
+            if addr_changed {
                 self.translate_dst(net, new_dst_addr)?;
                 modified = true;
             }
+            let mut port_change = None;
             if let (Some(mut transport), Some(new_dst_port)) =
                 (packet.try_tcp_udp_mut(), new_dst_port_opt)
                 && new_dst_port.get() != transport.dst_port().get()
             {
+                port_change = Some((transport.dst_port(), new_dst_port));
                 self.translate_dst_port(&mut transport, new_dst_port);
                 modified = true;
             }
+            if modified {
+                Self::fold_checksum_deltas(
+                    packet,
+                    addr_changed.then_some((dst_addr, new_dst_addr)),
+                    port_change,
+                );
+            }
         }
 
-        // ICMP Error messages
+        // ICMP Error messages.
+        //
+        // Left on the full recompute. `icmp_error_msg` already maintains the embedded headers'
+        // checksums incrementally, and says the outer ICMP checksum "will not be updated again
+        // when deparsing" -- but the outer ICMP checksum covers the whole quoted packet, and
+        // proving the two agree needs its own test. Correct and slower is the right default for a
+        // path this rare; revisit with a test rather than by assertion.
         if icmp_err {
             modified |= Self::translate_icmp_inner_packet_src_if_any(table, packet)?;
+            if modified {
+                packet.meta_mut().set_checksum_refresh(true);
+            }
         }
 
         if modified {
@@ -322,7 +395,11 @@ impl StaticNat {
             }
             Ok(modified) => {
                 if modified {
-                    packet.meta_mut().set_checksum_refresh(true);
+                    // Deliberately *not* setting `checksum_refresh` here. The translation paths
+                    // fold their own deltas in incrementally and set the flag only where they
+                    // cannot (an IP version change, or the ICMP-error path). Setting it here
+                    // unconditionally would override that and reinstate the full payload sum for
+                    // every packet -- which is exactly what it did until this was noticed.
                     debug!("{nfi}: Packet was NAT'ed");
                 } else {
                     debug!("{nfi}: No NAT translation needed");

--- a/nat/src/static_nat/test.rs
+++ b/nat/src/static_nat/test.rs
@@ -1254,3 +1254,88 @@ fn test_config_with_port_ranges_with_default() {
     assert_eq!(output_dst_port, orig_src_port);
     assert_eq!(done_reason, None);
 }
+
+/// After static NAT, the transport checksum must equal what a full recompute would produce, and
+/// the full recompute must have been skipped.
+///
+/// End-to-end through `StaticNat::process` rather than against the helpers, because this file
+/// mutates through a `TcpUdpMut` that cannot reach a checksum -- the delta is applied afterwards
+/// from values captured before, which is a shape with more room for the two to drift apart than
+/// `masquerade` or `portfw` have.
+#[test]
+#[cfg_attr(not(emulated), traced_test)]
+fn static_nat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+    use net::checksum::Checksum;
+    use net::headers::{Transport, TryHeaders, TryTransport};
+
+    let expose1 = VpcExpose::empty()
+        .make_static_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.0.0/16".into(),
+            Some(PortRange::new(4001, 5000).unwrap()),
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.0/16".into(),
+            Some(PortRange::new(8001, 9000).unwrap()),
+        ))
+        .unwrap();
+    let expose2 = VpcExpose::empty().ip(PrefixWithOptionalPorts::new(
+        "10.2.0.0/16".into(),
+        Some(PortRange::new(1, 5).unwrap()),
+    ));
+
+    let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
+    let nat_tables = build_nat_configuration(gw_config.external().overlay().vpc_table()).unwrap();
+    let (mut nat, mut tablesw) = StaticNat::new("static-nat");
+    tablesw.update_nat_tables(nat_tables);
+
+    let src_vni = Vni::new_checked(100).unwrap();
+    let dst_vni = Vni::new_checked(200).unwrap();
+
+    let mut packet = build_test_ipv4_packet_with_transport(u8::MAX, Some(NextHeader::TCP)).unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_static_nat_src(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+    set_addresses_v4(
+        &mut packet,
+        Ipv4Addr::new(1, 1, 0, 1),
+        Ipv4Addr::new(10, 2, 0, 1),
+    );
+    set_ports(&mut packet, 4001, 1);
+    // Start from a correct checksum, or the comparison proves nothing.
+    packet.update_checksums();
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let mut pkt_out = packets_out.into_iter().next().expect("one packet out");
+
+    // The translation must actually have happened, or this test would pass vacuously.
+    assert_ne!(
+        get_src_ip_v4(&pkt_out),
+        Ipv4Addr::new(1, 1, 0, 1),
+        "the packet was not translated; the test is not exercising anything"
+    );
+
+    let checksum_of = |p: &_| -> Option<u16> {
+        TryHeaders::headers(p)
+            .try_transport()
+            .and_then(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+    };
+
+    assert!(
+        !pkt_out.meta().checksum_refresh(),
+        "static NAT asked for a full payload recompute; the incremental path was not taken"
+    );
+    let incremental = checksum_of(&pkt_out);
+    pkt_out.update_checksums();
+    assert_eq!(
+        incremental,
+        checksum_of(&pkt_out),
+        "the incremental checksum after static NAT disagrees with a full recompute"
+    );
+}

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -703,7 +703,11 @@ impl EmbeddedTransport {
     }
 }
 
-fn address_words(addr: IpAddr) -> ArrayVec<u16, 8> {
+/// Split an IP address into the 16-bit words a one's-complement checksum is computed over.
+///
+/// Shared with the non-embedded `Transport` incremental update in the parent module: both need to
+/// walk an address a checksum word at a time, and having two copies of this is how they would drift.
+pub(super) fn address_words(addr: IpAddr) -> ArrayVec<u16, 8> {
     match addr {
         IpAddr::V4(addr) => {
             let [a, b, c, d] = addr.octets();

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -7,9 +7,10 @@
 use crate::checksum::Checksum;
 use crate::eth::ethtype::EthType;
 use crate::eth::{Eth, EthError};
+use crate::headers::embedded::address_words;
 use crate::icmp_any::{IcmpAny, IcmpAnyMut};
-use crate::icmp4::Icmp4;
-use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
+use crate::icmp4::{Icmp4, Icmp4Checksum};
+use crate::icmp6::{Icmp6, Icmp6Checksum, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
 use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
@@ -19,9 +20,9 @@ use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
 };
-use crate::tcp::{Tcp, TcpChecksumPayload, TcpPort};
+use crate::tcp::{Tcp, TcpChecksum, TcpChecksumPayload, TcpPort};
 use crate::tcp_udp::{TcpUdp, TcpUdpMut};
-use crate::udp::{Udp, UdpChecksumPayload, UdpEncap, UdpPort};
+use crate::udp::{Udp, UdpChecksum, UdpChecksumPayload, UdpEncap, UdpPort};
 use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::Vxlan;
 use arrayvec::ArrayVec;
@@ -242,6 +243,109 @@ impl Net {
 }
 
 impl Transport {
+    /// Read the transport checksum, if this transport has one.
+    ///
+    /// `None` for a UDP datagram over IPv4 whose checksum is `0`, which means *disabled* rather
+    /// than *zero* -- an incremental update must leave such a datagram alone rather than turn a
+    /// disabled checksum into a wrong one.
+    #[must_use]
+    fn checksum_for_increment(&self) -> Option<u16> {
+        match self {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => match udp.checksum().map(u16::from) {
+                Some(0) | None => None,
+                Some(current) => Some(current),
+            },
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        }
+    }
+
+    /// Write a transport checksum back, applying UDP's "0 means disabled" rule.
+    fn set_checksum_from_increment(&mut self, updated: u16) {
+        match self {
+            Transport::Tcp(tcp) => {
+                let _ = tcp.set_checksum(TcpChecksum::new(updated));
+            }
+            Transport::Udp(udp) => {
+                // A computed 0 has to be sent as 0xFFFF: the two are the same value in one's
+                // complement, and 0 is reserved to mean "no checksum".
+                let updated = if updated == 0 { u16::MAX } else { updated };
+                let _ = udp.set_checksum(UdpChecksum::new(updated));
+            }
+            Transport::Icmp4(icmp) => {
+                let _ = icmp.set_checksum(Icmp4Checksum::new(updated));
+            }
+            Transport::Icmp6(icmp) => {
+                let _ = icmp.set_checksum(Icmp6Checksum::new(updated));
+            }
+        }
+    }
+
+    /// Incrementally update this transport's checksum for a 16-bit field that changed from
+    /// `old_value` to `new_value` (RFC 1624).
+    ///
+    /// Use for a port or an ICMP identifier. Does nothing where there is no checksum to update.
+    pub fn increment_checksum_for_u16(&mut self, old_value: u16, new_value: u16) {
+        if old_value == new_value {
+            return;
+        }
+        let Some(current) = self.checksum_for_increment() else {
+            return;
+        };
+        let updated = match self {
+            Transport::Tcp(tcp) => u16::from(tcp.increment_update_checksum(
+                TcpChecksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Udp(udp) => u16::from(udp.increment_update_checksum(
+                UdpChecksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Icmp4(icmp) => u16::from(icmp.increment_update_checksum(
+                Icmp4Checksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Icmp6(icmp) => u16::from(icmp.increment_update_checksum(
+                Icmp6Checksum::new(current),
+                old_value,
+                new_value,
+            )),
+        };
+        self.set_checksum_from_increment(updated);
+    }
+
+    /// Incrementally update this transport's checksum for an IP address that changed.
+    ///
+    /// The address is covered by the TCP/UDP/ICMPv6 pseudo-header, so translating it invalidates
+    /// those checksums. **`ICMPv4` has no pseudo-header** and is therefore left alone -- getting that
+    /// backwards would corrupt every translated `ICMPv4` echo.
+    ///
+    /// A change of IP version (NAT64) is not an incremental update: the pseudo-header changes shape,
+    /// not just contents. Such a change is refused here and left to a full recompute.
+    ///
+    /// Returns whether the checksum was updated, so a caller can tell "nothing to do" from "this
+    /// needs a full recompute".
+    pub fn increment_checksum_for_address(&mut self, old: IpAddr, new: IpAddr) -> bool {
+        if old == new {
+            return true;
+        }
+        if matches!(self, Transport::Icmp4(_)) {
+            // No pseudo-header: the address is not covered.
+            return true;
+        }
+        if old.is_ipv4() != new.is_ipv4() {
+            return false;
+        }
+        for (old_word, new_word) in address_words(old).into_iter().zip(address_words(new)) {
+            self.increment_checksum_for_u16(old_word, new_word);
+        }
+        true
+    }
+
     pub(crate) fn update_checksum(
         &mut self,
         net: &Net,
@@ -1699,6 +1803,167 @@ mod test {
             };
         assert_eq!(headers, &parsed);
         assert_eq!(bytes_parsed, headers.size());
+    }
+
+    /// An incremental update must land on exactly the checksum a full recompute would.
+    ///
+    /// This is the whole justification for using RFC 1624 on the NAT path: it is only a valid
+    /// optimisation if it is *indistinguishable* from recomputing. Anything less and we would be
+    /// trading correctness for throughput, silently -- a wrong checksum is not dropped by us, it is
+    /// dropped by whatever receives the packet, minutes and several hops away.
+    ///
+    /// Generated headers, so the comparison covers every transport and both IP versions rather than
+    /// a hand-picked case.
+    fn incremental_matches_recompute(headers: &Headers) {
+        use crate::headers::TryVxlan;
+        use std::num::NonZero;
+
+        let Some(net) = headers.net.clone() else {
+            return;
+        };
+        let Some(transport) = headers.transport.clone() else {
+            return;
+        };
+        // ICMPv4 has no pseudo-header, so an address change must not move its checksum. That is
+        // asserted separately below rather than folded in here.
+        //
+        // VXLAN is excluded: `Headers::update_checksums` deliberately returns before touching the
+        // transport checksum for an encapsulated packet, so "full recompute" is a no-op there and
+        // there is nothing to compare an incremental update against.
+        if headers.try_vxlan().is_some() {
+            return;
+        }
+        let payload: &[u8] = b"the payload the full recompute has to read";
+
+        // Start from a packet whose checksum is actually correct, or the comparison is meaningless.
+        let mut base = headers.clone();
+        base.update_checksums(payload);
+
+        for (old_port, new_port) in [(1234u16, 4321u16), (80, 8080), (65535, 1)] {
+            let mut incremental = base.clone();
+            let mut recomputed = base.clone();
+
+            let (Some(old_nz), Some(new_nz)) = (NonZero::new(old_port), NonZero::new(new_port))
+            else {
+                continue;
+            };
+            // Only ports move here; give both copies the same starting port so the delta is real.
+            // A transport with no ports (ICMP) is skipped -- its identifier is covered elsewhere.
+            {
+                let inc_tp = incremental.transport.as_mut().unwrap();
+                if inc_tp.try_set_source(old_nz).is_err() {
+                    continue;
+                }
+                let rec_tp = recomputed.transport.as_mut().unwrap();
+                rec_tp.try_set_source(old_nz).unwrap();
+            }
+            incremental.update_checksums(payload);
+            recomputed.update_checksums(payload);
+
+            // Now change the port: one incrementally, one by full recompute.
+            let inc_tp = incremental.transport.as_mut().unwrap();
+            inc_tp.try_set_source(new_nz).unwrap();
+            inc_tp.increment_checksum_for_u16(old_port, new_port);
+
+            let rec_tp = recomputed.transport.as_mut().unwrap();
+            rec_tp.try_set_source(new_nz).unwrap();
+            recomputed.update_checksums(payload);
+
+            assert_eq!(
+                incremental.transport.as_ref().map(transport_checksum),
+                recomputed.transport.as_ref().map(transport_checksum),
+                "incremental port update {old_port}->{new_port} disagreed with a full recompute \
+                 for {:?} over {:?}",
+                transport_kind(&transport),
+                net_kind(&net),
+            );
+        }
+    }
+
+    fn transport_checksum(tp: &Transport) -> Option<u16> {
+        match tp {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => udp.checksum().map(u16::from),
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        }
+    }
+
+    fn transport_kind(tp: &Transport) -> &'static str {
+        match tp {
+            Transport::Tcp(_) => "tcp",
+            Transport::Udp(_) => "udp",
+            Transport::Icmp4(_) => "icmp4",
+            Transport::Icmp6(_) => "icmp6",
+        }
+    }
+
+    fn net_kind(net: &Net) -> &'static str {
+        match net {
+            Net::Ipv4(_) => "ipv4",
+            Net::Ipv6(_) => "ipv6",
+        }
+    }
+
+    /// A UDP checksum that incrementally computes to zero must be written as `0xFFFF`.
+    ///
+    /// On IPv4 a stored UDP checksum of `0` means **"no checksum"**, not "the checksum is zero".
+    /// The two are the same value in one's complement, so an update that happens to land on zero
+    /// must send `0xFFFF` instead -- otherwise a translated datagram silently loses checksum
+    /// protection for the rest of its life.
+    ///
+    /// Deliberately targeted rather than left to the property test: the result lands on zero for
+    /// roughly one input in 65536, so a random search almost never reaches it. (Confirmed: deleting
+    /// the rule leaves the property test passing.)
+    #[test]
+    fn a_udp_checksum_that_updates_to_zero_is_written_as_ffff() {
+        use crate::checksum::Checksum;
+        use crate::headers::Transport;
+        use crate::udp::{Udp, UdpChecksum, UdpPort};
+        use std::num::NonZero;
+
+        let mut udp = Udp::new(
+            UdpPort::new(NonZero::new(1234).unwrap()),
+            UdpPort::new(NonZero::new(4321).unwrap()),
+        );
+        let start = 0x1234u16;
+        udp.set_checksum(UdpChecksum::new(start)).unwrap();
+        let mut transport = Transport::Udp(udp);
+
+        // Find the `new` value that drives the raw RFC 1624 update to exactly zero. Using the
+        // primitive to derive it keeps this test honest: it cannot pass by picking a number that
+        // happens not to matter.
+        let old_value = 0xABCDu16;
+        let zeroing = (0..=u16::MAX).find(|new_value| {
+            let Transport::Udp(probe) = &mut transport.clone() else {
+                unreachable!()
+            };
+            u16::from(probe.increment_update_checksum(
+                UdpChecksum::new(start),
+                old_value,
+                *new_value,
+            )) == 0
+        });
+        let zeroing = zeroing.expect("some new value drives the update to zero");
+
+        transport.increment_checksum_for_u16(old_value, zeroing);
+
+        let Transport::Udp(result) = &transport else {
+            unreachable!()
+        };
+        assert_eq!(
+            result.checksum().map(u16::from),
+            Some(u16::MAX),
+            "an incremental update that computes to 0 must be stored as 0xFFFF, or the datagram \
+             reads as having no checksum at all"
+        );
+    }
+
+    #[test]
+    fn incremental_update_matches_full_recompute() {
+        bolero::check!()
+            .with_generator(CommonHeaders)
+            .for_each(incremental_matches_recompute);
     }
 
     #[test]

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -52,6 +52,14 @@ fn make_default_for_transport(transport_type: Option<NextHeader>) -> Option<Tran
             let udp = Udp::new(123.try_into().unwrap(), 456.try_into().unwrap());
             Some(Transport::Udp(udp))
         }
+        // Echo requests, because they are the ICMP traffic NAT actually translates: the identifier
+        // is what stands in for a port, and it is covered by the ICMP checksum.
+        Some(NextHeader::ICMP) => Some(Transport::Icmp4(Icmp4::with_type(
+            crate::icmp4::Icmp4Type::EchoRequest(crate::icmp4::Icmp4EchoRequest { id: 18, seq: 2 }),
+        ))),
+        Some(NextHeader::ICMP6) => Some(Transport::Icmp6(Icmp6::with_type(
+            Icmp6Type::EchoRequest(crate::icmp6::Icmp6EchoRequest { id: 18, seq: 2 }),
+        ))),
         Some(transport_type) => {
             panic!("make_default_for_transport: Unsupported transport type: {transport_type:?}")
         }

--- a/routing/src/interfaces/iftable.rs
+++ b/routing/src/interfaces/iftable.rs
@@ -10,6 +10,7 @@ use ahash::RandomState;
 use net::interface::address::IfAddr;
 use std::collections::HashMap;
 
+use net::eth::mac::SourceMac;
 use net::interface::InterfaceIndex;
 #[allow(unused)]
 use tracing::{debug, error, info};
@@ -221,6 +222,18 @@ impl IfTable {
     pub(super) fn set_iface_admin_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         if let Some(ifr) = self.get_interface_mut(ifindex) {
             ifr.set_admin_state(state);
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    /// Update the link-layer address of an interface
+    ///
+    /// Only meaningful for interface types that have one: setting a MAC on a loopback would be
+    /// changing its type, which an address change is not entitled to do.
+    //////////////////////////////////////////////////////////////////////
+    pub(super) fn set_iface_mac(&mut self, ifindex: InterfaceIndex, mac: SourceMac) {
+        if let Some(ifr) = self.get_interface_mut(ifindex) {
+            ifr.set_mac(mac);
         }
     }
 }

--- a/routing/src/interfaces/iftablerw.rs
+++ b/routing/src/interfaces/iftablerw.rs
@@ -11,6 +11,7 @@ use crate::rib::vrf::VrfId;
 use crate::rib::vrftable::VrfTable;
 use left_right::ReadHandleFactory;
 use left_right::{Absorb, ReadGuard, ReadHandle, WriteHandle};
+use net::eth::mac::SourceMac;
 use net::interface::InterfaceIndex;
 use net::interface::address::IfAddr;
 
@@ -28,6 +29,7 @@ enum IfTableChange {
     DelIpAddress((InterfaceIndex, IfAddr)),
     UpdateOpState((InterfaceIndex, IfState)),
     UpdateAdmState((InterfaceIndex, IfState)),
+    UpdateMac((InterfaceIndex, SourceMac)),
 }
 impl Absorb<IfTableChange> for IfTable {
     fn absorb_first(&mut self, change: &mut IfTableChange, _: &Self) {
@@ -59,6 +61,9 @@ impl Absorb<IfTableChange> for IfTable {
             }
             IfTableChange::UpdateAdmState((ifindex, state)) => {
                 self.set_iface_admin_state(*ifindex, *state);
+            }
+            IfTableChange::UpdateMac((ifindex, mac)) => {
+                self.set_iface_mac(*ifindex, *mac);
             }
         }
     }
@@ -125,6 +130,10 @@ impl IfTableWriter {
     pub fn set_iface_admin_state(&mut self, ifindex: InterfaceIndex, state: IfState) {
         self.0
             .append(IfTableChange::UpdateAdmState((ifindex, state)));
+        self.0.publish();
+    }
+    pub fn set_iface_mac(&mut self, ifindex: InterfaceIndex, mac: SourceMac) {
+        self.0.append(IfTableChange::UpdateMac((ifindex, mac)));
         self.0.publish();
     }
 
@@ -611,5 +620,84 @@ mod iftable_properties {
                     check(&world, &model, &format!("at step {step} of {changes:?}"));
                 }
             });
+    }
+}
+
+#[cfg(test)]
+mod mac_change_test {
+    use super::*;
+    use crate::interfaces::interface::{IfDataEthernet, IfType, RouterInterfaceConfig};
+    use net::eth::mac::Mac;
+
+    /// A MAC set after the configuration was built must reach the readers.
+    ///
+    /// This is the shape of a real failure, not a hypothetical. A control-plane tap is created
+    /// with the kernel's random address, the configuration is built and captures *that*, and only
+    /// afterwards does the tap take its DPDK port's MAC. Nothing carried the change: `EthEvent`
+    /// had no MAC field, so the datapath went on comparing every arriving frame against an address
+    /// the interface no longer had, and dropped all of them as `MacNotForUs` -- measured on
+    /// hardware as 767 frames lost and an ARP that never resolved.
+    #[test]
+    fn a_mac_set_after_configuration_reaches_the_readers() {
+        // The random address a tap is born with...
+        let born = SourceMac::new(Mac([0x02, 0x11, 0x22, 0x33, 0x44, 0x55])).expect("valid");
+        // ...and the port's, which it takes afterwards.
+        let adopted = SourceMac::new(Mac([0x58, 0xa2, 0xe1, 0xb3, 0x3d, 0x94])).expect("valid");
+        let ifindex = InterfaceIndex::try_new(2).expect("valid");
+
+        let (mut writer, reader) = IfTableWriter::new();
+        let mut config = RouterInterfaceConfig::new("enp2s1np0", ifindex);
+        config.set_iftype(IfType::Ethernet(IfDataEthernet { mac: born }));
+        writer
+            .add_interface(config)
+            .expect("could not add the interface");
+
+        assert_eq!(
+            reader
+                .enter()
+                .expect("a reader")
+                .get_interface(ifindex)
+                .expect("the interface")
+                .get_mac(),
+            Some(born),
+            "the table should start with the address the configuration captured"
+        );
+
+        writer.set_iface_mac(ifindex, adopted);
+
+        assert_eq!(
+            reader
+                .enter()
+                .expect("a reader")
+                .get_interface(ifindex)
+                .expect("the interface")
+                .get_mac(),
+            Some(adopted),
+            "the new address must reach readers, or the datapath drops every frame for itself"
+        );
+    }
+
+    /// An address change must not be able to change what kind of interface something is.
+    #[test]
+    fn setting_a_mac_on_a_loopback_is_ignored() {
+        let mac = SourceMac::new(Mac([0x58, 0xa2, 0xe1, 0xb3, 0x3d, 0x94])).expect("valid");
+        let ifindex = InterfaceIndex::try_new(1).expect("valid");
+
+        let (mut writer, reader) = IfTableWriter::new();
+        let mut config = RouterInterfaceConfig::new("lo", ifindex);
+        config.set_iftype(IfType::Loopback);
+        writer
+            .add_interface(config)
+            .expect("could not add the interface");
+
+        writer.set_iface_mac(ifindex, mac);
+
+        let table = reader.enter().expect("a reader");
+        let iface = table.get_interface(ifindex).expect("the interface");
+        assert_eq!(iface.get_mac(), None, "a loopback still has no MAC");
+        assert!(
+            matches!(iface.iftype, IfType::Loopback),
+            "and is still a loopback"
+        );
     }
 }

--- a/routing/src/interfaces/interface.rs
+++ b/routing/src/interfaces/interface.rs
@@ -237,6 +237,23 @@ impl Interface {
     }
 
     //////////////////////////////////////////////////////////////////
+    /// Replace the link-layer address, keeping the interface's type
+    ///
+    /// Ignored for a type that has no address: an address change is not entitled to turn a
+    /// loopback into an Ethernet interface. The datapath compares every arriving frame's
+    /// destination against this, so an interface whose MAC changes after the configuration was
+    /// built -- a control-plane tap taking its port's address, say -- drops every frame meant for
+    /// itself as `MacNotForUs` until this is applied.
+    //////////////////////////////////////////////////////////////////
+    pub fn set_mac(&mut self, mac: SourceMac) {
+        match &mut self.iftype {
+            IfType::Ethernet(inner) => inner.mac = mac,
+            IfType::Dot1q(inner) => inner.mac = mac,
+            IfType::Unknown | IfType::Loopback | IfType::Vxlan => {}
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////
     /// Get the MAC address of an [`Interface`], if any
     //////////////////////////////////////////////////////////////////
     #[must_use]

--- a/routing/src/router/ctl.rs
+++ b/routing/src/router/ctl.rs
@@ -252,7 +252,7 @@ fn handle_config(rio: &mut Rio, config: Arc<ValidatedGwConfig>) {
 fn handle_config_history(rio: &mut Rio, history: Arc<Vec<GwConfigMeta>>) {
     rio.cfg_history = history;
 }
-fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
+fn handle_ifevent(ev: &EthEvent, db: &mut RoutingDb) {
     let iftw = &mut db.iftw;
     let adm_state = if ev.ifup { IfState::Up } else { IfState::Down };
     let oper_state = if ev.iflowerup && ev.ifrunning && ev.carrier {
@@ -261,6 +261,9 @@ fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
         IfState::Down
     };
     let ifindex = ev.ifindex;
+    // Decided inside the read guard, applied outside it: the writer cannot be used while a read
+    // handle is open.
+    let mut mac_change = None;
     if let Some(iftable) = iftw.enter() {
         let Some(iface) = iftable.get_interface(ifindex) else {
             return;
@@ -273,11 +276,37 @@ fn handle_ifevent(ev: EthEvent, db: &mut RoutingDb) {
             ));
         }
         if iface.oper_state != oper_state {
-            revent!(RouterEvent::IfOperChange(ev, iface.oper_state, oper_state));
+            revent!(RouterEvent::IfOperChange(
+                ev.clone(),
+                iface.oper_state,
+                oper_state
+            ));
+        }
+        // A MAC that changed after the configuration was built. The datapath tests every arriving
+        // frame's destination against this address, so until it is applied the interface drops
+        // every unicast frame meant for it as `MacNotForUs` -- which is what a control-plane tap
+        // does between taking its random birth address and being given its port's.
+        //
+        // `None` means the message carried no address attribute, not that the address was removed.
+        if let Some(mac) = ev.mac
+            && iface.get_mac() != Some(mac)
+        {
+            info!(
+                "Interface {} ({}) changed mac {} -> {mac}",
+                ev.name,
+                ifindex,
+                iface
+                    .get_mac()
+                    .map_or_else(|| "none".to_string(), |m| m.to_string())
+            );
+            mac_change = Some(mac);
         }
     }
     iftw.set_iface_admin_state(ifindex, adm_state);
     iftw.set_iface_oper_state(ifindex, oper_state);
+    if let Some(mac) = mac_change {
+        iftw.set_iface_mac(ifindex, mac);
+    }
 }
 
 fn handle_bgp_peer_status_change(bgp_ev: BgpNeighEvent) {
@@ -304,7 +333,7 @@ pub(crate) fn handle_ctl_msg(rio: &mut Rio, db: &mut RoutingDb) {
             }
             Ok(RouterCtlMsg::Config(config)) => handle_config(rio, config),
             Ok(RouterCtlMsg::ConfigHistory(history)) => handle_config_history(rio, history),
-            Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(ev, db),
+            Ok(RouterCtlMsg::IfEvent(ev)) => handle_ifevent(&ev, db),
             Ok(RouterCtlMsg::BgpNeighStatus(bgp_ev)) => handle_bgp_peer_status_change(bgp_ev),
             Err(TryRecvError::Empty) => break,
             Err(e) => {

--- a/scripts/send_checksum_frames.py
+++ b/scripts/send_checksum_frames.py
@@ -1,0 +1,55 @@
+"""Send frames whose IP and/or UDP checksums are deliberately correct or corrupt.
+
+    send_checksum_frames.py <netdev> <dst-mac> good|bad-ip|bad-l4|bad-both <count>
+
+One corruption at a time, on purpose. A NIC that stamps GOOD unconditionally is
+indistinguishable from a working offload unless you can compare the modes -- and
+isolating IP from L4 is what showed that mlx5 reports the two independently.
+
+Companion to dpdk/examples/checksum_offload_probe.rs. Send *after* the probe is
+polling: EAL start-up in a container takes ~10s, and frames sent before then are
+simply lost.
+"""
+import socket, struct, sys
+
+dev, dst_mac, mode, count = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+dst = bytes.fromhex(dst_mac.replace(":", ""))
+src = bytes.fromhex("020000000002")
+
+def csum(b):
+    if len(b) % 2:
+        b += b"\x00"
+    s = sum(struct.unpack("!%dH" % (len(b) // 2), b))
+    while s >> 16:
+        s = (s & 0xFFFF) + (s >> 16)
+    return (~s) & 0xFFFF
+
+def frame(i, bad_ip, bad_l4):
+    payload = bytes(((i + j) & 0xFF) for j in range(64))
+    saddr = struct.pack("!BBBB", 10, 0, (i >> 8) & 0xFF, i & 0xFF)
+    daddr = struct.pack("!BBBB", 10, 1, 0, 1)
+    sport, dport = 4000 + (i % 1000), 4789
+    # UDP with a real checksum over the pseudo-header + payload.
+    udp_len = 8 + len(payload)
+    pseudo = saddr + daddr + struct.pack("!BBH", 0, 17, udp_len)
+    udp_nocsum = struct.pack("!HHHH", sport, dport, udp_len, 0) + payload
+    ucs = csum(pseudo + udp_nocsum) or 0xFFFF
+    if bad_l4:
+        ucs ^= 0xBEEF          # deliberately wrong L4 checksum
+    udp = struct.pack("!HHHH", sport, dport, udp_len, ucs) + payload
+
+    total = 20 + udp_len
+    hdr = struct.pack("!BBHHHBBH", 0x45, 0, total, i & 0xFFFF, 0, 64, 17, 0) + saddr + daddr
+    ics = csum(hdr)
+    if bad_ip:
+        ics ^= 0x1234          # deliberately wrong IP checksum
+    hdr = hdr[:10] + struct.pack("!H", ics) + hdr[12:]
+    return dst + src + b"\x08\x00" + hdr + udp
+
+s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+s.bind((dev, 0))
+bad_ip = mode in ("bad-ip", "bad-both")
+bad_l4 = mode in ("bad-l4", "bad-both")
+for i in range(count):
+    s.send(frame(i, bad_ip, bad_l4))
+print(f"sent {count} frames on {dev} to {dst_mac} (mode={mode}: bad_ip={bad_ip} bad_l4={bad_l4})")

--- a/stats/src/lib.rs
+++ b/stats/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod dpstats;
 mod dpstats_fuzz;
+mod port;
 mod rate;
 mod rate_fuzz;
 mod register;
@@ -16,6 +17,7 @@ mod vpc_stats;
 mod vpc_stats_fuzz;
 
 pub use dpstats::*;
+pub use port::*;
 pub use rate::*;
 pub use register::*;
 pub use spec::*;

--- a/stats/src/port.rs
+++ b/stats/src/port.rs
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Open Network Fabric Authors
+
+//! Counters the *device* keeps for a network port, as opposed to the ones the pipeline keeps.
+//!
+//! Everything else in this crate counts what the dataplane did with a packet. These count what
+//! happened before the dataplane ever saw it, which is the only place some failures are visible at
+//! all: a frame the NIC dropped for want of a free receive descriptor never reaches a worker, is
+//! never parsed, and is absent from every pipeline counter. Without
+//! [`rx_missed`](PortCounters::rx_missed) and [`rx_no_mbuf`](PortCounters::rx_no_mbuf) the symptom
+//! of an overloaded dataplane is indistinguishable from a quiet wire.
+//!
+//! That distinction is the whole reason this module exists: it is what makes a load test mean
+//! something.
+//!
+//! # Why counters and not gauges
+//!
+//! A device reports these cumulatively, monotonically increasing since the port started. That is
+//! exactly a Prometheus counter, so they are published with
+//! [`Counter::absolute`](metrics::Counter::absolute) rather than accumulated with `increment`.
+//! Publishing an absolute value is also idempotent, which matters because the poller is a timer:
+//! a missed tick loses resolution but never loses count, and a doubled tick cannot double-count.
+//!
+//! # Why the counters are a plain struct
+//!
+//! [`PortCounters`] deliberately names no DPDK type. This crate does not depend on `dpdk` and
+//! should not: a port's counters are not a DPDK concept, and the kernel driver has the same
+//! question to answer about its own interfaces. The driver converts.
+
+use crate::register::{Register, Registered};
+use crate::spec::MetricSpec;
+use metrics::Unit;
+
+/// Base id of the port counter metric family. Every series below is `{BASE}_{suffix}`.
+pub(crate) const PORT_METRIC_BASE: &str = "port";
+
+/// A snapshot of the counters a device keeps for one port.
+///
+/// Cumulative since the port started, not deltas.
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct PortCounters {
+    /// Packets the port received and delivered to the dataplane.
+    pub rx_packets: u64,
+    /// Packets the port transmitted.
+    pub tx_packets: u64,
+    /// Bytes the port received.
+    pub rx_bytes: u64,
+    /// Bytes the port transmitted.
+    pub tx_bytes: u64,
+    /// Packets the port had and dropped because no receive descriptor was free.
+    ///
+    /// "The wire delivered it and we were not keeping up." This is the counter that says a
+    /// dataplane is overloaded, and it is invisible to every pipeline counter because the packet
+    /// never reached a worker.
+    pub rx_missed: u64,
+    /// Erroneous packets received.
+    pub rx_errors: u64,
+    /// Packets that failed to transmit.
+    pub tx_errors: u64,
+    /// Receive mbuf allocation failures.
+    ///
+    /// "The pool was too small." Distinct from [`rx_missed`](Self::rx_missed), which is the
+    /// application being too slow rather than the pool being too small -- the remedies differ
+    /// (more workers or queues, versus a bigger pool), so the two must not be summed.
+    pub rx_no_mbuf: u64,
+}
+
+/// Registered metric handles for one port.
+///
+/// Registration is configuration work and publishing follows traffic, so the handles are built
+/// once when a port comes up and reused for every poll. Re-registering per publish is what made
+/// the VPC collector quadratic, and there is no reason to repeat it here.
+#[derive(Debug)]
+pub struct PortMetrics {
+    rx_packets: Registered<metrics::Counter>,
+    tx_packets: Registered<metrics::Counter>,
+    rx_bytes: Registered<metrics::Counter>,
+    tx_bytes: Registered<metrics::Counter>,
+    rx_missed: Registered<metrics::Counter>,
+    rx_errors: Registered<metrics::Counter>,
+    tx_errors: Registered<metrics::Counter>,
+    rx_no_mbuf: Registered<metrics::Counter>,
+}
+
+impl PortMetrics {
+    /// Register the counter family for the port named `port`.
+    ///
+    /// `port` is the configured interface name, which is what the rest of the system -- the
+    /// routing tables, the control-plane bridge, the operator -- knows the port by. Deliberately
+    /// not the DPDK port index, which is only the order the EAL happened to probe in and would
+    /// change between runs.
+    #[must_use]
+    pub fn new(port: &str) -> PortMetrics {
+        let counter = |suffix: &str, unit: Unit, description: &str| {
+            let mut spec = MetricSpec::new(
+                format!("{PORT_METRIC_BASE}_{suffix}"),
+                unit,
+                vec![("port".to_string(), port.to_string())],
+            );
+            spec.description = description.to_string();
+            spec.register()
+        };
+
+        PortMetrics {
+            rx_packets: counter("rx_packets", Unit::Count, "packets received by the port"),
+            tx_packets: counter("tx_packets", Unit::Count, "packets transmitted by the port"),
+            rx_bytes: counter("rx_bytes", Unit::Bytes, "bytes received by the port"),
+            tx_bytes: counter("tx_bytes", Unit::Bytes, "bytes transmitted by the port"),
+            rx_missed: counter(
+                "rx_missed",
+                Unit::Count,
+                "packets dropped by the port for want of a free receive descriptor; \
+                 the dataplane is not keeping up",
+            ),
+            rx_errors: counter("rx_errors", Unit::Count, "erroneous packets received"),
+            tx_errors: counter("tx_errors", Unit::Count, "packets that failed to transmit"),
+            rx_no_mbuf: counter(
+                "rx_no_mbuf",
+                Unit::Count,
+                "receive mbuf allocation failures; the port's pool is too small",
+            ),
+        }
+    }
+
+    /// Publish a counter snapshot.
+    ///
+    /// Absolute rather than incremental: see the module docs.
+    pub fn publish(&self, counters: &PortCounters) {
+        self.rx_packets.metric.absolute(counters.rx_packets);
+        self.tx_packets.metric.absolute(counters.tx_packets);
+        self.rx_bytes.metric.absolute(counters.rx_bytes);
+        self.tx_bytes.metric.absolute(counters.tx_bytes);
+        self.rx_missed.metric.absolute(counters.rx_missed);
+        self.rx_errors.metric.absolute(counters.rx_errors);
+        self.tx_errors.metric.absolute(counters.tx_errors);
+        self.rx_no_mbuf.metric.absolute(counters.rx_no_mbuf);
+    }
+}
+
+#[cfg(test)]
+mod exported {
+    use super::*;
+    use crate::scrape::Scrape;
+
+    /// A series suffix paired with the accessor for the field it must carry.
+    type CounterUnderTest = (&'static str, fn(&PortCounters) -> u64);
+
+    /// Every counter this module publishes.
+    const EVERY_COUNTER: [CounterUnderTest; 8] = [
+        ("rx_packets", |c| c.rx_packets),
+        ("tx_packets", |c| c.tx_packets),
+        ("rx_bytes", |c| c.rx_bytes),
+        ("tx_bytes", |c| c.tx_bytes),
+        ("rx_missed", |c| c.rx_missed),
+        ("rx_errors", |c| c.rx_errors),
+        ("tx_errors", |c| c.tx_errors),
+        ("rx_no_mbuf", |c| c.rx_no_mbuf),
+    ];
+
+    /// Distinct values throughout, so a counter wired to the wrong field cannot pass by accident.
+    fn distinct() -> PortCounters {
+        PortCounters {
+            rx_packets: 11,
+            tx_packets: 22,
+            rx_bytes: 33,
+            tx_bytes: 44,
+            rx_missed: 55,
+            rx_errors: 66,
+            tx_errors: 77,
+            rx_no_mbuf: 88,
+        }
+    }
+
+    fn published(scrape: &Scrape, suffix: &str, port: &str) -> Option<u64> {
+        scrape.counter(&format!("{PORT_METRIC_BASE}_{suffix}"), &[("port", port)])
+    }
+
+    /// Every field reaches its own series, under the port's name.
+    ///
+    /// The values are all different, so this fails if any two counters are crossed -- which a
+    /// same-value snapshot would happily accept.
+    #[test]
+    fn every_counter_reaches_its_own_series() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            PortMetrics::new("eth0").publish(&distinct());
+        });
+
+        let counters = distinct();
+        for (suffix, field) in EVERY_COUNTER {
+            assert_eq!(
+                published(&scrape, suffix, "eth0"),
+                Some(field(&counters)),
+                "port_{suffix} did not export the value it was given"
+            );
+        }
+    }
+
+    /// The counters a device reports are cumulative, so publishing the same snapshot twice must
+    /// leave the series where it was. Using `increment` instead of `absolute` would double it --
+    /// and would keep doubling on every poll, which is the failure this guards.
+    #[test]
+    fn republishing_a_snapshot_does_not_accumulate() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            let metrics = PortMetrics::new("eth0");
+            metrics.publish(&distinct());
+            metrics.publish(&distinct());
+            metrics.publish(&distinct());
+        });
+
+        assert_eq!(published(&scrape, "rx_packets", "eth0"), Some(11));
+        assert_eq!(published(&scrape, "rx_missed", "eth0"), Some(55));
+    }
+
+    /// A later, larger reading advances the series -- the ordinary case, and the one that would
+    /// break if `absolute` were mistaken for "set once".
+    #[test]
+    fn a_later_reading_advances_the_counter() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            let metrics = PortMetrics::new("eth0");
+            metrics.publish(&PortCounters {
+                rx_packets: 10,
+                ..PortCounters::default()
+            });
+            metrics.publish(&PortCounters {
+                rx_packets: 1_000,
+                ..PortCounters::default()
+            });
+        });
+
+        assert_eq!(published(&scrape, "rx_packets", "eth0"), Some(1_000));
+    }
+
+    /// Two ports get two independent series, distinguished by the `port` label.
+    ///
+    /// Sharing a series would silently sum the ports, which reads as one very busy port and hides
+    /// an idle one entirely.
+    #[test]
+    fn each_port_gets_its_own_series() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            PortMetrics::new("eth0").publish(&PortCounters {
+                rx_packets: 10,
+                ..PortCounters::default()
+            });
+            PortMetrics::new("eth1").publish(&PortCounters {
+                rx_packets: 4_000,
+                ..PortCounters::default()
+            });
+        });
+
+        assert_eq!(published(&scrape, "rx_packets", "eth0"), Some(10));
+        assert_eq!(published(&scrape, "rx_packets", "eth1"), Some(4_000));
+    }
+
+    /// Registration happens when the port comes up, not on every publish.
+    ///
+    /// Re-registering per publish is what made the VPC collector quadratic. One `PortMetrics` is
+    /// eight series however many times it publishes.
+    #[test]
+    fn publishing_does_not_re_register() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            let metrics = PortMetrics::new("eth0");
+            let after_registration = scrape.registrations();
+            assert_eq!(
+                after_registration,
+                EVERY_COUNTER.len(),
+                "a port should register exactly one series per counter"
+            );
+            for _ in 0..50 {
+                metrics.publish(&distinct());
+            }
+            assert_eq!(
+                scrape.registrations(),
+                after_registration,
+                "publishing re-registered the metric family"
+            );
+        });
+    }
+
+    /// Every series carries exactly the `port` label and nothing else.
+    ///
+    /// Two registration sites disagreeing about the base label set has happened before in this
+    /// crate and produced series with a duplicated label, so the shape is worth pinning.
+    #[test]
+    fn every_series_has_exactly_the_port_label() {
+        let scrape = Scrape::default();
+        metrics::with_local_recorder(&scrape, || {
+            PortMetrics::new("eth0").publish(&distinct());
+        });
+
+        for (suffix, _) in EVERY_COUNTER {
+            let shapes = scrape.label_shapes(&format!("{PORT_METRIC_BASE}_{suffix}"));
+            assert_eq!(
+                shapes,
+                [vec!["port".to_string()]].into_iter().collect(),
+                "port_{suffix} has the wrong label shape"
+            );
+        }
+    }
+}

--- a/stats/src/scrape.rs
+++ b/stats/src/scrape.rs
@@ -12,11 +12,23 @@ pub(crate) type SeriesId = (String, Labels);
 
 pub(crate) type Series = BTreeMap<SeriesId, f64>;
 
+/// Counters are kept separately from gauges and as `u64`.
+///
+/// Not folded into [`Series`] as `f64`: a counter is exactly an integer, and the port counters
+/// this records are device totals that can legitimately exceed `2^53`, where `f64` silently stops
+/// being able to represent consecutive values.
+///
+/// Worth knowing when reading older tests against this recorder: until the `port_*` family needed
+/// them, counters were recorded **nowhere**. `register_counter` returned `metrics::Counter::noop()`,
+/// so any assertion about a counter passed whatever the code under test did.
+pub(crate) type Counters = BTreeMap<SeriesId, u64>;
+
 pub(crate) type Shape = (String, Vec<String>);
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Scrape {
     held: Arc<Mutex<Series>>,
+    counters: Arc<Mutex<Counters>>,
     shapes: Arc<Mutex<BTreeSet<Shape>>>,
     registrations: Arc<AtomicUsize>,
 }
@@ -28,6 +40,21 @@ impl Scrape {
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect();
         self.held().get(&(name.to_string(), labels)).copied()
+    }
+
+    /// The current value of a counter series, or `None` if it was never registered.
+    ///
+    /// Separate from [`get`](Self::get), which reads gauges. Asking for a counter through `get`
+    /// returns `None` rather than silently reading a different series.
+    pub(crate) fn counter(&self, name: &str, labels: &[(&str, &str)]) -> Option<u64> {
+        let labels: Labels = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        self.counters
+            .lock()
+            .get(&(name.to_string(), labels))
+            .copied()
     }
 
     pub(crate) fn label_shapes(&self, name: &str) -> BTreeSet<Vec<String>> {
@@ -98,6 +125,35 @@ impl metrics::GaugeFn for Cell {
     }
 }
 
+/// A counter cell.
+///
+/// `absolute` takes the **maximum** rather than overwriting, which is the contract `CounterFn`
+/// documents and what `AtomicU64` (the reference implementation every real recorder uses) does:
+/// a counter may not go backwards, so a late-arriving smaller reading must not lower it. A test
+/// recorder that simply assigned would accept publishing code that a real recorder rejects.
+#[derive(Debug)]
+struct CounterCell {
+    at: SeriesId,
+    into: Arc<Mutex<Counters>>,
+}
+
+impl CounterCell {
+    fn with(&self, f: impl FnOnce(&mut u64)) {
+        let mut held = self.into.lock();
+        f(held.entry(self.at.clone()).or_insert(0));
+    }
+}
+
+impl metrics::CounterFn for CounterCell {
+    fn increment(&self, value: u64) {
+        self.with(|held| *held = held.saturating_add(value));
+    }
+
+    fn absolute(&self, value: u64) {
+        self.with(|held| *held = (*held).max(value));
+    }
+}
+
 impl metrics::Recorder for Scrape {
     fn describe_counter(
         &self,
@@ -123,8 +179,22 @@ impl metrics::Recorder for Scrape {
     ) {
     }
 
-    fn register_counter(&self, _: &metrics::Key, _: &metrics::Metadata<'_>) -> metrics::Counter {
-        metrics::Counter::noop()
+    fn register_counter(&self, key: &metrics::Key, _: &metrics::Metadata<'_>) -> metrics::Counter {
+        let labels = key
+            .labels()
+            .map(|label| (label.key().to_string(), label.value().to_string()))
+            .collect();
+        let at = (key.name().to_string(), labels);
+        self.registrations.fetch_add(1, Ordering::Relaxed);
+        self.shapes.lock().insert((
+            key.name().to_string(),
+            key.labels().map(|label| label.key().to_string()).collect(),
+        ));
+        self.counters.lock().entry(at.clone()).or_insert(0);
+        metrics::Counter::from_arc(Arc::new(CounterCell {
+            at,
+            into: self.counters.clone(),
+        }))
     }
 
     fn register_gauge(&self, key: &metrics::Key, _: &metrics::Metadata<'_>) -> metrics::Gauge {


### PR DESCRIPTION
> **Draft / do-not-merge.** This is proof-of-concept work to de-risk the DPDK driver's path to
> production and to make a fair kernel-vs-DPDK benchmark possible. It is one WIP commit covering
> five separable pieces; it wants splitting into a proper series before it is reviewable, and the
> git history is deliberately not clean yet.
>
> Purpose of this PR: build a release image and put it through vlab. If that is green, a benchmark
> gets scheduled.

Based on `pr/daniel-noland/dpdk-reconciled`.

## What is in it

**RSS is on.** The driver configured `rss: None`, so every frame landed on receive queue 0 and one
worker did all the work however many were configured. Now a standard Toeplitz key over whatever
subset of L3/L4 the device advertises, with `RSS_HASH` so the NIC reports the hash it steered by.
Measured on a BlueField-3: 4 workers, 40 000 frames, **9941 / 10050 / 10054 / 9955**. With RSS
disabled the same run puts all of it on worker 0.

Deliberately *not* symmetric. mlx5 rejects any hash function but the default at
`rte_eth_dev_configure` (symmetric Toeplitz is reachable only through the `rte_flow` RSS action),
and it would not help anyway: a NAT'd flow's reverse packet carries the *translated* tuple, not the
reversed one. Flow state lives in one shared `FlowTable`, so it does not need to.

**Port counters reach Prometheus.** `Dev::stats()` existed and was read only by a hardware test, so
`imissed` / `rx_nombuf` — the counters that distinguish "the wire is quiet" from "we are dropping" —
were invisible. Eight `port_*` counters now, polled by the DPDK supervisor (the only thread that
*can*: `Dev::stats` needs an `'eal`-branded device and `Eal` is `!Send`).

**Workers register as EAL lcores.** They were plain threads reporting `LCORE_ID_ANY`, for which
`rte_mempool_default_cache` returns `NULL` — so every `alloc_bulk` and every mbuf free went to the
shared ring under atomics, on every burst, both directions. The registration is now a `!Send +
!Sync` capability token (`dpdk::lcore::LCore`) that gates the APIs which genuinely require it; the
first of those is the new `dpdk::power`, the primitives for a halfway
interrupt/poll receive loop.

**Incremental NAT checksums (RFC 1624).** The algorithm already existed and was used for ICMP error
quoted headers, where a full recompute is impossible. The main NAT path did not use it: every
translation set `checksum_refresh`, and `ipforward` re-summed the whole payload. All four paths
(`masquerade` snat/dnat, `portfw` snat/dnat, `static_nat`) now fold the change in incrementally.
This is software, so **both drivers benefit** — which is what makes the comparison fair.

**Six hardware probes**, so these findings fail loudly on a DPDK bump rather than rotting:
`rss_capability`, `lcore_role`, `lcore_capacity`, `power_monitor`, `flow_async_lcore`,
`checksum_offload`.

## Verification

827 tests, clippy and rustdoc clean. Everything hardware-dependent was measured on the workstation
BF3, not inferred. Every new test was break-tested — several were vacuous on the first attempt and
are noted as such in the code.

## Known gaps, deliberately left

- **ICMP-error branches in `static_nat`** stay on the full recompute. `icmp_error_msg` maintains the
  embedded headers incrementally and claims the outer ICMP checksum is not touched again at
  deparse, but that checksum covers the whole quoted packet and proving the two agree needs its own
  test. Correct and slower is the right default for a rare path.
- **Workers are registered but not pinned.** `rte_thread_register` reads affinity and never sets it.
  Pinning needs a policy decision (which CPU, NUMA relative to the port, container cpuset,
  `isolcpus`) and is worth doing against a load test — which `port_rx_missed` now makes possible.
- **VXLAN checksum offload is unmeasured.** The offload probe covered plain IPv4/UDP; this is a
  VXLAN gateway and `OUTER_*_CKSUM` is unsupported on receive, so what mlx5 reports for the inner
  headers of an encapsulated frame is genuinely open.
- **The async `rte_flow` check could not be completed on this card** — it is not in switchdev/HWS
  mode, and both the new probe and the pre-existing `template_probe` SIGSEGV identically at the
  first HWS call. Source says the async engine has no lcore coupling at all (zero references in
  `lib/ethdev/rte_flow.c` *or* `mlx5_flow_hw.c`); the hardware confirmation is outstanding.
- The CI `EXPERIMENT (dpdk in vlab)` scaffolding inherited from the base branch still needs
  reverting before any of this merges.
