### PR TITLE
incremental checksums

### DIFF
--- a/nat/src/masquerade/nf.rs
+++ b/nat/src/masquerade/nf.rs
@@ -582,9 +582,13 @@ impl Masquerade {
         if let Err(error) = self.masquerade_packet(packet) {
             packet.done((&error).into());
             debug!("Did not masquerade packet: {error}");
-        } else {
-            packet.meta_mut().set_checksum_refresh(true);
         }
+        // Deliberately *not* setting `checksum_refresh` on success. `snat`/`dnat` fold their own
+        // changes into the transport checksum incrementally and set the flag only where they
+        // cannot. Setting it here unconditionally -- as this did -- silently reinstated the full
+        // payload sum for every masqueraded packet, so the incremental work was done and then
+        // thrown away. Nothing failed, which is why it survived: the packets were correct, just
+        // needlessly expensive.
     }
 }
 

--- a/nat/src/masquerade/packet.rs
+++ b/nat/src/masquerade/packet.rs
@@ -22,9 +22,9 @@ pub(crate) enum NatPacketError {
     UpdateNet(#[from] NetError),
     #[error("Failed to update transport header")]
     UpdateTransport(#[from] TransportError),
-    #[error("Failed to update ICMPv4 header")]
+    #[error("Failed to update `ICMPv4` header")]
     UpdateIcmpv4(#[from] Icmp4Error),
-    #[error("Failed to update ICMPv6 header")]
+    #[error("Failed to update `ICMPv6` header")]
     UpdateIcmpv6(#[from] Icmp6Error),
     #[error("Failed to NAT packet: unsupported traffic")]
     UnsupportedTraffic,
@@ -41,6 +41,10 @@ fn snat<Buf: PacketBufferMut>(
         UnicastIpAddr::try_from(new_src_ip).map_err(|_| NatPacketError::UnusableAddress)?;
 
     let mut modified = false;
+    // Set only where an incremental update is not possible (an ICMP path that carries no usable
+    // old value, or an IP version change). `ipforward` then does the full payload recompute; the
+    // ordinary case skips it entirely.
+    let mut needs_full_recompute = false;
     match packet
         .headers_mut()
         .pat_mut()
@@ -50,41 +54,57 @@ fn snat<Buf: PacketBufferMut>(
         .done()
     {
         Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
-            if ip.src_addr() != new_src_ip {
+            // Both fields are covered by the TCP/UDP pseudo-header, so each change is folded into
+            // the transport checksum incrementally (RFC 1624) rather than by re-summing the
+            // payload. The old value has to be read *before* the set, which is the only reason
+            // these are bound rather than compared inline.
+            let old_addr = ip.src_addr();
+            if old_addr != new_src.inner() {
                 ip.try_set_source(new_src)?;
-                modified = true;
+                if tp.increment_checksum_for_address(old_addr, new_src.inner()) {
+                    modified = true;
+                } else {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                    modified = true;
+                }
             }
             if let NatPort::Port(port) = natport {
+                let old_port = tp.src_port();
                 tp.try_set_source(port)?;
+                if let Some(old_port) = old_port {
+                    tp.increment_checksum_for_u16(old_port.get(), port.get());
+                } else {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
         Some((_, Net::Ipv6(_), Transport::Icmp4(_)) | (_, Net::Ipv4(_), Transport::Icmp6(_))) => {
             return Err(NatPacketError::UnsupportedTraffic);
         }
-        Some((_, ip, Transport::Icmp4(icmp))) => {
-            if ip.src_addr() != new_src_ip {
+        // Matched on the `Transport` rather than destructured into the inner `Icmp4`/`Icmp6`, so
+        // the checksum helpers -- which know that `ICMPv4` has no pseudo-header and `ICMPv6` does --
+        // stay reachable. Destructuring hands out an `&mut Icmp4`, which cannot answer that
+        // question, and that is precisely how the two get confused.
+        Some((_, ip, tp)) if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) => {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src.inner() {
                 ip.try_set_source(new_src)?;
+                // A no-op for `ICMPv4` (the address is not covered) and a real delta for `ICMPv6`.
+                if !tp.increment_checksum_for_address(old_addr, new_src.inner()) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
+                && let Some(current) = tp.identifier()
                 && current != id
             {
-                icmp.try_set_identifier(id)?;
-                modified = true;
-            }
-        }
-        Some((_, ip, Transport::Icmp6(icmp))) => {
-            if ip.src_addr() != new_src_ip {
-                ip.try_set_source(new_src)?;
-                modified = true;
-            }
-            if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
-                && current != id
-            {
-                icmp.try_set_identifier(id)?;
+                tp.try_set_identifier(id)?;
+                // The identifier lives inside the ICMP header, which the ICMP checksum covers --
+                // for both versions.
+                tp.increment_checksum_for_u16(current, id);
                 modified = true;
             }
         }
@@ -92,7 +112,7 @@ fn snat<Buf: PacketBufferMut>(
     }
     if modified {
         packet.meta_mut().src_natted(true);
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
     }
     Ok(())
 }
@@ -103,6 +123,9 @@ fn dnat<Buf: PacketBufferMut>(
     natport: NatPort,
 ) -> Result<(), NatPacketError> {
     let mut modified = false;
+    // See `snat`: set only where an incremental update is impossible, so the ordinary case skips
+    // the full payload recompute in `ipforward`.
+    let mut needs_full_recompute = false;
 
     match packet
         .headers_mut()
@@ -114,12 +137,23 @@ fn dnat<Buf: PacketBufferMut>(
     {
         // ipv4|ipv6 + UDP/TCP
         Some((_, ip, tp)) if matches!(tp, Transport::Udp(_) | Transport::Tcp(_)) => {
-            if ip.dst_addr() != new_dst_ip {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Port(port) = natport {
+                let old_port = tp.dst_port();
                 tp.try_set_destination(port)?;
+                if let Some(old_port) = old_port {
+                    tp.increment_checksum_for_u16(old_port.get(), port.get());
+                } else {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -127,32 +161,26 @@ fn dnat<Buf: PacketBufferMut>(
             return Err(NatPacketError::UnsupportedTraffic);
         }
 
-        // ipv4 + Icmp4
-        Some((_, ip, Transport::Icmp4(icmp))) => {
-            if ip.dst_addr() != new_dst_ip {
+        // `ICMPv4` and `ICMPv6`. Matched on the `Transport` rather than destructured, so the checksum
+        // helpers can apply the rule that differs between them: `ICMPv4` has no pseudo-header and so
+        // is untouched by an address change, `ICMPv6` has one and is not.
+        Some((_, ip, tp)) if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) => {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
+                && let Some(current) = tp.identifier()
                 && current != id
             {
-                icmp.try_set_identifier(id)?;
-                modified = true;
-            }
-        }
-
-        // ipv6 + Icmp6
-        Some((_, ip, Transport::Icmp6(icmp))) => {
-            if ip.dst_addr() != new_dst_ip {
-                ip.try_set_destination(new_dst_ip)?;
-                modified = true;
-            }
-            if let NatPort::Identifier(id) = natport
-                && let Some(current) = icmp.identifier()
-                && current != id
-            {
-                icmp.try_set_identifier(id)?;
+                tp.try_set_identifier(id)?;
+                // The identifier is inside the ICMP header, which the checksum covers, for both
+                // versions.
+                tp.increment_checksum_for_u16(current, id);
                 modified = true;
             }
         }
@@ -161,7 +189,7 @@ fn dnat<Buf: PacketBufferMut>(
 
     if modified {
         packet.meta_mut().dst_natted(true);
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
     }
     Ok(())
 }
@@ -191,5 +219,175 @@ pub(super) fn masquerade<Buf: PacketBufferMut>(
     match xlate.action {
         NatAction::SrcNat => snat(packet, xlate.use_ip, xlate.nat_port),
         NatAction::DstNat => dnat(packet, xlate.use_ip, xlate.nat_port),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod checksum_test {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::checksum::Checksum;
+    use net::headers::{TryHeaders, TryTransport};
+    use net::ip::NextHeader;
+    use net::packet::test_utils::build_test_tcp_ipv4_packet;
+    use std::num::NonZero;
+
+    /// Same requirement, for the ICMP paths.
+    ///
+    /// Separate from the TCP case because the rules differ and getting them confused is exactly how
+    /// this breaks: an **`ICMPv4`** checksum does not cover the address (no pseudo-header) but *does*
+    /// cover the identifier, while an **`ICMPv6`** checksum covers both. A conversion that handles
+    /// only TCP/UDP leaves these arms mutating the packet with no checksum update at all -- which
+    /// is worse than the full recompute it replaced, and invisible until something far away drops
+    /// the packet.
+    fn icmp_translation_agrees_with_a_recompute(next_header: NextHeader, ipv6: bool, source: bool) {
+        use net::packet::test_utils::{
+            build_test_ipv4_packet_with_transport, build_test_ipv6_packet_with_transport,
+        };
+
+        let mut packet: Packet<TestBuffer> = if ipv6 {
+            build_test_ipv6_packet_with_transport(64, Some(next_header)).unwrap()
+        } else {
+            build_test_ipv4_packet_with_transport(64, Some(next_header)).unwrap()
+        };
+        packet.update_checksums();
+
+        let new_src = if ipv6 {
+            UnicastIpAddr::try_from(IpAddr::from([
+                0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9,
+            ]))
+            .unwrap()
+        } else {
+            UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap()
+        };
+        if source {
+            snat(&mut packet, new_src.inner(), NatPort::Identifier(4321)).expect("snat");
+        } else {
+            dnat(&mut packet, new_src.inner(), NatPort::Identifier(4321)).expect("dnat");
+        }
+
+        let before = icmp_checksum(&packet);
+        if packet.meta().checksum_refresh() {
+            // Falling back is allowed; it is silently doing neither that is not.
+            return;
+        }
+        packet.update_checksums();
+        assert_eq!(
+            before,
+            icmp_checksum(&packet),
+            "after an ICMP translation the checksum disagrees with a full recompute, and \
+             checksum_refresh was not set either -- so nothing would ever fix it"
+        );
+    }
+
+    fn icmp_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet.headers().try_transport().and_then(|tp| match tp {
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn icmp4_snat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP, false, true);
+    }
+
+    #[test]
+    fn icmp6_snat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP6, true, true);
+    }
+
+    #[test]
+    fn icmp4_dnat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP, false, false);
+    }
+
+    #[test]
+    fn icmp6_dnat_agrees_with_a_recompute() {
+        icmp_translation_agrees_with_a_recompute(NextHeader::ICMP6, true, false);
+    }
+
+    /// The destination-translation counterpart of
+    /// [`snat_leaves_a_checksum_a_full_recompute_would_agree_with`]. Return traffic goes through
+    /// `dnat`, so leaving it on the full recompute would have halved the benefit and hidden any
+    /// mistake behind the direction that was tested.
+    #[test]
+    fn dnat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80);
+        packet.update_checksums();
+
+        let new_dst = IpAddr::from([9, 9, 9, 9]);
+        dnat(
+            &mut packet,
+            new_dst,
+            NatPort::Port(NonZero::new(4321).unwrap()),
+        )
+        .expect("dnat");
+
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "dnat asked for a full payload recompute; the incremental path was not taken"
+        );
+
+        let checksum_of = |p: &Packet<TestBuffer>| {
+            p.headers().try_transport().map(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+        };
+        let incremental = checksum_of(&packet).expect("a transport header");
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            checksum_of(&packet).expect("a transport header"),
+            "the incremental checksum after dnat disagrees with a full recompute"
+        );
+    }
+
+    /// After a source translation, the transport checksum must equal what a full recompute gives.
+    ///
+    /// This is the test that makes the incremental path trustworthy, and it did not exist before:
+    /// **no NAT test validated a checksum at all** (only the ICMP handler did), so the whole suite
+    /// would have passed just as happily with the arithmetic wrong. A bad checksum is not rejected
+    /// here -- it is rejected several hops away, by someone else, long after the fact.
+    #[test]
+    fn snat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80);
+        // Start from a packet whose checksum is right, or the comparison proves nothing.
+        packet.update_checksums();
+
+        let new_src = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        let new_port = NatPort::Port(NonZero::new(4321).unwrap());
+        snat(&mut packet, new_src.inner(), new_port).expect("snat");
+
+        // The whole point: the ordinary path must not ask for a full recompute.
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "snat asked for a full payload recompute; the incremental path was not taken"
+        );
+
+        let checksum_of = |p: &Packet<TestBuffer>| {
+            p.headers().try_transport().map(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+        };
+        let incremental = checksum_of(&packet).expect("a transport header");
+
+        // Force the full recompute over the same, already-translated packet and compare. Done in
+        // place rather than on a copy because `Packet` deliberately has no `Clone`.
+        packet.update_checksums();
+        let expected = checksum_of(&packet).expect("a transport header");
+
+        assert_eq!(
+            incremental, expected,
+            "the incremental checksum after snat disagrees with a full recompute"
+        );
     }
 }

--- a/nat/src/masquerade/test.rs
+++ b/nat/src/masquerade/test.rs
@@ -498,6 +498,48 @@ fn translation(packet: &Packet<TestBuffer>) -> (Ipv4Addr, u16) {
     )
 }
 
+/// Every masqueraded packet must leave with a correct checksum **and** without asking for a full
+/// payload recompute.
+///
+/// Folded into the shared helper so that every NF-level masquerade test is a guard for it. It
+/// exists because the incremental conversion was, for a while, entirely wasted: `snat`/`dnat` did
+/// the delta correctly and then `Masquerade::process` set `checksum_refresh` unconditionally,
+/// reinstating the full sum. Nothing failed -- the packets were correct, just needlessly
+/// expensive -- and the unit tests missed it because they call `snat`/`dnat` directly rather than
+/// through the network function.
+fn assert_masquerade_checksum_is_incremental(packet: &mut Packet<TestBuffer>) {
+    use net::checksum::Checksum;
+    use net::headers::{Transport, TryHeaders, TryTransport};
+
+    if packet.get_done().is_some() {
+        return; // dropped or filtered; nothing was translated
+    }
+    if !packet.meta().is_src_natted() && !packet.meta().is_dst_natted() {
+        return; // no translation happened, so there is no delta to check
+    }
+    let checksum_of = |p: &Packet<TestBuffer>| -> Option<u16> {
+        TryHeaders::headers(p)
+            .try_transport()
+            .and_then(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+    };
+    assert!(
+        !packet.meta().checksum_refresh(),
+        "a masqueraded packet asked for a full payload recompute; the incremental path was \
+         overridden somewhere above `snat`/`dnat`"
+    );
+    let incremental = checksum_of(packet);
+    packet.update_checksums();
+    assert_eq!(
+        incremental,
+        checksum_of(packet),
+        "a masqueraded packet's incremental checksum disagrees with a full recompute"
+    );
+}
+
 fn check_packet(
     nat: &mut Masquerade,
     src_vni: Vni,
@@ -521,8 +563,13 @@ fn check_packet(
     packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
 
     flow_lookup(nat.sessions(), &mut packet);
+    // Start from a correct checksum, so the assertion below is about this code and not about a
+    // malformed test packet: an incremental update is a delta and faithfully preserves an error in
+    // its input.
+    packet.update_checksums();
 
-    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let mut packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    assert_masquerade_checksum_is_incremental(&mut packets_out[0]);
     let hdr_out = packets_out[0].try_ipv4().unwrap();
     let udp_out = packets_out[0].try_udp().unwrap();
     let done_reason = packets_out[0].get_done();

--- a/nat/src/portfw/packet.rs
+++ b/nat/src/portfw/packet.rs
@@ -52,6 +52,9 @@ fn snat_packet<Buf: PacketBufferMut>(
     );
 
     let mut modified = false;
+    // See `masquerade::packet`: set only where an incremental update is impossible, so the ordinary
+    // case skips the full payload recompute in `ipforward`.
+    let mut needs_full_recompute = false;
     match packet
         .headers_mut()
         .pat_mut()
@@ -62,21 +65,35 @@ fn snat_packet<Buf: PacketBufferMut>(
     {
         // traffic can be port forwarded: it's Ip + UDP/TCP
         Some((_, ip, tp)) if is_port_forwardable(ip) => {
-            if ip.src_addr() != new_src_ip.inner() {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src_ip.inner() {
                 ip.try_set_source(new_src_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_src_ip.inner()) {
+                    // An IP version change is not an incremental update; fall back.
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let Some(p) = tp.src_port()
                 && p != new_src_port
             {
                 tp.try_set_source(new_src_port)?;
+                tp.increment_checksum_for_u16(p.get(), new_src_port.get());
                 modified = true;
             }
         }
-        // needed for ICMP error handling
-        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(ip) => {
-            if ip.src_addr() != new_src_ip.inner() {
+        // needed for ICMP error handling. Only the address changes here -- the identifier is left
+        // alone -- so this is a no-op for `ICMPv4` (no pseudo-header) and a real delta for `ICMPv6`.
+        // Matched on the `Transport` rather than the inner header so the helper can tell them apart.
+        Some((_, ip, tp))
+            if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) && is_icmp(ip) =>
+        {
+            let old_addr = ip.src_addr();
+            if old_addr != new_src_ip.inner() {
                 ip.try_set_source(new_src_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_src_ip.inner()) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -85,7 +102,7 @@ fn snat_packet<Buf: PacketBufferMut>(
         }
     }
     if modified {
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
         packet.meta_mut().src_natted(true);
     }
     Ok(modified)
@@ -104,6 +121,7 @@ fn dnat_packet<Buf: PacketBufferMut>(
     );
 
     let mut modified = false;
+    let mut needs_full_recompute = false;
     match packet
         .headers_mut()
         .pat_mut()
@@ -113,21 +131,32 @@ fn dnat_packet<Buf: PacketBufferMut>(
         .done()
     {
         Some((_, ip, tp)) if is_port_forwardable(ip) => {
-            if ip.dst_addr() != new_dst_ip {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
             if let Some(p) = tp.dst_port()
                 && p != new_dst_port
             {
                 tp.try_set_destination(new_dst_port)?;
+                tp.increment_checksum_for_u16(p.get(), new_dst_port.get());
                 modified = true;
             }
         }
-        // needed for ICMP error handling
-        Some((_, ip, Transport::Icmp4(_) | Transport::Icmp6(_))) if is_icmp(ip) => {
-            if ip.dst_addr() != new_dst_ip {
+        // needed for ICMP error handling; see `snat_packet` for why this matches on `Transport`.
+        Some((_, ip, tp))
+            if matches!(tp, Transport::Icmp4(_) | Transport::Icmp6(_)) && is_icmp(ip) =>
+        {
+            let old_addr = ip.dst_addr();
+            if old_addr != new_dst_ip {
                 ip.try_set_destination(new_dst_ip)?;
+                if !tp.increment_checksum_for_address(old_addr, new_dst_ip) {
+                    needs_full_recompute = true;
+                }
                 modified = true;
             }
         }
@@ -136,7 +165,7 @@ fn dnat_packet<Buf: PacketBufferMut>(
         }
     }
     if modified {
-        packet.meta_mut().set_checksum_refresh(true);
+        packet.meta_mut().set_checksum_refresh(needs_full_recompute);
         packet.meta_mut().dst_natted(true);
     }
     Ok(modified)
@@ -150,5 +179,127 @@ pub(crate) fn nat_packet<Buf: PacketBufferMut>(
     match state.action() {
         NatAction::DstNat => dnat_packet(packet, state.use_ip().inner(), state.use_port()),
         NatAction::SrcNat => snat_packet(packet, state.use_ip(), state.use_port()),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod checksum_test {
+    use super::*;
+    use net::buffer::TestBuffer;
+    use net::checksum::Checksum;
+    use net::headers::{TryHeaders, TryTransport};
+    use net::ip::NextHeader;
+    use net::packet::test_utils::{
+        build_test_ipv4_packet_with_transport, build_test_ipv6_packet_with_transport,
+        build_test_tcp_ipv4_packet,
+    };
+
+    fn transport_checksum(packet: &Packet<TestBuffer>) -> Option<u16> {
+        packet.headers().try_transport().and_then(|tp| match tp {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => udp.checksum().map(u16::from),
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        })
+    }
+
+    /// The incremental result must equal a full recompute, and the recompute must be skipped.
+    ///
+    /// Asserting both matters: a conversion that silently keeps setting `checksum_refresh` would
+    /// still be *correct*, and would look like it passed while delivering none of the benefit.
+    fn agrees_with_recompute(mut packet: Packet<TestBuffer>, source: bool) {
+        packet.update_checksums();
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        let new_port = NonZero::new(4321).unwrap();
+        let modified = if source {
+            snat_packet(&mut packet, new_ip, new_port).expect("snat_packet")
+        } else {
+            dnat_packet(&mut packet, new_ip.inner(), new_port).expect("dnat_packet")
+        };
+        assert!(modified, "the test packet was not actually translated");
+        assert!(
+            !packet.meta().checksum_refresh(),
+            "port forwarding asked for a full payload recompute; the incremental path was skipped"
+        );
+
+        let incremental = transport_checksum(&packet);
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            transport_checksum(&packet),
+            "the incremental checksum disagrees with a full recompute"
+        );
+    }
+
+    #[test]
+    fn tcp_snat_agrees_with_a_recompute() {
+        agrees_with_recompute(
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80),
+            true,
+        );
+    }
+
+    #[test]
+    fn tcp_dnat_agrees_with_a_recompute() {
+        agrees_with_recompute(
+            build_test_tcp_ipv4_packet("1.2.3.4", "5.6.7.8", 1234, 80),
+            false,
+        );
+    }
+
+    /// `ICMPv4` has no pseudo-header, so translating the address must leave its checksum *alone*.
+    ///
+    /// The interesting assertion is the negative one: an implementation that folded the address
+    /// delta into an `ICMPv4` checksum would corrupt every forwarded ICMP error, and it would look
+    /// exactly like working code until something downstream dropped the packet.
+    #[test]
+    fn icmp4_address_translation_does_not_move_the_checksum() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_ipv4_packet_with_transport(64, Some(NextHeader::ICMP)).unwrap();
+        packet.update_checksums();
+        let before = transport_checksum(&packet);
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([9, 9, 9, 9])).unwrap();
+        snat_packet(&mut packet, new_ip, NonZero::new(4321).unwrap()).expect("snat_packet");
+
+        assert_eq!(
+            transport_checksum(&packet),
+            before,
+            "an ICMPv4 checksum moved when only the IP address changed; ICMPv4 has no \
+             pseudo-header, so the address is not covered"
+        );
+        // And it still agrees with a recompute, i.e. it was right to leave it alone.
+        packet.update_checksums();
+        assert_eq!(transport_checksum(&packet), before);
+    }
+
+    /// `ICMPv6` *does* have a pseudo-header, so the same translation must move its checksum.
+    #[test]
+    fn icmp6_address_translation_does_move_the_checksum() {
+        let mut packet: Packet<TestBuffer> =
+            build_test_ipv6_packet_with_transport(64, Some(NextHeader::ICMP6)).unwrap();
+        packet.update_checksums();
+        let before = transport_checksum(&packet);
+
+        let new_ip = UnicastIpAddr::try_from(IpAddr::from([
+            0x20, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9,
+        ]))
+        .unwrap();
+        snat_packet(&mut packet, new_ip, NonZero::new(4321).unwrap()).expect("snat_packet");
+
+        let incremental = transport_checksum(&packet);
+        assert_ne!(
+            incremental, before,
+            "an ICMPv6 checksum did not move when the address changed; ICMPv6 has a \
+             pseudo-header, so the address is covered"
+        );
+        packet.update_checksums();
+        assert_eq!(
+            incremental,
+            transport_checksum(&packet),
+            "the incremental ICMPv6 checksum disagrees with a full recompute"
+        );
     }
 }

--- a/nat/src/static_nat/nf.rs
+++ b/nat/src/static_nat/nf.rs
@@ -10,7 +10,10 @@ use crate::icmp_handler::icmp_error_msg::{
 };
 pub use crate::static_nat::natrw::{NatTablesReader, NatTablesWriter}; // re-export
 use net::buffer::PacketBufferMut;
-use net::headers::{Net, NetError, TryEmbeddedTransport, TryInnerIp, TryIpMut, TryTcpUdpMut};
+use net::headers::{
+    Net, NetError, TryEmbeddedTransport, TryHeadersMut, TryInnerIp, TryIpMut, TryTcpUdpMut,
+    TryTransportMut,
+};
 use net::ip::UnicastIpAddr;
 use net::packet::{DoneReason, Packet, VpcDiscriminant};
 use net::tcp_udp::TcpUdpMut;
@@ -108,6 +111,34 @@ impl StaticNat {
         transport.set_dst_port(new_port);
     }
 
+    /// Fold an address and/or port change into the transport checksum (RFC 1624), or ask for a full
+    /// recompute if that is not possible.
+    ///
+    /// Split out because this file mutates through `TcpUdpMut`, which cannot reach a checksum, so
+    /// unlike `masquerade` and `portfw` the delta has to be applied after the fact from values
+    /// captured before. Same arithmetic, awkwarder plumbing.
+    fn fold_checksum_deltas<Buf: PacketBufferMut>(
+        packet: &mut Packet<Buf>,
+        addr_change: Option<(IpAddr, IpAddr)>,
+        port_change: Option<(NonZero<u16>, NonZero<u16>)>,
+    ) {
+        let Some(transport) = packet.headers_mut().try_transport_mut() else {
+            // No transport header to update; nothing to do and nothing to fall back to.
+            return;
+        };
+        let mut incremental_ok = true;
+        if let Some((old, new)) = addr_change {
+            incremental_ok &= transport.increment_checksum_for_address(old, new);
+        }
+        if let Some((old, new)) = port_change {
+            transport.increment_checksum_for_u16(old.get(), new.get());
+        }
+        if !incremental_ok {
+            // An IP version change; the pseudo-header changes shape, so only a recompute will do.
+            packet.meta_mut().set_checksum_refresh(true);
+        }
+    }
+
     fn translate_icmp_inner_packet_src_if_any<Buf: PacketBufferMut>(
         table: &PerVniTable,
         packet: &mut Packet<Buf>,
@@ -177,22 +208,45 @@ impl StaticNat {
             table.find_src_mapping(&src_addr, src_port_opt, dst_vni)
         {
             let net = packet.try_ip_mut().ok_or(StaticNatError::NoIpHeader)?;
-            if new_src_addr.inner() != src_addr {
+            let addr_changed = new_src_addr.inner() != src_addr;
+            if addr_changed {
                 self.translate_src(net, new_src_addr)?;
                 modified = true;
             }
+            // Captured for the checksum delta below. The mutation happens through a
+            // `TcpUdpMut`, which cannot reach the transport's checksum, so the old value has to
+            // survive past the borrow rather than being folded in on the spot the way
+            // `masquerade` and `portfw` do it.
+            let mut port_change = None;
             if let (Some(mut transport), Some(new_src_port)) =
                 (packet.try_tcp_udp_mut(), new_src_port_opt)
                 && new_src_port.get() != transport.src_port().get()
             {
+                port_change = Some((transport.src_port(), new_src_port));
                 self.translate_src_port(&mut transport, new_src_port);
                 modified = true;
             }
+            if modified {
+                Self::fold_checksum_deltas(
+                    packet,
+                    addr_changed.then_some((src_addr, new_src_addr.inner())),
+                    port_change,
+                );
+            }
         }
 
-        // ICMP Error messages
+        // ICMP Error messages.
+        //
+        // Left on the full recompute. `icmp_error_msg` already maintains the embedded headers'
+        // checksums incrementally, and says the outer ICMP checksum "will not be updated again
+        // when deparsing" -- but the outer ICMP checksum covers the whole quoted packet, and
+        // proving the two agree needs its own test. Correct and slower is the right default for a
+        // path this rare; revisit with a test rather than by assertion.
         if icmp_err {
             modified |= Self::translate_icmp_inner_packet_dst_if_any(table, packet, dst_vni)?;
+            if modified {
+                packet.meta_mut().set_checksum_refresh(true);
+            }
         }
 
         if modified {
@@ -222,22 +276,41 @@ impl StaticNat {
             table.find_dst_mapping(&dst_addr, dst_port_opt)
         {
             let net = packet.try_ip_mut().ok_or(StaticNatError::NoIpHeader)?;
-            if new_dst_addr != dst_addr {
+            let addr_changed = new_dst_addr != dst_addr;
+            if addr_changed {
                 self.translate_dst(net, new_dst_addr)?;
                 modified = true;
             }
+            let mut port_change = None;
             if let (Some(mut transport), Some(new_dst_port)) =
                 (packet.try_tcp_udp_mut(), new_dst_port_opt)
                 && new_dst_port.get() != transport.dst_port().get()
             {
+                port_change = Some((transport.dst_port(), new_dst_port));
                 self.translate_dst_port(&mut transport, new_dst_port);
                 modified = true;
             }
+            if modified {
+                Self::fold_checksum_deltas(
+                    packet,
+                    addr_changed.then_some((dst_addr, new_dst_addr)),
+                    port_change,
+                );
+            }
         }
 
-        // ICMP Error messages
+        // ICMP Error messages.
+        //
+        // Left on the full recompute. `icmp_error_msg` already maintains the embedded headers'
+        // checksums incrementally, and says the outer ICMP checksum "will not be updated again
+        // when deparsing" -- but the outer ICMP checksum covers the whole quoted packet, and
+        // proving the two agree needs its own test. Correct and slower is the right default for a
+        // path this rare; revisit with a test rather than by assertion.
         if icmp_err {
             modified |= Self::translate_icmp_inner_packet_src_if_any(table, packet)?;
+            if modified {
+                packet.meta_mut().set_checksum_refresh(true);
+            }
         }
 
         if modified {
@@ -322,7 +395,11 @@ impl StaticNat {
             }
             Ok(modified) => {
                 if modified {
-                    packet.meta_mut().set_checksum_refresh(true);
+                    // Deliberately *not* setting `checksum_refresh` here. The translation paths
+                    // fold their own deltas in incrementally and set the flag only where they
+                    // cannot (an IP version change, or the ICMP-error path). Setting it here
+                    // unconditionally would override that and reinstate the full payload sum for
+                    // every packet -- which is exactly what it did until this was noticed.
                     debug!("{nfi}: Packet was NAT'ed");
                 } else {
                     debug!("{nfi}: No NAT translation needed");

--- a/nat/src/static_nat/test.rs
+++ b/nat/src/static_nat/test.rs
@@ -1254,3 +1254,88 @@ fn test_config_with_port_ranges_with_default() {
     assert_eq!(output_dst_port, orig_src_port);
     assert_eq!(done_reason, None);
 }
+
+/// After static NAT, the transport checksum must equal what a full recompute would produce, and
+/// the full recompute must have been skipped.
+///
+/// End-to-end through `StaticNat::process` rather than against the helpers, because this file
+/// mutates through a `TcpUdpMut` that cannot reach a checksum -- the delta is applied afterwards
+/// from values captured before, which is a shape with more room for the two to drift apart than
+/// `masquerade` or `portfw` have.
+#[test]
+#[cfg_attr(not(emulated), traced_test)]
+fn static_nat_leaves_a_checksum_a_full_recompute_would_agree_with() {
+    use net::checksum::Checksum;
+    use net::headers::{Transport, TryHeaders, TryTransport};
+
+    let expose1 = VpcExpose::empty()
+        .make_static_nat()
+        .unwrap()
+        .ip(PrefixWithOptionalPorts::new(
+            "1.1.0.0/16".into(),
+            Some(PortRange::new(4001, 5000).unwrap()),
+        ))
+        .as_range(PrefixWithOptionalPorts::new(
+            "10.1.0.0/16".into(),
+            Some(PortRange::new(8001, 9000).unwrap()),
+        ))
+        .unwrap();
+    let expose2 = VpcExpose::empty().ip(PrefixWithOptionalPorts::new(
+        "10.2.0.0/16".into(),
+        Some(PortRange::new(1, 5).unwrap()),
+    ));
+
+    let gw_config = build_gwconfig_from_exposes(vec![expose1], vec![expose2]);
+    let nat_tables = build_nat_configuration(gw_config.external().overlay().vpc_table()).unwrap();
+    let (mut nat, mut tablesw) = StaticNat::new("static-nat");
+    tablesw.update_nat_tables(nat_tables);
+
+    let src_vni = Vni::new_checked(100).unwrap();
+    let dst_vni = Vni::new_checked(200).unwrap();
+
+    let mut packet = build_test_ipv4_packet_with_transport(u8::MAX, Some(NextHeader::TCP)).unwrap();
+    packet.meta_mut().set_overlay(true);
+    packet.meta_mut().set_static_nat_src(true);
+    packet.meta_mut().src_vpcd = Some(VpcDiscriminant::VNI(src_vni));
+    packet.meta_mut().dst_vpcd = Some(VpcDiscriminant::VNI(dst_vni));
+    set_addresses_v4(
+        &mut packet,
+        Ipv4Addr::new(1, 1, 0, 1),
+        Ipv4Addr::new(10, 2, 0, 1),
+    );
+    set_ports(&mut packet, 4001, 1);
+    // Start from a correct checksum, or the comparison proves nothing.
+    packet.update_checksums();
+
+    let packets_out: Vec<_> = nat.process(vec![packet].into_iter()).collect();
+    let mut pkt_out = packets_out.into_iter().next().expect("one packet out");
+
+    // The translation must actually have happened, or this test would pass vacuously.
+    assert_ne!(
+        get_src_ip_v4(&pkt_out),
+        Ipv4Addr::new(1, 1, 0, 1),
+        "the packet was not translated; the test is not exercising anything"
+    );
+
+    let checksum_of = |p: &_| -> Option<u16> {
+        TryHeaders::headers(p)
+            .try_transport()
+            .and_then(|tp| match tp {
+                Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+                Transport::Udp(udp) => udp.checksum().map(u16::from),
+                _ => None,
+            })
+    };
+
+    assert!(
+        !pkt_out.meta().checksum_refresh(),
+        "static NAT asked for a full payload recompute; the incremental path was not taken"
+    );
+    let incremental = checksum_of(&pkt_out);
+    pkt_out.update_checksums();
+    assert_eq!(
+        incremental,
+        checksum_of(&pkt_out),
+        "the incremental checksum after static NAT disagrees with a full recompute"
+    );
+}

--- a/net/src/headers/embedded.rs
+++ b/net/src/headers/embedded.rs
@@ -663,7 +663,11 @@ impl EmbeddedTransport {
     }
 }
 
-fn address_words(addr: IpAddr) -> ArrayVec<u16, 8> {
+/// Split an IP address into the 16-bit words a one's-complement checksum is computed over.
+///
+/// Shared with the non-embedded `Transport` incremental update in the parent module: both need to
+/// walk an address a checksum word at a time, and having two copies of this is how they would drift.
+pub(super) fn address_words(addr: IpAddr) -> ArrayVec<u16, 8> {
     match addr {
         IpAddr::V4(addr) => {
             let [a, b, c, d] = addr.octets();

--- a/net/src/headers/mod.rs
+++ b/net/src/headers/mod.rs
@@ -7,9 +7,10 @@
 use crate::checksum::Checksum;
 use crate::eth::ethtype::EthType;
 use crate::eth::{Eth, EthError};
+use crate::headers::embedded::address_words;
 use crate::icmp_any::{IcmpAny, IcmpAnyMut};
-use crate::icmp4::Icmp4;
-use crate::icmp6::{Icmp6, Icmp6ChecksumPayload};
+use crate::icmp4::{Icmp4, Icmp4Checksum};
+use crate::icmp6::{Icmp6, Icmp6Checksum, Icmp6ChecksumPayload};
 use crate::impl_from_for_enum;
 use crate::ip::{NextHeader, UnicastIpAddr};
 use crate::ip_auth::{Ipv4Auth, Ipv6Auth};
@@ -19,9 +20,9 @@ use crate::parse::{
     DeParse, DeParseError, IllegalBufferLength, IntoNonZeroUSize, LengthError, Parse, ParseError,
     Reader, Writer,
 };
-use crate::tcp::{Tcp, TcpChecksumPayload, TcpPort};
+use crate::tcp::{Tcp, TcpChecksum, TcpChecksumPayload, TcpPort};
 use crate::tcp_udp::{TcpUdp, TcpUdpMut};
-use crate::udp::{Udp, UdpChecksumPayload, UdpEncap, UdpPort};
+use crate::udp::{Udp, UdpChecksum, UdpChecksumPayload, UdpEncap, UdpPort};
 use crate::vlan::{Pcp, Vid, Vlan};
 use crate::vxlan::Vxlan;
 use arrayvec::ArrayVec;
@@ -242,6 +243,109 @@ impl Net {
 }
 
 impl Transport {
+    /// Read the transport checksum, if this transport has one.
+    ///
+    /// `None` for a UDP datagram over IPv4 whose checksum is `0`, which means *disabled* rather
+    /// than *zero* -- an incremental update must leave such a datagram alone rather than turn a
+    /// disabled checksum into a wrong one.
+    #[must_use]
+    fn checksum_for_increment(&self) -> Option<u16> {
+        match self {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => match udp.checksum().map(u16::from) {
+                Some(0) | None => None,
+                Some(current) => Some(current),
+            },
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        }
+    }
+
+    /// Write a transport checksum back, applying UDP's "0 means disabled" rule.
+    fn set_checksum_from_increment(&mut self, updated: u16) {
+        match self {
+            Transport::Tcp(tcp) => {
+                let _ = tcp.set_checksum(TcpChecksum::new(updated));
+            }
+            Transport::Udp(udp) => {
+                // A computed 0 has to be sent as 0xFFFF: the two are the same value in one's
+                // complement, and 0 is reserved to mean "no checksum".
+                let updated = if updated == 0 { u16::MAX } else { updated };
+                let _ = udp.set_checksum(UdpChecksum::new(updated));
+            }
+            Transport::Icmp4(icmp) => {
+                let _ = icmp.set_checksum(Icmp4Checksum::new(updated));
+            }
+            Transport::Icmp6(icmp) => {
+                let _ = icmp.set_checksum(Icmp6Checksum::new(updated));
+            }
+        }
+    }
+
+    /// Incrementally update this transport's checksum for a 16-bit field that changed from
+    /// `old_value` to `new_value` (RFC 1624).
+    ///
+    /// Use for a port or an ICMP identifier. Does nothing where there is no checksum to update.
+    pub fn increment_checksum_for_u16(&mut self, old_value: u16, new_value: u16) {
+        if old_value == new_value {
+            return;
+        }
+        let Some(current) = self.checksum_for_increment() else {
+            return;
+        };
+        let updated = match self {
+            Transport::Tcp(tcp) => u16::from(tcp.increment_update_checksum(
+                TcpChecksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Udp(udp) => u16::from(udp.increment_update_checksum(
+                UdpChecksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Icmp4(icmp) => u16::from(icmp.increment_update_checksum(
+                Icmp4Checksum::new(current),
+                old_value,
+                new_value,
+            )),
+            Transport::Icmp6(icmp) => u16::from(icmp.increment_update_checksum(
+                Icmp6Checksum::new(current),
+                old_value,
+                new_value,
+            )),
+        };
+        self.set_checksum_from_increment(updated);
+    }
+
+    /// Incrementally update this transport's checksum for an IP address that changed.
+    ///
+    /// The address is covered by the TCP/UDP/ICMPv6 pseudo-header, so translating it invalidates
+    /// those checksums. **`ICMPv4` has no pseudo-header** and is therefore left alone -- getting that
+    /// backwards would corrupt every translated `ICMPv4` echo.
+    ///
+    /// A change of IP version (NAT64) is not an incremental update: the pseudo-header changes shape,
+    /// not just contents. Such a change is refused here and left to a full recompute.
+    ///
+    /// Returns whether the checksum was updated, so a caller can tell "nothing to do" from "this
+    /// needs a full recompute".
+    pub fn increment_checksum_for_address(&mut self, old: IpAddr, new: IpAddr) -> bool {
+        if old == new {
+            return true;
+        }
+        if matches!(self, Transport::Icmp4(_)) {
+            // No pseudo-header: the address is not covered.
+            return true;
+        }
+        if old.is_ipv4() != new.is_ipv4() {
+            return false;
+        }
+        for (old_word, new_word) in address_words(old).into_iter().zip(address_words(new)) {
+            self.increment_checksum_for_u16(old_word, new_word);
+        }
+        true
+    }
+
     pub(crate) fn update_checksum(
         &mut self,
         net: &Net,
@@ -1685,6 +1789,167 @@ mod test {
             };
         assert_eq!(headers, &parsed);
         assert_eq!(bytes_parsed, headers.size());
+    }
+
+    /// An incremental update must land on exactly the checksum a full recompute would.
+    ///
+    /// This is the whole justification for using RFC 1624 on the NAT path: it is only a valid
+    /// optimisation if it is *indistinguishable* from recomputing. Anything less and we would be
+    /// trading correctness for throughput, silently -- a wrong checksum is not dropped by us, it is
+    /// dropped by whatever receives the packet, minutes and several hops away.
+    ///
+    /// Generated headers, so the comparison covers every transport and both IP versions rather than
+    /// a hand-picked case.
+    fn incremental_matches_recompute(headers: &Headers) {
+        use crate::headers::TryVxlan;
+        use std::num::NonZero;
+
+        let Some(net) = headers.net.clone() else {
+            return;
+        };
+        let Some(transport) = headers.transport.clone() else {
+            return;
+        };
+        // ICMPv4 has no pseudo-header, so an address change must not move its checksum. That is
+        // asserted separately below rather than folded in here.
+        //
+        // VXLAN is excluded: `Headers::update_checksums` deliberately returns before touching the
+        // transport checksum for an encapsulated packet, so "full recompute" is a no-op there and
+        // there is nothing to compare an incremental update against.
+        if headers.try_vxlan().is_some() {
+            return;
+        }
+        let payload: &[u8] = b"the payload the full recompute has to read";
+
+        // Start from a packet whose checksum is actually correct, or the comparison is meaningless.
+        let mut base = headers.clone();
+        base.update_checksums(payload);
+
+        for (old_port, new_port) in [(1234u16, 4321u16), (80, 8080), (65535, 1)] {
+            let mut incremental = base.clone();
+            let mut recomputed = base.clone();
+
+            let (Some(old_nz), Some(new_nz)) = (NonZero::new(old_port), NonZero::new(new_port))
+            else {
+                continue;
+            };
+            // Only ports move here; give both copies the same starting port so the delta is real.
+            // A transport with no ports (ICMP) is skipped -- its identifier is covered elsewhere.
+            {
+                let inc_tp = incremental.transport.as_mut().unwrap();
+                if inc_tp.try_set_source(old_nz).is_err() {
+                    continue;
+                }
+                let rec_tp = recomputed.transport.as_mut().unwrap();
+                rec_tp.try_set_source(old_nz).unwrap();
+            }
+            incremental.update_checksums(payload);
+            recomputed.update_checksums(payload);
+
+            // Now change the port: one incrementally, one by full recompute.
+            let inc_tp = incremental.transport.as_mut().unwrap();
+            inc_tp.try_set_source(new_nz).unwrap();
+            inc_tp.increment_checksum_for_u16(old_port, new_port);
+
+            let rec_tp = recomputed.transport.as_mut().unwrap();
+            rec_tp.try_set_source(new_nz).unwrap();
+            recomputed.update_checksums(payload);
+
+            assert_eq!(
+                incremental.transport.as_ref().map(transport_checksum),
+                recomputed.transport.as_ref().map(transport_checksum),
+                "incremental port update {old_port}->{new_port} disagreed with a full recompute \
+                 for {:?} over {:?}",
+                transport_kind(&transport),
+                net_kind(&net),
+            );
+        }
+    }
+
+    fn transport_checksum(tp: &Transport) -> Option<u16> {
+        match tp {
+            Transport::Tcp(tcp) => tcp.checksum().map(u16::from),
+            Transport::Udp(udp) => udp.checksum().map(u16::from),
+            Transport::Icmp4(icmp) => icmp.checksum().map(u16::from),
+            Transport::Icmp6(icmp) => icmp.checksum().map(u16::from),
+        }
+    }
+
+    fn transport_kind(tp: &Transport) -> &'static str {
+        match tp {
+            Transport::Tcp(_) => "tcp",
+            Transport::Udp(_) => "udp",
+            Transport::Icmp4(_) => "icmp4",
+            Transport::Icmp6(_) => "icmp6",
+        }
+    }
+
+    fn net_kind(net: &Net) -> &'static str {
+        match net {
+            Net::Ipv4(_) => "ipv4",
+            Net::Ipv6(_) => "ipv6",
+        }
+    }
+
+    /// A UDP checksum that incrementally computes to zero must be written as `0xFFFF`.
+    ///
+    /// On IPv4 a stored UDP checksum of `0` means **"no checksum"**, not "the checksum is zero".
+    /// The two are the same value in one's complement, so an update that happens to land on zero
+    /// must send `0xFFFF` instead -- otherwise a translated datagram silently loses checksum
+    /// protection for the rest of its life.
+    ///
+    /// Deliberately targeted rather than left to the property test: the result lands on zero for
+    /// roughly one input in 65536, so a random search almost never reaches it. (Confirmed: deleting
+    /// the rule leaves the property test passing.)
+    #[test]
+    fn a_udp_checksum_that_updates_to_zero_is_written_as_ffff() {
+        use crate::checksum::Checksum;
+        use crate::headers::Transport;
+        use crate::udp::{Udp, UdpChecksum, UdpPort};
+        use std::num::NonZero;
+
+        let mut udp = Udp::new(
+            UdpPort::new(NonZero::new(1234).unwrap()),
+            UdpPort::new(NonZero::new(4321).unwrap()),
+        );
+        let start = 0x1234u16;
+        udp.set_checksum(UdpChecksum::new(start)).unwrap();
+        let mut transport = Transport::Udp(udp);
+
+        // Find the `new` value that drives the raw RFC 1624 update to exactly zero. Using the
+        // primitive to derive it keeps this test honest: it cannot pass by picking a number that
+        // happens not to matter.
+        let old_value = 0xABCDu16;
+        let zeroing = (0..=u16::MAX).find(|new_value| {
+            let Transport::Udp(probe) = &mut transport.clone() else {
+                unreachable!()
+            };
+            u16::from(probe.increment_update_checksum(
+                UdpChecksum::new(start),
+                old_value,
+                *new_value,
+            )) == 0
+        });
+        let zeroing = zeroing.expect("some new value drives the update to zero");
+
+        transport.increment_checksum_for_u16(old_value, zeroing);
+
+        let Transport::Udp(result) = &transport else {
+            unreachable!()
+        };
+        assert_eq!(
+            result.checksum().map(u16::from),
+            Some(u16::MAX),
+            "an incremental update that computes to 0 must be stored as 0xFFFF, or the datagram \
+             reads as having no checksum at all"
+        );
+    }
+
+    #[test]
+    fn incremental_update_matches_full_recompute() {
+        bolero::check!()
+            .with_generator(CommonHeaders)
+            .for_each(incremental_matches_recompute);
     }
 
     #[test]

--- a/net/src/packet/test_utils.rs
+++ b/net/src/packet/test_utils.rs
@@ -51,6 +51,14 @@ fn make_default_for_transport(transport_type: Option<NextHeader>) -> Option<Tran
             let udp = Udp::new(123.try_into().unwrap(), 456.try_into().unwrap());
             Some(Transport::Udp(udp))
         }
+        // Echo requests, because they are the ICMP traffic NAT actually translates: the identifier
+        // is what stands in for a port, and it is covered by the ICMP checksum.
+        Some(NextHeader::ICMP) => Some(Transport::Icmp4(crate::icmp4::Icmp4::with_type(
+            crate::icmp4::Icmp4Type::EchoRequest(crate::icmp4::Icmp4EchoRequest { id: 18, seq: 2 }),
+        ))),
+        Some(NextHeader::ICMP6) => Some(Transport::Icmp6(crate::icmp6::Icmp6::with_type(
+            crate::icmp6::Icmp6Type::EchoRequest(crate::icmp6::Icmp6EchoRequest { id: 18, seq: 2 }),
+        ))),
         Some(transport_type) => {
             panic!("make_default_for_transport: Unsupported transport type: {transport_type:?}")
         }


### PR DESCRIPTION
> **Draft / do-not-merge for now.** Cut early to get CI and vlab running. Unlike the DPDK work this
> is scoped, self-contained, and a candidate to land ahead of DPDK — it is a single commit touching
> only `net` and `nat`, and it benefits the **kernel driver** just as much.

Backport of the incremental-checksum work from `pr/daniel-noland/dpdk-derisk` onto `main`.

## What and why

Every NAT translation set `checksum_refresh`, and `ipforward` answered it by recomputing the
transport checksum **over the whole payload**. For a NAT gateway that is most traffic; at 1500 bytes
it is ~1460 bytes pulled through L1d per packet that need not be read at all.

RFC 1624 was already implemented in `net/src/checksum.rs` and already used in production — but only
for ICMP error quoted headers, where a full recompute is *impossible* because the quote is
truncated. It was never applied where it is merely faster. This applies it to the ordinary paths:
`masquerade` snat/dnat, `portfw` snat/dnat, and `static_nat`.

`checksum_refresh` now means "a full recompute is *required*", and is set only where an incremental
update cannot be done.

## The three rules that make it correct

Copied from `EmbeddedTransport`, which already got them right:

- **ICMPv4 has no pseudo-header**, so an address change must *not* move its checksum. **ICMPv6 does**,
  so it must. The ICMP arms match on `&mut Transport` rather than destructuring to `&mut Icmp4` —
  an `&mut Icmp4` cannot answer that question, and that is exactly how the two get confused.
- A **UDP checksum of 0 on IPv4 means "disabled"** and is left alone; an update that *computes* to 0
  is stored as `0xFFFF`.
- An **IP version change** is refused and falls back to the full recompute.

## Testing

**No NAT test validated a checksum before this** — only the ICMP handler did, so the entire suite
would have passed with the arithmetic wrong. Twelve tests now do, each break-tested:

- `net`: incremental == full recompute (bolero, across transports and both IP versions), plus a
  *targeted* test for the UDP zero case — it lands on zero for about one input in 65536, and
  deleting the rule provably leaves the property test passing.
- `nat`: snat/dnat × TCP × ICMPv4 × ICMPv6 for masquerade, and for portfw the negative case
  (ICMPv4's checksum must *not* move) alongside the positive one.
- An NF-level guard folded into masquerade's shared `check_packet` helper, so every NF-level test
  asserts both that the recompute was skipped and that the checksum matches one.

`net`'s shared test builder gained ICMP echo support; without it no ICMP packet could be built for a
test at all.

## Also fixed

`Masquerade::process_packet` set `checksum_refresh(true)` unconditionally, overriding all of the
above — the delta was computed and the full sum reinstated on top. Correct packets, zero benefit, no
failing test. That is what the NF-level guard exists to prevent recurring.

## Deliberately left alone

The **ICMP-error branches in `static_nat`** keep the full recompute. `icmp_error_msg` maintains the
embedded headers incrementally and says the outer ICMP checksum is not touched again at deparse, but
that checksum covers the whole quoted packet and proving the two agree needs its own test. Correct
and slower is the right default for a path this rare.

## Notes for review

- Verified on this branch: `dataplane-net` 663 tests, `dataplane-nat` 176 tests, full workspace
  `cargo check --all-targets`, clippy and rustdoc clean.
- The backport deliberately does **not** carry the `upper_layer_proto` predicate change that
  `portfw` has on the DPDK branch. That is an unrelated IPv6 next-header fix and wants its own PR;
  `is_port_forwardable`/`is_icmp` keep their `main` signatures here.
